### PR TITLE
Add precinct-level results for the 2016 primaries in Angelina County

### DIFF
--- a/2016/20160301__tx__primary__angelina__precinct.csv
+++ b/2016/20160301__tx__primary__angelina__precinct.csv
@@ -1,0 +1,6990 @@
+﻿county,precinct,office,district,party,candidate,votes
+Angelina,1,Registered Voters - Total,,,,548
+Angelina,2,Registered Voters - Total,,,,2552
+Angelina,3,Registered Voters - Total,,,,1863
+Angelina,4,Registered Voters - Total,,,,1478
+Angelina,5,Registered Voters - Total,,,,1913
+Angelina,6,Registered Voters - Total,,,,435
+Angelina,7,Registered Voters - Total,,,,1013
+Angelina,8,Registered Voters - Total,,,,1099
+Angelina,9,Registered Voters - Total,,,,285
+Angelina,10,Registered Voters - Total,,,,1340
+Angelina,11,Registered Voters - Total,,,,1985
+Angelina,11B,Registered Voters - Total,,,,1278
+Angelina,12,Registered Voters - Total,,,,875
+Angelina,13,Registered Voters - Total,,,,670
+Angelina,14,Registered Voters - Total,,,,1779
+Angelina,15,Registered Voters - Total,,,,636
+Angelina,16,Registered Voters - Total,,,,2187
+Angelina,17,Registered Voters - Total,,,,1562
+Angelina,17B,Registered Voters - Total,,,,461
+Angelina,18,Registered Voters - Total,,,,641
+Angelina,19,Registered Voters - Total,,,,1450
+Angelina,20,Registered Voters - Total,,,,2900
+Angelina,21,Registered Voters - Total,,,,1182
+Angelina,22,Registered Voters - Total,,,,1076
+Angelina,23,Registered Voters - Total,,,,607
+Angelina,24,Registered Voters - Total,,,,2587
+Angelina,25,Registered Voters - Total,,,,2180
+Angelina,26,Registered Voters - Total,,,,1538
+Angelina,27,Registered Voters - Total,,,,340
+Angelina,28,Registered Voters - Total,,,,1046
+Angelina,29,Registered Voters - Total,,,,1484
+Angelina,30,Registered Voters - Total,,,,997
+Angelina,31,Registered Voters - Total,,,,440
+Angelina,32,Registered Voters - Total,,,,112
+Angelina,33,Registered Voters - Total,,,,1206
+Angelina,34,Registered Voters - Total,,,,2145
+Angelina,35,Registered Voters - Total,,,,1746
+Angelina,36,Registered Voters - Total,,,,0
+Angelina,37,Registered Voters - Total,,,,435
+Angelina,38,Registered Voters - Total,,,,388
+Angelina,39,Registered Voters - Total,,,,530
+Angelina,40,Registered Voters - Total,,,,835
+Angelina,1,Ballots Cast - Total,,,,130
+Angelina,2,Ballots Cast - Total,,,,453
+Angelina,3,Ballots Cast - Total,,,,616
+Angelina,4,Ballots Cast - Total,,,,351
+Angelina,5,Ballots Cast - Total,,,,493
+Angelina,6,Ballots Cast - Total,,,,174
+Angelina,7,Ballots Cast - Total,,,,450
+Angelina,8,Ballots Cast - Total,,,,507
+Angelina,9,Ballots Cast - Total,,,,130
+Angelina,10,Ballots Cast - Total,,,,354
+Angelina,11,Ballots Cast - Total,,,,765
+Angelina,11B,Ballots Cast - Total,,,,324
+Angelina,12,Ballots Cast - Total,,,,324
+Angelina,13,Ballots Cast - Total,,,,200
+Angelina,14,Ballots Cast - Total,,,,723
+Angelina,15,Ballots Cast - Total,,,,220
+Angelina,16,Ballots Cast - Total,,,,445
+Angelina,17,Ballots Cast - Total,,,,562
+Angelina,17B,Ballots Cast - Total,,,,124
+Angelina,18,Ballots Cast - Total,,,,207
+Angelina,19,Ballots Cast - Total,,,,639
+Angelina,20,Ballots Cast - Total,,,,472
+Angelina,21,Ballots Cast - Total,,,,442
+Angelina,22,Ballots Cast - Total,,,,414
+Angelina,23,Ballots Cast - Total,,,,222
+Angelina,24,Ballots Cast - Total,,,,744
+Angelina,25,Ballots Cast - Total,,,,748
+Angelina,26,Ballots Cast - Total,,,,718
+Angelina,27,Ballots Cast - Total,,,,154
+Angelina,28,Ballots Cast - Total,,,,426
+Angelina,29,Ballots Cast - Total,,,,568
+Angelina,30,Ballots Cast - Total,,,,307
+Angelina,31,Ballots Cast - Total,,,,116
+Angelina,32,Ballots Cast - Total,,,,52
+Angelina,33,Ballots Cast - Total,,,,486
+Angelina,34,Ballots Cast - Total,,,,840
+Angelina,35,Ballots Cast - Total,,,,704
+Angelina,36,Ballots Cast - Total,,,,1
+Angelina,37,Ballots Cast - Total,,,,171
+Angelina,38,Ballots Cast - Total,,,,130
+Angelina,39,Ballots Cast - Total,,,,163
+Angelina,40,Ballots Cast - Total,,,,271
+Angelina,1,Ballots Cast,,REP,,98
+Angelina,2,Ballots Cast,,REP,,185
+Angelina,3,Ballots Cast,,REP,,539
+Angelina,4,Ballots Cast,,REP,,255
+Angelina,5,Ballots Cast,,REP,,363
+Angelina,6,Ballots Cast,,REP,,153
+Angelina,7,Ballots Cast,,REP,,426
+Angelina,8,Ballots Cast,,REP,,482
+Angelina,9,Ballots Cast,,REP,,114
+Angelina,10,Ballots Cast,,REP,,243
+Angelina,11,Ballots Cast,,REP,,713
+Angelina,11B,Ballots Cast,,REP,,276
+Angelina,12,Ballots Cast,,REP,,285
+Angelina,13,Ballots Cast,,REP,,163
+Angelina,14,Ballots Cast,,REP,,608
+Angelina,15,Ballots Cast,,REP,,204
+Angelina,16,Ballots Cast,,REP,,310
+Angelina,17,Ballots Cast,,REP,,498
+Angelina,17B,Ballots Cast,,REP,,106
+Angelina,18,Ballots Cast,,REP,,171
+Angelina,19,Ballots Cast,,REP,,539
+Angelina,20,Ballots Cast,,REP,,97
+Angelina,21,Ballots Cast,,REP,,380
+Angelina,22,Ballots Cast,,REP,,354
+Angelina,23,Ballots Cast,,REP,,204
+Angelina,24,Ballots Cast,,REP,,665
+Angelina,25,Ballots Cast,,REP,,657
+Angelina,26,Ballots Cast,,REP,,661
+Angelina,27,Ballots Cast,,REP,,136
+Angelina,28,Ballots Cast,,REP,,385
+Angelina,29,Ballots Cast,,REP,,513
+Angelina,30,Ballots Cast,,REP,,284
+Angelina,31,Ballots Cast,,REP,,95
+Angelina,32,Ballots Cast,,REP,,48
+Angelina,33,Ballots Cast,,REP,,460
+Angelina,34,Ballots Cast,,REP,,744
+Angelina,35,Ballots Cast,,REP,,613
+Angelina,36,Ballots Cast,,REP,,1
+Angelina,37,Ballots Cast,,REP,,142
+Angelina,38,Ballots Cast,,REP,,116
+Angelina,39,Ballots Cast,,REP,,132
+Angelina,40,Ballots Cast,,REP,,217
+Angelina,1,Ballots Cast,,DEM,,32
+Angelina,2,Ballots Cast,,DEM,,268
+Angelina,3,Ballots Cast,,DEM,,77
+Angelina,4,Ballots Cast,,DEM,,96
+Angelina,5,Ballots Cast,,DEM,,130
+Angelina,6,Ballots Cast,,DEM,,21
+Angelina,7,Ballots Cast,,DEM,,24
+Angelina,8,Ballots Cast,,DEM,,25
+Angelina,9,Ballots Cast,,DEM,,16
+Angelina,10,Ballots Cast,,DEM,,111
+Angelina,11,Ballots Cast,,DEM,,52
+Angelina,11B,Ballots Cast,,DEM,,48
+Angelina,12,Ballots Cast,,DEM,,39
+Angelina,13,Ballots Cast,,DEM,,37
+Angelina,14,Ballots Cast,,DEM,,115
+Angelina,15,Ballots Cast,,DEM,,16
+Angelina,16,Ballots Cast,,DEM,,135
+Angelina,17,Ballots Cast,,DEM,,64
+Angelina,17B,Ballots Cast,,DEM,,18
+Angelina,18,Ballots Cast,,DEM,,36
+Angelina,19,Ballots Cast,,DEM,,100
+Angelina,20,Ballots Cast,,DEM,,375
+Angelina,21,Ballots Cast,,DEM,,62
+Angelina,22,Ballots Cast,,DEM,,60
+Angelina,23,Ballots Cast,,DEM,,18
+Angelina,24,Ballots Cast,,DEM,,79
+Angelina,25,Ballots Cast,,DEM,,91
+Angelina,26,Ballots Cast,,DEM,,57
+Angelina,27,Ballots Cast,,DEM,,18
+Angelina,28,Ballots Cast,,DEM,,41
+Angelina,29,Ballots Cast,,DEM,,55
+Angelina,30,Ballots Cast,,DEM,,23
+Angelina,31,Ballots Cast,,DEM,,21
+Angelina,32,Ballots Cast,,DEM,,4
+Angelina,33,Ballots Cast,,DEM,,26
+Angelina,34,Ballots Cast,,DEM,,96
+Angelina,35,Ballots Cast,,DEM,,91
+Angelina,36,Ballots Cast,,DEM,,0
+Angelina,37,Ballots Cast,,DEM,,29
+Angelina,38,Ballots Cast,,DEM,,14
+Angelina,39,Ballots Cast,,DEM,,31
+Angelina,40,Ballots Cast,,DEM,,54
+Angelina,1,U.S. House,1,REP,Anthony Culler,5
+Angelina,2,U.S. House,1,REP,Anthony Culler,7
+Angelina,3,U.S. House,1,REP,Anthony Culler,21
+Angelina,4,U.S. House,1,REP,Anthony Culler,12
+Angelina,5,U.S. House,1,REP,Anthony Culler,15
+Angelina,6,U.S. House,1,REP,Anthony Culler,3
+Angelina,7,U.S. House,1,REP,Anthony Culler,9
+Angelina,8,U.S. House,1,REP,Anthony Culler,16
+Angelina,9,U.S. House,1,REP,Anthony Culler,3
+Angelina,10,U.S. House,1,REP,Anthony Culler,10
+Angelina,11,U.S. House,1,REP,Anthony Culler,21
+Angelina,11B,U.S. House,1,REP,Anthony Culler,11
+Angelina,12,U.S. House,1,REP,Anthony Culler,9
+Angelina,13,U.S. House,1,REP,Anthony Culler,4
+Angelina,14,U.S. House,1,REP,Anthony Culler,15
+Angelina,15,U.S. House,1,REP,Anthony Culler,3
+Angelina,16,U.S. House,1,REP,Anthony Culler,14
+Angelina,17,U.S. House,1,REP,Anthony Culler,23
+Angelina,17B,U.S. House,1,REP,Anthony Culler,6
+Angelina,18,U.S. House,1,REP,Anthony Culler,6
+Angelina,19,U.S. House,1,REP,Anthony Culler,16
+Angelina,20,U.S. House,1,REP,Anthony Culler,7
+Angelina,21,U.S. House,1,REP,Anthony Culler,11
+Angelina,22,U.S. House,1,REP,Anthony Culler,6
+Angelina,23,U.S. House,1,REP,Anthony Culler,4
+Angelina,24,U.S. House,1,REP,Anthony Culler,12
+Angelina,25,U.S. House,1,REP,Anthony Culler,22
+Angelina,26,U.S. House,1,REP,Anthony Culler,29
+Angelina,27,U.S. House,1,REP,Anthony Culler,5
+Angelina,28,U.S. House,1,REP,Anthony Culler,9
+Angelina,29,U.S. House,1,REP,Anthony Culler,11
+Angelina,30,U.S. House,1,REP,Anthony Culler,11
+Angelina,31,U.S. House,1,REP,Anthony Culler,1
+Angelina,32,U.S. House,1,REP,Anthony Culler,0
+Angelina,33,U.S. House,1,REP,Anthony Culler,12
+Angelina,34,U.S. House,1,REP,Anthony Culler,11
+Angelina,35,U.S. House,1,REP,Anthony Culler,21
+Angelina,36,U.S. House,1,REP,Anthony Culler,0
+Angelina,37,U.S. House,1,REP,Anthony Culler,5
+Angelina,38,U.S. House,1,REP,Anthony Culler,7
+Angelina,39,U.S. House,1,REP,Anthony Culler,4
+Angelina,40,U.S. House,1,REP,Anthony Culler,11
+Angelina,1,U.S. House,1,REP,Simon Winston,22
+Angelina,2,U.S. House,1,REP,Simon Winston,50
+Angelina,3,U.S. House,1,REP,Simon Winston,164
+Angelina,4,U.S. House,1,REP,Simon Winston,77
+Angelina,5,U.S. House,1,REP,Simon Winston,79
+Angelina,6,U.S. House,1,REP,Simon Winston,54
+Angelina,7,U.S. House,1,REP,Simon Winston,107
+Angelina,8,U.S. House,1,REP,Simon Winston,124
+Angelina,9,U.S. House,1,REP,Simon Winston,28
+Angelina,10,U.S. House,1,REP,Simon Winston,48
+Angelina,11,U.S. House,1,REP,Simon Winston,225
+Angelina,11B,U.S. House,1,REP,Simon Winston,88
+Angelina,12,U.S. House,1,REP,Simon Winston,76
+Angelina,13,U.S. House,1,REP,Simon Winston,51
+Angelina,14,U.S. House,1,REP,Simon Winston,136
+Angelina,15,U.S. House,1,REP,Simon Winston,58
+Angelina,16,U.S. House,1,REP,Simon Winston,71
+Angelina,17,U.S. House,1,REP,Simon Winston,112
+Angelina,17B,U.S. House,1,REP,Simon Winston,39
+Angelina,18,U.S. House,1,REP,Simon Winston,49
+Angelina,19,U.S. House,1,REP,Simon Winston,138
+Angelina,20,U.S. House,1,REP,Simon Winston,20
+Angelina,21,U.S. House,1,REP,Simon Winston,96
+Angelina,22,U.S. House,1,REP,Simon Winston,106
+Angelina,23,U.S. House,1,REP,Simon Winston,53
+Angelina,24,U.S. House,1,REP,Simon Winston,156
+Angelina,25,U.S. House,1,REP,Simon Winston,170
+Angelina,26,U.S. House,1,REP,Simon Winston,158
+Angelina,27,U.S. House,1,REP,Simon Winston,30
+Angelina,28,U.S. House,1,REP,Simon Winston,88
+Angelina,29,U.S. House,1,REP,Simon Winston,146
+Angelina,30,U.S. House,1,REP,Simon Winston,78
+Angelina,31,U.S. House,1,REP,Simon Winston,24
+Angelina,32,U.S. House,1,REP,Simon Winston,13
+Angelina,33,U.S. House,1,REP,Simon Winston,136
+Angelina,34,U.S. House,1,REP,Simon Winston,282
+Angelina,35,U.S. House,1,REP,Simon Winston,164
+Angelina,36,U.S. House,1,REP,Simon Winston,0
+Angelina,37,U.S. House,1,REP,Simon Winston,45
+Angelina,38,U.S. House,1,REP,Simon Winston,37
+Angelina,39,U.S. House,1,REP,Simon Winston,29
+Angelina,40,U.S. House,1,REP,Simon Winston,62
+Angelina,1,U.S. House,1,REP,Louie Gohmert,65
+Angelina,2,U.S. House,1,REP,Louie Gohmert,114
+Angelina,3,U.S. House,1,REP,Louie Gohmert,319
+Angelina,4,U.S. House,1,REP,Louie Gohmert,150
+Angelina,5,U.S. House,1,REP,Louie Gohmert,250
+Angelina,6,U.S. House,1,REP,Louie Gohmert,83
+Angelina,7,U.S. House,1,REP,Louie Gohmert,299
+Angelina,8,U.S. House,1,REP,Louie Gohmert,319
+Angelina,9,U.S. House,1,REP,Louie Gohmert,76
+Angelina,10,U.S. House,1,REP,Louie Gohmert,169
+Angelina,11,U.S. House,1,REP,Louie Gohmert,414
+Angelina,11B,U.S. House,1,REP,Louie Gohmert,148
+Angelina,12,U.S. House,1,REP,Louie Gohmert,183
+Angelina,13,U.S. House,1,REP,Louie Gohmert,101
+Angelina,14,U.S. House,1,REP,Louie Gohmert,423
+Angelina,15,U.S. House,1,REP,Louie Gohmert,128
+Angelina,16,U.S. House,1,REP,Louie Gohmert,202
+Angelina,17,U.S. House,1,REP,Louie Gohmert,315
+Angelina,17B,U.S. House,1,REP,Louie Gohmert,53
+Angelina,18,U.S. House,1,REP,Louie Gohmert,113
+Angelina,19,U.S. House,1,REP,Louie Gohmert,362
+Angelina,20,U.S. House,1,REP,Louie Gohmert,62
+Angelina,21,U.S. House,1,REP,Louie Gohmert,251
+Angelina,22,U.S. House,1,REP,Louie Gohmert,217
+Angelina,23,U.S. House,1,REP,Louie Gohmert,131
+Angelina,24,U.S. House,1,REP,Louie Gohmert,445
+Angelina,25,U.S. House,1,REP,Louie Gohmert,422
+Angelina,26,U.S. House,1,REP,Louie Gohmert,452
+Angelina,27,U.S. House,1,REP,Louie Gohmert,88
+Angelina,28,U.S. House,1,REP,Louie Gohmert,269
+Angelina,29,U.S. House,1,REP,Louie Gohmert,321
+Angelina,30,U.S. House,1,REP,Louie Gohmert,164
+Angelina,31,U.S. House,1,REP,Louie Gohmert,64
+Angelina,32,U.S. House,1,REP,Louie Gohmert,31
+Angelina,33,U.S. House,1,REP,Louie Gohmert,277
+Angelina,34,U.S. House,1,REP,Louie Gohmert,408
+Angelina,35,U.S. House,1,REP,Louie Gohmert,390
+Angelina,36,U.S. House,1,REP,Louie Gohmert,1
+Angelina,37,U.S. House,1,REP,Louie Gohmert,83
+Angelina,38,U.S. House,1,REP,Louie Gohmert,63
+Angelina,39,U.S. House,1,REP,Louie Gohmert,92
+Angelina,40,U.S. House,1,REP,Louie Gohmert,133
+Angelina,1,U.S. House,1,REP,OVER VOTES,0
+Angelina,2,U.S. House,1,REP,OVER VOTES,0
+Angelina,3,U.S. House,1,REP,OVER VOTES,0
+Angelina,4,U.S. House,1,REP,OVER VOTES,0
+Angelina,5,U.S. House,1,REP,OVER VOTES,0
+Angelina,6,U.S. House,1,REP,OVER VOTES,0
+Angelina,7,U.S. House,1,REP,OVER VOTES,0
+Angelina,8,U.S. House,1,REP,OVER VOTES,0
+Angelina,9,U.S. House,1,REP,OVER VOTES,0
+Angelina,10,U.S. House,1,REP,OVER VOTES,0
+Angelina,11,U.S. House,1,REP,OVER VOTES,0
+Angelina,11B,U.S. House,1,REP,OVER VOTES,0
+Angelina,12,U.S. House,1,REP,OVER VOTES,0
+Angelina,13,U.S. House,1,REP,OVER VOTES,0
+Angelina,14,U.S. House,1,REP,OVER VOTES,0
+Angelina,15,U.S. House,1,REP,OVER VOTES,0
+Angelina,16,U.S. House,1,REP,OVER VOTES,0
+Angelina,17,U.S. House,1,REP,OVER VOTES,0
+Angelina,17B,U.S. House,1,REP,OVER VOTES,0
+Angelina,18,U.S. House,1,REP,OVER VOTES,0
+Angelina,19,U.S. House,1,REP,OVER VOTES,0
+Angelina,20,U.S. House,1,REP,OVER VOTES,0
+Angelina,21,U.S. House,1,REP,OVER VOTES,0
+Angelina,22,U.S. House,1,REP,OVER VOTES,0
+Angelina,23,U.S. House,1,REP,OVER VOTES,0
+Angelina,24,U.S. House,1,REP,OVER VOTES,0
+Angelina,25,U.S. House,1,REP,OVER VOTES,0
+Angelina,26,U.S. House,1,REP,OVER VOTES,0
+Angelina,27,U.S. House,1,REP,OVER VOTES,0
+Angelina,28,U.S. House,1,REP,OVER VOTES,0
+Angelina,29,U.S. House,1,REP,OVER VOTES,0
+Angelina,30,U.S. House,1,REP,OVER VOTES,0
+Angelina,31,U.S. House,1,REP,OVER VOTES,0
+Angelina,32,U.S. House,1,REP,OVER VOTES,0
+Angelina,33,U.S. House,1,REP,OVER VOTES,0
+Angelina,34,U.S. House,1,REP,OVER VOTES,0
+Angelina,35,U.S. House,1,REP,OVER VOTES,0
+Angelina,36,U.S. House,1,REP,OVER VOTES,0
+Angelina,37,U.S. House,1,REP,OVER VOTES,0
+Angelina,38,U.S. House,1,REP,OVER VOTES,0
+Angelina,39,U.S. House,1,REP,OVER VOTES,0
+Angelina,40,U.S. House,1,REP,OVER VOTES,0
+Angelina,1,U.S. House,1,REP,UNDER VOTES,6
+Angelina,2,U.S. House,1,REP,UNDER VOTES,14
+Angelina,3,U.S. House,1,REP,UNDER VOTES,35
+Angelina,4,U.S. House,1,REP,UNDER VOTES,16
+Angelina,5,U.S. House,1,REP,UNDER VOTES,19
+Angelina,6,U.S. House,1,REP,UNDER VOTES,13
+Angelina,7,U.S. House,1,REP,UNDER VOTES,11
+Angelina,8,U.S. House,1,REP,UNDER VOTES,23
+Angelina,9,U.S. House,1,REP,UNDER VOTES,7
+Angelina,10,U.S. House,1,REP,UNDER VOTES,16
+Angelina,11,U.S. House,1,REP,UNDER VOTES,53
+Angelina,11B,U.S. House,1,REP,UNDER VOTES,29
+Angelina,12,U.S. House,1,REP,UNDER VOTES,17
+Angelina,13,U.S. House,1,REP,UNDER VOTES,7
+Angelina,14,U.S. House,1,REP,UNDER VOTES,34
+Angelina,15,U.S. House,1,REP,UNDER VOTES,15
+Angelina,16,U.S. House,1,REP,UNDER VOTES,23
+Angelina,17,U.S. House,1,REP,UNDER VOTES,48
+Angelina,17B,U.S. House,1,REP,UNDER VOTES,8
+Angelina,18,U.S. House,1,REP,UNDER VOTES,3
+Angelina,19,U.S. House,1,REP,UNDER VOTES,23
+Angelina,20,U.S. House,1,REP,UNDER VOTES,8
+Angelina,21,U.S. House,1,REP,UNDER VOTES,22
+Angelina,22,U.S. House,1,REP,UNDER VOTES,25
+Angelina,23,U.S. House,1,REP,UNDER VOTES,16
+Angelina,24,U.S. House,1,REP,UNDER VOTES,52
+Angelina,25,U.S. House,1,REP,UNDER VOTES,43
+Angelina,26,U.S. House,1,REP,UNDER VOTES,22
+Angelina,27,U.S. House,1,REP,UNDER VOTES,13
+Angelina,28,U.S. House,1,REP,UNDER VOTES,19
+Angelina,29,U.S. House,1,REP,UNDER VOTES,35
+Angelina,30,U.S. House,1,REP,UNDER VOTES,31
+Angelina,31,U.S. House,1,REP,UNDER VOTES,6
+Angelina,32,U.S. House,1,REP,UNDER VOTES,4
+Angelina,33,U.S. House,1,REP,UNDER VOTES,35
+Angelina,34,U.S. House,1,REP,UNDER VOTES,43
+Angelina,35,U.S. House,1,REP,UNDER VOTES,38
+Angelina,36,U.S. House,1,REP,UNDER VOTES,0
+Angelina,37,U.S. House,1,REP,UNDER VOTES,9
+Angelina,38,U.S. House,1,REP,UNDER VOTES,9
+Angelina,39,U.S. House,1,REP,UNDER VOTES,7
+Angelina,40,U.S. House,1,REP,UNDER VOTES,11
+Angelina,1,Railroad Commissioner,,REP,Lance N. Christian,9
+Angelina,2,Railroad Commissioner,,REP,Lance N. Christian,20
+Angelina,3,Railroad Commissioner,,REP,Lance N. Christian,50
+Angelina,4,Railroad Commissioner,,REP,Lance N. Christian,27
+Angelina,5,Railroad Commissioner,,REP,Lance N. Christian,33
+Angelina,6,Railroad Commissioner,,REP,Lance N. Christian,17
+Angelina,7,Railroad Commissioner,,REP,Lance N. Christian,41
+Angelina,8,Railroad Commissioner,,REP,Lance N. Christian,49
+Angelina,9,Railroad Commissioner,,REP,Lance N. Christian,10
+Angelina,10,Railroad Commissioner,,REP,Lance N. Christian,37
+Angelina,11,Railroad Commissioner,,REP,Lance N. Christian,73
+Angelina,11B,Railroad Commissioner,,REP,Lance N. Christian,36
+Angelina,12,Railroad Commissioner,,REP,Lance N. Christian,22
+Angelina,13,Railroad Commissioner,,REP,Lance N. Christian,17
+Angelina,14,Railroad Commissioner,,REP,Lance N. Christian,57
+Angelina,15,Railroad Commissioner,,REP,Lance N. Christian,10
+Angelina,16,Railroad Commissioner,,REP,Lance N. Christian,30
+Angelina,17,Railroad Commissioner,,REP,Lance N. Christian,47
+Angelina,17B,Railroad Commissioner,,REP,Lance N. Christian,5
+Angelina,18,Railroad Commissioner,,REP,Lance N. Christian,12
+Angelina,19,Railroad Commissioner,,REP,Lance N. Christian,50
+Angelina,20,Railroad Commissioner,,REP,Lance N. Christian,6
+Angelina,21,Railroad Commissioner,,REP,Lance N. Christian,30
+Angelina,22,Railroad Commissioner,,REP,Lance N. Christian,30
+Angelina,23,Railroad Commissioner,,REP,Lance N. Christian,17
+Angelina,24,Railroad Commissioner,,REP,Lance N. Christian,55
+Angelina,25,Railroad Commissioner,,REP,Lance N. Christian,60
+Angelina,26,Railroad Commissioner,,REP,Lance N. Christian,52
+Angelina,27,Railroad Commissioner,,REP,Lance N. Christian,9
+Angelina,28,Railroad Commissioner,,REP,Lance N. Christian,46
+Angelina,29,Railroad Commissioner,,REP,Lance N. Christian,58
+Angelina,30,Railroad Commissioner,,REP,Lance N. Christian,25
+Angelina,31,Railroad Commissioner,,REP,Lance N. Christian,17
+Angelina,32,Railroad Commissioner,,REP,Lance N. Christian,2
+Angelina,33,Railroad Commissioner,,REP,Lance N. Christian,54
+Angelina,34,Railroad Commissioner,,REP,Lance N. Christian,68
+Angelina,35,Railroad Commissioner,,REP,Lance N. Christian,45
+Angelina,36,Railroad Commissioner,,REP,Lance N. Christian,0
+Angelina,37,Railroad Commissioner,,REP,Lance N. Christian,18
+Angelina,38,Railroad Commissioner,,REP,Lance N. Christian,15
+Angelina,39,Railroad Commissioner,,REP,Lance N. Christian,10
+Angelina,40,Railroad Commissioner,,REP,Lance N. Christian,24
+Angelina,1,Railroad Commissioner,,REP,Wayne Christian,48
+Angelina,2,Railroad Commissioner,,REP,Wayne Christian,79
+Angelina,3,Railroad Commissioner,,REP,Wayne Christian,264
+Angelina,4,Railroad Commissioner,,REP,Wayne Christian,113
+Angelina,5,Railroad Commissioner,,REP,Wayne Christian,170
+Angelina,6,Railroad Commissioner,,REP,Wayne Christian,73
+Angelina,7,Railroad Commissioner,,REP,Wayne Christian,217
+Angelina,8,Railroad Commissioner,,REP,Wayne Christian,240
+Angelina,9,Railroad Commissioner,,REP,Wayne Christian,41
+Angelina,10,Railroad Commissioner,,REP,Wayne Christian,108
+Angelina,11,Railroad Commissioner,,REP,Wayne Christian,306
+Angelina,11B,Railroad Commissioner,,REP,Wayne Christian,106
+Angelina,12,Railroad Commissioner,,REP,Wayne Christian,153
+Angelina,13,Railroad Commissioner,,REP,Wayne Christian,68
+Angelina,14,Railroad Commissioner,,REP,Wayne Christian,296
+Angelina,15,Railroad Commissioner,,REP,Wayne Christian,99
+Angelina,16,Railroad Commissioner,,REP,Wayne Christian,114
+Angelina,17,Railroad Commissioner,,REP,Wayne Christian,205
+Angelina,17B,Railroad Commissioner,,REP,Wayne Christian,49
+Angelina,18,Railroad Commissioner,,REP,Wayne Christian,90
+Angelina,19,Railroad Commissioner,,REP,Wayne Christian,255
+Angelina,20,Railroad Commissioner,,REP,Wayne Christian,42
+Angelina,21,Railroad Commissioner,,REP,Wayne Christian,214
+Angelina,22,Railroad Commissioner,,REP,Wayne Christian,188
+Angelina,23,Railroad Commissioner,,REP,Wayne Christian,105
+Angelina,24,Railroad Commissioner,,REP,Wayne Christian,323
+Angelina,25,Railroad Commissioner,,REP,Wayne Christian,316
+Angelina,26,Railroad Commissioner,,REP,Wayne Christian,362
+Angelina,27,Railroad Commissioner,,REP,Wayne Christian,68
+Angelina,28,Railroad Commissioner,,REP,Wayne Christian,187
+Angelina,29,Railroad Commissioner,,REP,Wayne Christian,244
+Angelina,30,Railroad Commissioner,,REP,Wayne Christian,96
+Angelina,31,Railroad Commissioner,,REP,Wayne Christian,51
+Angelina,32,Railroad Commissioner,,REP,Wayne Christian,20
+Angelina,33,Railroad Commissioner,,REP,Wayne Christian,210
+Angelina,34,Railroad Commissioner,,REP,Wayne Christian,289
+Angelina,35,Railroad Commissioner,,REP,Wayne Christian,298
+Angelina,36,Railroad Commissioner,,REP,Wayne Christian,0
+Angelina,37,Railroad Commissioner,,REP,Wayne Christian,67
+Angelina,38,Railroad Commissioner,,REP,Wayne Christian,45
+Angelina,39,Railroad Commissioner,,REP,Wayne Christian,65
+Angelina,40,Railroad Commissioner,,REP,Wayne Christian,101
+Angelina,1,Railroad Commissioner,,REP,Ron Hale,4
+Angelina,2,Railroad Commissioner,,REP,Ron Hale,13
+Angelina,3,Railroad Commissioner,,REP,Ron Hale,46
+Angelina,4,Railroad Commissioner,,REP,Ron Hale,12
+Angelina,5,Railroad Commissioner,,REP,Ron Hale,21
+Angelina,6,Railroad Commissioner,,REP,Ron Hale,12
+Angelina,7,Railroad Commissioner,,REP,Ron Hale,18
+Angelina,8,Railroad Commissioner,,REP,Ron Hale,31
+Angelina,9,Railroad Commissioner,,REP,Ron Hale,7
+Angelina,10,Railroad Commissioner,,REP,Ron Hale,12
+Angelina,11,Railroad Commissioner,,REP,Ron Hale,51
+Angelina,11B,Railroad Commissioner,,REP,Ron Hale,16
+Angelina,12,Railroad Commissioner,,REP,Ron Hale,25
+Angelina,13,Railroad Commissioner,,REP,Ron Hale,17
+Angelina,14,Railroad Commissioner,,REP,Ron Hale,30
+Angelina,15,Railroad Commissioner,,REP,Ron Hale,13
+Angelina,16,Railroad Commissioner,,REP,Ron Hale,20
+Angelina,17,Railroad Commissioner,,REP,Ron Hale,42
+Angelina,17B,Railroad Commissioner,,REP,Ron Hale,18
+Angelina,18,Railroad Commissioner,,REP,Ron Hale,4
+Angelina,19,Railroad Commissioner,,REP,Ron Hale,16
+Angelina,20,Railroad Commissioner,,REP,Ron Hale,5
+Angelina,21,Railroad Commissioner,,REP,Ron Hale,27
+Angelina,22,Railroad Commissioner,,REP,Ron Hale,21
+Angelina,23,Railroad Commissioner,,REP,Ron Hale,16
+Angelina,24,Railroad Commissioner,,REP,Ron Hale,30
+Angelina,25,Railroad Commissioner,,REP,Ron Hale,51
+Angelina,26,Railroad Commissioner,,REP,Ron Hale,41
+Angelina,27,Railroad Commissioner,,REP,Ron Hale,10
+Angelina,28,Railroad Commissioner,,REP,Ron Hale,17
+Angelina,29,Railroad Commissioner,,REP,Ron Hale,26
+Angelina,30,Railroad Commissioner,,REP,Ron Hale,34
+Angelina,31,Railroad Commissioner,,REP,Ron Hale,3
+Angelina,32,Railroad Commissioner,,REP,Ron Hale,5
+Angelina,33,Railroad Commissioner,,REP,Ron Hale,37
+Angelina,34,Railroad Commissioner,,REP,Ron Hale,45
+Angelina,35,Railroad Commissioner,,REP,Ron Hale,44
+Angelina,36,Railroad Commissioner,,REP,Ron Hale,0
+Angelina,37,Railroad Commissioner,,REP,Ron Hale,11
+Angelina,38,Railroad Commissioner,,REP,Ron Hale,5
+Angelina,39,Railroad Commissioner,,REP,Ron Hale,11
+Angelina,40,Railroad Commissioner,,REP,Ron Hale,15
+Angelina,1,Railroad Commissioner,,REP,John Greytok,2
+Angelina,2,Railroad Commissioner,,REP,John Greytok,3
+Angelina,3,Railroad Commissioner,,REP,John Greytok,4
+Angelina,4,Railroad Commissioner,,REP,John Greytok,3
+Angelina,5,Railroad Commissioner,,REP,John Greytok,6
+Angelina,6,Railroad Commissioner,,REP,John Greytok,2
+Angelina,7,Railroad Commissioner,,REP,John Greytok,4
+Angelina,8,Railroad Commissioner,,REP,John Greytok,10
+Angelina,9,Railroad Commissioner,,REP,John Greytok,2
+Angelina,10,Railroad Commissioner,,REP,John Greytok,2
+Angelina,11,Railroad Commissioner,,REP,John Greytok,11
+Angelina,11B,Railroad Commissioner,,REP,John Greytok,8
+Angelina,12,Railroad Commissioner,,REP,John Greytok,3
+Angelina,13,Railroad Commissioner,,REP,John Greytok,3
+Angelina,14,Railroad Commissioner,,REP,John Greytok,7
+Angelina,15,Railroad Commissioner,,REP,John Greytok,2
+Angelina,16,Railroad Commissioner,,REP,John Greytok,9
+Angelina,17,Railroad Commissioner,,REP,John Greytok,8
+Angelina,17B,Railroad Commissioner,,REP,John Greytok,0
+Angelina,18,Railroad Commissioner,,REP,John Greytok,3
+Angelina,19,Railroad Commissioner,,REP,John Greytok,10
+Angelina,20,Railroad Commissioner,,REP,John Greytok,1
+Angelina,21,Railroad Commissioner,,REP,John Greytok,3
+Angelina,22,Railroad Commissioner,,REP,John Greytok,10
+Angelina,23,Railroad Commissioner,,REP,John Greytok,5
+Angelina,24,Railroad Commissioner,,REP,John Greytok,15
+Angelina,25,Railroad Commissioner,,REP,John Greytok,7
+Angelina,26,Railroad Commissioner,,REP,John Greytok,9
+Angelina,27,Railroad Commissioner,,REP,John Greytok,2
+Angelina,28,Railroad Commissioner,,REP,John Greytok,12
+Angelina,29,Railroad Commissioner,,REP,John Greytok,7
+Angelina,30,Railroad Commissioner,,REP,John Greytok,6
+Angelina,31,Railroad Commissioner,,REP,John Greytok,1
+Angelina,32,Railroad Commissioner,,REP,John Greytok,3
+Angelina,33,Railroad Commissioner,,REP,John Greytok,6
+Angelina,34,Railroad Commissioner,,REP,John Greytok,14
+Angelina,35,Railroad Commissioner,,REP,John Greytok,8
+Angelina,36,Railroad Commissioner,,REP,John Greytok,0
+Angelina,37,Railroad Commissioner,,REP,John Greytok,3
+Angelina,38,Railroad Commissioner,,REP,John Greytok,1
+Angelina,39,Railroad Commissioner,,REP,John Greytok,6
+Angelina,40,Railroad Commissioner,,REP,John Greytok,3
+Angelina,1,Railroad Commissioner,,REP,Weston Martinez,4
+Angelina,2,Railroad Commissioner,,REP,Weston Martinez,17
+Angelina,3,Railroad Commissioner,,REP,Weston Martinez,21
+Angelina,4,Railroad Commissioner,,REP,Weston Martinez,7
+Angelina,5,Railroad Commissioner,,REP,Weston Martinez,23
+Angelina,6,Railroad Commissioner,,REP,Weston Martinez,1
+Angelina,7,Railroad Commissioner,,REP,Weston Martinez,7
+Angelina,8,Railroad Commissioner,,REP,Weston Martinez,13
+Angelina,9,Railroad Commissioner,,REP,Weston Martinez,4
+Angelina,10,Railroad Commissioner,,REP,Weston Martinez,10
+Angelina,11,Railroad Commissioner,,REP,Weston Martinez,16
+Angelina,11B,Railroad Commissioner,,REP,Weston Martinez,3
+Angelina,12,Railroad Commissioner,,REP,Weston Martinez,7
+Angelina,13,Railroad Commissioner,,REP,Weston Martinez,8
+Angelina,14,Railroad Commissioner,,REP,Weston Martinez,17
+Angelina,15,Railroad Commissioner,,REP,Weston Martinez,13
+Angelina,16,Railroad Commissioner,,REP,Weston Martinez,21
+Angelina,17,Railroad Commissioner,,REP,Weston Martinez,14
+Angelina,17B,Railroad Commissioner,,REP,Weston Martinez,6
+Angelina,18,Railroad Commissioner,,REP,Weston Martinez,9
+Angelina,19,Railroad Commissioner,,REP,Weston Martinez,23
+Angelina,20,Railroad Commissioner,,REP,Weston Martinez,9
+Angelina,21,Railroad Commissioner,,REP,Weston Martinez,13
+Angelina,22,Railroad Commissioner,,REP,Weston Martinez,13
+Angelina,23,Railroad Commissioner,,REP,Weston Martinez,5
+Angelina,24,Railroad Commissioner,,REP,Weston Martinez,18
+Angelina,25,Railroad Commissioner,,REP,Weston Martinez,23
+Angelina,26,Railroad Commissioner,,REP,Weston Martinez,15
+Angelina,27,Railroad Commissioner,,REP,Weston Martinez,0
+Angelina,28,Railroad Commissioner,,REP,Weston Martinez,12
+Angelina,29,Railroad Commissioner,,REP,Weston Martinez,5
+Angelina,30,Railroad Commissioner,,REP,Weston Martinez,10
+Angelina,31,Railroad Commissioner,,REP,Weston Martinez,7
+Angelina,32,Railroad Commissioner,,REP,Weston Martinez,2
+Angelina,33,Railroad Commissioner,,REP,Weston Martinez,12
+Angelina,34,Railroad Commissioner,,REP,Weston Martinez,35
+Angelina,35,Railroad Commissioner,,REP,Weston Martinez,25
+Angelina,36,Railroad Commissioner,,REP,Weston Martinez,1
+Angelina,37,Railroad Commissioner,,REP,Weston Martinez,4
+Angelina,38,Railroad Commissioner,,REP,Weston Martinez,9
+Angelina,39,Railroad Commissioner,,REP,Weston Martinez,2
+Angelina,40,Railroad Commissioner,,REP,Weston Martinez,7
+Angelina,1,Railroad Commissioner,,REP,Doug Jeffrey,4
+Angelina,2,Railroad Commissioner,,REP,Doug Jeffrey,11
+Angelina,3,Railroad Commissioner,,REP,Doug Jeffrey,16
+Angelina,4,Railroad Commissioner,,REP,Doug Jeffrey,13
+Angelina,5,Railroad Commissioner,,REP,Doug Jeffrey,19
+Angelina,6,Railroad Commissioner,,REP,Doug Jeffrey,8
+Angelina,7,Railroad Commissioner,,REP,Doug Jeffrey,13
+Angelina,8,Railroad Commissioner,,REP,Doug Jeffrey,12
+Angelina,9,Railroad Commissioner,,REP,Doug Jeffrey,4
+Angelina,10,Railroad Commissioner,,REP,Doug Jeffrey,7
+Angelina,11,Railroad Commissioner,,REP,Doug Jeffrey,22
+Angelina,11B,Railroad Commissioner,,REP,Doug Jeffrey,6
+Angelina,12,Railroad Commissioner,,REP,Doug Jeffrey,4
+Angelina,13,Railroad Commissioner,,REP,Doug Jeffrey,7
+Angelina,14,Railroad Commissioner,,REP,Doug Jeffrey,25
+Angelina,15,Railroad Commissioner,,REP,Doug Jeffrey,7
+Angelina,16,Railroad Commissioner,,REP,Doug Jeffrey,13
+Angelina,17,Railroad Commissioner,,REP,Doug Jeffrey,25
+Angelina,17B,Railroad Commissioner,,REP,Doug Jeffrey,1
+Angelina,18,Railroad Commissioner,,REP,Doug Jeffrey,6
+Angelina,19,Railroad Commissioner,,REP,Doug Jeffrey,11
+Angelina,20,Railroad Commissioner,,REP,Doug Jeffrey,4
+Angelina,21,Railroad Commissioner,,REP,Doug Jeffrey,7
+Angelina,22,Railroad Commissioner,,REP,Doug Jeffrey,16
+Angelina,23,Railroad Commissioner,,REP,Doug Jeffrey,7
+Angelina,24,Railroad Commissioner,,REP,Doug Jeffrey,27
+Angelina,25,Railroad Commissioner,,REP,Doug Jeffrey,20
+Angelina,26,Railroad Commissioner,,REP,Doug Jeffrey,19
+Angelina,27,Railroad Commissioner,,REP,Doug Jeffrey,5
+Angelina,28,Railroad Commissioner,,REP,Doug Jeffrey,20
+Angelina,29,Railroad Commissioner,,REP,Doug Jeffrey,14
+Angelina,30,Railroad Commissioner,,REP,Doug Jeffrey,14
+Angelina,31,Railroad Commissioner,,REP,Doug Jeffrey,3
+Angelina,32,Railroad Commissioner,,REP,Doug Jeffrey,0
+Angelina,33,Railroad Commissioner,,REP,Doug Jeffrey,11
+Angelina,34,Railroad Commissioner,,REP,Doug Jeffrey,40
+Angelina,35,Railroad Commissioner,,REP,Doug Jeffrey,14
+Angelina,36,Railroad Commissioner,,REP,Doug Jeffrey,0
+Angelina,37,Railroad Commissioner,,REP,Doug Jeffrey,4
+Angelina,38,Railroad Commissioner,,REP,Doug Jeffrey,6
+Angelina,39,Railroad Commissioner,,REP,Doug Jeffrey,3
+Angelina,40,Railroad Commissioner,,REP,Doug Jeffrey,7
+Angelina,1,Railroad Commissioner,,REP,Gary Gates,7
+Angelina,2,Railroad Commissioner,,REP,Gary Gates,17
+Angelina,3,Railroad Commissioner,,REP,Gary Gates,46
+Angelina,4,Railroad Commissioner,,REP,Gary Gates,24
+Angelina,5,Railroad Commissioner,,REP,Gary Gates,29
+Angelina,6,Railroad Commissioner,,REP,Gary Gates,15
+Angelina,7,Railroad Commissioner,,REP,Gary Gates,39
+Angelina,8,Railroad Commissioner,,REP,Gary Gates,40
+Angelina,9,Railroad Commissioner,,REP,Gary Gates,18
+Angelina,10,Railroad Commissioner,,REP,Gary Gates,29
+Angelina,11,Railroad Commissioner,,REP,Gary Gates,75
+Angelina,11B,Railroad Commissioner,,REP,Gary Gates,25
+Angelina,12,Railroad Commissioner,,REP,Gary Gates,26
+Angelina,13,Railroad Commissioner,,REP,Gary Gates,15
+Angelina,14,Railroad Commissioner,,REP,Gary Gates,53
+Angelina,15,Railroad Commissioner,,REP,Gary Gates,27
+Angelina,16,Railroad Commissioner,,REP,Gary Gates,42
+Angelina,17,Railroad Commissioner,,REP,Gary Gates,59
+Angelina,17B,Railroad Commissioner,,REP,Gary Gates,11
+Angelina,18,Railroad Commissioner,,REP,Gary Gates,23
+Angelina,19,Railroad Commissioner,,REP,Gary Gates,50
+Angelina,20,Railroad Commissioner,,REP,Gary Gates,7
+Angelina,21,Railroad Commissioner,,REP,Gary Gates,28
+Angelina,22,Railroad Commissioner,,REP,Gary Gates,20
+Angelina,23,Railroad Commissioner,,REP,Gary Gates,12
+Angelina,24,Railroad Commissioner,,REP,Gary Gates,53
+Angelina,25,Railroad Commissioner,,REP,Gary Gates,59
+Angelina,26,Railroad Commissioner,,REP,Gary Gates,52
+Angelina,27,Railroad Commissioner,,REP,Gary Gates,16
+Angelina,28,Railroad Commissioner,,REP,Gary Gates,27
+Angelina,29,Railroad Commissioner,,REP,Gary Gates,40
+Angelina,30,Railroad Commissioner,,REP,Gary Gates,30
+Angelina,31,Railroad Commissioner,,REP,Gary Gates,5
+Angelina,32,Railroad Commissioner,,REP,Gary Gates,7
+Angelina,33,Railroad Commissioner,,REP,Gary Gates,33
+Angelina,34,Railroad Commissioner,,REP,Gary Gates,68
+Angelina,35,Railroad Commissioner,,REP,Gary Gates,48
+Angelina,36,Railroad Commissioner,,REP,Gary Gates,0
+Angelina,37,Railroad Commissioner,,REP,Gary Gates,12
+Angelina,38,Railroad Commissioner,,REP,Gary Gates,10
+Angelina,39,Railroad Commissioner,,REP,Gary Gates,10
+Angelina,40,Railroad Commissioner,,REP,Gary Gates,21
+Angelina,1,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,2,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,3,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,4,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,5,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,6,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,7,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,8,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,9,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,10,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,11,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,11B,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,12,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,13,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,14,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,15,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,16,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,17,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,17B,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,18,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,19,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,20,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,21,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,22,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,23,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,24,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,25,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,26,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,27,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,28,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,29,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,30,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,31,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,32,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,33,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,34,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,35,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,36,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,37,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,38,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,39,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,40,Railroad Commissioner,,REP,OVER VOTES,0
+Angelina,1,Railroad Commissioner,,REP,UNDER VOTES,20
+Angelina,2,Railroad Commissioner,,REP,UNDER VOTES,25
+Angelina,3,Railroad Commissioner,,REP,UNDER VOTES,92
+Angelina,4,Railroad Commissioner,,REP,UNDER VOTES,56
+Angelina,5,Railroad Commissioner,,REP,UNDER VOTES,62
+Angelina,6,Railroad Commissioner,,REP,UNDER VOTES,25
+Angelina,7,Railroad Commissioner,,REP,UNDER VOTES,87
+Angelina,8,Railroad Commissioner,,REP,UNDER VOTES,87
+Angelina,9,Railroad Commissioner,,REP,UNDER VOTES,28
+Angelina,10,Railroad Commissioner,,REP,UNDER VOTES,38
+Angelina,11,Railroad Commissioner,,REP,UNDER VOTES,159
+Angelina,11B,Railroad Commissioner,,REP,UNDER VOTES,76
+Angelina,12,Railroad Commissioner,,REP,UNDER VOTES,45
+Angelina,13,Railroad Commissioner,,REP,UNDER VOTES,28
+Angelina,14,Railroad Commissioner,,REP,UNDER VOTES,123
+Angelina,15,Railroad Commissioner,,REP,UNDER VOTES,33
+Angelina,16,Railroad Commissioner,,REP,UNDER VOTES,61
+Angelina,17,Railroad Commissioner,,REP,UNDER VOTES,98
+Angelina,17B,Railroad Commissioner,,REP,UNDER VOTES,16
+Angelina,18,Railroad Commissioner,,REP,UNDER VOTES,24
+Angelina,19,Railroad Commissioner,,REP,UNDER VOTES,124
+Angelina,20,Railroad Commissioner,,REP,UNDER VOTES,23
+Angelina,21,Railroad Commissioner,,REP,UNDER VOTES,58
+Angelina,22,Railroad Commissioner,,REP,UNDER VOTES,56
+Angelina,23,Railroad Commissioner,,REP,UNDER VOTES,37
+Angelina,24,Railroad Commissioner,,REP,UNDER VOTES,144
+Angelina,25,Railroad Commissioner,,REP,UNDER VOTES,121
+Angelina,26,Railroad Commissioner,,REP,UNDER VOTES,111
+Angelina,27,Railroad Commissioner,,REP,UNDER VOTES,26
+Angelina,28,Railroad Commissioner,,REP,UNDER VOTES,64
+Angelina,29,Railroad Commissioner,,REP,UNDER VOTES,119
+Angelina,30,Railroad Commissioner,,REP,UNDER VOTES,69
+Angelina,31,Railroad Commissioner,,REP,UNDER VOTES,8
+Angelina,32,Railroad Commissioner,,REP,UNDER VOTES,9
+Angelina,33,Railroad Commissioner,,REP,UNDER VOTES,97
+Angelina,34,Railroad Commissioner,,REP,UNDER VOTES,185
+Angelina,35,Railroad Commissioner,,REP,UNDER VOTES,131
+Angelina,36,Railroad Commissioner,,REP,UNDER VOTES,0
+Angelina,37,Railroad Commissioner,,REP,UNDER VOTES,23
+Angelina,38,Railroad Commissioner,,REP,UNDER VOTES,25
+Angelina,39,Railroad Commissioner,,REP,UNDER VOTES,25
+Angelina,40,Railroad Commissioner,,REP,UNDER VOTES,39
+Angelina,1,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,40
+Angelina,2,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,89
+Angelina,3,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,245
+Angelina,4,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,124
+Angelina,5,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,160
+Angelina,6,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,70
+Angelina,7,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,210
+Angelina,8,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,222
+Angelina,9,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,37
+Angelina,10,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,107
+Angelina,11,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,326
+Angelina,11B,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,111
+Angelina,12,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,159
+Angelina,13,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,69
+Angelina,14,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,276
+Angelina,15,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,96
+Angelina,16,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,141
+Angelina,17,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,245
+Angelina,17B,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,39
+Angelina,18,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,89
+Angelina,19,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,211
+Angelina,20,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,40
+Angelina,21,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,187
+Angelina,22,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,155
+Angelina,23,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,103
+Angelina,24,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,266
+Angelina,25,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,323
+Angelina,26,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,324
+Angelina,27,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,65
+Angelina,28,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,187
+Angelina,29,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,238
+Angelina,30,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,139
+Angelina,31,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,52
+Angelina,32,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,22
+Angelina,33,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,228
+Angelina,34,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,252
+Angelina,35,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,260
+Angelina,36,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,1
+Angelina,37,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,65
+Angelina,38,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,54
+Angelina,39,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,55
+Angelina,40,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,94
+Angelina,1,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,38
+Angelina,2,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,62
+Angelina,3,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,185
+Angelina,4,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,75
+Angelina,5,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,117
+Angelina,6,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,43
+Angelina,7,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,103
+Angelina,8,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,136
+Angelina,9,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,38
+Angelina,10,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,89
+Angelina,11,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,198
+Angelina,11B,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,84
+Angelina,12,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,68
+Angelina,13,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,54
+Angelina,14,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,163
+Angelina,15,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,68
+Angelina,16,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,95
+Angelina,17,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,135
+Angelina,17B,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,40
+Angelina,18,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,54
+Angelina,19,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,168
+Angelina,20,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,31
+Angelina,21,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,123
+Angelina,22,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,125
+Angelina,23,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,56
+Angelina,24,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,225
+Angelina,25,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,189
+Angelina,26,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,196
+Angelina,27,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,36
+Angelina,28,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,108
+Angelina,29,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,141
+Angelina,30,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,70
+Angelina,31,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,26
+Angelina,32,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,15
+Angelina,33,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,107
+Angelina,34,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,290
+Angelina,35,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,192
+Angelina,36,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,0
+Angelina,37,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,51
+Angelina,38,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,32
+Angelina,39,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,44
+Angelina,40,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,77
+Angelina,1,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,2,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,3,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,4,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,5,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,6,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,7,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,8,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,9,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,10,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,11,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,11B,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,12,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,13,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,14,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,15,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,16,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,17,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,17B,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,18,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,19,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,20,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,21,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,22,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,23,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,24,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,25,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,26,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,27,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,28,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,29,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,30,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,31,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,32,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,33,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,34,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,35,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,36,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,37,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,38,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,39,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,40,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0
+Angelina,1,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,20
+Angelina,2,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,34
+Angelina,3,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,109
+Angelina,4,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,56
+Angelina,5,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,86
+Angelina,6,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,40
+Angelina,7,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,113
+Angelina,8,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,124
+Angelina,9,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,39
+Angelina,10,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,47
+Angelina,11,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,189
+Angelina,11B,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,81
+Angelina,12,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,58
+Angelina,13,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,40
+Angelina,14,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,169
+Angelina,15,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,40
+Angelina,16,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,74
+Angelina,17,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,118
+Angelina,17B,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,27
+Angelina,18,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,28
+Angelina,19,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,160
+Angelina,20,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,26
+Angelina,21,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,70
+Angelina,22,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,74
+Angelina,23,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,45
+Angelina,24,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,174
+Angelina,25,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,145
+Angelina,26,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,141
+Angelina,27,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,35
+Angelina,28,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,90
+Angelina,29,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,134
+Angelina,30,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,75
+Angelina,31,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,17
+Angelina,32,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,11
+Angelina,33,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,125
+Angelina,34,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,202
+Angelina,35,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,161
+Angelina,36,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,0
+Angelina,37,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,26
+Angelina,38,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,30
+Angelina,39,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,33
+Angelina,40,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,46
+Angelina,1,"Justice, Supreme Court, Place 5",,REP,Paul Green,47
+Angelina,2,"Justice, Supreme Court, Place 5",,REP,Paul Green,95
+Angelina,3,"Justice, Supreme Court, Place 5",,REP,Paul Green,235
+Angelina,4,"Justice, Supreme Court, Place 5",,REP,Paul Green,116
+Angelina,5,"Justice, Supreme Court, Place 5",,REP,Paul Green,158
+Angelina,6,"Justice, Supreme Court, Place 5",,REP,Paul Green,63
+Angelina,7,"Justice, Supreme Court, Place 5",,REP,Paul Green,159
+Angelina,8,"Justice, Supreme Court, Place 5",,REP,Paul Green,188
+Angelina,9,"Justice, Supreme Court, Place 5",,REP,Paul Green,41
+Angelina,10,"Justice, Supreme Court, Place 5",,REP,Paul Green,115
+Angelina,11,"Justice, Supreme Court, Place 5",,REP,Paul Green,294
+Angelina,11B,"Justice, Supreme Court, Place 5",,REP,Paul Green,112
+Angelina,12,"Justice, Supreme Court, Place 5",,REP,Paul Green,141
+Angelina,13,"Justice, Supreme Court, Place 5",,REP,Paul Green,85
+Angelina,14,"Justice, Supreme Court, Place 5",,REP,Paul Green,255
+Angelina,15,"Justice, Supreme Court, Place 5",,REP,Paul Green,98
+Angelina,16,"Justice, Supreme Court, Place 5",,REP,Paul Green,140
+Angelina,17,"Justice, Supreme Court, Place 5",,REP,Paul Green,197
+Angelina,17B,"Justice, Supreme Court, Place 5",,REP,Paul Green,38
+Angelina,18,"Justice, Supreme Court, Place 5",,REP,Paul Green,87
+Angelina,19,"Justice, Supreme Court, Place 5",,REP,Paul Green,237
+Angelina,20,"Justice, Supreme Court, Place 5",,REP,Paul Green,45
+Angelina,21,"Justice, Supreme Court, Place 5",,REP,Paul Green,184
+Angelina,22,"Justice, Supreme Court, Place 5",,REP,Paul Green,147
+Angelina,23,"Justice, Supreme Court, Place 5",,REP,Paul Green,89
+Angelina,24,"Justice, Supreme Court, Place 5",,REP,Paul Green,249
+Angelina,25,"Justice, Supreme Court, Place 5",,REP,Paul Green,304
+Angelina,26,"Justice, Supreme Court, Place 5",,REP,Paul Green,285
+Angelina,27,"Justice, Supreme Court, Place 5",,REP,Paul Green,59
+Angelina,28,"Justice, Supreme Court, Place 5",,REP,Paul Green,158
+Angelina,29,"Justice, Supreme Court, Place 5",,REP,Paul Green,202
+Angelina,30,"Justice, Supreme Court, Place 5",,REP,Paul Green,116
+Angelina,31,"Justice, Supreme Court, Place 5",,REP,Paul Green,50
+Angelina,32,"Justice, Supreme Court, Place 5",,REP,Paul Green,15
+Angelina,33,"Justice, Supreme Court, Place 5",,REP,Paul Green,172
+Angelina,34,"Justice, Supreme Court, Place 5",,REP,Paul Green,334
+Angelina,35,"Justice, Supreme Court, Place 5",,REP,Paul Green,252
+Angelina,36,"Justice, Supreme Court, Place 5",,REP,Paul Green,0
+Angelina,37,"Justice, Supreme Court, Place 5",,REP,Paul Green,65
+Angelina,38,"Justice, Supreme Court, Place 5",,REP,Paul Green,50
+Angelina,39,"Justice, Supreme Court, Place 5",,REP,Paul Green,57
+Angelina,40,"Justice, Supreme Court, Place 5",,REP,Paul Green,102
+Angelina,1,"Justice, Supreme Court, Place 5",,REP,Rick Green,28
+Angelina,2,"Justice, Supreme Court, Place 5",,REP,Rick Green,56
+Angelina,3,"Justice, Supreme Court, Place 5",,REP,Rick Green,188
+Angelina,4,"Justice, Supreme Court, Place 5",,REP,Rick Green,72
+Angelina,5,"Justice, Supreme Court, Place 5",,REP,Rick Green,113
+Angelina,6,"Justice, Supreme Court, Place 5",,REP,Rick Green,50
+Angelina,7,"Justice, Supreme Court, Place 5",,REP,Rick Green,141
+Angelina,8,"Justice, Supreme Court, Place 5",,REP,Rick Green,167
+Angelina,9,"Justice, Supreme Court, Place 5",,REP,Rick Green,26
+Angelina,10,"Justice, Supreme Court, Place 5",,REP,Rick Green,78
+Angelina,11,"Justice, Supreme Court, Place 5",,REP,Rick Green,209
+Angelina,11B,"Justice, Supreme Court, Place 5",,REP,Rick Green,83
+Angelina,12,"Justice, Supreme Court, Place 5",,REP,Rick Green,83
+Angelina,13,"Justice, Supreme Court, Place 5",,REP,Rick Green,37
+Angelina,14,"Justice, Supreme Court, Place 5",,REP,Rick Green,167
+Angelina,15,"Justice, Supreme Court, Place 5",,REP,Rick Green,57
+Angelina,16,"Justice, Supreme Court, Place 5",,REP,Rick Green,92
+Angelina,17,"Justice, Supreme Court, Place 5",,REP,Rick Green,165
+Angelina,17B,"Justice, Supreme Court, Place 5",,REP,Rick Green,40
+Angelina,18,"Justice, Supreme Court, Place 5",,REP,Rick Green,51
+Angelina,19,"Justice, Supreme Court, Place 5",,REP,Rick Green,128
+Angelina,20,"Justice, Supreme Court, Place 5",,REP,Rick Green,27
+Angelina,21,"Justice, Supreme Court, Place 5",,REP,Rick Green,112
+Angelina,22,"Justice, Supreme Court, Place 5",,REP,Rick Green,117
+Angelina,23,"Justice, Supreme Court, Place 5",,REP,Rick Green,70
+Angelina,24,"Justice, Supreme Court, Place 5",,REP,Rick Green,230
+Angelina,25,"Justice, Supreme Court, Place 5",,REP,Rick Green,197
+Angelina,26,"Justice, Supreme Court, Place 5",,REP,Rick Green,223
+Angelina,27,"Justice, Supreme Court, Place 5",,REP,Rick Green,37
+Angelina,28,"Justice, Supreme Court, Place 5",,REP,Rick Green,129
+Angelina,29,"Justice, Supreme Court, Place 5",,REP,Rick Green,156
+Angelina,30,"Justice, Supreme Court, Place 5",,REP,Rick Green,86
+Angelina,31,"Justice, Supreme Court, Place 5",,REP,Rick Green,29
+Angelina,32,"Justice, Supreme Court, Place 5",,REP,Rick Green,21
+Angelina,33,"Justice, Supreme Court, Place 5",,REP,Rick Green,148
+Angelina,34,"Justice, Supreme Court, Place 5",,REP,Rick Green,177
+Angelina,35,"Justice, Supreme Court, Place 5",,REP,Rick Green,181
+Angelina,36,"Justice, Supreme Court, Place 5",,REP,Rick Green,1
+Angelina,37,"Justice, Supreme Court, Place 5",,REP,Rick Green,46
+Angelina,38,"Justice, Supreme Court, Place 5",,REP,Rick Green,32
+Angelina,39,"Justice, Supreme Court, Place 5",,REP,Rick Green,39
+Angelina,40,"Justice, Supreme Court, Place 5",,REP,Rick Green,60
+Angelina,1,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,2,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,3,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,4,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,5,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,6,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,7,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,8,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,9,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,10,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,11,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,11B,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,12,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,13,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,14,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,15,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,16,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,17,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,17B,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,18,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,19,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,20,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,21,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,22,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,23,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,24,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,25,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,26,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,27,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,28,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,29,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,30,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,31,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,32,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,33,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,34,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,35,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,36,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,37,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,38,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,39,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,40,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0
+Angelina,1,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,23
+Angelina,2,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,34
+Angelina,3,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,116
+Angelina,4,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,67
+Angelina,5,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,92
+Angelina,6,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,40
+Angelina,7,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,126
+Angelina,8,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,127
+Angelina,9,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,47
+Angelina,10,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,50
+Angelina,11,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,210
+Angelina,11B,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,81
+Angelina,12,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,61
+Angelina,13,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,41
+Angelina,14,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,186
+Angelina,15,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,49
+Angelina,16,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,78
+Angelina,17,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,136
+Angelina,17B,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,28
+Angelina,18,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,33
+Angelina,19,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,174
+Angelina,20,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,25
+Angelina,21,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,84
+Angelina,22,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,90
+Angelina,23,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,45
+Angelina,24,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,186
+Angelina,25,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,156
+Angelina,26,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,153
+Angelina,27,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,40
+Angelina,28,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,98
+Angelina,29,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,155
+Angelina,30,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,82
+Angelina,31,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,16
+Angelina,32,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,12
+Angelina,33,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,140
+Angelina,34,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,233
+Angelina,35,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,180
+Angelina,36,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,0
+Angelina,37,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,31
+Angelina,38,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,34
+Angelina,39,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,36
+Angelina,40,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,55
+Angelina,1,"Justice, Supreme Court, Place 9",,REP,Joe Pool,42
+Angelina,2,"Justice, Supreme Court, Place 9",,REP,Joe Pool,96
+Angelina,3,"Justice, Supreme Court, Place 9",,REP,Joe Pool,275
+Angelina,4,"Justice, Supreme Court, Place 9",,REP,Joe Pool,137
+Angelina,5,"Justice, Supreme Court, Place 9",,REP,Joe Pool,154
+Angelina,6,"Justice, Supreme Court, Place 9",,REP,Joe Pool,76
+Angelina,7,"Justice, Supreme Court, Place 9",,REP,Joe Pool,183
+Angelina,8,"Justice, Supreme Court, Place 9",,REP,Joe Pool,224
+Angelina,9,"Justice, Supreme Court, Place 9",,REP,Joe Pool,34
+Angelina,10,"Justice, Supreme Court, Place 9",,REP,Joe Pool,116
+Angelina,11,"Justice, Supreme Court, Place 9",,REP,Joe Pool,338
+Angelina,11B,"Justice, Supreme Court, Place 9",,REP,Joe Pool,119
+Angelina,12,"Justice, Supreme Court, Place 9",,REP,Joe Pool,148
+Angelina,13,"Justice, Supreme Court, Place 9",,REP,Joe Pool,64
+Angelina,14,"Justice, Supreme Court, Place 9",,REP,Joe Pool,268
+Angelina,15,"Justice, Supreme Court, Place 9",,REP,Joe Pool,94
+Angelina,16,"Justice, Supreme Court, Place 9",,REP,Joe Pool,124
+Angelina,17,"Justice, Supreme Court, Place 9",,REP,Joe Pool,223
+Angelina,17B,"Justice, Supreme Court, Place 9",,REP,Joe Pool,47
+Angelina,18,"Justice, Supreme Court, Place 9",,REP,Joe Pool,75
+Angelina,19,"Justice, Supreme Court, Place 9",,REP,Joe Pool,176
+Angelina,20,"Justice, Supreme Court, Place 9",,REP,Joe Pool,44
+Angelina,21,"Justice, Supreme Court, Place 9",,REP,Joe Pool,187
+Angelina,22,"Justice, Supreme Court, Place 9",,REP,Joe Pool,177
+Angelina,23,"Justice, Supreme Court, Place 9",,REP,Joe Pool,109
+Angelina,24,"Justice, Supreme Court, Place 9",,REP,Joe Pool,296
+Angelina,25,"Justice, Supreme Court, Place 9",,REP,Joe Pool,329
+Angelina,26,"Justice, Supreme Court, Place 9",,REP,Joe Pool,293
+Angelina,27,"Justice, Supreme Court, Place 9",,REP,Joe Pool,76
+Angelina,28,"Justice, Supreme Court, Place 9",,REP,Joe Pool,162
+Angelina,29,"Justice, Supreme Court, Place 9",,REP,Joe Pool,250
+Angelina,30,"Justice, Supreme Court, Place 9",,REP,Joe Pool,139
+Angelina,31,"Justice, Supreme Court, Place 9",,REP,Joe Pool,45
+Angelina,32,"Justice, Supreme Court, Place 9",,REP,Joe Pool,21
+Angelina,33,"Justice, Supreme Court, Place 9",,REP,Joe Pool,226
+Angelina,34,"Justice, Supreme Court, Place 9",,REP,Joe Pool,257
+Angelina,35,"Justice, Supreme Court, Place 9",,REP,Joe Pool,244
+Angelina,36,"Justice, Supreme Court, Place 9",,REP,Joe Pool,0
+Angelina,37,"Justice, Supreme Court, Place 9",,REP,Joe Pool,75
+Angelina,38,"Justice, Supreme Court, Place 9",,REP,Joe Pool,54
+Angelina,39,"Justice, Supreme Court, Place 9",,REP,Joe Pool,57
+Angelina,40,"Justice, Supreme Court, Place 9",,REP,Joe Pool,91
+Angelina,1,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,34
+Angelina,2,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,55
+Angelina,3,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,150
+Angelina,4,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,59
+Angelina,5,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,120
+Angelina,6,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,36
+Angelina,7,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,118
+Angelina,8,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,129
+Angelina,9,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,39
+Angelina,10,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,77
+Angelina,11,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,162
+Angelina,11B,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,70
+Angelina,12,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,79
+Angelina,13,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,57
+Angelina,14,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,170
+Angelina,15,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,67
+Angelina,16,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,108
+Angelina,17,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,153
+Angelina,17B,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,32
+Angelina,18,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,65
+Angelina,19,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,189
+Angelina,20,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,27
+Angelina,21,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,111
+Angelina,22,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,92
+Angelina,23,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,52
+Angelina,24,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,187
+Angelina,25,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,171
+Angelina,26,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,214
+Angelina,27,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,22
+Angelina,28,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,122
+Angelina,29,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,117
+Angelina,30,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,62
+Angelina,31,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,33
+Angelina,32,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,15
+Angelina,33,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,104
+Angelina,34,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,263
+Angelina,35,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,205
+Angelina,36,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,1
+Angelina,37,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,39
+Angelina,38,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,29
+Angelina,39,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,43
+Angelina,40,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,75
+Angelina,1,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,2,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,3,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,4,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,5,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,6,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,7,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,8,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,9,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,10,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,11,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,11B,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,12,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,13,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,14,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,15,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,16,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,17,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,17B,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,18,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,19,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,20,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,21,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,22,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,23,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,24,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,25,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,26,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,27,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,28,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,29,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,30,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,31,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,32,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,33,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,34,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,35,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,36,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,37,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,38,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,39,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,40,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0
+Angelina,1,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,22
+Angelina,2,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,34
+Angelina,3,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,114
+Angelina,4,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,59
+Angelina,5,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,89
+Angelina,6,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,41
+Angelina,7,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,125
+Angelina,8,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,129
+Angelina,9,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,41
+Angelina,10,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,50
+Angelina,11,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,213
+Angelina,11B,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,87
+Angelina,12,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,58
+Angelina,13,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,42
+Angelina,14,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,170
+Angelina,15,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,43
+Angelina,16,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,78
+Angelina,17,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,122
+Angelina,17B,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,27
+Angelina,18,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,31
+Angelina,19,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,174
+Angelina,20,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,26
+Angelina,21,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,82
+Angelina,22,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,85
+Angelina,23,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,43
+Angelina,24,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,182
+Angelina,25,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,157
+Angelina,26,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,154
+Angelina,27,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,38
+Angelina,28,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,101
+Angelina,29,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,146
+Angelina,30,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,83
+Angelina,31,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,17
+Angelina,32,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,12
+Angelina,33,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,130
+Angelina,34,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,224
+Angelina,35,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,164
+Angelina,36,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,0
+Angelina,37,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,28
+Angelina,38,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,33
+Angelina,39,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,32
+Angelina,40,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,51
+Angelina,1,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,35
+Angelina,2,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,52
+Angelina,3,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,161
+Angelina,4,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,85
+Angelina,5,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,110
+Angelina,6,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,56
+Angelina,7,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,125
+Angelina,8,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,142
+Angelina,9,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,20
+Angelina,10,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,85
+Angelina,11,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,200
+Angelina,11B,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,72
+Angelina,12,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,82
+Angelina,13,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,46
+Angelina,14,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,168
+Angelina,15,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,65
+Angelina,16,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,91
+Angelina,17,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,135
+Angelina,17B,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,33
+Angelina,18,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,53
+Angelina,19,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,145
+Angelina,20,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,32
+Angelina,21,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,118
+Angelina,22,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,105
+Angelina,23,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,70
+Angelina,24,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,187
+Angelina,25,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,203
+Angelina,26,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,196
+Angelina,27,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,39
+Angelina,28,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,98
+Angelina,29,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,144
+Angelina,30,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,76
+Angelina,31,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,31
+Angelina,32,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,16
+Angelina,33,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,150
+Angelina,34,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,167
+Angelina,35,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,157
+Angelina,36,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,0
+Angelina,37,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,41
+Angelina,38,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,25
+Angelina,39,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,38
+Angelina,40,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,63
+Angelina,1,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,22
+Angelina,2,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,61
+Angelina,3,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,160
+Angelina,4,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,73
+Angelina,5,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,96
+Angelina,6,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,32
+Angelina,7,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,73
+Angelina,8,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,116
+Angelina,9,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,32
+Angelina,10,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,66
+Angelina,11,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,168
+Angelina,11B,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,83
+Angelina,12,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,77
+Angelina,13,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,53
+Angelina,14,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,153
+Angelina,15,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,56
+Angelina,16,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,86
+Angelina,17,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,141
+Angelina,17B,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,33
+Angelina,18,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,53
+Angelina,19,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,100
+Angelina,20,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,23
+Angelina,21,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,118
+Angelina,22,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,93
+Angelina,23,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,47
+Angelina,24,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,167
+Angelina,25,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,176
+Angelina,26,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,160
+Angelina,27,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,37
+Angelina,28,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,103
+Angelina,29,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,114
+Angelina,30,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,87
+Angelina,31,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,27
+Angelina,32,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,14
+Angelina,33,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,91
+Angelina,34,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,221
+Angelina,35,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,164
+Angelina,36,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,0
+Angelina,37,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,48
+Angelina,38,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,37
+Angelina,39,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,33
+Angelina,40,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,71
+Angelina,1,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,12
+Angelina,2,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,30
+Angelina,3,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,92
+Angelina,4,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,28
+Angelina,5,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,56
+Angelina,6,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,22
+Angelina,7,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,85
+Angelina,8,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,83
+Angelina,9,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,14
+Angelina,10,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,36
+Angelina,11,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,94
+Angelina,11B,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,31
+Angelina,12,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,62
+Angelina,13,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,18
+Angelina,14,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,90
+Angelina,15,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,33
+Angelina,16,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,41
+Angelina,17,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,70
+Angelina,17B,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,13
+Angelina,18,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,27
+Angelina,19,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,96
+Angelina,20,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,14
+Angelina,21,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,58
+Angelina,22,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,60
+Angelina,23,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,36
+Angelina,24,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,104
+Angelina,25,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,111
+Angelina,26,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,122
+Angelina,27,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,17
+Angelina,28,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,70
+Angelina,29,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,90
+Angelina,30,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,35
+Angelina,31,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,13
+Angelina,32,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,6
+Angelina,33,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,70
+Angelina,34,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,95
+Angelina,35,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,91
+Angelina,36,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,1
+Angelina,37,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,23
+Angelina,38,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,16
+Angelina,39,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,23
+Angelina,40,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,28
+Angelina,1,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,2,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,3,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,4,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,5,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,6,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,7,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,8,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,9,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,10,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,11,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,11B,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,12,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,13,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,14,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,15,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,16,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,17,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,17B,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,18,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,19,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,20,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,21,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,22,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,23,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,24,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,25,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,26,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,27,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,28,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,29,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,30,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,31,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,32,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,33,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,34,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,35,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,36,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,37,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,38,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,39,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,40,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0
+Angelina,1,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,29
+Angelina,2,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,42
+Angelina,3,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,125
+Angelina,4,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,69
+Angelina,5,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,101
+Angelina,6,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,43
+Angelina,7,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,143
+Angelina,8,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,141
+Angelina,9,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,48
+Angelina,10,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,56
+Angelina,11,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,252
+Angelina,11B,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,90
+Angelina,12,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,64
+Angelina,13,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,46
+Angelina,14,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,197
+Angelina,15,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,50
+Angelina,16,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,92
+Angelina,17,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,152
+Angelina,17B,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,27
+Angelina,18,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,38
+Angelina,19,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,198
+Angelina,20,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,28
+Angelina,21,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,86
+Angelina,22,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,96
+Angelina,23,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,51
+Angelina,24,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,207
+Angelina,25,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,167
+Angelina,26,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,183
+Angelina,27,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,43
+Angelina,28,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,114
+Angelina,29,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,165
+Angelina,30,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,86
+Angelina,31,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,24
+Angelina,32,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,12
+Angelina,33,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,149
+Angelina,34,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,261
+Angelina,35,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,201
+Angelina,36,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,0
+Angelina,37,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,30
+Angelina,38,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,38
+Angelina,39,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,38
+Angelina,40,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,55
+Angelina,1,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,10
+Angelina,2,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,39
+Angelina,3,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,113
+Angelina,4,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,47
+Angelina,5,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,75
+Angelina,6,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,31
+Angelina,7,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,88
+Angelina,8,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,83
+Angelina,9,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,18
+Angelina,10,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,48
+Angelina,11,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,108
+Angelina,11B,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,45
+Angelina,12,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,68
+Angelina,13,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,13
+Angelina,14,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,99
+Angelina,15,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,36
+Angelina,16,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,68
+Angelina,17,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,74
+Angelina,17B,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,18
+Angelina,18,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,27
+Angelina,19,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,81
+Angelina,20,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,16
+Angelina,21,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,74
+Angelina,22,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,99
+Angelina,23,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,40
+Angelina,24,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,118
+Angelina,25,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,141
+Angelina,26,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,110
+Angelina,27,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,31
+Angelina,28,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,59
+Angelina,29,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,102
+Angelina,30,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,52
+Angelina,31,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,21
+Angelina,32,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,3
+Angelina,33,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,80
+Angelina,34,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,109
+Angelina,35,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,95
+Angelina,36,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,0
+Angelina,37,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,27
+Angelina,38,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,21
+Angelina,39,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,21
+Angelina,40,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,34
+Angelina,1,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,37
+Angelina,2,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,81
+Angelina,3,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,214
+Angelina,4,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,99
+Angelina,5,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,142
+Angelina,6,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,61
+Angelina,7,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,153
+Angelina,8,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,193
+Angelina,9,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,34
+Angelina,10,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,96
+Angelina,11,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,274
+Angelina,11B,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,100
+Angelina,12,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,115
+Angelina,13,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,74
+Angelina,14,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,217
+Angelina,15,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,86
+Angelina,16,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,111
+Angelina,17,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,200
+Angelina,17B,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,39
+Angelina,18,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,67
+Angelina,19,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,167
+Angelina,20,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,39
+Angelina,21,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,142
+Angelina,22,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,122
+Angelina,23,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,84
+Angelina,24,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,217
+Angelina,25,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,243
+Angelina,26,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,263
+Angelina,27,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,52
+Angelina,28,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,154
+Angelina,29,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,190
+Angelina,30,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,109
+Angelina,31,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,30
+Angelina,32,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,27
+Angelina,33,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,163
+Angelina,34,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,245
+Angelina,35,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,224
+Angelina,36,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,0
+Angelina,37,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,54
+Angelina,38,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,39
+Angelina,39,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,55
+Angelina,40,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,91
+Angelina,1,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,10
+Angelina,2,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,18
+Angelina,3,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,72
+Angelina,4,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,25
+Angelina,5,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,36
+Angelina,6,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,14
+Angelina,7,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,27
+Angelina,8,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,51
+Angelina,9,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,5
+Angelina,10,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,25
+Angelina,11,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,57
+Angelina,11B,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,29
+Angelina,12,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,29
+Angelina,13,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,15
+Angelina,14,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,68
+Angelina,15,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,24
+Angelina,16,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,26
+Angelina,17,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,53
+Angelina,17B,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,14
+Angelina,18,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,23
+Angelina,19,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,42
+Angelina,20,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,11
+Angelina,21,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,55
+Angelina,22,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,25
+Angelina,23,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,20
+Angelina,24,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,81
+Angelina,25,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,66
+Angelina,26,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,86
+Angelina,27,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,11
+Angelina,28,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,39
+Angelina,29,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,43
+Angelina,30,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,27
+Angelina,31,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,13
+Angelina,32,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,3
+Angelina,33,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,45
+Angelina,34,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,58
+Angelina,35,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,66
+Angelina,36,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,1
+Angelina,37,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,16
+Angelina,38,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,12
+Angelina,39,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,7
+Angelina,40,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,19
+Angelina,1,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,13
+Angelina,2,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,5
+Angelina,3,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,18
+Angelina,4,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,19
+Angelina,5,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,16
+Angelina,6,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,8
+Angelina,7,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,23
+Angelina,8,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,23
+Angelina,9,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,10
+Angelina,10,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,19
+Angelina,11,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,36
+Angelina,11B,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,16
+Angelina,12,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,14
+Angelina,13,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,19
+Angelina,14,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,33
+Angelina,15,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,14
+Angelina,16,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,21
+Angelina,17,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,30
+Angelina,17B,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,6
+Angelina,18,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,15
+Angelina,19,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,54
+Angelina,20,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,7
+Angelina,21,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,25
+Angelina,22,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,19
+Angelina,23,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,11
+Angelina,24,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,51
+Angelina,25,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,39
+Angelina,26,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,32
+Angelina,27,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,1
+Angelina,28,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,31
+Angelina,29,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,16
+Angelina,30,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,10
+Angelina,31,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,9
+Angelina,32,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,5
+Angelina,33,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,27
+Angelina,34,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,85
+Angelina,35,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,39
+Angelina,36,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,0
+Angelina,37,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,19
+Angelina,38,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,10
+Angelina,39,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,12
+Angelina,40,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,19
+Angelina,1,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,2,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,3,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,4,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,5,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,6,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,7,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,8,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,9,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,10,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,11,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,11B,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,12,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,13,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,14,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,15,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,16,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,17,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,17B,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,18,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,19,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,20,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,21,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,22,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,23,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,24,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,25,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,26,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,27,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,28,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,29,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,30,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,31,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,32,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,33,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,34,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,35,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,36,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,37,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,38,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,39,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,40,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0
+Angelina,1,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,28
+Angelina,2,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,42
+Angelina,3,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,122
+Angelina,4,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,65
+Angelina,5,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,94
+Angelina,6,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,39
+Angelina,7,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,135
+Angelina,8,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,132
+Angelina,9,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,47
+Angelina,10,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,55
+Angelina,11,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,238
+Angelina,11B,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,86
+Angelina,12,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,59
+Angelina,13,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,42
+Angelina,14,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,191
+Angelina,15,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,44
+Angelina,16,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,84
+Angelina,17,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,141
+Angelina,17B,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,29
+Angelina,18,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,39
+Angelina,19,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,195
+Angelina,20,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,24
+Angelina,21,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,84
+Angelina,22,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,89
+Angelina,23,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,49
+Angelina,24,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,198
+Angelina,25,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,168
+Angelina,26,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,170
+Angelina,27,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,41
+Angelina,28,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,102
+Angelina,29,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,162
+Angelina,30,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,86
+Angelina,31,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,22
+Angelina,32,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,10
+Angelina,33,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,145
+Angelina,34,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,247
+Angelina,35,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,189
+Angelina,36,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,0
+Angelina,37,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,26
+Angelina,38,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,34
+Angelina,39,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,37
+Angelina,40,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,54
+Angelina,1,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,38
+Angelina,2,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,81
+Angelina,3,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,267
+Angelina,4,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,110
+Angelina,5,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,157
+Angelina,6,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,74
+Angelina,7,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,162
+Angelina,8,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,193
+Angelina,9,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,38
+Angelina,10,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,103
+Angelina,11,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,298
+Angelina,11B,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,120
+Angelina,12,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,128
+Angelina,13,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,66
+Angelina,14,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,234
+Angelina,15,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,94
+Angelina,16,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,150
+Angelina,17,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,218
+Angelina,17B,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,46
+Angelina,18,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,60
+Angelina,19,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,146
+Angelina,20,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,46
+Angelina,21,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,169
+Angelina,22,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,160
+Angelina,23,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,98
+Angelina,24,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,304
+Angelina,25,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,315
+Angelina,26,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,312
+Angelina,27,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,70
+Angelina,28,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,154
+Angelina,29,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,201
+Angelina,30,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,125
+Angelina,31,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,48
+Angelina,32,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,22
+Angelina,33,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,204
+Angelina,34,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,250
+Angelina,35,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,229
+Angelina,36,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,0
+Angelina,37,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,68
+Angelina,38,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,49
+Angelina,39,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,48
+Angelina,40,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,93
+Angelina,1,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,27
+Angelina,2,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,62
+Angelina,3,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,143
+Angelina,4,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,76
+Angelina,5,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,97
+Angelina,6,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,33
+Angelina,7,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,122
+Angelina,8,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,144
+Angelina,9,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,27
+Angelina,10,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,77
+Angelina,11,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,175
+Angelina,11B,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,64
+Angelina,12,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,92
+Angelina,13,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,51
+Angelina,14,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,162
+Angelina,15,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,61
+Angelina,16,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,69
+Angelina,17,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,130
+Angelina,17B,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,30
+Angelina,18,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,70
+Angelina,19,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,182
+Angelina,20,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,21
+Angelina,21,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,123
+Angelina,22,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,97
+Angelina,23,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,57
+Angelina,24,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,154
+Angelina,25,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,160
+Angelina,26,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,166
+Angelina,27,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,23
+Angelina,28,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,116
+Angelina,29,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,141
+Angelina,30,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,68
+Angelina,31,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,24
+Angelina,32,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,12
+Angelina,33,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,110
+Angelina,34,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,221
+Angelina,35,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,174
+Angelina,36,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,1
+Angelina,37,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,42
+Angelina,38,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,34
+Angelina,39,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,42
+Angelina,40,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,67
+Angelina,1,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,2,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,3,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,4,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,5,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,6,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,7,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,8,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,9,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,10,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,11,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,11B,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,12,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,13,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,14,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,15,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,16,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,17,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,17B,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,18,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,19,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,20,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,21,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,22,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,23,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,24,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,25,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,26,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,27,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,28,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,29,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,30,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,31,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,32,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,33,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,34,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,35,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,36,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,37,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,38,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,39,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,40,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0
+Angelina,1,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,33
+Angelina,2,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,42
+Angelina,3,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,129
+Angelina,4,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,69
+Angelina,5,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,109
+Angelina,6,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,46
+Angelina,7,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,142
+Angelina,8,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,145
+Angelina,9,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,49
+Angelina,10,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,63
+Angelina,11,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,240
+Angelina,11B,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,92
+Angelina,12,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,65
+Angelina,13,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,46
+Angelina,14,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,212
+Angelina,15,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,49
+Angelina,16,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,91
+Angelina,17,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,150
+Angelina,17B,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,30
+Angelina,18,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,41
+Angelina,19,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,211
+Angelina,20,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,30
+Angelina,21,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,88
+Angelina,22,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,97
+Angelina,23,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,49
+Angelina,24,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,207
+Angelina,25,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,182
+Angelina,26,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,183
+Angelina,27,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,43
+Angelina,28,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,115
+Angelina,29,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,171
+Angelina,30,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,91
+Angelina,31,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,23
+Angelina,32,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,14
+Angelina,33,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,146
+Angelina,34,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,273
+Angelina,35,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,210
+Angelina,36,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,0
+Angelina,37,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,32
+Angelina,38,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,33
+Angelina,39,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,42
+Angelina,40,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,57
+Angelina,1,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,54
+Angelina,2,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,76
+Angelina,3,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,214
+Angelina,4,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,99
+Angelina,5,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,148
+Angelina,6,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,66
+Angelina,7,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,197
+Angelina,8,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,218
+Angelina,9,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,56
+Angelina,10,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,111
+Angelina,11,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,263
+Angelina,11B,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,89
+Angelina,12,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,135
+Angelina,13,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,74
+Angelina,14,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,291
+Angelina,15,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,85
+Angelina,16,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,117
+Angelina,17,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,156
+Angelina,17B,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,33
+Angelina,18,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,101
+Angelina,19,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,305
+Angelina,20,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,30
+Angelina,21,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,142
+Angelina,22,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,130
+Angelina,23,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,92
+Angelina,24,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,245
+Angelina,25,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,250
+Angelina,26,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,314
+Angelina,27,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,50
+Angelina,28,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,160
+Angelina,29,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,171
+Angelina,30,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,103
+Angelina,31,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,42
+Angelina,32,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,21
+Angelina,33,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,163
+Angelina,34,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,442
+Angelina,35,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,286
+Angelina,36,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,1
+Angelina,37,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,56
+Angelina,38,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,50
+Angelina,39,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,48
+Angelina,40,"Member, State Board of Education, Place 9",,REP,Keven M. Ellis,101
+Angelina,1,"Member, State Board of Education, Place 9",,REP,Hank Hering,9
+Angelina,2,"Member, State Board of Education, Place 9",,REP,Hank Hering,17
+Angelina,3,"Member, State Board of Education, Place 9",,REP,Hank Hering,71
+Angelina,4,"Member, State Board of Education, Place 9",,REP,Hank Hering,35
+Angelina,5,"Member, State Board of Education, Place 9",,REP,Hank Hering,48
+Angelina,6,"Member, State Board of Education, Place 9",,REP,Hank Hering,23
+Angelina,7,"Member, State Board of Education, Place 9",,REP,Hank Hering,36
+Angelina,8,"Member, State Board of Education, Place 9",,REP,Hank Hering,56
+Angelina,9,"Member, State Board of Education, Place 9",,REP,Hank Hering,3
+Angelina,10,"Member, State Board of Education, Place 9",,REP,Hank Hering,23
+Angelina,11,"Member, State Board of Education, Place 9",,REP,Hank Hering,86
+Angelina,11B,"Member, State Board of Education, Place 9",,REP,Hank Hering,26
+Angelina,12,"Member, State Board of Education, Place 9",,REP,Hank Hering,35
+Angelina,13,"Member, State Board of Education, Place 9",,REP,Hank Hering,22
+Angelina,14,"Member, State Board of Education, Place 9",,REP,Hank Hering,64
+Angelina,15,"Member, State Board of Education, Place 9",,REP,Hank Hering,21
+Angelina,16,"Member, State Board of Education, Place 9",,REP,Hank Hering,26
+Angelina,17,"Member, State Board of Education, Place 9",,REP,Hank Hering,78
+Angelina,17B,"Member, State Board of Education, Place 9",,REP,Hank Hering,17
+Angelina,18,"Member, State Board of Education, Place 9",,REP,Hank Hering,18
+Angelina,19,"Member, State Board of Education, Place 9",,REP,Hank Hering,47
+Angelina,20,"Member, State Board of Education, Place 9",,REP,Hank Hering,15
+Angelina,21,"Member, State Board of Education, Place 9",,REP,Hank Hering,43
+Angelina,22,"Member, State Board of Education, Place 9",,REP,Hank Hering,47
+Angelina,23,"Member, State Board of Education, Place 9",,REP,Hank Hering,18
+Angelina,24,"Member, State Board of Education, Place 9",,REP,Hank Hering,80
+Angelina,25,"Member, State Board of Education, Place 9",,REP,Hank Hering,88
+Angelina,26,"Member, State Board of Education, Place 9",,REP,Hank Hering,60
+Angelina,27,"Member, State Board of Education, Place 9",,REP,Hank Hering,12
+Angelina,28,"Member, State Board of Education, Place 9",,REP,Hank Hering,38
+Angelina,29,"Member, State Board of Education, Place 9",,REP,Hank Hering,72
+Angelina,30,"Member, State Board of Education, Place 9",,REP,Hank Hering,34
+Angelina,31,"Member, State Board of Education, Place 9",,REP,Hank Hering,10
+Angelina,32,"Member, State Board of Education, Place 9",,REP,Hank Hering,6
+Angelina,33,"Member, State Board of Education, Place 9",,REP,Hank Hering,78
+Angelina,34,"Member, State Board of Education, Place 9",,REP,Hank Hering,34
+Angelina,35,"Member, State Board of Education, Place 9",,REP,Hank Hering,51
+Angelina,36,"Member, State Board of Education, Place 9",,REP,Hank Hering,0
+Angelina,37,"Member, State Board of Education, Place 9",,REP,Hank Hering,14
+Angelina,38,"Member, State Board of Education, Place 9",,REP,Hank Hering,15
+Angelina,39,"Member, State Board of Education, Place 9",,REP,Hank Hering,11
+Angelina,40,"Member, State Board of Education, Place 9",,REP,Hank Hering,23
+Angelina,1,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,18
+Angelina,2,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,58
+Angelina,3,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,149
+Angelina,4,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,65
+Angelina,5,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,92
+Angelina,6,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,32
+Angelina,7,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,82
+Angelina,8,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,111
+Angelina,9,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,23
+Angelina,10,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,70
+Angelina,11,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,166
+Angelina,11B,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,78
+Angelina,12,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,67
+Angelina,13,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,39
+Angelina,14,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,123
+Angelina,15,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,56
+Angelina,16,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,97
+Angelina,17,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,133
+Angelina,17B,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,33
+Angelina,18,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,32
+Angelina,19,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,82
+Angelina,20,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,27
+Angelina,21,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,125
+Angelina,22,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,96
+Angelina,23,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,54
+Angelina,24,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,169
+Angelina,25,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,182
+Angelina,26,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,156
+Angelina,27,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,35
+Angelina,28,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,100
+Angelina,29,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,135
+Angelina,30,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,69
+Angelina,31,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,26
+Angelina,32,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,9
+Angelina,33,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,92
+Angelina,34,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,137
+Angelina,35,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,147
+Angelina,36,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,0
+Angelina,37,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,49
+Angelina,38,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,25
+Angelina,39,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,40
+Angelina,40,"Member, State Board of Education, Place 9",,REP,Mary Lou Bruner,55
+Angelina,1,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,2,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,3,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,4,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,5,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,6,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,7,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,8,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,9,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,10,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,11,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,11B,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,12,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,13,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,14,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,15,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,16,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,17,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,17B,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,18,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,19,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,20,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,21,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,22,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,23,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,24,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,25,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,26,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,27,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,28,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,29,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,30,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,31,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,32,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,33,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,34,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,35,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,36,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,37,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,38,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,39,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,40,"Member, State Board of Education, Place 9",,REP,OVER VOTES,0
+Angelina,1,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,17
+Angelina,2,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,34
+Angelina,3,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,105
+Angelina,4,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,56
+Angelina,5,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,75
+Angelina,6,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,32
+Angelina,7,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,111
+Angelina,8,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,97
+Angelina,9,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,32
+Angelina,10,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,39
+Angelina,11,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,198
+Angelina,11B,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,83
+Angelina,12,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,48
+Angelina,13,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,28
+Angelina,14,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,130
+Angelina,15,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,42
+Angelina,16,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,70
+Angelina,17,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,131
+Angelina,17B,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,23
+Angelina,18,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,20
+Angelina,19,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,105
+Angelina,20,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,25
+Angelina,21,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,70
+Angelina,22,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,81
+Angelina,23,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,40
+Angelina,24,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,171
+Angelina,25,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,137
+Angelina,26,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,131
+Angelina,27,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,39
+Angelina,28,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,87
+Angelina,29,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,135
+Angelina,30,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,78
+Angelina,31,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,17
+Angelina,32,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,12
+Angelina,33,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,127
+Angelina,34,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,131
+Angelina,35,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,129
+Angelina,36,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,0
+Angelina,37,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,23
+Angelina,38,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,26
+Angelina,39,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,33
+Angelina,40,"Member, State Board of Education, Place 9",,REP,UNDER VOTES,38
+Angelina,1,State Representative,57,REP,Trent Ashby,85
+Angelina,2,State Representative,57,REP,Trent Ashby,159
+Angelina,3,State Representative,57,REP,Trent Ashby,468
+Angelina,4,State Representative,57,REP,Trent Ashby,207
+Angelina,5,State Representative,57,REP,Trent Ashby,313
+Angelina,6,State Representative,57,REP,Trent Ashby,133
+Angelina,7,State Representative,57,REP,Trent Ashby,381
+Angelina,8,State Representative,57,REP,Trent Ashby,424
+Angelina,9,State Representative,57,REP,Trent Ashby,94
+Angelina,10,State Representative,57,REP,Trent Ashby,216
+Angelina,11,State Representative,57,REP,Trent Ashby,606
+Angelina,11B,State Representative,57,REP,Trent Ashby,231
+Angelina,12,State Representative,57,REP,Trent Ashby,258
+Angelina,13,State Representative,57,REP,Trent Ashby,144
+Angelina,14,State Representative,57,REP,Trent Ashby,520
+Angelina,15,State Representative,57,REP,Trent Ashby,182
+Angelina,16,State Representative,57,REP,Trent Ashby,262
+Angelina,17,State Representative,57,REP,Trent Ashby,401
+Angelina,17B,State Representative,57,REP,Trent Ashby,81
+Angelina,18,State Representative,57,REP,Trent Ashby,154
+Angelina,19,State Representative,57,REP,Trent Ashby,488
+Angelina,20,State Representative,57,REP,Trent Ashby,78
+Angelina,21,State Representative,57,REP,Trent Ashby,347
+Angelina,22,State Representative,57,REP,Trent Ashby,309
+Angelina,23,State Representative,57,REP,Trent Ashby,180
+Angelina,24,State Representative,57,REP,Trent Ashby,571
+Angelina,25,State Representative,57,REP,Trent Ashby,581
+Angelina,26,State Representative,57,REP,Trent Ashby,589
+Angelina,27,State Representative,57,REP,Trent Ashby,109
+Angelina,28,State Representative,57,REP,Trent Ashby,336
+Angelina,29,State Representative,57,REP,Trent Ashby,424
+Angelina,30,State Representative,57,REP,Trent Ashby,231
+Angelina,31,State Representative,57,REP,Trent Ashby,83
+Angelina,32,State Representative,57,REP,Trent Ashby,40
+Angelina,33,State Representative,57,REP,Trent Ashby,376
+Angelina,34,State Representative,57,REP,Trent Ashby,657
+Angelina,35,State Representative,57,REP,Trent Ashby,531
+Angelina,36,State Representative,57,REP,Trent Ashby,1
+Angelina,37,State Representative,57,REP,Trent Ashby,120
+Angelina,38,State Representative,57,REP,Trent Ashby,94
+Angelina,39,State Representative,57,REP,Trent Ashby,114
+Angelina,40,State Representative,57,REP,Trent Ashby,187
+Angelina,1,State Representative,57,REP,OVER VOTES,0
+Angelina,2,State Representative,57,REP,OVER VOTES,0
+Angelina,3,State Representative,57,REP,OVER VOTES,0
+Angelina,4,State Representative,57,REP,OVER VOTES,0
+Angelina,5,State Representative,57,REP,OVER VOTES,0
+Angelina,6,State Representative,57,REP,OVER VOTES,0
+Angelina,7,State Representative,57,REP,OVER VOTES,0
+Angelina,8,State Representative,57,REP,OVER VOTES,0
+Angelina,9,State Representative,57,REP,OVER VOTES,0
+Angelina,10,State Representative,57,REP,OVER VOTES,0
+Angelina,11,State Representative,57,REP,OVER VOTES,0
+Angelina,11B,State Representative,57,REP,OVER VOTES,0
+Angelina,12,State Representative,57,REP,OVER VOTES,0
+Angelina,13,State Representative,57,REP,OVER VOTES,0
+Angelina,14,State Representative,57,REP,OVER VOTES,0
+Angelina,15,State Representative,57,REP,OVER VOTES,0
+Angelina,16,State Representative,57,REP,OVER VOTES,0
+Angelina,17,State Representative,57,REP,OVER VOTES,0
+Angelina,17B,State Representative,57,REP,OVER VOTES,0
+Angelina,18,State Representative,57,REP,OVER VOTES,0
+Angelina,19,State Representative,57,REP,OVER VOTES,0
+Angelina,20,State Representative,57,REP,OVER VOTES,0
+Angelina,21,State Representative,57,REP,OVER VOTES,0
+Angelina,22,State Representative,57,REP,OVER VOTES,0
+Angelina,23,State Representative,57,REP,OVER VOTES,0
+Angelina,24,State Representative,57,REP,OVER VOTES,0
+Angelina,25,State Representative,57,REP,OVER VOTES,0
+Angelina,26,State Representative,57,REP,OVER VOTES,0
+Angelina,27,State Representative,57,REP,OVER VOTES,0
+Angelina,28,State Representative,57,REP,OVER VOTES,0
+Angelina,29,State Representative,57,REP,OVER VOTES,0
+Angelina,30,State Representative,57,REP,OVER VOTES,0
+Angelina,31,State Representative,57,REP,OVER VOTES,0
+Angelina,32,State Representative,57,REP,OVER VOTES,0
+Angelina,33,State Representative,57,REP,OVER VOTES,0
+Angelina,34,State Representative,57,REP,OVER VOTES,0
+Angelina,35,State Representative,57,REP,OVER VOTES,0
+Angelina,36,State Representative,57,REP,OVER VOTES,0
+Angelina,37,State Representative,57,REP,OVER VOTES,0
+Angelina,38,State Representative,57,REP,OVER VOTES,0
+Angelina,39,State Representative,57,REP,OVER VOTES,0
+Angelina,40,State Representative,57,REP,OVER VOTES,0
+Angelina,1,State Representative,57,REP,UNDER VOTES,13
+Angelina,2,State Representative,57,REP,UNDER VOTES,26
+Angelina,3,State Representative,57,REP,UNDER VOTES,71
+Angelina,4,State Representative,57,REP,UNDER VOTES,48
+Angelina,5,State Representative,57,REP,UNDER VOTES,50
+Angelina,6,State Representative,57,REP,UNDER VOTES,20
+Angelina,7,State Representative,57,REP,UNDER VOTES,45
+Angelina,8,State Representative,57,REP,UNDER VOTES,58
+Angelina,9,State Representative,57,REP,UNDER VOTES,20
+Angelina,10,State Representative,57,REP,UNDER VOTES,27
+Angelina,11,State Representative,57,REP,UNDER VOTES,107
+Angelina,11B,State Representative,57,REP,UNDER VOTES,45
+Angelina,12,State Representative,57,REP,UNDER VOTES,27
+Angelina,13,State Representative,57,REP,UNDER VOTES,19
+Angelina,14,State Representative,57,REP,UNDER VOTES,88
+Angelina,15,State Representative,57,REP,UNDER VOTES,22
+Angelina,16,State Representative,57,REP,UNDER VOTES,48
+Angelina,17,State Representative,57,REP,UNDER VOTES,97
+Angelina,17B,State Representative,57,REP,UNDER VOTES,25
+Angelina,18,State Representative,57,REP,UNDER VOTES,17
+Angelina,19,State Representative,57,REP,UNDER VOTES,51
+Angelina,20,State Representative,57,REP,UNDER VOTES,19
+Angelina,21,State Representative,57,REP,UNDER VOTES,33
+Angelina,22,State Representative,57,REP,UNDER VOTES,45
+Angelina,23,State Representative,57,REP,UNDER VOTES,24
+Angelina,24,State Representative,57,REP,UNDER VOTES,94
+Angelina,25,State Representative,57,REP,UNDER VOTES,76
+Angelina,26,State Representative,57,REP,UNDER VOTES,72
+Angelina,27,State Representative,57,REP,UNDER VOTES,27
+Angelina,28,State Representative,57,REP,UNDER VOTES,49
+Angelina,29,State Representative,57,REP,UNDER VOTES,89
+Angelina,30,State Representative,57,REP,UNDER VOTES,53
+Angelina,31,State Representative,57,REP,UNDER VOTES,12
+Angelina,32,State Representative,57,REP,UNDER VOTES,8
+Angelina,33,State Representative,57,REP,UNDER VOTES,84
+Angelina,34,State Representative,57,REP,UNDER VOTES,87
+Angelina,35,State Representative,57,REP,UNDER VOTES,82
+Angelina,36,State Representative,57,REP,UNDER VOTES,0
+Angelina,37,State Representative,57,REP,UNDER VOTES,22
+Angelina,38,State Representative,57,REP,UNDER VOTES,22
+Angelina,39,State Representative,57,REP,UNDER VOTES,18
+Angelina,40,State Representative,57,REP,UNDER VOTES,30
+Angelina,1,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,64
+Angelina,2,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,134
+Angelina,3,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,376
+Angelina,4,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,162
+Angelina,5,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,240
+Angelina,6,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,100
+Angelina,7,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,285
+Angelina,8,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,325
+Angelina,9,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,67
+Angelina,10,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,165
+Angelina,11,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,444
+Angelina,11B,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,164
+Angelina,12,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,203
+Angelina,13,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,110
+Angelina,14,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,380
+Angelina,15,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,146
+Angelina,16,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,203
+Angelina,17,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,305
+Angelina,17B,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,64
+Angelina,18,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,120
+Angelina,19,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,338
+Angelina,20,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,64
+Angelina,21,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,264
+Angelina,22,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,236
+Angelina,23,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,147
+Angelina,24,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,425
+Angelina,25,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,459
+Angelina,26,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,451
+Angelina,27,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,87
+Angelina,28,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,264
+Angelina,29,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,313
+Angelina,30,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,186
+Angelina,31,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,72
+Angelina,32,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,32
+Angelina,33,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,284
+Angelina,34,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,468
+Angelina,35,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,386
+Angelina,36,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,1
+Angelina,37,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,100
+Angelina,38,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,77
+Angelina,39,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,98
+Angelina,40,"Justice, 12th Court of Appeals District, Place 2",,REP,Brian Hoyle,153
+Angelina,1,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,2,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,3,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,4,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,5,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,6,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,7,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,8,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,9,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,10,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,11,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,11B,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,12,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,13,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,14,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,15,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,16,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,17,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,17B,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,18,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,19,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,20,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,3
+Angelina,21,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,22,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,23,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,24,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,25,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,26,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,27,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,28,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,29,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,30,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,31,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,32,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,33,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,34,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,35,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,36,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,37,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,38,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,39,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,40,"Justice, 12th Court of Appeals District, Place 2",,REP,OVER VOTES,0
+Angelina,1,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,34
+Angelina,2,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,51
+Angelina,3,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,163
+Angelina,4,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,93
+Angelina,5,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,123
+Angelina,6,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,53
+Angelina,7,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,141
+Angelina,8,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,157
+Angelina,9,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,47
+Angelina,10,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,78
+Angelina,11,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,269
+Angelina,11B,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,112
+Angelina,12,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,82
+Angelina,13,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,53
+Angelina,14,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,228
+Angelina,15,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,58
+Angelina,16,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,107
+Angelina,17,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,193
+Angelina,17B,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,42
+Angelina,18,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,51
+Angelina,19,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,201
+Angelina,20,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,33
+Angelina,21,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,116
+Angelina,22,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,118
+Angelina,23,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,57
+Angelina,24,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,240
+Angelina,25,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,198
+Angelina,26,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,210
+Angelina,27,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,49
+Angelina,28,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,121
+Angelina,29,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,200
+Angelina,30,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,98
+Angelina,31,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,23
+Angelina,32,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,16
+Angelina,33,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,176
+Angelina,34,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,276
+Angelina,35,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,227
+Angelina,36,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,0
+Angelina,37,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,42
+Angelina,38,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,39
+Angelina,39,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,34
+Angelina,40,"Justice, 12th Court of Appeals District, Place 2",,REP,UNDER VOTES,64
+Angelina,1,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,65
+Angelina,2,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,136
+Angelina,3,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,377
+Angelina,4,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,163
+Angelina,5,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,245
+Angelina,6,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,99
+Angelina,7,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,286
+Angelina,8,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,321
+Angelina,9,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,67
+Angelina,10,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,165
+Angelina,11,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,440
+Angelina,11B,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,163
+Angelina,12,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,201
+Angelina,13,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,109
+Angelina,14,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,380
+Angelina,15,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,145
+Angelina,16,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,199
+Angelina,17,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,309
+Angelina,17B,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,67
+Angelina,18,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,119
+Angelina,19,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,334
+Angelina,20,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,64
+Angelina,21,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,264
+Angelina,22,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,237
+Angelina,23,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,149
+Angelina,24,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,439
+Angelina,25,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,454
+Angelina,26,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,453
+Angelina,27,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,87
+Angelina,28,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,268
+Angelina,29,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,310
+Angelina,30,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,188
+Angelina,31,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,72
+Angelina,32,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,31
+Angelina,33,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,281
+Angelina,34,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,468
+Angelina,35,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,396
+Angelina,36,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,1
+Angelina,37,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,102
+Angelina,38,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,78
+Angelina,39,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,95
+Angelina,40,"Justice, 12th Court of Appeals District, Place 3",,REP,Greg Neely,149
+Angelina,1,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,2,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,3,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,4,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,5,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,6,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,7,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,8,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,9,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,10,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,11,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,11B,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,12,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,13,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,14,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,15,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,16,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,17,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,17B,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,18,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,19,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,20,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,21,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,22,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,23,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,24,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,25,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,26,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,27,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,28,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,29,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,30,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,31,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,32,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,33,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,34,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,35,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,36,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,37,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,38,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,39,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,40,"Justice, 12th Court of Appeals District, Place 3",,REP,OVER VOTES,0
+Angelina,1,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,33
+Angelina,2,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,49
+Angelina,3,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,162
+Angelina,4,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,92
+Angelina,5,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,118
+Angelina,6,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,54
+Angelina,7,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,140
+Angelina,8,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,161
+Angelina,9,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,47
+Angelina,10,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,78
+Angelina,11,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,273
+Angelina,11B,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,113
+Angelina,12,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,84
+Angelina,13,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,54
+Angelina,14,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,228
+Angelina,15,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,59
+Angelina,16,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,111
+Angelina,17,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,189
+Angelina,17B,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,39
+Angelina,18,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,52
+Angelina,19,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,205
+Angelina,20,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,33
+Angelina,21,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,116
+Angelina,22,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,117
+Angelina,23,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,55
+Angelina,24,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,226
+Angelina,25,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,203
+Angelina,26,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,208
+Angelina,27,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,49
+Angelina,28,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,117
+Angelina,29,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,203
+Angelina,30,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,96
+Angelina,31,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,23
+Angelina,32,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,17
+Angelina,33,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,179
+Angelina,34,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,276
+Angelina,35,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,217
+Angelina,36,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,0
+Angelina,37,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,40
+Angelina,38,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,38
+Angelina,39,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,37
+Angelina,40,"Justice, 12th Court of Appeals District, Place 3",,REP,UNDER VOTES,68
+Angelina,1,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,18
+Angelina,2,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,45
+Angelina,3,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,136
+Angelina,4,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,53
+Angelina,5,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,82
+Angelina,6,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,40
+Angelina,7,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,93
+Angelina,8,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,103
+Angelina,9,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,25
+Angelina,10,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,51
+Angelina,11,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,178
+Angelina,11B,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,66
+Angelina,12,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,67
+Angelina,13,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,46
+Angelina,14,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,120
+Angelina,15,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,61
+Angelina,16,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,68
+Angelina,17,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,112
+Angelina,17B,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,28
+Angelina,18,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,28
+Angelina,19,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,99
+Angelina,20,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,21
+Angelina,21,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,79
+Angelina,22,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,68
+Angelina,23,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,40
+Angelina,24,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,151
+Angelina,25,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,148
+Angelina,26,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,165
+Angelina,27,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,24
+Angelina,28,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,102
+Angelina,29,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,92
+Angelina,30,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,68
+Angelina,31,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,21
+Angelina,32,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,7
+Angelina,33,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,105
+Angelina,34,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,188
+Angelina,35,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,155
+Angelina,36,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,0
+Angelina,37,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,35
+Angelina,38,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,32
+Angelina,39,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,29
+Angelina,40,"District Attorney, 159th Judicial District",,REP,Katrina Carswell,49
+Angelina,1,"District Attorney, 159th Judicial District",,REP,Joe Martin,74
+Angelina,2,"District Attorney, 159th Judicial District",,REP,Joe Martin,123
+Angelina,3,"District Attorney, 159th Judicial District",,REP,Joe Martin,337
+Angelina,4,"District Attorney, 159th Judicial District",,REP,Joe Martin,159
+Angelina,5,"District Attorney, 159th Judicial District",,REP,Joe Martin,239
+Angelina,6,"District Attorney, 159th Judicial District",,REP,Joe Martin,94
+Angelina,7,"District Attorney, 159th Judicial District",,REP,Joe Martin,278
+Angelina,8,"District Attorney, 159th Judicial District",,REP,Joe Martin,331
+Angelina,9,"District Attorney, 159th Judicial District",,REP,Joe Martin,76
+Angelina,10,"District Attorney, 159th Judicial District",,REP,Joe Martin,166
+Angelina,11,"District Attorney, 159th Judicial District",,REP,Joe Martin,425
+Angelina,11B,"District Attorney, 159th Judicial District",,REP,Joe Martin,163
+Angelina,12,"District Attorney, 159th Judicial District",,REP,Joe Martin,186
+Angelina,13,"District Attorney, 159th Judicial District",,REP,Joe Martin,106
+Angelina,14,"District Attorney, 159th Judicial District",,REP,Joe Martin,443
+Angelina,15,"District Attorney, 159th Judicial District",,REP,Joe Martin,123
+Angelina,16,"District Attorney, 159th Judicial District",,REP,Joe Martin,206
+Angelina,17,"District Attorney, 159th Judicial District",,REP,Joe Martin,305
+Angelina,17B,"District Attorney, 159th Judicial District",,REP,Joe Martin,64
+Angelina,18,"District Attorney, 159th Judicial District",,REP,Joe Martin,134
+Angelina,19,"District Attorney, 159th Judicial District",,REP,Joe Martin,390
+Angelina,20,"District Attorney, 159th Judicial District",,REP,Joe Martin,57
+Angelina,21,"District Attorney, 159th Judicial District",,REP,Joe Martin,265
+Angelina,22,"District Attorney, 159th Judicial District",,REP,Joe Martin,249
+Angelina,23,"District Attorney, 159th Judicial District",,REP,Joe Martin,141
+Angelina,24,"District Attorney, 159th Judicial District",,REP,Joe Martin,414
+Angelina,25,"District Attorney, 159th Judicial District",,REP,Joe Martin,445
+Angelina,26,"District Attorney, 159th Judicial District",,REP,Joe Martin,432
+Angelina,27,"District Attorney, 159th Judicial District",,REP,Joe Martin,88
+Angelina,28,"District Attorney, 159th Judicial District",,REP,Joe Martin,238
+Angelina,29,"District Attorney, 159th Judicial District",,REP,Joe Martin,348
+Angelina,30,"District Attorney, 159th Judicial District",,REP,Joe Martin,167
+Angelina,31,"District Attorney, 159th Judicial District",,REP,Joe Martin,65
+Angelina,32,"District Attorney, 159th Judicial District",,REP,Joe Martin,35
+Angelina,33,"District Attorney, 159th Judicial District",,REP,Joe Martin,284
+Angelina,34,"District Attorney, 159th Judicial District",,REP,Joe Martin,483
+Angelina,35,"District Attorney, 159th Judicial District",,REP,Joe Martin,393
+Angelina,36,"District Attorney, 159th Judicial District",,REP,Joe Martin,1
+Angelina,37,"District Attorney, 159th Judicial District",,REP,Joe Martin,92
+Angelina,38,"District Attorney, 159th Judicial District",,REP,Joe Martin,67
+Angelina,39,"District Attorney, 159th Judicial District",,REP,Joe Martin,90
+Angelina,40,"District Attorney, 159th Judicial District",,REP,Joe Martin,146
+Angelina,1,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,2,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,3,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,4,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,5,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,6,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,7,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,8,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,9,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,10,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,11,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,11B,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,12,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,13,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,14,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,15,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,16,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,17,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,17B,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,18,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,19,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,20,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,21,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,22,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,23,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,24,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,25,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,26,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,27,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,28,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,29,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,30,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,31,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,32,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,33,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,34,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,35,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,36,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,37,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,38,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,39,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,40,"District Attorney, 159th Judicial District",,REP,OVER VOTES,0
+Angelina,1,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,6
+Angelina,2,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,17
+Angelina,3,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,66
+Angelina,4,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,43
+Angelina,5,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,42
+Angelina,6,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,19
+Angelina,7,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,55
+Angelina,8,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,48
+Angelina,9,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,13
+Angelina,10,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,26
+Angelina,11,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,110
+Angelina,11B,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,47
+Angelina,12,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,32
+Angelina,13,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,11
+Angelina,14,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,45
+Angelina,15,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,20
+Angelina,16,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,36
+Angelina,17,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,81
+Angelina,17B,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,14
+Angelina,18,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,9
+Angelina,19,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,50
+Angelina,20,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,19
+Angelina,21,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,36
+Angelina,22,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,37
+Angelina,23,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,23
+Angelina,24,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,100
+Angelina,25,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,64
+Angelina,26,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,64
+Angelina,27,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,24
+Angelina,28,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,45
+Angelina,29,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,73
+Angelina,30,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,49
+Angelina,31,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,9
+Angelina,32,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,6
+Angelina,33,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,71
+Angelina,34,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,73
+Angelina,35,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,65
+Angelina,36,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,0
+Angelina,37,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,15
+Angelina,38,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,17
+Angelina,39,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,13
+Angelina,40,"District Attorney, 159th Judicial District",,REP,UNDER VOTES,22
+Angelina,1,County Attorney,,REP,Cary D. Kirby,69
+Angelina,2,County Attorney,,REP,Cary D. Kirby,134
+Angelina,3,County Attorney,,REP,Cary D. Kirby,394
+Angelina,4,County Attorney,,REP,Cary D. Kirby,172
+Angelina,5,County Attorney,,REP,Cary D. Kirby,258
+Angelina,6,County Attorney,,REP,Cary D. Kirby,106
+Angelina,7,County Attorney,,REP,Cary D. Kirby,305
+Angelina,8,County Attorney,,REP,Cary D. Kirby,351
+Angelina,9,County Attorney,,REP,Cary D. Kirby,77
+Angelina,10,County Attorney,,REP,Cary D. Kirby,178
+Angelina,11,County Attorney,,REP,Cary D. Kirby,487
+Angelina,11B,County Attorney,,REP,Cary D. Kirby,177
+Angelina,12,County Attorney,,REP,Cary D. Kirby,213
+Angelina,13,County Attorney,,REP,Cary D. Kirby,122
+Angelina,14,County Attorney,,REP,Cary D. Kirby,422
+Angelina,15,County Attorney,,REP,Cary D. Kirby,151
+Angelina,16,County Attorney,,REP,Cary D. Kirby,215
+Angelina,17,County Attorney,,REP,Cary D. Kirby,323
+Angelina,17B,County Attorney,,REP,Cary D. Kirby,75
+Angelina,18,County Attorney,,REP,Cary D. Kirby,129
+Angelina,19,County Attorney,,REP,Cary D. Kirby,383
+Angelina,20,County Attorney,,REP,Cary D. Kirby,70
+Angelina,21,County Attorney,,REP,Cary D. Kirby,284
+Angelina,22,County Attorney,,REP,Cary D. Kirby,256
+Angelina,23,County Attorney,,REP,Cary D. Kirby,150
+Angelina,24,County Attorney,,REP,Cary D. Kirby,453
+Angelina,25,County Attorney,,REP,Cary D. Kirby,491
+Angelina,26,County Attorney,,REP,Cary D. Kirby,481
+Angelina,27,County Attorney,,REP,Cary D. Kirby,94
+Angelina,28,County Attorney,,REP,Cary D. Kirby,284
+Angelina,29,County Attorney,,REP,Cary D. Kirby,333
+Angelina,30,County Attorney,,REP,Cary D. Kirby,192
+Angelina,31,County Attorney,,REP,Cary D. Kirby,74
+Angelina,32,County Attorney,,REP,Cary D. Kirby,39
+Angelina,33,County Attorney,,REP,Cary D. Kirby,306
+Angelina,34,County Attorney,,REP,Cary D. Kirby,516
+Angelina,35,County Attorney,,REP,Cary D. Kirby,439
+Angelina,36,County Attorney,,REP,Cary D. Kirby,1
+Angelina,37,County Attorney,,REP,Cary D. Kirby,104
+Angelina,38,County Attorney,,REP,Cary D. Kirby,81
+Angelina,39,County Attorney,,REP,Cary D. Kirby,97
+Angelina,40,County Attorney,,REP,Cary D. Kirby,157
+Angelina,1,County Attorney,,REP,OVER VOTES,0
+Angelina,2,County Attorney,,REP,OVER VOTES,0
+Angelina,3,County Attorney,,REP,OVER VOTES,0
+Angelina,4,County Attorney,,REP,OVER VOTES,0
+Angelina,5,County Attorney,,REP,OVER VOTES,0
+Angelina,6,County Attorney,,REP,OVER VOTES,0
+Angelina,7,County Attorney,,REP,OVER VOTES,0
+Angelina,8,County Attorney,,REP,OVER VOTES,0
+Angelina,9,County Attorney,,REP,OVER VOTES,0
+Angelina,10,County Attorney,,REP,OVER VOTES,0
+Angelina,11,County Attorney,,REP,OVER VOTES,0
+Angelina,11B,County Attorney,,REP,OVER VOTES,0
+Angelina,12,County Attorney,,REP,OVER VOTES,0
+Angelina,13,County Attorney,,REP,OVER VOTES,0
+Angelina,14,County Attorney,,REP,OVER VOTES,0
+Angelina,15,County Attorney,,REP,OVER VOTES,0
+Angelina,16,County Attorney,,REP,OVER VOTES,0
+Angelina,17,County Attorney,,REP,OVER VOTES,0
+Angelina,17B,County Attorney,,REP,OVER VOTES,0
+Angelina,18,County Attorney,,REP,OVER VOTES,0
+Angelina,19,County Attorney,,REP,OVER VOTES,0
+Angelina,20,County Attorney,,REP,OVER VOTES,0
+Angelina,21,County Attorney,,REP,OVER VOTES,0
+Angelina,22,County Attorney,,REP,OVER VOTES,0
+Angelina,23,County Attorney,,REP,OVER VOTES,0
+Angelina,24,County Attorney,,REP,OVER VOTES,0
+Angelina,25,County Attorney,,REP,OVER VOTES,0
+Angelina,26,County Attorney,,REP,OVER VOTES,0
+Angelina,27,County Attorney,,REP,OVER VOTES,0
+Angelina,28,County Attorney,,REP,OVER VOTES,0
+Angelina,29,County Attorney,,REP,OVER VOTES,0
+Angelina,30,County Attorney,,REP,OVER VOTES,0
+Angelina,31,County Attorney,,REP,OVER VOTES,0
+Angelina,32,County Attorney,,REP,OVER VOTES,0
+Angelina,33,County Attorney,,REP,OVER VOTES,0
+Angelina,34,County Attorney,,REP,OVER VOTES,0
+Angelina,35,County Attorney,,REP,OVER VOTES,0
+Angelina,36,County Attorney,,REP,OVER VOTES,0
+Angelina,37,County Attorney,,REP,OVER VOTES,0
+Angelina,38,County Attorney,,REP,OVER VOTES,0
+Angelina,39,County Attorney,,REP,OVER VOTES,0
+Angelina,40,County Attorney,,REP,OVER VOTES,0
+Angelina,1,County Attorney,,REP,UNDER VOTES,29
+Angelina,2,County Attorney,,REP,UNDER VOTES,51
+Angelina,3,County Attorney,,REP,UNDER VOTES,145
+Angelina,4,County Attorney,,REP,UNDER VOTES,83
+Angelina,5,County Attorney,,REP,UNDER VOTES,105
+Angelina,6,County Attorney,,REP,UNDER VOTES,47
+Angelina,7,County Attorney,,REP,UNDER VOTES,121
+Angelina,8,County Attorney,,REP,UNDER VOTES,131
+Angelina,9,County Attorney,,REP,UNDER VOTES,37
+Angelina,10,County Attorney,,REP,UNDER VOTES,65
+Angelina,11,County Attorney,,REP,UNDER VOTES,226
+Angelina,11B,County Attorney,,REP,UNDER VOTES,99
+Angelina,12,County Attorney,,REP,UNDER VOTES,72
+Angelina,13,County Attorney,,REP,UNDER VOTES,41
+Angelina,14,County Attorney,,REP,UNDER VOTES,186
+Angelina,15,County Attorney,,REP,UNDER VOTES,53
+Angelina,16,County Attorney,,REP,UNDER VOTES,95
+Angelina,17,County Attorney,,REP,UNDER VOTES,175
+Angelina,17B,County Attorney,,REP,UNDER VOTES,31
+Angelina,18,County Attorney,,REP,UNDER VOTES,42
+Angelina,19,County Attorney,,REP,UNDER VOTES,156
+Angelina,20,County Attorney,,REP,UNDER VOTES,27
+Angelina,21,County Attorney,,REP,UNDER VOTES,96
+Angelina,22,County Attorney,,REP,UNDER VOTES,98
+Angelina,23,County Attorney,,REP,UNDER VOTES,54
+Angelina,24,County Attorney,,REP,UNDER VOTES,212
+Angelina,25,County Attorney,,REP,UNDER VOTES,166
+Angelina,26,County Attorney,,REP,UNDER VOTES,180
+Angelina,27,County Attorney,,REP,UNDER VOTES,42
+Angelina,28,County Attorney,,REP,UNDER VOTES,101
+Angelina,29,County Attorney,,REP,UNDER VOTES,180
+Angelina,30,County Attorney,,REP,UNDER VOTES,92
+Angelina,31,County Attorney,,REP,UNDER VOTES,21
+Angelina,32,County Attorney,,REP,UNDER VOTES,9
+Angelina,33,County Attorney,,REP,UNDER VOTES,154
+Angelina,34,County Attorney,,REP,UNDER VOTES,228
+Angelina,35,County Attorney,,REP,UNDER VOTES,174
+Angelina,36,County Attorney,,REP,UNDER VOTES,0
+Angelina,37,County Attorney,,REP,UNDER VOTES,38
+Angelina,38,County Attorney,,REP,UNDER VOTES,35
+Angelina,39,County Attorney,,REP,UNDER VOTES,35
+Angelina,40,County Attorney,,REP,UNDER VOTES,60
+Angelina,1,Sheriff,,REP,Greg Sanches,85
+Angelina,2,Sheriff,,REP,Greg Sanches,161
+Angelina,3,Sheriff,,REP,Greg Sanches,463
+Angelina,4,Sheriff,,REP,Greg Sanches,214
+Angelina,5,Sheriff,,REP,Greg Sanches,323
+Angelina,6,Sheriff,,REP,Greg Sanches,123
+Angelina,7,Sheriff,,REP,Greg Sanches,384
+Angelina,8,Sheriff,,REP,Greg Sanches,447
+Angelina,9,Sheriff,,REP,Greg Sanches,86
+Angelina,10,Sheriff,,REP,Greg Sanches,211
+Angelina,11,Sheriff,,REP,Greg Sanches,595
+Angelina,11B,Sheriff,,REP,Greg Sanches,234
+Angelina,12,Sheriff,,REP,Greg Sanches,242
+Angelina,13,Sheriff,,REP,Greg Sanches,141
+Angelina,14,Sheriff,,REP,Greg Sanches,533
+Angelina,15,Sheriff,,REP,Greg Sanches,182
+Angelina,16,Sheriff,,REP,Greg Sanches,264
+Angelina,17,Sheriff,,REP,Greg Sanches,388
+Angelina,17B,Sheriff,,REP,Greg Sanches,81
+Angelina,18,Sheriff,,REP,Greg Sanches,149
+Angelina,19,Sheriff,,REP,Greg Sanches,458
+Angelina,20,Sheriff,,REP,Greg Sanches,82
+Angelina,21,Sheriff,,REP,Greg Sanches,334
+Angelina,22,Sheriff,,REP,Greg Sanches,313
+Angelina,23,Sheriff,,REP,Greg Sanches,178
+Angelina,24,Sheriff,,REP,Greg Sanches,559
+Angelina,25,Sheriff,,REP,Greg Sanches,593
+Angelina,26,Sheriff,,REP,Greg Sanches,575
+Angelina,27,Sheriff,,REP,Greg Sanches,116
+Angelina,28,Sheriff,,REP,Greg Sanches,333
+Angelina,29,Sheriff,,REP,Greg Sanches,443
+Angelina,30,Sheriff,,REP,Greg Sanches,234
+Angelina,31,Sheriff,,REP,Greg Sanches,83
+Angelina,32,Sheriff,,REP,Greg Sanches,39
+Angelina,33,Sheriff,,REP,Greg Sanches,379
+Angelina,34,Sheriff,,REP,Greg Sanches,644
+Angelina,35,Sheriff,,REP,Greg Sanches,521
+Angelina,36,Sheriff,,REP,Greg Sanches,1
+Angelina,37,Sheriff,,REP,Greg Sanches,123
+Angelina,38,Sheriff,,REP,Greg Sanches,99
+Angelina,39,Sheriff,,REP,Greg Sanches,117
+Angelina,40,Sheriff,,REP,Greg Sanches,190
+Angelina,1,Sheriff,,REP,OVER VOTES,0
+Angelina,2,Sheriff,,REP,OVER VOTES,0
+Angelina,3,Sheriff,,REP,OVER VOTES,0
+Angelina,4,Sheriff,,REP,OVER VOTES,0
+Angelina,5,Sheriff,,REP,OVER VOTES,0
+Angelina,6,Sheriff,,REP,OVER VOTES,0
+Angelina,7,Sheriff,,REP,OVER VOTES,0
+Angelina,8,Sheriff,,REP,OVER VOTES,0
+Angelina,9,Sheriff,,REP,OVER VOTES,0
+Angelina,10,Sheriff,,REP,OVER VOTES,0
+Angelina,11,Sheriff,,REP,OVER VOTES,0
+Angelina,11B,Sheriff,,REP,OVER VOTES,0
+Angelina,12,Sheriff,,REP,OVER VOTES,0
+Angelina,13,Sheriff,,REP,OVER VOTES,0
+Angelina,14,Sheriff,,REP,OVER VOTES,0
+Angelina,15,Sheriff,,REP,OVER VOTES,0
+Angelina,16,Sheriff,,REP,OVER VOTES,0
+Angelina,17,Sheriff,,REP,OVER VOTES,0
+Angelina,17B,Sheriff,,REP,OVER VOTES,0
+Angelina,18,Sheriff,,REP,OVER VOTES,0
+Angelina,19,Sheriff,,REP,OVER VOTES,0
+Angelina,20,Sheriff,,REP,OVER VOTES,0
+Angelina,21,Sheriff,,REP,OVER VOTES,0
+Angelina,22,Sheriff,,REP,OVER VOTES,0
+Angelina,23,Sheriff,,REP,OVER VOTES,0
+Angelina,24,Sheriff,,REP,OVER VOTES,0
+Angelina,25,Sheriff,,REP,OVER VOTES,0
+Angelina,26,Sheriff,,REP,OVER VOTES,0
+Angelina,27,Sheriff,,REP,OVER VOTES,0
+Angelina,28,Sheriff,,REP,OVER VOTES,0
+Angelina,29,Sheriff,,REP,OVER VOTES,0
+Angelina,30,Sheriff,,REP,OVER VOTES,0
+Angelina,31,Sheriff,,REP,OVER VOTES,0
+Angelina,32,Sheriff,,REP,OVER VOTES,0
+Angelina,33,Sheriff,,REP,OVER VOTES,0
+Angelina,34,Sheriff,,REP,OVER VOTES,0
+Angelina,35,Sheriff,,REP,OVER VOTES,0
+Angelina,36,Sheriff,,REP,OVER VOTES,0
+Angelina,37,Sheriff,,REP,OVER VOTES,0
+Angelina,38,Sheriff,,REP,OVER VOTES,0
+Angelina,39,Sheriff,,REP,OVER VOTES,0
+Angelina,40,Sheriff,,REP,OVER VOTES,0
+Angelina,1,Sheriff,,REP,UNDER VOTES,13
+Angelina,2,Sheriff,,REP,UNDER VOTES,24
+Angelina,3,Sheriff,,REP,UNDER VOTES,76
+Angelina,4,Sheriff,,REP,UNDER VOTES,41
+Angelina,5,Sheriff,,REP,UNDER VOTES,40
+Angelina,6,Sheriff,,REP,UNDER VOTES,30
+Angelina,7,Sheriff,,REP,UNDER VOTES,42
+Angelina,8,Sheriff,,REP,UNDER VOTES,35
+Angelina,9,Sheriff,,REP,UNDER VOTES,28
+Angelina,10,Sheriff,,REP,UNDER VOTES,32
+Angelina,11,Sheriff,,REP,UNDER VOTES,118
+Angelina,11B,Sheriff,,REP,UNDER VOTES,42
+Angelina,12,Sheriff,,REP,UNDER VOTES,43
+Angelina,13,Sheriff,,REP,UNDER VOTES,22
+Angelina,14,Sheriff,,REP,UNDER VOTES,75
+Angelina,15,Sheriff,,REP,UNDER VOTES,22
+Angelina,16,Sheriff,,REP,UNDER VOTES,46
+Angelina,17,Sheriff,,REP,UNDER VOTES,110
+Angelina,17B,Sheriff,,REP,UNDER VOTES,25
+Angelina,18,Sheriff,,REP,UNDER VOTES,22
+Angelina,19,Sheriff,,REP,UNDER VOTES,81
+Angelina,20,Sheriff,,REP,UNDER VOTES,15
+Angelina,21,Sheriff,,REP,UNDER VOTES,46
+Angelina,22,Sheriff,,REP,UNDER VOTES,41
+Angelina,23,Sheriff,,REP,UNDER VOTES,26
+Angelina,24,Sheriff,,REP,UNDER VOTES,106
+Angelina,25,Sheriff,,REP,UNDER VOTES,64
+Angelina,26,Sheriff,,REP,UNDER VOTES,86
+Angelina,27,Sheriff,,REP,UNDER VOTES,20
+Angelina,28,Sheriff,,REP,UNDER VOTES,52
+Angelina,29,Sheriff,,REP,UNDER VOTES,70
+Angelina,30,Sheriff,,REP,UNDER VOTES,50
+Angelina,31,Sheriff,,REP,UNDER VOTES,12
+Angelina,32,Sheriff,,REP,UNDER VOTES,9
+Angelina,33,Sheriff,,REP,UNDER VOTES,81
+Angelina,34,Sheriff,,REP,UNDER VOTES,100
+Angelina,35,Sheriff,,REP,UNDER VOTES,92
+Angelina,36,Sheriff,,REP,UNDER VOTES,0
+Angelina,37,Sheriff,,REP,UNDER VOTES,19
+Angelina,38,Sheriff,,REP,UNDER VOTES,17
+Angelina,39,Sheriff,,REP,UNDER VOTES,15
+Angelina,40,Sheriff,,REP,UNDER VOTES,27
+Angelina,1,County Tax Assessor-Collector,,REP,David Stua,14
+Angelina,2,County Tax Assessor-Collector,,REP,David Stua,31
+Angelina,3,County Tax Assessor-Collector,,REP,David Stua,100
+Angelina,4,County Tax Assessor-Collector,,REP,David Stua,53
+Angelina,5,County Tax Assessor-Collector,,REP,David Stua,64
+Angelina,6,County Tax Assessor-Collector,,REP,David Stua,29
+Angelina,7,County Tax Assessor-Collector,,REP,David Stua,90
+Angelina,8,County Tax Assessor-Collector,,REP,David Stua,88
+Angelina,9,County Tax Assessor-Collector,,REP,David Stua,17
+Angelina,10,County Tax Assessor-Collector,,REP,David Stua,56
+Angelina,11,County Tax Assessor-Collector,,REP,David Stua,75
+Angelina,11B,County Tax Assessor-Collector,,REP,David Stua,16
+Angelina,12,County Tax Assessor-Collector,,REP,David Stua,45
+Angelina,13,County Tax Assessor-Collector,,REP,David Stua,23
+Angelina,14,County Tax Assessor-Collector,,REP,David Stua,112
+Angelina,15,County Tax Assessor-Collector,,REP,David Stua,37
+Angelina,16,County Tax Assessor-Collector,,REP,David Stua,44
+Angelina,17,County Tax Assessor-Collector,,REP,David Stua,50
+Angelina,17B,County Tax Assessor-Collector,,REP,David Stua,10
+Angelina,18,County Tax Assessor-Collector,,REP,David Stua,30
+Angelina,19,County Tax Assessor-Collector,,REP,David Stua,83
+Angelina,20,County Tax Assessor-Collector,,REP,David Stua,19
+Angelina,21,County Tax Assessor-Collector,,REP,David Stua,83
+Angelina,22,County Tax Assessor-Collector,,REP,David Stua,58
+Angelina,23,County Tax Assessor-Collector,,REP,David Stua,46
+Angelina,24,County Tax Assessor-Collector,,REP,David Stua,121
+Angelina,25,County Tax Assessor-Collector,,REP,David Stua,139
+Angelina,26,County Tax Assessor-Collector,,REP,David Stua,89
+Angelina,27,County Tax Assessor-Collector,,REP,David Stua,19
+Angelina,28,County Tax Assessor-Collector,,REP,David Stua,52
+Angelina,29,County Tax Assessor-Collector,,REP,David Stua,77
+Angelina,30,County Tax Assessor-Collector,,REP,David Stua,26
+Angelina,31,County Tax Assessor-Collector,,REP,David Stua,16
+Angelina,32,County Tax Assessor-Collector,,REP,David Stua,2
+Angelina,33,County Tax Assessor-Collector,,REP,David Stua,38
+Angelina,34,County Tax Assessor-Collector,,REP,David Stua,93
+Angelina,35,County Tax Assessor-Collector,,REP,David Stua,102
+Angelina,36,County Tax Assessor-Collector,,REP,David Stua,0
+Angelina,37,County Tax Assessor-Collector,,REP,David Stua,19
+Angelina,38,County Tax Assessor-Collector,,REP,David Stua,24
+Angelina,39,County Tax Assessor-Collector,,REP,David Stua,27
+Angelina,40,County Tax Assessor-Collector,,REP,David Stua,34
+Angelina,1,County Tax Assessor-Collector,,REP,Bobby Boles,13
+Angelina,2,County Tax Assessor-Collector,,REP,Bobby Boles,32
+Angelina,3,County Tax Assessor-Collector,,REP,Bobby Boles,93
+Angelina,4,County Tax Assessor-Collector,,REP,Bobby Boles,58
+Angelina,5,County Tax Assessor-Collector,,REP,Bobby Boles,36
+Angelina,6,County Tax Assessor-Collector,,REP,Bobby Boles,37
+Angelina,7,County Tax Assessor-Collector,,REP,Bobby Boles,86
+Angelina,8,County Tax Assessor-Collector,,REP,Bobby Boles,77
+Angelina,9,County Tax Assessor-Collector,,REP,Bobby Boles,19
+Angelina,10,County Tax Assessor-Collector,,REP,Bobby Boles,40
+Angelina,11,County Tax Assessor-Collector,,REP,Bobby Boles,168
+Angelina,11B,County Tax Assessor-Collector,,REP,Bobby Boles,57
+Angelina,12,County Tax Assessor-Collector,,REP,Bobby Boles,53
+Angelina,13,County Tax Assessor-Collector,,REP,Bobby Boles,16
+Angelina,14,County Tax Assessor-Collector,,REP,Bobby Boles,93
+Angelina,15,County Tax Assessor-Collector,,REP,Bobby Boles,28
+Angelina,16,County Tax Assessor-Collector,,REP,Bobby Boles,38
+Angelina,17,County Tax Assessor-Collector,,REP,Bobby Boles,96
+Angelina,17B,County Tax Assessor-Collector,,REP,Bobby Boles,17
+Angelina,18,County Tax Assessor-Collector,,REP,Bobby Boles,27
+Angelina,19,County Tax Assessor-Collector,,REP,Bobby Boles,65
+Angelina,20,County Tax Assessor-Collector,,REP,Bobby Boles,17
+Angelina,21,County Tax Assessor-Collector,,REP,Bobby Boles,74
+Angelina,22,County Tax Assessor-Collector,,REP,Bobby Boles,96
+Angelina,23,County Tax Assessor-Collector,,REP,Bobby Boles,40
+Angelina,24,County Tax Assessor-Collector,,REP,Bobby Boles,109
+Angelina,25,County Tax Assessor-Collector,,REP,Bobby Boles,133
+Angelina,26,County Tax Assessor-Collector,,REP,Bobby Boles,122
+Angelina,27,County Tax Assessor-Collector,,REP,Bobby Boles,21
+Angelina,28,County Tax Assessor-Collector,,REP,Bobby Boles,78
+Angelina,29,County Tax Assessor-Collector,,REP,Bobby Boles,123
+Angelina,30,County Tax Assessor-Collector,,REP,Bobby Boles,66
+Angelina,31,County Tax Assessor-Collector,,REP,Bobby Boles,15
+Angelina,32,County Tax Assessor-Collector,,REP,Bobby Boles,12
+Angelina,33,County Tax Assessor-Collector,,REP,Bobby Boles,95
+Angelina,34,County Tax Assessor-Collector,,REP,Bobby Boles,69
+Angelina,35,County Tax Assessor-Collector,,REP,Bobby Boles,86
+Angelina,36,County Tax Assessor-Collector,,REP,Bobby Boles,0
+Angelina,37,County Tax Assessor-Collector,,REP,Bobby Boles,36
+Angelina,38,County Tax Assessor-Collector,,REP,Bobby Boles,17
+Angelina,39,County Tax Assessor-Collector,,REP,Bobby Boles,21
+Angelina,40,County Tax Assessor-Collector,,REP,Bobby Boles,24
+Angelina,1,County Tax Assessor-Collector,,REP,Billie Page,38
+Angelina,2,County Tax Assessor-Collector,,REP,Billie Page,64
+Angelina,3,County Tax Assessor-Collector,,REP,Billie Page,180
+Angelina,4,County Tax Assessor-Collector,,REP,Billie Page,85
+Angelina,5,County Tax Assessor-Collector,,REP,Billie Page,135
+Angelina,6,County Tax Assessor-Collector,,REP,Billie Page,50
+Angelina,7,County Tax Assessor-Collector,,REP,Billie Page,99
+Angelina,8,County Tax Assessor-Collector,,REP,Billie Page,145
+Angelina,9,County Tax Assessor-Collector,,REP,Billie Page,37
+Angelina,10,County Tax Assessor-Collector,,REP,Billie Page,74
+Angelina,11,County Tax Assessor-Collector,,REP,Billie Page,150
+Angelina,11B,County Tax Assessor-Collector,,REP,Billie Page,54
+Angelina,12,County Tax Assessor-Collector,,REP,Billie Page,107
+Angelina,13,County Tax Assessor-Collector,,REP,Billie Page,54
+Angelina,14,County Tax Assessor-Collector,,REP,Billie Page,204
+Angelina,15,County Tax Assessor-Collector,,REP,Billie Page,53
+Angelina,16,County Tax Assessor-Collector,,REP,Billie Page,80
+Angelina,17,County Tax Assessor-Collector,,REP,Billie Page,113
+Angelina,17B,County Tax Assessor-Collector,,REP,Billie Page,24
+Angelina,18,County Tax Assessor-Collector,,REP,Billie Page,68
+Angelina,19,County Tax Assessor-Collector,,REP,Billie Page,225
+Angelina,20,County Tax Assessor-Collector,,REP,Billie Page,25
+Angelina,21,County Tax Assessor-Collector,,REP,Billie Page,113
+Angelina,22,County Tax Assessor-Collector,,REP,Billie Page,108
+Angelina,23,County Tax Assessor-Collector,,REP,Billie Page,60
+Angelina,24,County Tax Assessor-Collector,,REP,Billie Page,193
+Angelina,25,County Tax Assessor-Collector,,REP,Billie Page,173
+Angelina,26,County Tax Assessor-Collector,,REP,Billie Page,226
+Angelina,27,County Tax Assessor-Collector,,REP,Billie Page,40
+Angelina,28,County Tax Assessor-Collector,,REP,Billie Page,119
+Angelina,29,County Tax Assessor-Collector,,REP,Billie Page,153
+Angelina,30,County Tax Assessor-Collector,,REP,Billie Page,52
+Angelina,31,County Tax Assessor-Collector,,REP,Billie Page,17
+Angelina,32,County Tax Assessor-Collector,,REP,Billie Page,8
+Angelina,33,County Tax Assessor-Collector,,REP,Billie Page,82
+Angelina,34,County Tax Assessor-Collector,,REP,Billie Page,277
+Angelina,35,County Tax Assessor-Collector,,REP,Billie Page,215
+Angelina,36,County Tax Assessor-Collector,,REP,Billie Page,0
+Angelina,37,County Tax Assessor-Collector,,REP,Billie Page,37
+Angelina,38,County Tax Assessor-Collector,,REP,Billie Page,32
+Angelina,39,County Tax Assessor-Collector,,REP,Billie Page,34
+Angelina,40,County Tax Assessor-Collector,,REP,Billie Page,79
+Angelina,1,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",19
+Angelina,2,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",28
+Angelina,3,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",95
+Angelina,4,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",28
+Angelina,5,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",66
+Angelina,6,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",17
+Angelina,7,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",80
+Angelina,8,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",93
+Angelina,9,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",18
+Angelina,10,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",43
+Angelina,11,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",235
+Angelina,11B,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",114
+Angelina,12,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",39
+Angelina,13,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",47
+Angelina,14,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",93
+Angelina,15,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",56
+Angelina,16,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",90
+Angelina,17,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",177
+Angelina,17B,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",45
+Angelina,18,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",29
+Angelina,19,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",82
+Angelina,20,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",20
+Angelina,21,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",70
+Angelina,22,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",53
+Angelina,23,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",27
+Angelina,24,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",111
+Angelina,25,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",120
+Angelina,26,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",156
+Angelina,27,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",35
+Angelina,28,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",69
+Angelina,29,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",82
+Angelina,30,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",105
+Angelina,31,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",35
+Angelina,32,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",22
+Angelina,33,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",201
+Angelina,34,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",142
+Angelina,35,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",115
+Angelina,36,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",1
+Angelina,37,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",31
+Angelina,38,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",23
+Angelina,39,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",26
+Angelina,40,County Tax Assessor-Collector,,REP,"Lisha ""Shorti"" Hammock",47
+Angelina,1,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,2,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,3,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,4,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,5,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,6,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,7,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,8,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,9,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,10,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,11,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,11B,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,12,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,13,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,14,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,15,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,16,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,17,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,17B,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,18,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,19,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,20,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,21,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,22,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,23,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,24,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,25,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,26,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,27,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,28,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,29,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,30,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,31,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,32,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,33,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,34,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,35,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,36,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,37,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,38,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,39,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,40,County Tax Assessor-Collector,,REP,OVER VOTES,0
+Angelina,1,County Tax Assessor-Collector,,REP,UNDER VOTES,14
+Angelina,2,County Tax Assessor-Collector,,REP,UNDER VOTES,30
+Angelina,3,County Tax Assessor-Collector,,REP,UNDER VOTES,71
+Angelina,4,County Tax Assessor-Collector,,REP,UNDER VOTES,31
+Angelina,5,County Tax Assessor-Collector,,REP,UNDER VOTES,62
+Angelina,6,County Tax Assessor-Collector,,REP,UNDER VOTES,20
+Angelina,7,County Tax Assessor-Collector,,REP,UNDER VOTES,71
+Angelina,8,County Tax Assessor-Collector,,REP,UNDER VOTES,79
+Angelina,9,County Tax Assessor-Collector,,REP,UNDER VOTES,23
+Angelina,10,County Tax Assessor-Collector,,REP,UNDER VOTES,30
+Angelina,11,County Tax Assessor-Collector,,REP,UNDER VOTES,85
+Angelina,11B,County Tax Assessor-Collector,,REP,UNDER VOTES,35
+Angelina,12,County Tax Assessor-Collector,,REP,UNDER VOTES,41
+Angelina,13,County Tax Assessor-Collector,,REP,UNDER VOTES,23
+Angelina,14,County Tax Assessor-Collector,,REP,UNDER VOTES,106
+Angelina,15,County Tax Assessor-Collector,,REP,UNDER VOTES,30
+Angelina,16,County Tax Assessor-Collector,,REP,UNDER VOTES,58
+Angelina,17,County Tax Assessor-Collector,,REP,UNDER VOTES,62
+Angelina,17B,County Tax Assessor-Collector,,REP,UNDER VOTES,10
+Angelina,18,County Tax Assessor-Collector,,REP,UNDER VOTES,17
+Angelina,19,County Tax Assessor-Collector,,REP,UNDER VOTES,84
+Angelina,20,County Tax Assessor-Collector,,REP,UNDER VOTES,16
+Angelina,21,County Tax Assessor-Collector,,REP,UNDER VOTES,40
+Angelina,22,County Tax Assessor-Collector,,REP,UNDER VOTES,39
+Angelina,23,County Tax Assessor-Collector,,REP,UNDER VOTES,31
+Angelina,24,County Tax Assessor-Collector,,REP,UNDER VOTES,131
+Angelina,25,County Tax Assessor-Collector,,REP,UNDER VOTES,92
+Angelina,26,County Tax Assessor-Collector,,REP,UNDER VOTES,68
+Angelina,27,County Tax Assessor-Collector,,REP,UNDER VOTES,21
+Angelina,28,County Tax Assessor-Collector,,REP,UNDER VOTES,67
+Angelina,29,County Tax Assessor-Collector,,REP,UNDER VOTES,78
+Angelina,30,County Tax Assessor-Collector,,REP,UNDER VOTES,35
+Angelina,31,County Tax Assessor-Collector,,REP,UNDER VOTES,12
+Angelina,32,County Tax Assessor-Collector,,REP,UNDER VOTES,4
+Angelina,33,County Tax Assessor-Collector,,REP,UNDER VOTES,44
+Angelina,34,County Tax Assessor-Collector,,REP,UNDER VOTES,163
+Angelina,35,County Tax Assessor-Collector,,REP,UNDER VOTES,95
+Angelina,36,County Tax Assessor-Collector,,REP,UNDER VOTES,0
+Angelina,37,County Tax Assessor-Collector,,REP,UNDER VOTES,19
+Angelina,38,County Tax Assessor-Collector,,REP,UNDER VOTES,20
+Angelina,39,County Tax Assessor-Collector,,REP,UNDER VOTES,24
+Angelina,40,County Tax Assessor-Collector,,REP,UNDER VOTES,33
+Angelina,6,"County Commissioner, Precinct No. 1",,REP,Greg Harrison,109
+Angelina,7,"County Commissioner, Precinct No. 1",,REP,Greg Harrison,343
+Angelina,8,"County Commissioner, Precinct No. 1",,REP,Greg Harrison,387
+Angelina,19,"County Commissioner, Precinct No. 1",,REP,Greg Harrison,390
+Angelina,21,"County Commissioner, Precinct No. 1",,REP,Greg Harrison,302
+Angelina,22,"County Commissioner, Precinct No. 1",,REP,Greg Harrison,279
+Angelina,23,"County Commissioner, Precinct No. 1",,REP,Greg Harrison,169
+Angelina,24,"County Commissioner, Precinct No. 1",,REP,Greg Harrison,508
+Angelina,25,"County Commissioner, Precinct No. 1",,REP,Greg Harrison,543
+Angelina,29,"County Commissioner, Precinct No. 1",,REP,Greg Harrison,380
+Angelina,39,"County Commissioner, Precinct No. 1",,REP,Greg Harrison,107
+Angelina,6,"County Commissioner, Precinct No. 1",,REP,OVER VOTES,0
+Angelina,7,"County Commissioner, Precinct No. 1",,REP,OVER VOTES,0
+Angelina,8,"County Commissioner, Precinct No. 1",,REP,OVER VOTES,0
+Angelina,19,"County Commissioner, Precinct No. 1",,REP,OVER VOTES,0
+Angelina,21,"County Commissioner, Precinct No. 1",,REP,OVER VOTES,0
+Angelina,22,"County Commissioner, Precinct No. 1",,REP,OVER VOTES,0
+Angelina,23,"County Commissioner, Precinct No. 1",,REP,OVER VOTES,0
+Angelina,24,"County Commissioner, Precinct No. 1",,REP,OVER VOTES,0
+Angelina,25,"County Commissioner, Precinct No. 1",,REP,OVER VOTES,0
+Angelina,29,"County Commissioner, Precinct No. 1",,REP,OVER VOTES,0
+Angelina,39,"County Commissioner, Precinct No. 1",,REP,OVER VOTES,0
+Angelina,6,"County Commissioner, Precinct No. 1",,REP,UNDER VOTES,44
+Angelina,7,"County Commissioner, Precinct No. 1",,REP,UNDER VOTES,83
+Angelina,8,"County Commissioner, Precinct No. 1",,REP,UNDER VOTES,95
+Angelina,19,"County Commissioner, Precinct No. 1",,REP,UNDER VOTES,149
+Angelina,21,"County Commissioner, Precinct No. 1",,REP,UNDER VOTES,78
+Angelina,22,"County Commissioner, Precinct No. 1",,REP,UNDER VOTES,75
+Angelina,23,"County Commissioner, Precinct No. 1",,REP,UNDER VOTES,35
+Angelina,24,"County Commissioner, Precinct No. 1",,REP,UNDER VOTES,157
+Angelina,25,"County Commissioner, Precinct No. 1",,REP,UNDER VOTES,114
+Angelina,29,"County Commissioner, Precinct No. 1",,REP,UNDER VOTES,133
+Angelina,39,"County Commissioner, Precinct No. 1",,REP,UNDER VOTES,25
+Angelina,1,"County Commissioner, Precinct No. 3",,REP,Terry Pitts,43
+Angelina,3,"County Commissioner, Precinct No. 3",,REP,Terry Pitts,284
+Angelina,11,"County Commissioner, Precinct No. 3",,REP,Terry Pitts,376
+Angelina,11B,"County Commissioner, Precinct No. 3",,REP,Terry Pitts,104
+Angelina,12,"County Commissioner, Precinct No. 3",,REP,Terry Pitts,116
+Angelina,26,"County Commissioner, Precinct No. 3",,REP,Terry Pitts,428
+Angelina,30,"County Commissioner, Precinct No. 3",,REP,Terry Pitts,107
+Angelina,33,"County Commissioner, Precinct No. 3",,REP,Terry Pitts,233
+Angelina,35,"County Commissioner, Precinct No. 3",,REP,Terry Pitts,219
+Angelina,37,"County Commissioner, Precinct No. 3",,REP,Terry Pitts,74
+Angelina,40,"County Commissioner, Precinct No. 3",,REP,Terry Pitts,78
+Angelina,1,"County Commissioner, Precinct No. 3",,REP,Todd Hopson,15
+Angelina,3,"County Commissioner, Precinct No. 3",,REP,Todd Hopson,60
+Angelina,11,"County Commissioner, Precinct No. 3",,REP,Todd Hopson,118
+Angelina,11B,"County Commissioner, Precinct No. 3",,REP,Todd Hopson,69
+Angelina,12,"County Commissioner, Precinct No. 3",,REP,Todd Hopson,34
+Angelina,26,"County Commissioner, Precinct No. 3",,REP,Todd Hopson,54
+Angelina,30,"County Commissioner, Precinct No. 3",,REP,Todd Hopson,44
+Angelina,33,"County Commissioner, Precinct No. 3",,REP,Todd Hopson,74
+Angelina,35,"County Commissioner, Precinct No. 3",,REP,Todd Hopson,79
+Angelina,37,"County Commissioner, Precinct No. 3",,REP,Todd Hopson,12
+Angelina,40,"County Commissioner, Precinct No. 3",,REP,Todd Hopson,33
+Angelina,1,"County Commissioner, Precinct No. 3",,REP,Ivy Collins,20
+Angelina,3,"County Commissioner, Precinct No. 3",,REP,Ivy Collins,145
+Angelina,11,"County Commissioner, Precinct No. 3",,REP,Ivy Collins,151
+Angelina,11B,"County Commissioner, Precinct No. 3",,REP,Ivy Collins,69
+Angelina,12,"County Commissioner, Precinct No. 3",,REP,Ivy Collins,97
+Angelina,26,"County Commissioner, Precinct No. 3",,REP,Ivy Collins,125
+Angelina,30,"County Commissioner, Precinct No. 3",,REP,Ivy Collins,96
+Angelina,33,"County Commissioner, Precinct No. 3",,REP,Ivy Collins,114
+Angelina,35,"County Commissioner, Precinct No. 3",,REP,Ivy Collins,186
+Angelina,37,"County Commissioner, Precinct No. 3",,REP,Ivy Collins,35
+Angelina,40,"County Commissioner, Precinct No. 3",,REP,Ivy Collins,65
+Angelina,1,"County Commissioner, Precinct No. 3",,REP,OVER VOTES,0
+Angelina,3,"County Commissioner, Precinct No. 3",,REP,OVER VOTES,0
+Angelina,11,"County Commissioner, Precinct No. 3",,REP,OVER VOTES,0
+Angelina,11B,"County Commissioner, Precinct No. 3",,REP,OVER VOTES,0
+Angelina,12,"County Commissioner, Precinct No. 3",,REP,OVER VOTES,0
+Angelina,26,"County Commissioner, Precinct No. 3",,REP,OVER VOTES,0
+Angelina,30,"County Commissioner, Precinct No. 3",,REP,OVER VOTES,0
+Angelina,33,"County Commissioner, Precinct No. 3",,REP,OVER VOTES,0
+Angelina,35,"County Commissioner, Precinct No. 3",,REP,OVER VOTES,0
+Angelina,37,"County Commissioner, Precinct No. 3",,REP,OVER VOTES,0
+Angelina,40,"County Commissioner, Precinct No. 3",,REP,OVER VOTES,0
+Angelina,1,"County Commissioner, Precinct No. 3",,REP,UNDER VOTES,20
+Angelina,3,"County Commissioner, Precinct No. 3",,REP,UNDER VOTES,50
+Angelina,11,"County Commissioner, Precinct No. 3",,REP,UNDER VOTES,68
+Angelina,11B,"County Commissioner, Precinct No. 3",,REP,UNDER VOTES,34
+Angelina,12,"County Commissioner, Precinct No. 3",,REP,UNDER VOTES,38
+Angelina,26,"County Commissioner, Precinct No. 3",,REP,UNDER VOTES,54
+Angelina,30,"County Commissioner, Precinct No. 3",,REP,UNDER VOTES,37
+Angelina,33,"County Commissioner, Precinct No. 3",,REP,UNDER VOTES,39
+Angelina,35,"County Commissioner, Precinct No. 3",,REP,UNDER VOTES,129
+Angelina,37,"County Commissioner, Precinct No. 3",,REP,UNDER VOTES,21
+Angelina,40,"County Commissioner, Precinct No. 3",,REP,UNDER VOTES,41
+Angelina,1,"Constable, Precinct No. 1",,REP,Tom Selman,78
+Angelina,2,"Constable, Precinct No. 1",,REP,Tom Selman,148
+Angelina,3,"Constable, Precinct No. 1",,REP,Tom Selman,435
+Angelina,5,"Constable, Precinct No. 1",,REP,Tom Selman,286
+Angelina,9,"Constable, Precinct No. 1",,REP,Tom Selman,80
+Angelina,10,"Constable, Precinct No. 1",,REP,Tom Selman,195
+Angelina,12,"Constable, Precinct No. 1",,REP,Tom Selman,225
+Angelina,13,"Constable, Precinct No. 1",,REP,Tom Selman,137
+Angelina,14,"Constable, Precinct No. 1",,REP,Tom Selman,476
+Angelina,18,"Constable, Precinct No. 1",,REP,Tom Selman,139
+Angelina,19,"Constable, Precinct No. 1",,REP,Tom Selman,424
+Angelina,20,"Constable, Precinct No. 1",,REP,Tom Selman,72
+Angelina,34,"Constable, Precinct No. 1",,REP,Tom Selman,570
+Angelina,35,"Constable, Precinct No. 1",,REP,Tom Selman,477
+Angelina,39,"Constable, Precinct No. 1",,REP,Tom Selman,111
+Angelina,40,"Constable, Precinct No. 1",,REP,Tom Selman,174
+Angelina,1,"Constable, Precinct No. 1",,REP,OVER VOTES,0
+Angelina,2,"Constable, Precinct No. 1",,REP,OVER VOTES,0
+Angelina,3,"Constable, Precinct No. 1",,REP,OVER VOTES,0
+Angelina,5,"Constable, Precinct No. 1",,REP,OVER VOTES,0
+Angelina,9,"Constable, Precinct No. 1",,REP,OVER VOTES,0
+Angelina,10,"Constable, Precinct No. 1",,REP,OVER VOTES,0
+Angelina,12,"Constable, Precinct No. 1",,REP,OVER VOTES,0
+Angelina,13,"Constable, Precinct No. 1",,REP,OVER VOTES,0
+Angelina,14,"Constable, Precinct No. 1",,REP,OVER VOTES,0
+Angelina,18,"Constable, Precinct No. 1",,REP,OVER VOTES,0
+Angelina,19,"Constable, Precinct No. 1",,REP,OVER VOTES,0
+Angelina,20,"Constable, Precinct No. 1",,REP,OVER VOTES,0
+Angelina,34,"Constable, Precinct No. 1",,REP,OVER VOTES,0
+Angelina,35,"Constable, Precinct No. 1",,REP,OVER VOTES,0
+Angelina,39,"Constable, Precinct No. 1",,REP,OVER VOTES,0
+Angelina,40,"Constable, Precinct No. 1",,REP,OVER VOTES,0
+Angelina,1,"Constable, Precinct No. 1",,REP,UNDER VOTES,20
+Angelina,2,"Constable, Precinct No. 1",,REP,UNDER VOTES,37
+Angelina,3,"Constable, Precinct No. 1",,REP,UNDER VOTES,104
+Angelina,5,"Constable, Precinct No. 1",,REP,UNDER VOTES,77
+Angelina,9,"Constable, Precinct No. 1",,REP,UNDER VOTES,34
+Angelina,10,"Constable, Precinct No. 1",,REP,UNDER VOTES,48
+Angelina,12,"Constable, Precinct No. 1",,REP,UNDER VOTES,60
+Angelina,13,"Constable, Precinct No. 1",,REP,UNDER VOTES,26
+Angelina,14,"Constable, Precinct No. 1",,REP,UNDER VOTES,132
+Angelina,18,"Constable, Precinct No. 1",,REP,UNDER VOTES,32
+Angelina,19,"Constable, Precinct No. 1",,REP,UNDER VOTES,115
+Angelina,20,"Constable, Precinct No. 1",,REP,UNDER VOTES,25
+Angelina,34,"Constable, Precinct No. 1",,REP,UNDER VOTES,174
+Angelina,35,"Constable, Precinct No. 1",,REP,UNDER VOTES,136
+Angelina,39,"Constable, Precinct No. 1",,REP,UNDER VOTES,21
+Angelina,40,"Constable, Precinct No. 1",,REP,UNDER VOTES,43
+Angelina,4,"Constable, Precinct No. 2",,REP,James Romero,25
+Angelina,6,"Constable, Precinct No. 2",,REP,James Romero,5
+Angelina,7,"Constable, Precinct No. 2",,REP,James Romero,21
+Angelina,8,"Constable, Precinct No. 2",,REP,James Romero,25
+Angelina,21,"Constable, Precinct No. 2",,REP,James Romero,34
+Angelina,22,"Constable, Precinct No. 2",,REP,James Romero,23
+Angelina,23,"Constable, Precinct No. 2",,REP,James Romero,14
+Angelina,24,"Constable, Precinct No. 2",,REP,James Romero,42
+Angelina,25,"Constable, Precinct No. 2",,REP,James Romero,62
+Angelina,29,"Constable, Precinct No. 2",,REP,James Romero,23
+Angelina,36,"Constable, Precinct No. 2",,REP,James Romero,1
+Angelina,4,"Constable, Precinct No. 2",,REP,Trae Trevathan,106
+Angelina,6,"Constable, Precinct No. 2",,REP,Trae Trevathan,86
+Angelina,7,"Constable, Precinct No. 2",,REP,Trae Trevathan,240
+Angelina,8,"Constable, Precinct No. 2",,REP,Trae Trevathan,243
+Angelina,21,"Constable, Precinct No. 2",,REP,Trae Trevathan,242
+Angelina,22,"Constable, Precinct No. 2",,REP,Trae Trevathan,237
+Angelina,23,"Constable, Precinct No. 2",,REP,Trae Trevathan,104
+Angelina,24,"Constable, Precinct No. 2",,REP,Trae Trevathan,325
+Angelina,25,"Constable, Precinct No. 2",,REP,Trae Trevathan,321
+Angelina,29,"Constable, Precinct No. 2",,REP,Trae Trevathan,349
+Angelina,36,"Constable, Precinct No. 2",,REP,Trae Trevathan,0
+Angelina,4,"Constable, Precinct No. 2",,REP,Rob Willmon,79
+Angelina,6,"Constable, Precinct No. 2",,REP,Rob Willmon,47
+Angelina,7,"Constable, Precinct No. 2",,REP,Rob Willmon,107
+Angelina,8,"Constable, Precinct No. 2",,REP,Rob Willmon,153
+Angelina,21,"Constable, Precinct No. 2",,REP,Rob Willmon,77
+Angelina,22,"Constable, Precinct No. 2",,REP,Rob Willmon,59
+Angelina,23,"Constable, Precinct No. 2",,REP,Rob Willmon,57
+Angelina,24,"Constable, Precinct No. 2",,REP,Rob Willmon,190
+Angelina,25,"Constable, Precinct No. 2",,REP,Rob Willmon,202
+Angelina,29,"Constable, Precinct No. 2",,REP,Rob Willmon,84
+Angelina,36,"Constable, Precinct No. 2",,REP,Rob Willmon,0
+Angelina,4,"Constable, Precinct No. 2",,REP,OVER VOTES,0
+Angelina,6,"Constable, Precinct No. 2",,REP,OVER VOTES,0
+Angelina,7,"Constable, Precinct No. 2",,REP,OVER VOTES,0
+Angelina,8,"Constable, Precinct No. 2",,REP,OVER VOTES,0
+Angelina,21,"Constable, Precinct No. 2",,REP,OVER VOTES,0
+Angelina,22,"Constable, Precinct No. 2",,REP,OVER VOTES,0
+Angelina,23,"Constable, Precinct No. 2",,REP,OVER VOTES,0
+Angelina,24,"Constable, Precinct No. 2",,REP,OVER VOTES,0
+Angelina,25,"Constable, Precinct No. 2",,REP,OVER VOTES,0
+Angelina,29,"Constable, Precinct No. 2",,REP,OVER VOTES,0
+Angelina,36,"Constable, Precinct No. 2",,REP,OVER VOTES,0
+Angelina,4,"Constable, Precinct No. 2",,REP,UNDER VOTES,45
+Angelina,6,"Constable, Precinct No. 2",,REP,UNDER VOTES,15
+Angelina,7,"Constable, Precinct No. 2",,REP,UNDER VOTES,58
+Angelina,8,"Constable, Precinct No. 2",,REP,UNDER VOTES,61
+Angelina,21,"Constable, Precinct No. 2",,REP,UNDER VOTES,27
+Angelina,22,"Constable, Precinct No. 2",,REP,UNDER VOTES,35
+Angelina,23,"Constable, Precinct No. 2",,REP,UNDER VOTES,29
+Angelina,24,"Constable, Precinct No. 2",,REP,UNDER VOTES,108
+Angelina,25,"Constable, Precinct No. 2",,REP,UNDER VOTES,72
+Angelina,29,"Constable, Precinct No. 2",,REP,UNDER VOTES,57
+Angelina,36,"Constable, Precinct No. 2",,REP,UNDER VOTES,0
+Angelina,11,"Constable, Precinct No. 3",,REP,Chad Wilson,578
+Angelina,11B,"Constable, Precinct No. 3",,REP,Chad Wilson,213
+Angelina,17,"Constable, Precinct No. 3",,REP,Chad Wilson,364
+Angelina,17B,"Constable, Precinct No. 3",,REP,Chad Wilson,79
+Angelina,26,"Constable, Precinct No. 3",,REP,Chad Wilson,533
+Angelina,30,"Constable, Precinct No. 3",,REP,Chad Wilson,223
+Angelina,32,"Constable, Precinct No. 3",,REP,Chad Wilson,41
+Angelina,33,"Constable, Precinct No. 3",,REP,Chad Wilson,372
+Angelina,11,"Constable, Precinct No. 3",,REP,OVER VOTES,0
+Angelina,11B,"Constable, Precinct No. 3",,REP,OVER VOTES,0
+Angelina,17,"Constable, Precinct No. 3",,REP,OVER VOTES,0
+Angelina,17B,"Constable, Precinct No. 3",,REP,OVER VOTES,0
+Angelina,26,"Constable, Precinct No. 3",,REP,OVER VOTES,0
+Angelina,30,"Constable, Precinct No. 3",,REP,OVER VOTES,0
+Angelina,32,"Constable, Precinct No. 3",,REP,OVER VOTES,0
+Angelina,33,"Constable, Precinct No. 3",,REP,OVER VOTES,0
+Angelina,11,"Constable, Precinct No. 3",,REP,UNDER VOTES,135
+Angelina,11B,"Constable, Precinct No. 3",,REP,UNDER VOTES,63
+Angelina,17,"Constable, Precinct No. 3",,REP,UNDER VOTES,134
+Angelina,17B,"Constable, Precinct No. 3",,REP,UNDER VOTES,27
+Angelina,26,"Constable, Precinct No. 3",,REP,UNDER VOTES,128
+Angelina,30,"Constable, Precinct No. 3",,REP,UNDER VOTES,61
+Angelina,32,"Constable, Precinct No. 3",,REP,UNDER VOTES,7
+Angelina,33,"Constable, Precinct No. 3",,REP,UNDER VOTES,88
+Angelina,15,"Constable, Precinct No. 4",,REP,Ray Anthony,182
+Angelina,16,"Constable, Precinct No. 4",,REP,Ray Anthony,256
+Angelina,27,"Constable, Precinct No. 4",,REP,Ray Anthony,117
+Angelina,28,"Constable, Precinct No. 4",,REP,Ray Anthony,310
+Angelina,31,"Constable, Precinct No. 4",,REP,Ray Anthony,86
+Angelina,37,"Constable, Precinct No. 4",,REP,Ray Anthony,107
+Angelina,38,"Constable, Precinct No. 4",,REP,Ray Anthony,94
+Angelina,15,"Constable, Precinct No. 4",,REP,OVER VOTES,0
+Angelina,16,"Constable, Precinct No. 4",,REP,OVER VOTES,0
+Angelina,27,"Constable, Precinct No. 4",,REP,OVER VOTES,0
+Angelina,28,"Constable, Precinct No. 4",,REP,OVER VOTES,0
+Angelina,31,"Constable, Precinct No. 4",,REP,OVER VOTES,0
+Angelina,37,"Constable, Precinct No. 4",,REP,OVER VOTES,0
+Angelina,38,"Constable, Precinct No. 4",,REP,OVER VOTES,0
+Angelina,15,"Constable, Precinct No. 4",,REP,UNDER VOTES,22
+Angelina,16,"Constable, Precinct No. 4",,REP,UNDER VOTES,54
+Angelina,27,"Constable, Precinct No. 4",,REP,UNDER VOTES,19
+Angelina,28,"Constable, Precinct No. 4",,REP,UNDER VOTES,75
+Angelina,31,"Constable, Precinct No. 4",,REP,UNDER VOTES,9
+Angelina,37,"Constable, Precinct No. 4",,REP,UNDER VOTES,35
+Angelina,38,"Constable, Precinct No. 4",,REP,UNDER VOTES,22
+Angelina,1,County Chairman,,REP,Donald Baum,68
+Angelina,2,County Chairman,,REP,Donald Baum,129
+Angelina,3,County Chairman,,REP,Donald Baum,399
+Angelina,4,County Chairman,,REP,Donald Baum,177
+Angelina,5,County Chairman,,REP,Donald Baum,263
+Angelina,6,County Chairman,,REP,Donald Baum,108
+Angelina,7,County Chairman,,REP,Donald Baum,302
+Angelina,8,County Chairman,,REP,Donald Baum,350
+Angelina,9,County Chairman,,REP,Donald Baum,71
+Angelina,10,County Chairman,,REP,Donald Baum,174
+Angelina,11,County Chairman,,REP,Donald Baum,480
+Angelina,11B,County Chairman,,REP,Donald Baum,176
+Angelina,12,County Chairman,,REP,Donald Baum,214
+Angelina,13,County Chairman,,REP,Donald Baum,118
+Angelina,14,County Chairman,,REP,Donald Baum,408
+Angelina,15,County Chairman,,REP,Donald Baum,156
+Angelina,16,County Chairman,,REP,Donald Baum,204
+Angelina,17,County Chairman,,REP,Donald Baum,309
+Angelina,17B,County Chairman,,REP,Donald Baum,70
+Angelina,18,County Chairman,,REP,Donald Baum,126
+Angelina,19,County Chairman,,REP,Donald Baum,365
+Angelina,20,County Chairman,,REP,Donald Baum,69
+Angelina,21,County Chairman,,REP,Donald Baum,282
+Angelina,22,County Chairman,,REP,Donald Baum,249
+Angelina,23,County Chairman,,REP,Donald Baum,158
+Angelina,24,County Chairman,,REP,Donald Baum,449
+Angelina,25,County Chairman,,REP,Donald Baum,472
+Angelina,26,County Chairman,,REP,Donald Baum,493
+Angelina,27,County Chairman,,REP,Donald Baum,91
+Angelina,28,County Chairman,,REP,Donald Baum,271
+Angelina,29,County Chairman,,REP,Donald Baum,329
+Angelina,30,County Chairman,,REP,Donald Baum,190
+Angelina,31,County Chairman,,REP,Donald Baum,73
+Angelina,32,County Chairman,,REP,Donald Baum,37
+Angelina,33,County Chairman,,REP,Donald Baum,296
+Angelina,34,County Chairman,,REP,Donald Baum,508
+Angelina,35,County Chairman,,REP,Donald Baum,415
+Angelina,36,County Chairman,,REP,Donald Baum,1
+Angelina,37,County Chairman,,REP,Donald Baum,101
+Angelina,38,County Chairman,,REP,Donald Baum,84
+Angelina,39,County Chairman,,REP,Donald Baum,103
+Angelina,40,County Chairman,,REP,Donald Baum,158
+Angelina,1,County Chairman,,REP,OVER VOTES,0
+Angelina,2,County Chairman,,REP,OVER VOTES,0
+Angelina,3,County Chairman,,REP,OVER VOTES,0
+Angelina,4,County Chairman,,REP,OVER VOTES,0
+Angelina,5,County Chairman,,REP,OVER VOTES,0
+Angelina,6,County Chairman,,REP,OVER VOTES,0
+Angelina,7,County Chairman,,REP,OVER VOTES,0
+Angelina,8,County Chairman,,REP,OVER VOTES,0
+Angelina,9,County Chairman,,REP,OVER VOTES,0
+Angelina,10,County Chairman,,REP,OVER VOTES,0
+Angelina,11,County Chairman,,REP,OVER VOTES,0
+Angelina,11B,County Chairman,,REP,OVER VOTES,0
+Angelina,12,County Chairman,,REP,OVER VOTES,0
+Angelina,13,County Chairman,,REP,OVER VOTES,0
+Angelina,14,County Chairman,,REP,OVER VOTES,0
+Angelina,15,County Chairman,,REP,OVER VOTES,0
+Angelina,16,County Chairman,,REP,OVER VOTES,0
+Angelina,17,County Chairman,,REP,OVER VOTES,0
+Angelina,17B,County Chairman,,REP,OVER VOTES,0
+Angelina,18,County Chairman,,REP,OVER VOTES,0
+Angelina,19,County Chairman,,REP,OVER VOTES,0
+Angelina,20,County Chairman,,REP,OVER VOTES,0
+Angelina,21,County Chairman,,REP,OVER VOTES,0
+Angelina,22,County Chairman,,REP,OVER VOTES,0
+Angelina,23,County Chairman,,REP,OVER VOTES,0
+Angelina,24,County Chairman,,REP,OVER VOTES,0
+Angelina,25,County Chairman,,REP,OVER VOTES,0
+Angelina,26,County Chairman,,REP,OVER VOTES,0
+Angelina,27,County Chairman,,REP,OVER VOTES,0
+Angelina,28,County Chairman,,REP,OVER VOTES,0
+Angelina,29,County Chairman,,REP,OVER VOTES,0
+Angelina,30,County Chairman,,REP,OVER VOTES,0
+Angelina,31,County Chairman,,REP,OVER VOTES,0
+Angelina,32,County Chairman,,REP,OVER VOTES,0
+Angelina,33,County Chairman,,REP,OVER VOTES,0
+Angelina,34,County Chairman,,REP,OVER VOTES,0
+Angelina,35,County Chairman,,REP,OVER VOTES,0
+Angelina,36,County Chairman,,REP,OVER VOTES,0
+Angelina,37,County Chairman,,REP,OVER VOTES,0
+Angelina,38,County Chairman,,REP,OVER VOTES,0
+Angelina,39,County Chairman,,REP,OVER VOTES,0
+Angelina,40,County Chairman,,REP,OVER VOTES,0
+Angelina,1,County Chairman,,REP,UNDER VOTES,30
+Angelina,2,County Chairman,,REP,UNDER VOTES,56
+Angelina,3,County Chairman,,REP,UNDER VOTES,140
+Angelina,4,County Chairman,,REP,UNDER VOTES,78
+Angelina,5,County Chairman,,REP,UNDER VOTES,100
+Angelina,6,County Chairman,,REP,UNDER VOTES,45
+Angelina,7,County Chairman,,REP,UNDER VOTES,124
+Angelina,8,County Chairman,,REP,UNDER VOTES,132
+Angelina,9,County Chairman,,REP,UNDER VOTES,43
+Angelina,10,County Chairman,,REP,UNDER VOTES,69
+Angelina,11,County Chairman,,REP,UNDER VOTES,233
+Angelina,11B,County Chairman,,REP,UNDER VOTES,100
+Angelina,12,County Chairman,,REP,UNDER VOTES,71
+Angelina,13,County Chairman,,REP,UNDER VOTES,45
+Angelina,14,County Chairman,,REP,UNDER VOTES,200
+Angelina,15,County Chairman,,REP,UNDER VOTES,48
+Angelina,16,County Chairman,,REP,UNDER VOTES,106
+Angelina,17,County Chairman,,REP,UNDER VOTES,189
+Angelina,17B,County Chairman,,REP,UNDER VOTES,36
+Angelina,18,County Chairman,,REP,UNDER VOTES,45
+Angelina,19,County Chairman,,REP,UNDER VOTES,174
+Angelina,20,County Chairman,,REP,UNDER VOTES,28
+Angelina,21,County Chairman,,REP,UNDER VOTES,98
+Angelina,22,County Chairman,,REP,UNDER VOTES,105
+Angelina,23,County Chairman,,REP,UNDER VOTES,46
+Angelina,24,County Chairman,,REP,UNDER VOTES,216
+Angelina,25,County Chairman,,REP,UNDER VOTES,185
+Angelina,26,County Chairman,,REP,UNDER VOTES,168
+Angelina,27,County Chairman,,REP,UNDER VOTES,45
+Angelina,28,County Chairman,,REP,UNDER VOTES,114
+Angelina,29,County Chairman,,REP,UNDER VOTES,184
+Angelina,30,County Chairman,,REP,UNDER VOTES,94
+Angelina,31,County Chairman,,REP,UNDER VOTES,22
+Angelina,32,County Chairman,,REP,UNDER VOTES,11
+Angelina,33,County Chairman,,REP,UNDER VOTES,164
+Angelina,34,County Chairman,,REP,UNDER VOTES,236
+Angelina,35,County Chairman,,REP,UNDER VOTES,198
+Angelina,36,County Chairman,,REP,UNDER VOTES,0
+Angelina,37,County Chairman,,REP,UNDER VOTES,41
+Angelina,38,County Chairman,,REP,UNDER VOTES,32
+Angelina,39,County Chairman,,REP,UNDER VOTES,29
+Angelina,40,County Chairman,,REP,UNDER VOTES,59
+Angelina,1,Proposition 1,,REP,Yes,57
+Angelina,2,Proposition 1,,REP,Yes,120
+Angelina,3,Proposition 1,,REP,Yes,368
+Angelina,4,Proposition 1,,REP,Yes,180
+Angelina,5,Proposition 1,,REP,Yes,238
+Angelina,6,Proposition 1,,REP,Yes,101
+Angelina,7,Proposition 1,,REP,Yes,309
+Angelina,8,Proposition 1,,REP,Yes,330
+Angelina,9,Proposition 1,,REP,Yes,67
+Angelina,10,Proposition 1,,REP,Yes,162
+Angelina,11,Proposition 1,,REP,Yes,484
+Angelina,11B,Proposition 1,,REP,Yes,182
+Angelina,12,Proposition 1,,REP,Yes,198
+Angelina,13,Proposition 1,,REP,Yes,103
+Angelina,14,Proposition 1,,REP,Yes,410
+Angelina,15,Proposition 1,,REP,Yes,145
+Angelina,16,Proposition 1,,REP,Yes,209
+Angelina,17,Proposition 1,,REP,Yes,331
+Angelina,17B,Proposition 1,,REP,Yes,85
+Angelina,18,Proposition 1,,REP,Yes,117
+Angelina,19,Proposition 1,,REP,Yes,340
+Angelina,20,Proposition 1,,REP,Yes,63
+Angelina,21,Proposition 1,,REP,Yes,260
+Angelina,22,Proposition 1,,REP,Yes,242
+Angelina,23,Proposition 1,,REP,Yes,143
+Angelina,24,Proposition 1,,REP,Yes,455
+Angelina,25,Proposition 1,,REP,Yes,436
+Angelina,26,Proposition 1,,REP,Yes,458
+Angelina,27,Proposition 1,,REP,Yes,96
+Angelina,28,Proposition 1,,REP,Yes,265
+Angelina,29,Proposition 1,,REP,Yes,356
+Angelina,30,Proposition 1,,REP,Yes,182
+Angelina,31,Proposition 1,,REP,Yes,67
+Angelina,32,Proposition 1,,REP,Yes,36
+Angelina,33,Proposition 1,,REP,Yes,308
+Angelina,34,Proposition 1,,REP,Yes,478
+Angelina,35,Proposition 1,,REP,Yes,418
+Angelina,36,Proposition 1,,REP,Yes,1
+Angelina,37,Proposition 1,,REP,Yes,104
+Angelina,38,Proposition 1,,REP,Yes,89
+Angelina,39,Proposition 1,,REP,Yes,93
+Angelina,40,Proposition 1,,REP,Yes,144
+Angelina,1,Proposition 1,,REP,No,33
+Angelina,2,Proposition 1,,REP,No,47
+Angelina,3,Proposition 1,,REP,No,137
+Angelina,4,Proposition 1,,REP,No,55
+Angelina,5,Proposition 1,,REP,No,97
+Angelina,6,Proposition 1,,REP,No,37
+Angelina,7,Proposition 1,,REP,No,81
+Angelina,8,Proposition 1,,REP,No,107
+Angelina,9,Proposition 1,,REP,No,30
+Angelina,10,Proposition 1,,REP,No,60
+Angelina,11,Proposition 1,,REP,No,157
+Angelina,11B,Proposition 1,,REP,No,63
+Angelina,12,Proposition 1,,REP,No,67
+Angelina,13,Proposition 1,,REP,No,50
+Angelina,14,Proposition 1,,REP,No,147
+Angelina,15,Proposition 1,,REP,No,39
+Angelina,16,Proposition 1,,REP,No,72
+Angelina,17,Proposition 1,,REP,No,116
+Angelina,17B,Proposition 1,,REP,No,13
+Angelina,18,Proposition 1,,REP,No,43
+Angelina,19,Proposition 1,,REP,No,148
+Angelina,20,Proposition 1,,REP,No,22
+Angelina,21,Proposition 1,,REP,No,92
+Angelina,22,Proposition 1,,REP,No,86
+Angelina,23,Proposition 1,,REP,No,46
+Angelina,24,Proposition 1,,REP,No,156
+Angelina,25,Proposition 1,,REP,No,166
+Angelina,26,Proposition 1,,REP,No,144
+Angelina,27,Proposition 1,,REP,No,25
+Angelina,28,Proposition 1,,REP,No,99
+Angelina,29,Proposition 1,,REP,No,114
+Angelina,30,Proposition 1,,REP,No,70
+Angelina,31,Proposition 1,,REP,No,17
+Angelina,32,Proposition 1,,REP,No,10
+Angelina,33,Proposition 1,,REP,No,102
+Angelina,34,Proposition 1,,REP,No,202
+Angelina,35,Proposition 1,,REP,No,148
+Angelina,36,Proposition 1,,REP,No,0
+Angelina,37,Proposition 1,,REP,No,33
+Angelina,38,Proposition 1,,REP,No,20
+Angelina,39,Proposition 1,,REP,No,33
+Angelina,40,Proposition 1,,REP,No,60
+Angelina,1,Proposition 1,,REP,OVER VOTES,0
+Angelina,2,Proposition 1,,REP,OVER VOTES,0
+Angelina,3,Proposition 1,,REP,OVER VOTES,0
+Angelina,4,Proposition 1,,REP,OVER VOTES,0
+Angelina,5,Proposition 1,,REP,OVER VOTES,0
+Angelina,6,Proposition 1,,REP,OVER VOTES,0
+Angelina,7,Proposition 1,,REP,OVER VOTES,0
+Angelina,8,Proposition 1,,REP,OVER VOTES,0
+Angelina,9,Proposition 1,,REP,OVER VOTES,0
+Angelina,10,Proposition 1,,REP,OVER VOTES,0
+Angelina,11,Proposition 1,,REP,OVER VOTES,0
+Angelina,11B,Proposition 1,,REP,OVER VOTES,0
+Angelina,12,Proposition 1,,REP,OVER VOTES,0
+Angelina,13,Proposition 1,,REP,OVER VOTES,0
+Angelina,14,Proposition 1,,REP,OVER VOTES,0
+Angelina,15,Proposition 1,,REP,OVER VOTES,0
+Angelina,16,Proposition 1,,REP,OVER VOTES,0
+Angelina,17,Proposition 1,,REP,OVER VOTES,0
+Angelina,17B,Proposition 1,,REP,OVER VOTES,0
+Angelina,18,Proposition 1,,REP,OVER VOTES,0
+Angelina,19,Proposition 1,,REP,OVER VOTES,0
+Angelina,20,Proposition 1,,REP,OVER VOTES,0
+Angelina,21,Proposition 1,,REP,OVER VOTES,0
+Angelina,22,Proposition 1,,REP,OVER VOTES,0
+Angelina,23,Proposition 1,,REP,OVER VOTES,0
+Angelina,24,Proposition 1,,REP,OVER VOTES,0
+Angelina,25,Proposition 1,,REP,OVER VOTES,0
+Angelina,26,Proposition 1,,REP,OVER VOTES,0
+Angelina,27,Proposition 1,,REP,OVER VOTES,0
+Angelina,28,Proposition 1,,REP,OVER VOTES,0
+Angelina,29,Proposition 1,,REP,OVER VOTES,0
+Angelina,30,Proposition 1,,REP,OVER VOTES,0
+Angelina,31,Proposition 1,,REP,OVER VOTES,0
+Angelina,32,Proposition 1,,REP,OVER VOTES,0
+Angelina,33,Proposition 1,,REP,OVER VOTES,0
+Angelina,34,Proposition 1,,REP,OVER VOTES,0
+Angelina,35,Proposition 1,,REP,OVER VOTES,0
+Angelina,36,Proposition 1,,REP,OVER VOTES,0
+Angelina,37,Proposition 1,,REP,OVER VOTES,0
+Angelina,38,Proposition 1,,REP,OVER VOTES,0
+Angelina,39,Proposition 1,,REP,OVER VOTES,0
+Angelina,40,Proposition 1,,REP,OVER VOTES,0
+Angelina,1,Proposition 1,,REP,UNDER VOTES,8
+Angelina,2,Proposition 1,,REP,UNDER VOTES,18
+Angelina,3,Proposition 1,,REP,UNDER VOTES,34
+Angelina,4,Proposition 1,,REP,UNDER VOTES,20
+Angelina,5,Proposition 1,,REP,UNDER VOTES,28
+Angelina,6,Proposition 1,,REP,UNDER VOTES,15
+Angelina,7,Proposition 1,,REP,UNDER VOTES,36
+Angelina,8,Proposition 1,,REP,UNDER VOTES,45
+Angelina,9,Proposition 1,,REP,UNDER VOTES,17
+Angelina,10,Proposition 1,,REP,UNDER VOTES,21
+Angelina,11,Proposition 1,,REP,UNDER VOTES,72
+Angelina,11B,Proposition 1,,REP,UNDER VOTES,31
+Angelina,12,Proposition 1,,REP,UNDER VOTES,20
+Angelina,13,Proposition 1,,REP,UNDER VOTES,10
+Angelina,14,Proposition 1,,REP,UNDER VOTES,51
+Angelina,15,Proposition 1,,REP,UNDER VOTES,20
+Angelina,16,Proposition 1,,REP,UNDER VOTES,29
+Angelina,17,Proposition 1,,REP,UNDER VOTES,51
+Angelina,17B,Proposition 1,,REP,UNDER VOTES,8
+Angelina,18,Proposition 1,,REP,UNDER VOTES,11
+Angelina,19,Proposition 1,,REP,UNDER VOTES,51
+Angelina,20,Proposition 1,,REP,UNDER VOTES,12
+Angelina,21,Proposition 1,,REP,UNDER VOTES,28
+Angelina,22,Proposition 1,,REP,UNDER VOTES,26
+Angelina,23,Proposition 1,,REP,UNDER VOTES,15
+Angelina,24,Proposition 1,,REP,UNDER VOTES,54
+Angelina,25,Proposition 1,,REP,UNDER VOTES,55
+Angelina,26,Proposition 1,,REP,UNDER VOTES,59
+Angelina,27,Proposition 1,,REP,UNDER VOTES,15
+Angelina,28,Proposition 1,,REP,UNDER VOTES,21
+Angelina,29,Proposition 1,,REP,UNDER VOTES,43
+Angelina,30,Proposition 1,,REP,UNDER VOTES,32
+Angelina,31,Proposition 1,,REP,UNDER VOTES,11
+Angelina,32,Proposition 1,,REP,UNDER VOTES,2
+Angelina,33,Proposition 1,,REP,UNDER VOTES,50
+Angelina,34,Proposition 1,,REP,UNDER VOTES,64
+Angelina,35,Proposition 1,,REP,UNDER VOTES,47
+Angelina,36,Proposition 1,,REP,UNDER VOTES,0
+Angelina,37,Proposition 1,,REP,UNDER VOTES,5
+Angelina,38,Proposition 1,,REP,UNDER VOTES,7
+Angelina,39,Proposition 1,,REP,UNDER VOTES,6
+Angelina,40,Proposition 1,,REP,UNDER VOTES,13
+Angelina,1,Proposition 2,,REP,Yes,53
+Angelina,2,Proposition 2,,REP,Yes,96
+Angelina,3,Proposition 2,,REP,Yes,303
+Angelina,4,Proposition 2,,REP,Yes,125
+Angelina,5,Proposition 2,,REP,Yes,201
+Angelina,6,Proposition 2,,REP,Yes,82
+Angelina,7,Proposition 2,,REP,Yes,253
+Angelina,8,Proposition 2,,REP,Yes,278
+Angelina,9,Proposition 2,,REP,Yes,72
+Angelina,10,Proposition 2,,REP,Yes,140
+Angelina,11,Proposition 2,,REP,Yes,394
+Angelina,11B,Proposition 2,,REP,Yes,147
+Angelina,12,Proposition 2,,REP,Yes,152
+Angelina,13,Proposition 2,,REP,Yes,94
+Angelina,14,Proposition 2,,REP,Yes,351
+Angelina,15,Proposition 2,,REP,Yes,107
+Angelina,16,Proposition 2,,REP,Yes,167
+Angelina,17,Proposition 2,,REP,Yes,261
+Angelina,17B,Proposition 2,,REP,Yes,63
+Angelina,18,Proposition 2,,REP,Yes,109
+Angelina,19,Proposition 2,,REP,Yes,328
+Angelina,20,Proposition 2,,REP,Yes,52
+Angelina,21,Proposition 2,,REP,Yes,216
+Angelina,22,Proposition 2,,REP,Yes,210
+Angelina,23,Proposition 2,,REP,Yes,101
+Angelina,24,Proposition 2,,REP,Yes,346
+Angelina,25,Proposition 2,,REP,Yes,378
+Angelina,26,Proposition 2,,REP,Yes,377
+Angelina,27,Proposition 2,,REP,Yes,70
+Angelina,28,Proposition 2,,REP,Yes,225
+Angelina,29,Proposition 2,,REP,Yes,278
+Angelina,30,Proposition 2,,REP,Yes,154
+Angelina,31,Proposition 2,,REP,Yes,49
+Angelina,32,Proposition 2,,REP,Yes,22
+Angelina,33,Proposition 2,,REP,Yes,252
+Angelina,34,Proposition 2,,REP,Yes,483
+Angelina,35,Proposition 2,,REP,Yes,347
+Angelina,36,Proposition 2,,REP,Yes,1
+Angelina,37,Proposition 2,,REP,Yes,75
+Angelina,38,Proposition 2,,REP,Yes,64
+Angelina,39,Proposition 2,,REP,Yes,85
+Angelina,40,Proposition 2,,REP,Yes,130
+Angelina,1,Proposition 2,,REP,No,40
+Angelina,2,Proposition 2,,REP,No,83
+Angelina,3,Proposition 2,,REP,No,209
+Angelina,4,Proposition 2,,REP,No,115
+Angelina,5,Proposition 2,,REP,No,144
+Angelina,6,Proposition 2,,REP,No,58
+Angelina,7,Proposition 2,,REP,No,149
+Angelina,8,Proposition 2,,REP,No,167
+Angelina,9,Proposition 2,,REP,No,28
+Angelina,10,Proposition 2,,REP,No,93
+Angelina,11,Proposition 2,,REP,No,253
+Angelina,11B,Proposition 2,,REP,No,98
+Angelina,12,Proposition 2,,REP,No,118
+Angelina,13,Proposition 2,,REP,No,62
+Angelina,14,Proposition 2,,REP,No,216
+Angelina,15,Proposition 2,,REP,No,81
+Angelina,16,Proposition 2,,REP,No,121
+Angelina,17,Proposition 2,,REP,No,197
+Angelina,17B,Proposition 2,,REP,No,38
+Angelina,18,Proposition 2,,REP,No,53
+Angelina,19,Proposition 2,,REP,No,171
+Angelina,20,Proposition 2,,REP,No,37
+Angelina,21,Proposition 2,,REP,No,139
+Angelina,22,Proposition 2,,REP,No,120
+Angelina,23,Proposition 2,,REP,No,89
+Angelina,24,Proposition 2,,REP,No,270
+Angelina,25,Proposition 2,,REP,No,231
+Angelina,26,Proposition 2,,REP,No,236
+Angelina,27,Proposition 2,,REP,No,58
+Angelina,28,Proposition 2,,REP,No,146
+Angelina,29,Proposition 2,,REP,No,185
+Angelina,30,Proposition 2,,REP,No,107
+Angelina,31,Proposition 2,,REP,No,39
+Angelina,32,Proposition 2,,REP,No,23
+Angelina,33,Proposition 2,,REP,No,163
+Angelina,34,Proposition 2,,REP,No,216
+Angelina,35,Proposition 2,,REP,No,227
+Angelina,36,Proposition 2,,REP,No,0
+Angelina,37,Proposition 2,,REP,No,60
+Angelina,38,Proposition 2,,REP,No,40
+Angelina,39,Proposition 2,,REP,No,44
+Angelina,40,Proposition 2,,REP,No,77
+Angelina,1,Proposition 2,,REP,OVER VOTES,0
+Angelina,2,Proposition 2,,REP,OVER VOTES,0
+Angelina,3,Proposition 2,,REP,OVER VOTES,0
+Angelina,4,Proposition 2,,REP,OVER VOTES,0
+Angelina,5,Proposition 2,,REP,OVER VOTES,0
+Angelina,6,Proposition 2,,REP,OVER VOTES,0
+Angelina,7,Proposition 2,,REP,OVER VOTES,0
+Angelina,8,Proposition 2,,REP,OVER VOTES,0
+Angelina,9,Proposition 2,,REP,OVER VOTES,0
+Angelina,10,Proposition 2,,REP,OVER VOTES,0
+Angelina,11,Proposition 2,,REP,OVER VOTES,0
+Angelina,11B,Proposition 2,,REP,OVER VOTES,0
+Angelina,12,Proposition 2,,REP,OVER VOTES,0
+Angelina,13,Proposition 2,,REP,OVER VOTES,0
+Angelina,14,Proposition 2,,REP,OVER VOTES,0
+Angelina,15,Proposition 2,,REP,OVER VOTES,0
+Angelina,16,Proposition 2,,REP,OVER VOTES,0
+Angelina,17,Proposition 2,,REP,OVER VOTES,0
+Angelina,17B,Proposition 2,,REP,OVER VOTES,0
+Angelina,18,Proposition 2,,REP,OVER VOTES,0
+Angelina,19,Proposition 2,,REP,OVER VOTES,0
+Angelina,20,Proposition 2,,REP,OVER VOTES,0
+Angelina,21,Proposition 2,,REP,OVER VOTES,0
+Angelina,22,Proposition 2,,REP,OVER VOTES,0
+Angelina,23,Proposition 2,,REP,OVER VOTES,0
+Angelina,24,Proposition 2,,REP,OVER VOTES,0
+Angelina,25,Proposition 2,,REP,OVER VOTES,0
+Angelina,26,Proposition 2,,REP,OVER VOTES,0
+Angelina,27,Proposition 2,,REP,OVER VOTES,0
+Angelina,28,Proposition 2,,REP,OVER VOTES,0
+Angelina,29,Proposition 2,,REP,OVER VOTES,0
+Angelina,30,Proposition 2,,REP,OVER VOTES,0
+Angelina,31,Proposition 2,,REP,OVER VOTES,0
+Angelina,32,Proposition 2,,REP,OVER VOTES,0
+Angelina,33,Proposition 2,,REP,OVER VOTES,0
+Angelina,34,Proposition 2,,REP,OVER VOTES,0
+Angelina,35,Proposition 2,,REP,OVER VOTES,0
+Angelina,36,Proposition 2,,REP,OVER VOTES,0
+Angelina,37,Proposition 2,,REP,OVER VOTES,0
+Angelina,38,Proposition 2,,REP,OVER VOTES,0
+Angelina,39,Proposition 2,,REP,OVER VOTES,0
+Angelina,40,Proposition 2,,REP,OVER VOTES,0
+Angelina,1,Proposition 2,,REP,UNDER VOTES,5
+Angelina,2,Proposition 2,,REP,UNDER VOTES,6
+Angelina,3,Proposition 2,,REP,UNDER VOTES,27
+Angelina,4,Proposition 2,,REP,UNDER VOTES,15
+Angelina,5,Proposition 2,,REP,UNDER VOTES,18
+Angelina,6,Proposition 2,,REP,UNDER VOTES,13
+Angelina,7,Proposition 2,,REP,UNDER VOTES,24
+Angelina,8,Proposition 2,,REP,UNDER VOTES,37
+Angelina,9,Proposition 2,,REP,UNDER VOTES,14
+Angelina,10,Proposition 2,,REP,UNDER VOTES,10
+Angelina,11,Proposition 2,,REP,UNDER VOTES,66
+Angelina,11B,Proposition 2,,REP,UNDER VOTES,31
+Angelina,12,Proposition 2,,REP,UNDER VOTES,15
+Angelina,13,Proposition 2,,REP,UNDER VOTES,7
+Angelina,14,Proposition 2,,REP,UNDER VOTES,41
+Angelina,15,Proposition 2,,REP,UNDER VOTES,16
+Angelina,16,Proposition 2,,REP,UNDER VOTES,22
+Angelina,17,Proposition 2,,REP,UNDER VOTES,40
+Angelina,17B,Proposition 2,,REP,UNDER VOTES,5
+Angelina,18,Proposition 2,,REP,UNDER VOTES,9
+Angelina,19,Proposition 2,,REP,UNDER VOTES,40
+Angelina,20,Proposition 2,,REP,UNDER VOTES,8
+Angelina,21,Proposition 2,,REP,UNDER VOTES,25
+Angelina,22,Proposition 2,,REP,UNDER VOTES,24
+Angelina,23,Proposition 2,,REP,UNDER VOTES,14
+Angelina,24,Proposition 2,,REP,UNDER VOTES,49
+Angelina,25,Proposition 2,,REP,UNDER VOTES,48
+Angelina,26,Proposition 2,,REP,UNDER VOTES,48
+Angelina,27,Proposition 2,,REP,UNDER VOTES,8
+Angelina,28,Proposition 2,,REP,UNDER VOTES,14
+Angelina,29,Proposition 2,,REP,UNDER VOTES,50
+Angelina,30,Proposition 2,,REP,UNDER VOTES,23
+Angelina,31,Proposition 2,,REP,UNDER VOTES,7
+Angelina,32,Proposition 2,,REP,UNDER VOTES,3
+Angelina,33,Proposition 2,,REP,UNDER VOTES,45
+Angelina,34,Proposition 2,,REP,UNDER VOTES,45
+Angelina,35,Proposition 2,,REP,UNDER VOTES,39
+Angelina,36,Proposition 2,,REP,UNDER VOTES,0
+Angelina,37,Proposition 2,,REP,UNDER VOTES,7
+Angelina,38,Proposition 2,,REP,UNDER VOTES,12
+Angelina,39,Proposition 2,,REP,UNDER VOTES,3
+Angelina,40,Proposition 2,,REP,UNDER VOTES,10
+Angelina,1,Proposition 3,,REP,Yes,75
+Angelina,2,Proposition 3,,REP,Yes,141
+Angelina,3,Proposition 3,,REP,Yes,395
+Angelina,4,Proposition 3,,REP,Yes,198
+Angelina,5,Proposition 3,,REP,Yes,285
+Angelina,6,Proposition 3,,REP,Yes,105
+Angelina,7,Proposition 3,,REP,Yes,323
+Angelina,8,Proposition 3,,REP,Yes,359
+Angelina,9,Proposition 3,,REP,Yes,83
+Angelina,10,Proposition 3,,REP,Yes,185
+Angelina,11,Proposition 3,,REP,Yes,530
+Angelina,11B,Proposition 3,,REP,Yes,181
+Angelina,12,Proposition 3,,REP,Yes,223
+Angelina,13,Proposition 3,,REP,Yes,120
+Angelina,14,Proposition 3,,REP,Yes,462
+Angelina,15,Proposition 3,,REP,Yes,153
+Angelina,16,Proposition 3,,REP,Yes,230
+Angelina,17,Proposition 3,,REP,Yes,370
+Angelina,17B,Proposition 3,,REP,Yes,80
+Angelina,18,Proposition 3,,REP,Yes,124
+Angelina,19,Proposition 3,,REP,Yes,423
+Angelina,20,Proposition 3,,REP,Yes,71
+Angelina,21,Proposition 3,,REP,Yes,287
+Angelina,22,Proposition 3,,REP,Yes,269
+Angelina,23,Proposition 3,,REP,Yes,152
+Angelina,24,Proposition 3,,REP,Yes,472
+Angelina,25,Proposition 3,,REP,Yes,466
+Angelina,26,Proposition 3,,REP,Yes,478
+Angelina,27,Proposition 3,,REP,Yes,96
+Angelina,28,Proposition 3,,REP,Yes,292
+Angelina,29,Proposition 3,,REP,Yes,357
+Angelina,30,Proposition 3,,REP,Yes,211
+Angelina,31,Proposition 3,,REP,Yes,71
+Angelina,32,Proposition 3,,REP,Yes,38
+Angelina,33,Proposition 3,,REP,Yes,321
+Angelina,34,Proposition 3,,REP,Yes,579
+Angelina,35,Proposition 3,,REP,Yes,463
+Angelina,36,Proposition 3,,REP,Yes,1
+Angelina,37,Proposition 3,,REP,Yes,114
+Angelina,38,Proposition 3,,REP,Yes,82
+Angelina,39,Proposition 3,,REP,Yes,105
+Angelina,40,Proposition 3,,REP,Yes,171
+Angelina,1,Proposition 3,,REP,No,15
+Angelina,2,Proposition 3,,REP,No,33
+Angelina,3,Proposition 3,,REP,No,109
+Angelina,4,Proposition 3,,REP,No,41
+Angelina,5,Proposition 3,,REP,No,58
+Angelina,6,Proposition 3,,REP,No,34
+Angelina,7,Proposition 3,,REP,No,66
+Angelina,8,Proposition 3,,REP,No,71
+Angelina,9,Proposition 3,,REP,No,15
+Angelina,10,Proposition 3,,REP,No,42
+Angelina,11,Proposition 3,,REP,No,111
+Angelina,11B,Proposition 3,,REP,No,55
+Angelina,12,Proposition 3,,REP,No,43
+Angelina,13,Proposition 3,,REP,No,31
+Angelina,14,Proposition 3,,REP,No,95
+Angelina,15,Proposition 3,,REP,No,32
+Angelina,16,Proposition 3,,REP,No,55
+Angelina,17,Proposition 3,,REP,No,83
+Angelina,17B,Proposition 3,,REP,No,17
+Angelina,18,Proposition 3,,REP,No,35
+Angelina,19,Proposition 3,,REP,No,72
+Angelina,20,Proposition 3,,REP,No,20
+Angelina,21,Proposition 3,,REP,No,70
+Angelina,22,Proposition 3,,REP,No,58
+Angelina,23,Proposition 3,,REP,No,37
+Angelina,24,Proposition 3,,REP,No,125
+Angelina,25,Proposition 3,,REP,No,131
+Angelina,26,Proposition 3,,REP,No,116
+Angelina,27,Proposition 3,,REP,No,27
+Angelina,28,Proposition 3,,REP,No,65
+Angelina,29,Proposition 3,,REP,No,108
+Angelina,30,Proposition 3,,REP,No,40
+Angelina,31,Proposition 3,,REP,No,16
+Angelina,32,Proposition 3,,REP,No,5
+Angelina,33,Proposition 3,,REP,No,84
+Angelina,34,Proposition 3,,REP,No,111
+Angelina,35,Proposition 3,,REP,No,97
+Angelina,36,Proposition 3,,REP,No,0
+Angelina,37,Proposition 3,,REP,No,21
+Angelina,38,Proposition 3,,REP,No,20
+Angelina,39,Proposition 3,,REP,No,18
+Angelina,40,Proposition 3,,REP,No,33
+Angelina,1,Proposition 3,,REP,OVER VOTES,0
+Angelina,2,Proposition 3,,REP,OVER VOTES,0
+Angelina,3,Proposition 3,,REP,OVER VOTES,0
+Angelina,4,Proposition 3,,REP,OVER VOTES,0
+Angelina,5,Proposition 3,,REP,OVER VOTES,0
+Angelina,6,Proposition 3,,REP,OVER VOTES,0
+Angelina,7,Proposition 3,,REP,OVER VOTES,0
+Angelina,8,Proposition 3,,REP,OVER VOTES,0
+Angelina,9,Proposition 3,,REP,OVER VOTES,0
+Angelina,10,Proposition 3,,REP,OVER VOTES,0
+Angelina,11,Proposition 3,,REP,OVER VOTES,0
+Angelina,11B,Proposition 3,,REP,OVER VOTES,0
+Angelina,12,Proposition 3,,REP,OVER VOTES,0
+Angelina,13,Proposition 3,,REP,OVER VOTES,0
+Angelina,14,Proposition 3,,REP,OVER VOTES,0
+Angelina,15,Proposition 3,,REP,OVER VOTES,0
+Angelina,16,Proposition 3,,REP,OVER VOTES,0
+Angelina,17,Proposition 3,,REP,OVER VOTES,0
+Angelina,17B,Proposition 3,,REP,OVER VOTES,0
+Angelina,18,Proposition 3,,REP,OVER VOTES,0
+Angelina,19,Proposition 3,,REP,OVER VOTES,0
+Angelina,20,Proposition 3,,REP,OVER VOTES,0
+Angelina,21,Proposition 3,,REP,OVER VOTES,0
+Angelina,22,Proposition 3,,REP,OVER VOTES,0
+Angelina,23,Proposition 3,,REP,OVER VOTES,0
+Angelina,24,Proposition 3,,REP,OVER VOTES,0
+Angelina,25,Proposition 3,,REP,OVER VOTES,0
+Angelina,26,Proposition 3,,REP,OVER VOTES,0
+Angelina,27,Proposition 3,,REP,OVER VOTES,0
+Angelina,28,Proposition 3,,REP,OVER VOTES,0
+Angelina,29,Proposition 3,,REP,OVER VOTES,0
+Angelina,30,Proposition 3,,REP,OVER VOTES,0
+Angelina,31,Proposition 3,,REP,OVER VOTES,0
+Angelina,32,Proposition 3,,REP,OVER VOTES,0
+Angelina,33,Proposition 3,,REP,OVER VOTES,0
+Angelina,34,Proposition 3,,REP,OVER VOTES,0
+Angelina,35,Proposition 3,,REP,OVER VOTES,0
+Angelina,36,Proposition 3,,REP,OVER VOTES,0
+Angelina,37,Proposition 3,,REP,OVER VOTES,0
+Angelina,38,Proposition 3,,REP,OVER VOTES,0
+Angelina,39,Proposition 3,,REP,OVER VOTES,0
+Angelina,40,Proposition 3,,REP,OVER VOTES,0
+Angelina,1,Proposition 3,,REP,UNDER VOTES,8
+Angelina,2,Proposition 3,,REP,UNDER VOTES,11
+Angelina,3,Proposition 3,,REP,UNDER VOTES,35
+Angelina,4,Proposition 3,,REP,UNDER VOTES,16
+Angelina,5,Proposition 3,,REP,UNDER VOTES,20
+Angelina,6,Proposition 3,,REP,UNDER VOTES,14
+Angelina,7,Proposition 3,,REP,UNDER VOTES,37
+Angelina,8,Proposition 3,,REP,UNDER VOTES,52
+Angelina,9,Proposition 3,,REP,UNDER VOTES,16
+Angelina,10,Proposition 3,,REP,UNDER VOTES,16
+Angelina,11,Proposition 3,,REP,UNDER VOTES,72
+Angelina,11B,Proposition 3,,REP,UNDER VOTES,40
+Angelina,12,Proposition 3,,REP,UNDER VOTES,19
+Angelina,13,Proposition 3,,REP,UNDER VOTES,12
+Angelina,14,Proposition 3,,REP,UNDER VOTES,51
+Angelina,15,Proposition 3,,REP,UNDER VOTES,19
+Angelina,16,Proposition 3,,REP,UNDER VOTES,25
+Angelina,17,Proposition 3,,REP,UNDER VOTES,45
+Angelina,17B,Proposition 3,,REP,UNDER VOTES,9
+Angelina,18,Proposition 3,,REP,UNDER VOTES,12
+Angelina,19,Proposition 3,,REP,UNDER VOTES,44
+Angelina,20,Proposition 3,,REP,UNDER VOTES,6
+Angelina,21,Proposition 3,,REP,UNDER VOTES,23
+Angelina,22,Proposition 3,,REP,UNDER VOTES,27
+Angelina,23,Proposition 3,,REP,UNDER VOTES,15
+Angelina,24,Proposition 3,,REP,UNDER VOTES,68
+Angelina,25,Proposition 3,,REP,UNDER VOTES,60
+Angelina,26,Proposition 3,,REP,UNDER VOTES,67
+Angelina,27,Proposition 3,,REP,UNDER VOTES,13
+Angelina,28,Proposition 3,,REP,UNDER VOTES,28
+Angelina,29,Proposition 3,,REP,UNDER VOTES,48
+Angelina,30,Proposition 3,,REP,UNDER VOTES,33
+Angelina,31,Proposition 3,,REP,UNDER VOTES,8
+Angelina,32,Proposition 3,,REP,UNDER VOTES,5
+Angelina,33,Proposition 3,,REP,UNDER VOTES,55
+Angelina,34,Proposition 3,,REP,UNDER VOTES,54
+Angelina,35,Proposition 3,,REP,UNDER VOTES,53
+Angelina,36,Proposition 3,,REP,UNDER VOTES,0
+Angelina,37,Proposition 3,,REP,UNDER VOTES,7
+Angelina,38,Proposition 3,,REP,UNDER VOTES,14
+Angelina,39,Proposition 3,,REP,UNDER VOTES,9
+Angelina,40,Proposition 3,,REP,UNDER VOTES,13
+Angelina,1,Proposition 4,,REP,Yes,85
+Angelina,2,Proposition 4,,REP,Yes,169
+Angelina,3,Proposition 4,,REP,Yes,470
+Angelina,4,Proposition 4,,REP,Yes,230
+Angelina,5,Proposition 4,,REP,Yes,319
+Angelina,6,Proposition 4,,REP,Yes,127
+Angelina,7,Proposition 4,,REP,Yes,373
+Angelina,8,Proposition 4,,REP,Yes,430
+Angelina,9,Proposition 4,,REP,Yes,97
+Angelina,10,Proposition 4,,REP,Yes,217
+Angelina,11,Proposition 4,,REP,Yes,612
+Angelina,11B,Proposition 4,,REP,Yes,226
+Angelina,12,Proposition 4,,REP,Yes,261
+Angelina,13,Proposition 4,,REP,Yes,141
+Angelina,14,Proposition 4,,REP,Yes,530
+Angelina,15,Proposition 4,,REP,Yes,178
+Angelina,16,Proposition 4,,REP,Yes,253
+Angelina,17,Proposition 4,,REP,Yes,422
+Angelina,17B,Proposition 4,,REP,Yes,90
+Angelina,18,Proposition 4,,REP,Yes,147
+Angelina,19,Proposition 4,,REP,Yes,480
+Angelina,20,Proposition 4,,REP,Yes,83
+Angelina,21,Proposition 4,,REP,Yes,337
+Angelina,22,Proposition 4,,REP,Yes,318
+Angelina,23,Proposition 4,,REP,Yes,181
+Angelina,24,Proposition 4,,REP,Yes,571
+Angelina,25,Proposition 4,,REP,Yes,568
+Angelina,26,Proposition 4,,REP,Yes,577
+Angelina,27,Proposition 4,,REP,Yes,115
+Angelina,28,Proposition 4,,REP,Yes,347
+Angelina,29,Proposition 4,,REP,Yes,433
+Angelina,30,Proposition 4,,REP,Yes,241
+Angelina,31,Proposition 4,,REP,Yes,81
+Angelina,32,Proposition 4,,REP,Yes,41
+Angelina,33,Proposition 4,,REP,Yes,383
+Angelina,34,Proposition 4,,REP,Yes,668
+Angelina,35,Proposition 4,,REP,Yes,539
+Angelina,36,Proposition 4,,REP,Yes,1
+Angelina,37,Proposition 4,,REP,Yes,129
+Angelina,38,Proposition 4,,REP,Yes,100
+Angelina,39,Proposition 4,,REP,Yes,117
+Angelina,40,Proposition 4,,REP,Yes,199
+Angelina,1,Proposition 4,,REP,No,4
+Angelina,2,Proposition 4,,REP,No,6
+Angelina,3,Proposition 4,,REP,No,32
+Angelina,4,Proposition 4,,REP,No,8
+Angelina,5,Proposition 4,,REP,No,15
+Angelina,6,Proposition 4,,REP,No,11
+Angelina,7,Proposition 4,,REP,No,15
+Angelina,8,Proposition 4,,REP,No,11
+Angelina,9,Proposition 4,,REP,No,5
+Angelina,10,Proposition 4,,REP,No,9
+Angelina,11,Proposition 4,,REP,No,22
+Angelina,11B,Proposition 4,,REP,No,15
+Angelina,12,Proposition 4,,REP,No,3
+Angelina,13,Proposition 4,,REP,No,8
+Angelina,14,Proposition 4,,REP,No,30
+Angelina,15,Proposition 4,,REP,No,8
+Angelina,16,Proposition 4,,REP,No,23
+Angelina,17,Proposition 4,,REP,No,23
+Angelina,17B,Proposition 4,,REP,No,8
+Angelina,18,Proposition 4,,REP,No,12
+Angelina,19,Proposition 4,,REP,No,20
+Angelina,20,Proposition 4,,REP,No,6
+Angelina,21,Proposition 4,,REP,No,17
+Angelina,22,Proposition 4,,REP,No,12
+Angelina,23,Proposition 4,,REP,No,10
+Angelina,24,Proposition 4,,REP,No,30
+Angelina,25,Proposition 4,,REP,No,31
+Angelina,26,Proposition 4,,REP,No,20
+Angelina,27,Proposition 4,,REP,No,8
+Angelina,28,Proposition 4,,REP,No,14
+Angelina,29,Proposition 4,,REP,No,35
+Angelina,30,Proposition 4,,REP,No,10
+Angelina,31,Proposition 4,,REP,No,5
+Angelina,32,Proposition 4,,REP,No,4
+Angelina,33,Proposition 4,,REP,No,23
+Angelina,34,Proposition 4,,REP,No,33
+Angelina,35,Proposition 4,,REP,No,21
+Angelina,36,Proposition 4,,REP,No,0
+Angelina,37,Proposition 4,,REP,No,5
+Angelina,38,Proposition 4,,REP,No,2
+Angelina,39,Proposition 4,,REP,No,10
+Angelina,40,Proposition 4,,REP,No,7
+Angelina,1,Proposition 4,,REP,OVER VOTES,0
+Angelina,2,Proposition 4,,REP,OVER VOTES,0
+Angelina,3,Proposition 4,,REP,OVER VOTES,0
+Angelina,4,Proposition 4,,REP,OVER VOTES,0
+Angelina,5,Proposition 4,,REP,OVER VOTES,0
+Angelina,6,Proposition 4,,REP,OVER VOTES,0
+Angelina,7,Proposition 4,,REP,OVER VOTES,0
+Angelina,8,Proposition 4,,REP,OVER VOTES,0
+Angelina,9,Proposition 4,,REP,OVER VOTES,0
+Angelina,10,Proposition 4,,REP,OVER VOTES,0
+Angelina,11,Proposition 4,,REP,OVER VOTES,0
+Angelina,11B,Proposition 4,,REP,OVER VOTES,0
+Angelina,12,Proposition 4,,REP,OVER VOTES,0
+Angelina,13,Proposition 4,,REP,OVER VOTES,0
+Angelina,14,Proposition 4,,REP,OVER VOTES,0
+Angelina,15,Proposition 4,,REP,OVER VOTES,0
+Angelina,16,Proposition 4,,REP,OVER VOTES,0
+Angelina,17,Proposition 4,,REP,OVER VOTES,0
+Angelina,17B,Proposition 4,,REP,OVER VOTES,0
+Angelina,18,Proposition 4,,REP,OVER VOTES,0
+Angelina,19,Proposition 4,,REP,OVER VOTES,0
+Angelina,20,Proposition 4,,REP,OVER VOTES,0
+Angelina,21,Proposition 4,,REP,OVER VOTES,0
+Angelina,22,Proposition 4,,REP,OVER VOTES,0
+Angelina,23,Proposition 4,,REP,OVER VOTES,0
+Angelina,24,Proposition 4,,REP,OVER VOTES,0
+Angelina,25,Proposition 4,,REP,OVER VOTES,0
+Angelina,26,Proposition 4,,REP,OVER VOTES,0
+Angelina,27,Proposition 4,,REP,OVER VOTES,0
+Angelina,28,Proposition 4,,REP,OVER VOTES,0
+Angelina,29,Proposition 4,,REP,OVER VOTES,0
+Angelina,30,Proposition 4,,REP,OVER VOTES,0
+Angelina,31,Proposition 4,,REP,OVER VOTES,0
+Angelina,32,Proposition 4,,REP,OVER VOTES,0
+Angelina,33,Proposition 4,,REP,OVER VOTES,0
+Angelina,34,Proposition 4,,REP,OVER VOTES,0
+Angelina,35,Proposition 4,,REP,OVER VOTES,0
+Angelina,36,Proposition 4,,REP,OVER VOTES,0
+Angelina,37,Proposition 4,,REP,OVER VOTES,0
+Angelina,38,Proposition 4,,REP,OVER VOTES,0
+Angelina,39,Proposition 4,,REP,OVER VOTES,0
+Angelina,40,Proposition 4,,REP,OVER VOTES,0
+Angelina,1,Proposition 4,,REP,UNDER VOTES,9
+Angelina,2,Proposition 4,,REP,UNDER VOTES,10
+Angelina,3,Proposition 4,,REP,UNDER VOTES,37
+Angelina,4,Proposition 4,,REP,UNDER VOTES,17
+Angelina,5,Proposition 4,,REP,UNDER VOTES,29
+Angelina,6,Proposition 4,,REP,UNDER VOTES,15
+Angelina,7,Proposition 4,,REP,UNDER VOTES,38
+Angelina,8,Proposition 4,,REP,UNDER VOTES,41
+Angelina,9,Proposition 4,,REP,UNDER VOTES,12
+Angelina,10,Proposition 4,,REP,UNDER VOTES,17
+Angelina,11,Proposition 4,,REP,UNDER VOTES,79
+Angelina,11B,Proposition 4,,REP,UNDER VOTES,35
+Angelina,12,Proposition 4,,REP,UNDER VOTES,21
+Angelina,13,Proposition 4,,REP,UNDER VOTES,14
+Angelina,14,Proposition 4,,REP,UNDER VOTES,48
+Angelina,15,Proposition 4,,REP,UNDER VOTES,18
+Angelina,16,Proposition 4,,REP,UNDER VOTES,34
+Angelina,17,Proposition 4,,REP,UNDER VOTES,53
+Angelina,17B,Proposition 4,,REP,UNDER VOTES,8
+Angelina,18,Proposition 4,,REP,UNDER VOTES,12
+Angelina,19,Proposition 4,,REP,UNDER VOTES,39
+Angelina,20,Proposition 4,,REP,UNDER VOTES,8
+Angelina,21,Proposition 4,,REP,UNDER VOTES,26
+Angelina,22,Proposition 4,,REP,UNDER VOTES,24
+Angelina,23,Proposition 4,,REP,UNDER VOTES,13
+Angelina,24,Proposition 4,,REP,UNDER VOTES,64
+Angelina,25,Proposition 4,,REP,UNDER VOTES,58
+Angelina,26,Proposition 4,,REP,UNDER VOTES,64
+Angelina,27,Proposition 4,,REP,UNDER VOTES,13
+Angelina,28,Proposition 4,,REP,UNDER VOTES,24
+Angelina,29,Proposition 4,,REP,UNDER VOTES,45
+Angelina,30,Proposition 4,,REP,UNDER VOTES,33
+Angelina,31,Proposition 4,,REP,UNDER VOTES,9
+Angelina,32,Proposition 4,,REP,UNDER VOTES,3
+Angelina,33,Proposition 4,,REP,UNDER VOTES,54
+Angelina,34,Proposition 4,,REP,UNDER VOTES,43
+Angelina,35,Proposition 4,,REP,UNDER VOTES,53
+Angelina,36,Proposition 4,,REP,UNDER VOTES,0
+Angelina,37,Proposition 4,,REP,UNDER VOTES,8
+Angelina,38,Proposition 4,,REP,UNDER VOTES,14
+Angelina,39,Proposition 4,,REP,UNDER VOTES,5
+Angelina,40,Proposition 4,,REP,UNDER VOTES,11
+Angelina,1,President,,DEM,Martin J. O'Malley,1
+Angelina,2,President,,DEM,Martin J. O'Malley,1
+Angelina,3,President,,DEM,Martin J. O'Malley,1
+Angelina,4,President,,DEM,Martin J. O'Malley,1
+Angelina,5,President,,DEM,Martin J. O'Malley,2
+Angelina,6,President,,DEM,Martin J. O'Malley,0
+Angelina,7,President,,DEM,Martin J. O'Malley,1
+Angelina,8,President,,DEM,Martin J. O'Malley,0
+Angelina,9,President,,DEM,Martin J. O'Malley,0
+Angelina,10,President,,DEM,Martin J. O'Malley,2
+Angelina,11,President,,DEM,Martin J. O'Malley,0
+Angelina,11B,President,,DEM,Martin J. O'Malley,1
+Angelina,12,President,,DEM,Martin J. O'Malley,0
+Angelina,13,President,,DEM,Martin J. O'Malley,0
+Angelina,14,President,,DEM,Martin J. O'Malley,0
+Angelina,15,President,,DEM,Martin J. O'Malley,0
+Angelina,16,President,,DEM,Martin J. O'Malley,0
+Angelina,17,President,,DEM,Martin J. O'Malley,1
+Angelina,17B,President,,DEM,Martin J. O'Malley,0
+Angelina,18,President,,DEM,Martin J. O'Malley,0
+Angelina,19,President,,DEM,Martin J. O'Malley,0
+Angelina,20,President,,DEM,Martin J. O'Malley,1
+Angelina,21,President,,DEM,Martin J. O'Malley,2
+Angelina,22,President,,DEM,Martin J. O'Malley,2
+Angelina,23,President,,DEM,Martin J. O'Malley,0
+Angelina,24,President,,DEM,Martin J. O'Malley,0
+Angelina,25,President,,DEM,Martin J. O'Malley,0
+Angelina,26,President,,DEM,Martin J. O'Malley,0
+Angelina,27,President,,DEM,Martin J. O'Malley,0
+Angelina,28,President,,DEM,Martin J. O'Malley,0
+Angelina,29,President,,DEM,Martin J. O'Malley,0
+Angelina,30,President,,DEM,Martin J. O'Malley,0
+Angelina,31,President,,DEM,Martin J. O'Malley,1
+Angelina,32,President,,DEM,Martin J. O'Malley,0
+Angelina,33,President,,DEM,Martin J. O'Malley,0
+Angelina,34,President,,DEM,Martin J. O'Malley,0
+Angelina,35,President,,DEM,Martin J. O'Malley,1
+Angelina,36,President,,DEM,Martin J. O'Malley,0
+Angelina,37,President,,DEM,Martin J. O'Malley,0
+Angelina,38,President,,DEM,Martin J. O'Malley,0
+Angelina,39,President,,DEM,Martin J. O'Malley,0
+Angelina,40,President,,DEM,Martin J. O'Malley,1
+Angelina,1,President,,DEM,Hillary Clinton,26
+Angelina,2,President,,DEM,Hillary Clinton,226
+Angelina,3,President,,DEM,Hillary Clinton,55
+Angelina,4,President,,DEM,Hillary Clinton,78
+Angelina,5,President,,DEM,Hillary Clinton,85
+Angelina,6,President,,DEM,Hillary Clinton,15
+Angelina,7,President,,DEM,Hillary Clinton,11
+Angelina,8,President,,DEM,Hillary Clinton,18
+Angelina,9,President,,DEM,Hillary Clinton,10
+Angelina,10,President,,DEM,Hillary Clinton,96
+Angelina,11,President,,DEM,Hillary Clinton,38
+Angelina,11B,President,,DEM,Hillary Clinton,26
+Angelina,12,President,,DEM,Hillary Clinton,21
+Angelina,13,President,,DEM,Hillary Clinton,30
+Angelina,14,President,,DEM,Hillary Clinton,79
+Angelina,15,President,,DEM,Hillary Clinton,11
+Angelina,16,President,,DEM,Hillary Clinton,108
+Angelina,17,President,,DEM,Hillary Clinton,44
+Angelina,17B,President,,DEM,Hillary Clinton,12
+Angelina,18,President,,DEM,Hillary Clinton,21
+Angelina,19,President,,DEM,Hillary Clinton,64
+Angelina,20,President,,DEM,Hillary Clinton,326
+Angelina,21,President,,DEM,Hillary Clinton,46
+Angelina,22,President,,DEM,Hillary Clinton,33
+Angelina,23,President,,DEM,Hillary Clinton,7
+Angelina,24,President,,DEM,Hillary Clinton,43
+Angelina,25,President,,DEM,Hillary Clinton,57
+Angelina,26,President,,DEM,Hillary Clinton,38
+Angelina,27,President,,DEM,Hillary Clinton,12
+Angelina,28,President,,DEM,Hillary Clinton,26
+Angelina,29,President,,DEM,Hillary Clinton,35
+Angelina,30,President,,DEM,Hillary Clinton,12
+Angelina,31,President,,DEM,Hillary Clinton,15
+Angelina,32,President,,DEM,Hillary Clinton,1
+Angelina,33,President,,DEM,Hillary Clinton,13
+Angelina,34,President,,DEM,Hillary Clinton,64
+Angelina,35,President,,DEM,Hillary Clinton,66
+Angelina,36,President,,DEM,Hillary Clinton,0
+Angelina,37,President,,DEM,Hillary Clinton,15
+Angelina,38,President,,DEM,Hillary Clinton,6
+Angelina,39,President,,DEM,Hillary Clinton,24
+Angelina,40,President,,DEM,Hillary Clinton,40
+Angelina,1,President,,DEM,Keith Judd,0
+Angelina,2,President,,DEM,Keith Judd,0
+Angelina,3,President,,DEM,Keith Judd,0
+Angelina,4,President,,DEM,Keith Judd,1
+Angelina,5,President,,DEM,Keith Judd,0
+Angelina,6,President,,DEM,Keith Judd,1
+Angelina,7,President,,DEM,Keith Judd,0
+Angelina,8,President,,DEM,Keith Judd,0
+Angelina,9,President,,DEM,Keith Judd,0
+Angelina,10,President,,DEM,Keith Judd,0
+Angelina,11,President,,DEM,Keith Judd,0
+Angelina,11B,President,,DEM,Keith Judd,0
+Angelina,12,President,,DEM,Keith Judd,2
+Angelina,13,President,,DEM,Keith Judd,0
+Angelina,14,President,,DEM,Keith Judd,0
+Angelina,15,President,,DEM,Keith Judd,0
+Angelina,16,President,,DEM,Keith Judd,0
+Angelina,17,President,,DEM,Keith Judd,0
+Angelina,17B,President,,DEM,Keith Judd,0
+Angelina,18,President,,DEM,Keith Judd,0
+Angelina,19,President,,DEM,Keith Judd,0
+Angelina,20,President,,DEM,Keith Judd,3
+Angelina,21,President,,DEM,Keith Judd,0
+Angelina,22,President,,DEM,Keith Judd,0
+Angelina,23,President,,DEM,Keith Judd,0
+Angelina,24,President,,DEM,Keith Judd,0
+Angelina,25,President,,DEM,Keith Judd,0
+Angelina,26,President,,DEM,Keith Judd,1
+Angelina,27,President,,DEM,Keith Judd,0
+Angelina,28,President,,DEM,Keith Judd,0
+Angelina,29,President,,DEM,Keith Judd,0
+Angelina,30,President,,DEM,Keith Judd,0
+Angelina,31,President,,DEM,Keith Judd,1
+Angelina,32,President,,DEM,Keith Judd,0
+Angelina,33,President,,DEM,Keith Judd,0
+Angelina,34,President,,DEM,Keith Judd,0
+Angelina,35,President,,DEM,Keith Judd,0
+Angelina,36,President,,DEM,Keith Judd,0
+Angelina,37,President,,DEM,Keith Judd,0
+Angelina,38,President,,DEM,Keith Judd,0
+Angelina,39,President,,DEM,Keith Judd,0
+Angelina,40,President,,DEM,Keith Judd,0
+Angelina,1,President,,DEM,Star Locke,0
+Angelina,2,President,,DEM,Star Locke,0
+Angelina,3,President,,DEM,Star Locke,0
+Angelina,4,President,,DEM,Star Locke,0
+Angelina,5,President,,DEM,Star Locke,0
+Angelina,6,President,,DEM,Star Locke,0
+Angelina,7,President,,DEM,Star Locke,0
+Angelina,8,President,,DEM,Star Locke,0
+Angelina,9,President,,DEM,Star Locke,0
+Angelina,10,President,,DEM,Star Locke,0
+Angelina,11,President,,DEM,Star Locke,1
+Angelina,11B,President,,DEM,Star Locke,0
+Angelina,12,President,,DEM,Star Locke,0
+Angelina,13,President,,DEM,Star Locke,0
+Angelina,14,President,,DEM,Star Locke,0
+Angelina,15,President,,DEM,Star Locke,0
+Angelina,16,President,,DEM,Star Locke,0
+Angelina,17,President,,DEM,Star Locke,0
+Angelina,17B,President,,DEM,Star Locke,0
+Angelina,18,President,,DEM,Star Locke,0
+Angelina,19,President,,DEM,Star Locke,0
+Angelina,20,President,,DEM,Star Locke,3
+Angelina,21,President,,DEM,Star Locke,0
+Angelina,22,President,,DEM,Star Locke,0
+Angelina,23,President,,DEM,Star Locke,0
+Angelina,24,President,,DEM,Star Locke,0
+Angelina,25,President,,DEM,Star Locke,0
+Angelina,26,President,,DEM,Star Locke,1
+Angelina,27,President,,DEM,Star Locke,0
+Angelina,28,President,,DEM,Star Locke,0
+Angelina,29,President,,DEM,Star Locke,0
+Angelina,30,President,,DEM,Star Locke,0
+Angelina,31,President,,DEM,Star Locke,0
+Angelina,32,President,,DEM,Star Locke,0
+Angelina,33,President,,DEM,Star Locke,0
+Angelina,34,President,,DEM,Star Locke,0
+Angelina,35,President,,DEM,Star Locke,0
+Angelina,36,President,,DEM,Star Locke,0
+Angelina,37,President,,DEM,Star Locke,0
+Angelina,38,President,,DEM,Star Locke,0
+Angelina,39,President,,DEM,Star Locke,0
+Angelina,40,President,,DEM,Star Locke,0
+Angelina,1,President,,DEM,Calvis L. Hawes,0
+Angelina,2,President,,DEM,Calvis L. Hawes,0
+Angelina,3,President,,DEM,Calvis L. Hawes,0
+Angelina,4,President,,DEM,Calvis L. Hawes,1
+Angelina,5,President,,DEM,Calvis L. Hawes,0
+Angelina,6,President,,DEM,Calvis L. Hawes,0
+Angelina,7,President,,DEM,Calvis L. Hawes,0
+Angelina,8,President,,DEM,Calvis L. Hawes,0
+Angelina,9,President,,DEM,Calvis L. Hawes,0
+Angelina,10,President,,DEM,Calvis L. Hawes,0
+Angelina,11,President,,DEM,Calvis L. Hawes,0
+Angelina,11B,President,,DEM,Calvis L. Hawes,0
+Angelina,12,President,,DEM,Calvis L. Hawes,0
+Angelina,13,President,,DEM,Calvis L. Hawes,0
+Angelina,14,President,,DEM,Calvis L. Hawes,0
+Angelina,15,President,,DEM,Calvis L. Hawes,0
+Angelina,16,President,,DEM,Calvis L. Hawes,0
+Angelina,17,President,,DEM,Calvis L. Hawes,0
+Angelina,17B,President,,DEM,Calvis L. Hawes,0
+Angelina,18,President,,DEM,Calvis L. Hawes,0
+Angelina,19,President,,DEM,Calvis L. Hawes,0
+Angelina,20,President,,DEM,Calvis L. Hawes,2
+Angelina,21,President,,DEM,Calvis L. Hawes,0
+Angelina,22,President,,DEM,Calvis L. Hawes,0
+Angelina,23,President,,DEM,Calvis L. Hawes,0
+Angelina,24,President,,DEM,Calvis L. Hawes,0
+Angelina,25,President,,DEM,Calvis L. Hawes,0
+Angelina,26,President,,DEM,Calvis L. Hawes,0
+Angelina,27,President,,DEM,Calvis L. Hawes,0
+Angelina,28,President,,DEM,Calvis L. Hawes,0
+Angelina,29,President,,DEM,Calvis L. Hawes,0
+Angelina,30,President,,DEM,Calvis L. Hawes,0
+Angelina,31,President,,DEM,Calvis L. Hawes,0
+Angelina,32,President,,DEM,Calvis L. Hawes,0
+Angelina,33,President,,DEM,Calvis L. Hawes,0
+Angelina,34,President,,DEM,Calvis L. Hawes,0
+Angelina,35,President,,DEM,Calvis L. Hawes,0
+Angelina,36,President,,DEM,Calvis L. Hawes,0
+Angelina,37,President,,DEM,Calvis L. Hawes,0
+Angelina,38,President,,DEM,Calvis L. Hawes,0
+Angelina,39,President,,DEM,Calvis L. Hawes,0
+Angelina,40,President,,DEM,Calvis L. Hawes,0
+Angelina,1,President,,DEM,Bernie Sanders,4
+Angelina,2,President,,DEM,Bernie Sanders,31
+Angelina,3,President,,DEM,Bernie Sanders,18
+Angelina,4,President,,DEM,Bernie Sanders,10
+Angelina,5,President,,DEM,Bernie Sanders,41
+Angelina,6,President,,DEM,Bernie Sanders,4
+Angelina,7,President,,DEM,Bernie Sanders,8
+Angelina,8,President,,DEM,Bernie Sanders,6
+Angelina,9,President,,DEM,Bernie Sanders,5
+Angelina,10,President,,DEM,Bernie Sanders,10
+Angelina,11,President,,DEM,Bernie Sanders,11
+Angelina,11B,President,,DEM,Bernie Sanders,20
+Angelina,12,President,,DEM,Bernie Sanders,13
+Angelina,13,President,,DEM,Bernie Sanders,7
+Angelina,14,President,,DEM,Bernie Sanders,33
+Angelina,15,President,,DEM,Bernie Sanders,3
+Angelina,16,President,,DEM,Bernie Sanders,21
+Angelina,17,President,,DEM,Bernie Sanders,18
+Angelina,17B,President,,DEM,Bernie Sanders,6
+Angelina,18,President,,DEM,Bernie Sanders,14
+Angelina,19,President,,DEM,Bernie Sanders,36
+Angelina,20,President,,DEM,Bernie Sanders,28
+Angelina,21,President,,DEM,Bernie Sanders,14
+Angelina,22,President,,DEM,Bernie Sanders,17
+Angelina,23,President,,DEM,Bernie Sanders,10
+Angelina,24,President,,DEM,Bernie Sanders,33
+Angelina,25,President,,DEM,Bernie Sanders,31
+Angelina,26,President,,DEM,Bernie Sanders,15
+Angelina,27,President,,DEM,Bernie Sanders,6
+Angelina,28,President,,DEM,Bernie Sanders,13
+Angelina,29,President,,DEM,Bernie Sanders,16
+Angelina,30,President,,DEM,Bernie Sanders,8
+Angelina,31,President,,DEM,Bernie Sanders,3
+Angelina,32,President,,DEM,Bernie Sanders,3
+Angelina,33,President,,DEM,Bernie Sanders,12
+Angelina,34,President,,DEM,Bernie Sanders,32
+Angelina,35,President,,DEM,Bernie Sanders,21
+Angelina,36,President,,DEM,Bernie Sanders,0
+Angelina,37,President,,DEM,Bernie Sanders,14
+Angelina,38,President,,DEM,Bernie Sanders,8
+Angelina,39,President,,DEM,Bernie Sanders,6
+Angelina,40,President,,DEM,Bernie Sanders,13
+Angelina,1,President,,DEM,"Roque ""Rocky"" De La Fuente",0
+Angelina,2,President,,DEM,"Roque ""Rocky"" De La Fuente",0
+Angelina,3,President,,DEM,"Roque ""Rocky"" De La Fuente",0
+Angelina,4,President,,DEM,"Roque ""Rocky"" De La Fuente",0
+Angelina,5,President,,DEM,"Roque ""Rocky"" De La Fuente",0
+Angelina,6,President,,DEM,"Roque ""Rocky"" De La Fuente",0
+Angelina,7,President,,DEM,"Roque ""Rocky"" De La Fuente",0
+Angelina,8,President,,DEM,"Roque ""Rocky"" De La Fuente",0
+Angelina,9,President,,DEM,"Roque ""Rocky"" De La Fuente",0
+Angelina,10,President,,DEM,"Roque ""Rocky"" De La Fuente",0
+Angelina,11,President,,DEM,"Roque ""Rocky"" De La Fuente",0
+Angelina,11B,President,,DEM,"Roque ""Rocky"" De La Fuente",0
+Angelina,12,President,,DEM,"Roque ""Rocky"" De La Fuente",1
+Angelina,13,President,,DEM,"Roque ""Rocky"" De La Fuente",0
+Angelina,14,President,,DEM,"Roque ""Rocky"" De La Fuente",1
+Angelina,15,President,,DEM,"Roque ""Rocky"" De La Fuente",0
+Angelina,16,President,,DEM,"Roque ""Rocky"" De La Fuente",4
+Angelina,17,President,,DEM,"Roque ""Rocky"" De La Fuente",0
+Angelina,17B,President,,DEM,"Roque ""Rocky"" De La Fuente",0
+Angelina,18,President,,DEM,"Roque ""Rocky"" De La Fuente",1
+Angelina,19,President,,DEM,"Roque ""Rocky"" De La Fuente",0
+Angelina,20,President,,DEM,"Roque ""Rocky"" De La Fuente",1
+Angelina,21,President,,DEM,"Roque ""Rocky"" De La Fuente",0
+Angelina,22,President,,DEM,"Roque ""Rocky"" De La Fuente",0
+Angelina,23,President,,DEM,"Roque ""Rocky"" De La Fuente",1
+Angelina,24,President,,DEM,"Roque ""Rocky"" De La Fuente",1
+Angelina,25,President,,DEM,"Roque ""Rocky"" De La Fuente",0
+Angelina,26,President,,DEM,"Roque ""Rocky"" De La Fuente",0
+Angelina,27,President,,DEM,"Roque ""Rocky"" De La Fuente",0
+Angelina,28,President,,DEM,"Roque ""Rocky"" De La Fuente",1
+Angelina,29,President,,DEM,"Roque ""Rocky"" De La Fuente",0
+Angelina,30,President,,DEM,"Roque ""Rocky"" De La Fuente",1
+Angelina,31,President,,DEM,"Roque ""Rocky"" De La Fuente",0
+Angelina,32,President,,DEM,"Roque ""Rocky"" De La Fuente",0
+Angelina,33,President,,DEM,"Roque ""Rocky"" De La Fuente",0
+Angelina,34,President,,DEM,"Roque ""Rocky"" De La Fuente",0
+Angelina,35,President,,DEM,"Roque ""Rocky"" De La Fuente",0
+Angelina,36,President,,DEM,"Roque ""Rocky"" De La Fuente",0
+Angelina,37,President,,DEM,"Roque ""Rocky"" De La Fuente",0
+Angelina,38,President,,DEM,"Roque ""Rocky"" De La Fuente",0
+Angelina,39,President,,DEM,"Roque ""Rocky"" De La Fuente",0
+Angelina,40,President,,DEM,"Roque ""Rocky"" De La Fuente",0
+Angelina,1,President,,DEM,Willie L. Wilson,1
+Angelina,2,President,,DEM,Willie L. Wilson,3
+Angelina,3,President,,DEM,Willie L. Wilson,1
+Angelina,4,President,,DEM,Willie L. Wilson,1
+Angelina,5,President,,DEM,Willie L. Wilson,0
+Angelina,6,President,,DEM,Willie L. Wilson,0
+Angelina,7,President,,DEM,Willie L. Wilson,1
+Angelina,8,President,,DEM,Willie L. Wilson,1
+Angelina,9,President,,DEM,Willie L. Wilson,0
+Angelina,10,President,,DEM,Willie L. Wilson,2
+Angelina,11,President,,DEM,Willie L. Wilson,0
+Angelina,11B,President,,DEM,Willie L. Wilson,0
+Angelina,12,President,,DEM,Willie L. Wilson,0
+Angelina,13,President,,DEM,Willie L. Wilson,0
+Angelina,14,President,,DEM,Willie L. Wilson,0
+Angelina,15,President,,DEM,Willie L. Wilson,1
+Angelina,16,President,,DEM,Willie L. Wilson,2
+Angelina,17,President,,DEM,Willie L. Wilson,1
+Angelina,17B,President,,DEM,Willie L. Wilson,0
+Angelina,18,President,,DEM,Willie L. Wilson,0
+Angelina,19,President,,DEM,Willie L. Wilson,0
+Angelina,20,President,,DEM,Willie L. Wilson,8
+Angelina,21,President,,DEM,Willie L. Wilson,0
+Angelina,22,President,,DEM,Willie L. Wilson,1
+Angelina,23,President,,DEM,Willie L. Wilson,0
+Angelina,24,President,,DEM,Willie L. Wilson,1
+Angelina,25,President,,DEM,Willie L. Wilson,0
+Angelina,26,President,,DEM,Willie L. Wilson,1
+Angelina,27,President,,DEM,Willie L. Wilson,0
+Angelina,28,President,,DEM,Willie L. Wilson,0
+Angelina,29,President,,DEM,Willie L. Wilson,0
+Angelina,30,President,,DEM,Willie L. Wilson,1
+Angelina,31,President,,DEM,Willie L. Wilson,0
+Angelina,32,President,,DEM,Willie L. Wilson,0
+Angelina,33,President,,DEM,Willie L. Wilson,0
+Angelina,34,President,,DEM,Willie L. Wilson,0
+Angelina,35,President,,DEM,Willie L. Wilson,0
+Angelina,36,President,,DEM,Willie L. Wilson,0
+Angelina,37,President,,DEM,Willie L. Wilson,0
+Angelina,38,President,,DEM,Willie L. Wilson,0
+Angelina,39,President,,DEM,Willie L. Wilson,0
+Angelina,40,President,,DEM,Willie L. Wilson,0
+Angelina,1,President,,DEM,OVER VOTES,0
+Angelina,2,President,,DEM,OVER VOTES,0
+Angelina,3,President,,DEM,OVER VOTES,0
+Angelina,4,President,,DEM,OVER VOTES,0
+Angelina,5,President,,DEM,OVER VOTES,0
+Angelina,6,President,,DEM,OVER VOTES,0
+Angelina,7,President,,DEM,OVER VOTES,0
+Angelina,8,President,,DEM,OVER VOTES,0
+Angelina,9,President,,DEM,OVER VOTES,0
+Angelina,10,President,,DEM,OVER VOTES,0
+Angelina,11,President,,DEM,OVER VOTES,0
+Angelina,11B,President,,DEM,OVER VOTES,0
+Angelina,12,President,,DEM,OVER VOTES,0
+Angelina,13,President,,DEM,OVER VOTES,0
+Angelina,14,President,,DEM,OVER VOTES,0
+Angelina,15,President,,DEM,OVER VOTES,0
+Angelina,16,President,,DEM,OVER VOTES,0
+Angelina,17,President,,DEM,OVER VOTES,0
+Angelina,17B,President,,DEM,OVER VOTES,0
+Angelina,18,President,,DEM,OVER VOTES,0
+Angelina,19,President,,DEM,OVER VOTES,0
+Angelina,20,President,,DEM,OVER VOTES,0
+Angelina,21,President,,DEM,OVER VOTES,0
+Angelina,22,President,,DEM,OVER VOTES,0
+Angelina,23,President,,DEM,OVER VOTES,0
+Angelina,24,President,,DEM,OVER VOTES,0
+Angelina,25,President,,DEM,OVER VOTES,0
+Angelina,26,President,,DEM,OVER VOTES,0
+Angelina,27,President,,DEM,OVER VOTES,0
+Angelina,28,President,,DEM,OVER VOTES,0
+Angelina,29,President,,DEM,OVER VOTES,0
+Angelina,30,President,,DEM,OVER VOTES,0
+Angelina,31,President,,DEM,OVER VOTES,0
+Angelina,32,President,,DEM,OVER VOTES,0
+Angelina,33,President,,DEM,OVER VOTES,0
+Angelina,34,President,,DEM,OVER VOTES,0
+Angelina,35,President,,DEM,OVER VOTES,0
+Angelina,36,President,,DEM,OVER VOTES,0
+Angelina,37,President,,DEM,OVER VOTES,0
+Angelina,38,President,,DEM,OVER VOTES,0
+Angelina,39,President,,DEM,OVER VOTES,0
+Angelina,40,President,,DEM,OVER VOTES,0
+Angelina,1,President,,DEM,UNDER VOTES,0
+Angelina,2,President,,DEM,UNDER VOTES,7
+Angelina,3,President,,DEM,UNDER VOTES,2
+Angelina,4,President,,DEM,UNDER VOTES,4
+Angelina,5,President,,DEM,UNDER VOTES,2
+Angelina,6,President,,DEM,UNDER VOTES,1
+Angelina,7,President,,DEM,UNDER VOTES,3
+Angelina,8,President,,DEM,UNDER VOTES,0
+Angelina,9,President,,DEM,UNDER VOTES,1
+Angelina,10,President,,DEM,UNDER VOTES,1
+Angelina,11,President,,DEM,UNDER VOTES,2
+Angelina,11B,President,,DEM,UNDER VOTES,1
+Angelina,12,President,,DEM,UNDER VOTES,2
+Angelina,13,President,,DEM,UNDER VOTES,0
+Angelina,14,President,,DEM,UNDER VOTES,2
+Angelina,15,President,,DEM,UNDER VOTES,1
+Angelina,16,President,,DEM,UNDER VOTES,0
+Angelina,17,President,,DEM,UNDER VOTES,0
+Angelina,17B,President,,DEM,UNDER VOTES,0
+Angelina,18,President,,DEM,UNDER VOTES,0
+Angelina,19,President,,DEM,UNDER VOTES,0
+Angelina,20,President,,DEM,UNDER VOTES,3
+Angelina,21,President,,DEM,UNDER VOTES,0
+Angelina,22,President,,DEM,UNDER VOTES,7
+Angelina,23,President,,DEM,UNDER VOTES,0
+Angelina,24,President,,DEM,UNDER VOTES,1
+Angelina,25,President,,DEM,UNDER VOTES,3
+Angelina,26,President,,DEM,UNDER VOTES,1
+Angelina,27,President,,DEM,UNDER VOTES,0
+Angelina,28,President,,DEM,UNDER VOTES,1
+Angelina,29,President,,DEM,UNDER VOTES,4
+Angelina,30,President,,DEM,UNDER VOTES,1
+Angelina,31,President,,DEM,UNDER VOTES,1
+Angelina,32,President,,DEM,UNDER VOTES,0
+Angelina,33,President,,DEM,UNDER VOTES,1
+Angelina,34,President,,DEM,UNDER VOTES,0
+Angelina,35,President,,DEM,UNDER VOTES,3
+Angelina,36,President,,DEM,UNDER VOTES,0
+Angelina,37,President,,DEM,UNDER VOTES,0
+Angelina,38,President,,DEM,UNDER VOTES,0
+Angelina,39,President,,DEM,UNDER VOTES,1
+Angelina,40,President,,DEM,UNDER VOTES,0
+Angelina,1,U.S. House,1,DEM,Shirley J. McKellar,21
+Angelina,2,U.S. House,1,DEM,Shirley J. McKellar,165
+Angelina,3,U.S. House,1,DEM,Shirley J. McKellar,49
+Angelina,4,U.S. House,1,DEM,Shirley J. McKellar,54
+Angelina,5,U.S. House,1,DEM,Shirley J. McKellar,90
+Angelina,6,U.S. House,1,DEM,Shirley J. McKellar,15
+Angelina,7,U.S. House,1,DEM,Shirley J. McKellar,16
+Angelina,8,U.S. House,1,DEM,Shirley J. McKellar,20
+Angelina,9,U.S. House,1,DEM,Shirley J. McKellar,11
+Angelina,10,U.S. House,1,DEM,Shirley J. McKellar,68
+Angelina,11,U.S. House,1,DEM,Shirley J. McKellar,34
+Angelina,11B,U.S. House,1,DEM,Shirley J. McKellar,30
+Angelina,12,U.S. House,1,DEM,Shirley J. McKellar,25
+Angelina,13,U.S. House,1,DEM,Shirley J. McKellar,20
+Angelina,14,U.S. House,1,DEM,Shirley J. McKellar,79
+Angelina,15,U.S. House,1,DEM,Shirley J. McKellar,11
+Angelina,16,U.S. House,1,DEM,Shirley J. McKellar,90
+Angelina,17,U.S. House,1,DEM,Shirley J. McKellar,38
+Angelina,17B,U.S. House,1,DEM,Shirley J. McKellar,10
+Angelina,18,U.S. House,1,DEM,Shirley J. McKellar,26
+Angelina,19,U.S. House,1,DEM,Shirley J. McKellar,76
+Angelina,20,U.S. House,1,DEM,Shirley J. McKellar,196
+Angelina,21,U.S. House,1,DEM,Shirley J. McKellar,46
+Angelina,22,U.S. House,1,DEM,Shirley J. McKellar,34
+Angelina,23,U.S. House,1,DEM,Shirley J. McKellar,15
+Angelina,24,U.S. House,1,DEM,Shirley J. McKellar,58
+Angelina,25,U.S. House,1,DEM,Shirley J. McKellar,54
+Angelina,26,U.S. House,1,DEM,Shirley J. McKellar,38
+Angelina,27,U.S. House,1,DEM,Shirley J. McKellar,10
+Angelina,28,U.S. House,1,DEM,Shirley J. McKellar,31
+Angelina,29,U.S. House,1,DEM,Shirley J. McKellar,37
+Angelina,30,U.S. House,1,DEM,Shirley J. McKellar,14
+Angelina,31,U.S. House,1,DEM,Shirley J. McKellar,11
+Angelina,32,U.S. House,1,DEM,Shirley J. McKellar,1
+Angelina,33,U.S. House,1,DEM,Shirley J. McKellar,20
+Angelina,34,U.S. House,1,DEM,Shirley J. McKellar,69
+Angelina,35,U.S. House,1,DEM,Shirley J. McKellar,61
+Angelina,36,U.S. House,1,DEM,Shirley J. McKellar,0
+Angelina,37,U.S. House,1,DEM,Shirley J. McKellar,24
+Angelina,38,U.S. House,1,DEM,Shirley J. McKellar,11
+Angelina,39,U.S. House,1,DEM,Shirley J. McKellar,18
+Angelina,40,U.S. House,1,DEM,Shirley J. McKellar,39
+Angelina,1,U.S. House,1,DEM,OVER VOTES,0
+Angelina,2,U.S. House,1,DEM,OVER VOTES,0
+Angelina,3,U.S. House,1,DEM,OVER VOTES,0
+Angelina,4,U.S. House,1,DEM,OVER VOTES,0
+Angelina,5,U.S. House,1,DEM,OVER VOTES,0
+Angelina,6,U.S. House,1,DEM,OVER VOTES,0
+Angelina,7,U.S. House,1,DEM,OVER VOTES,0
+Angelina,8,U.S. House,1,DEM,OVER VOTES,0
+Angelina,9,U.S. House,1,DEM,OVER VOTES,0
+Angelina,10,U.S. House,1,DEM,OVER VOTES,0
+Angelina,11,U.S. House,1,DEM,OVER VOTES,0
+Angelina,11B,U.S. House,1,DEM,OVER VOTES,0
+Angelina,12,U.S. House,1,DEM,OVER VOTES,0
+Angelina,13,U.S. House,1,DEM,OVER VOTES,0
+Angelina,14,U.S. House,1,DEM,OVER VOTES,0
+Angelina,15,U.S. House,1,DEM,OVER VOTES,0
+Angelina,16,U.S. House,1,DEM,OVER VOTES,0
+Angelina,17,U.S. House,1,DEM,OVER VOTES,0
+Angelina,17B,U.S. House,1,DEM,OVER VOTES,0
+Angelina,18,U.S. House,1,DEM,OVER VOTES,0
+Angelina,19,U.S. House,1,DEM,OVER VOTES,0
+Angelina,20,U.S. House,1,DEM,OVER VOTES,0
+Angelina,21,U.S. House,1,DEM,OVER VOTES,0
+Angelina,22,U.S. House,1,DEM,OVER VOTES,0
+Angelina,23,U.S. House,1,DEM,OVER VOTES,0
+Angelina,24,U.S. House,1,DEM,OVER VOTES,0
+Angelina,25,U.S. House,1,DEM,OVER VOTES,0
+Angelina,26,U.S. House,1,DEM,OVER VOTES,0
+Angelina,27,U.S. House,1,DEM,OVER VOTES,0
+Angelina,28,U.S. House,1,DEM,OVER VOTES,0
+Angelina,29,U.S. House,1,DEM,OVER VOTES,0
+Angelina,30,U.S. House,1,DEM,OVER VOTES,0
+Angelina,31,U.S. House,1,DEM,OVER VOTES,0
+Angelina,32,U.S. House,1,DEM,OVER VOTES,0
+Angelina,33,U.S. House,1,DEM,OVER VOTES,0
+Angelina,34,U.S. House,1,DEM,OVER VOTES,0
+Angelina,35,U.S. House,1,DEM,OVER VOTES,0
+Angelina,36,U.S. House,1,DEM,OVER VOTES,0
+Angelina,37,U.S. House,1,DEM,OVER VOTES,0
+Angelina,38,U.S. House,1,DEM,OVER VOTES,0
+Angelina,39,U.S. House,1,DEM,OVER VOTES,0
+Angelina,40,U.S. House,1,DEM,OVER VOTES,0
+Angelina,1,U.S. House,1,DEM,UNDER VOTES,11
+Angelina,2,U.S. House,1,DEM,UNDER VOTES,101
+Angelina,3,U.S. House,1,DEM,UNDER VOTES,28
+Angelina,4,U.S. House,1,DEM,UNDER VOTES,42
+Angelina,5,U.S. House,1,DEM,UNDER VOTES,40
+Angelina,6,U.S. House,1,DEM,UNDER VOTES,6
+Angelina,7,U.S. House,1,DEM,UNDER VOTES,8
+Angelina,8,U.S. House,1,DEM,UNDER VOTES,5
+Angelina,9,U.S. House,1,DEM,UNDER VOTES,5
+Angelina,10,U.S. House,1,DEM,UNDER VOTES,43
+Angelina,11,U.S. House,1,DEM,UNDER VOTES,18
+Angelina,11B,U.S. House,1,DEM,UNDER VOTES,18
+Angelina,12,U.S. House,1,DEM,UNDER VOTES,14
+Angelina,13,U.S. House,1,DEM,UNDER VOTES,17
+Angelina,14,U.S. House,1,DEM,UNDER VOTES,36
+Angelina,15,U.S. House,1,DEM,UNDER VOTES,5
+Angelina,16,U.S. House,1,DEM,UNDER VOTES,45
+Angelina,17,U.S. House,1,DEM,UNDER VOTES,26
+Angelina,17B,U.S. House,1,DEM,UNDER VOTES,8
+Angelina,18,U.S. House,1,DEM,UNDER VOTES,10
+Angelina,19,U.S. House,1,DEM,UNDER VOTES,24
+Angelina,20,U.S. House,1,DEM,UNDER VOTES,179
+Angelina,21,U.S. House,1,DEM,UNDER VOTES,16
+Angelina,22,U.S. House,1,DEM,UNDER VOTES,26
+Angelina,23,U.S. House,1,DEM,UNDER VOTES,3
+Angelina,24,U.S. House,1,DEM,UNDER VOTES,21
+Angelina,25,U.S. House,1,DEM,UNDER VOTES,37
+Angelina,26,U.S. House,1,DEM,UNDER VOTES,19
+Angelina,27,U.S. House,1,DEM,UNDER VOTES,8
+Angelina,28,U.S. House,1,DEM,UNDER VOTES,10
+Angelina,29,U.S. House,1,DEM,UNDER VOTES,18
+Angelina,30,U.S. House,1,DEM,UNDER VOTES,9
+Angelina,31,U.S. House,1,DEM,UNDER VOTES,10
+Angelina,32,U.S. House,1,DEM,UNDER VOTES,3
+Angelina,33,U.S. House,1,DEM,UNDER VOTES,6
+Angelina,34,U.S. House,1,DEM,UNDER VOTES,27
+Angelina,35,U.S. House,1,DEM,UNDER VOTES,30
+Angelina,36,U.S. House,1,DEM,UNDER VOTES,0
+Angelina,37,U.S. House,1,DEM,UNDER VOTES,5
+Angelina,38,U.S. House,1,DEM,UNDER VOTES,3
+Angelina,39,U.S. House,1,DEM,UNDER VOTES,13
+Angelina,40,U.S. House,1,DEM,UNDER VOTES,15
+Angelina,1,Railroad Commissioner,,DEM,Cody Garrett,7
+Angelina,2,Railroad Commissioner,,DEM,Cody Garrett,70
+Angelina,3,Railroad Commissioner,,DEM,Cody Garrett,20
+Angelina,4,Railroad Commissioner,,DEM,Cody Garrett,22
+Angelina,5,Railroad Commissioner,,DEM,Cody Garrett,39
+Angelina,6,Railroad Commissioner,,DEM,Cody Garrett,7
+Angelina,7,Railroad Commissioner,,DEM,Cody Garrett,8
+Angelina,8,Railroad Commissioner,,DEM,Cody Garrett,5
+Angelina,9,Railroad Commissioner,,DEM,Cody Garrett,7
+Angelina,10,Railroad Commissioner,,DEM,Cody Garrett,34
+Angelina,11,Railroad Commissioner,,DEM,Cody Garrett,20
+Angelina,11B,Railroad Commissioner,,DEM,Cody Garrett,13
+Angelina,12,Railroad Commissioner,,DEM,Cody Garrett,7
+Angelina,13,Railroad Commissioner,,DEM,Cody Garrett,4
+Angelina,14,Railroad Commissioner,,DEM,Cody Garrett,42
+Angelina,15,Railroad Commissioner,,DEM,Cody Garrett,4
+Angelina,16,Railroad Commissioner,,DEM,Cody Garrett,36
+Angelina,17,Railroad Commissioner,,DEM,Cody Garrett,10
+Angelina,17B,Railroad Commissioner,,DEM,Cody Garrett,8
+Angelina,18,Railroad Commissioner,,DEM,Cody Garrett,6
+Angelina,19,Railroad Commissioner,,DEM,Cody Garrett,16
+Angelina,20,Railroad Commissioner,,DEM,Cody Garrett,89
+Angelina,21,Railroad Commissioner,,DEM,Cody Garrett,20
+Angelina,22,Railroad Commissioner,,DEM,Cody Garrett,19
+Angelina,23,Railroad Commissioner,,DEM,Cody Garrett,4
+Angelina,24,Railroad Commissioner,,DEM,Cody Garrett,22
+Angelina,25,Railroad Commissioner,,DEM,Cody Garrett,16
+Angelina,26,Railroad Commissioner,,DEM,Cody Garrett,11
+Angelina,27,Railroad Commissioner,,DEM,Cody Garrett,4
+Angelina,28,Railroad Commissioner,,DEM,Cody Garrett,17
+Angelina,29,Railroad Commissioner,,DEM,Cody Garrett,16
+Angelina,30,Railroad Commissioner,,DEM,Cody Garrett,2
+Angelina,31,Railroad Commissioner,,DEM,Cody Garrett,5
+Angelina,32,Railroad Commissioner,,DEM,Cody Garrett,1
+Angelina,33,Railroad Commissioner,,DEM,Cody Garrett,11
+Angelina,34,Railroad Commissioner,,DEM,Cody Garrett,20
+Angelina,35,Railroad Commissioner,,DEM,Cody Garrett,24
+Angelina,36,Railroad Commissioner,,DEM,Cody Garrett,0
+Angelina,37,Railroad Commissioner,,DEM,Cody Garrett,14
+Angelina,38,Railroad Commissioner,,DEM,Cody Garrett,8
+Angelina,39,Railroad Commissioner,,DEM,Cody Garrett,10
+Angelina,40,Railroad Commissioner,,DEM,Cody Garrett,14
+Angelina,1,Railroad Commissioner,,DEM,Lon Burnam,6
+Angelina,2,Railroad Commissioner,,DEM,Lon Burnam,34
+Angelina,3,Railroad Commissioner,,DEM,Lon Burnam,12
+Angelina,4,Railroad Commissioner,,DEM,Lon Burnam,6
+Angelina,5,Railroad Commissioner,,DEM,Lon Burnam,16
+Angelina,6,Railroad Commissioner,,DEM,Lon Burnam,2
+Angelina,7,Railroad Commissioner,,DEM,Lon Burnam,3
+Angelina,8,Railroad Commissioner,,DEM,Lon Burnam,5
+Angelina,9,Railroad Commissioner,,DEM,Lon Burnam,3
+Angelina,10,Railroad Commissioner,,DEM,Lon Burnam,12
+Angelina,11,Railroad Commissioner,,DEM,Lon Burnam,9
+Angelina,11B,Railroad Commissioner,,DEM,Lon Burnam,9
+Angelina,12,Railroad Commissioner,,DEM,Lon Burnam,11
+Angelina,13,Railroad Commissioner,,DEM,Lon Burnam,5
+Angelina,14,Railroad Commissioner,,DEM,Lon Burnam,16
+Angelina,15,Railroad Commissioner,,DEM,Lon Burnam,1
+Angelina,16,Railroad Commissioner,,DEM,Lon Burnam,16
+Angelina,17,Railroad Commissioner,,DEM,Lon Burnam,11
+Angelina,17B,Railroad Commissioner,,DEM,Lon Burnam,2
+Angelina,18,Railroad Commissioner,,DEM,Lon Burnam,8
+Angelina,19,Railroad Commissioner,,DEM,Lon Burnam,21
+Angelina,20,Railroad Commissioner,,DEM,Lon Burnam,40
+Angelina,21,Railroad Commissioner,,DEM,Lon Burnam,19
+Angelina,22,Railroad Commissioner,,DEM,Lon Burnam,7
+Angelina,23,Railroad Commissioner,,DEM,Lon Burnam,5
+Angelina,24,Railroad Commissioner,,DEM,Lon Burnam,13
+Angelina,25,Railroad Commissioner,,DEM,Lon Burnam,22
+Angelina,26,Railroad Commissioner,,DEM,Lon Burnam,19
+Angelina,27,Railroad Commissioner,,DEM,Lon Burnam,5
+Angelina,28,Railroad Commissioner,,DEM,Lon Burnam,4
+Angelina,29,Railroad Commissioner,,DEM,Lon Burnam,6
+Angelina,30,Railroad Commissioner,,DEM,Lon Burnam,4
+Angelina,31,Railroad Commissioner,,DEM,Lon Burnam,3
+Angelina,32,Railroad Commissioner,,DEM,Lon Burnam,1
+Angelina,33,Railroad Commissioner,,DEM,Lon Burnam,2
+Angelina,34,Railroad Commissioner,,DEM,Lon Burnam,23
+Angelina,35,Railroad Commissioner,,DEM,Lon Burnam,11
+Angelina,36,Railroad Commissioner,,DEM,Lon Burnam,0
+Angelina,37,Railroad Commissioner,,DEM,Lon Burnam,3
+Angelina,38,Railroad Commissioner,,DEM,Lon Burnam,1
+Angelina,39,Railroad Commissioner,,DEM,Lon Burnam,5
+Angelina,40,Railroad Commissioner,,DEM,Lon Burnam,10
+Angelina,1,Railroad Commissioner,,DEM,Grady Yarbrough,12
+Angelina,2,Railroad Commissioner,,DEM,Grady Yarbrough,91
+Angelina,3,Railroad Commissioner,,DEM,Grady Yarbrough,31
+Angelina,4,Railroad Commissioner,,DEM,Grady Yarbrough,31
+Angelina,5,Railroad Commissioner,,DEM,Grady Yarbrough,48
+Angelina,6,Railroad Commissioner,,DEM,Grady Yarbrough,9
+Angelina,7,Railroad Commissioner,,DEM,Grady Yarbrough,6
+Angelina,8,Railroad Commissioner,,DEM,Grady Yarbrough,11
+Angelina,9,Railroad Commissioner,,DEM,Grady Yarbrough,3
+Angelina,10,Railroad Commissioner,,DEM,Grady Yarbrough,35
+Angelina,11,Railroad Commissioner,,DEM,Grady Yarbrough,14
+Angelina,11B,Railroad Commissioner,,DEM,Grady Yarbrough,17
+Angelina,12,Railroad Commissioner,,DEM,Grady Yarbrough,14
+Angelina,13,Railroad Commissioner,,DEM,Grady Yarbrough,20
+Angelina,14,Railroad Commissioner,,DEM,Grady Yarbrough,27
+Angelina,15,Railroad Commissioner,,DEM,Grady Yarbrough,5
+Angelina,16,Railroad Commissioner,,DEM,Grady Yarbrough,52
+Angelina,17,Railroad Commissioner,,DEM,Grady Yarbrough,31
+Angelina,17B,Railroad Commissioner,,DEM,Grady Yarbrough,3
+Angelina,18,Railroad Commissioner,,DEM,Grady Yarbrough,14
+Angelina,19,Railroad Commissioner,,DEM,Grady Yarbrough,31
+Angelina,20,Railroad Commissioner,,DEM,Grady Yarbrough,116
+Angelina,21,Railroad Commissioner,,DEM,Grady Yarbrough,18
+Angelina,22,Railroad Commissioner,,DEM,Grady Yarbrough,22
+Angelina,23,Railroad Commissioner,,DEM,Grady Yarbrough,8
+Angelina,24,Railroad Commissioner,,DEM,Grady Yarbrough,25
+Angelina,25,Railroad Commissioner,,DEM,Grady Yarbrough,25
+Angelina,26,Railroad Commissioner,,DEM,Grady Yarbrough,19
+Angelina,27,Railroad Commissioner,,DEM,Grady Yarbrough,3
+Angelina,28,Railroad Commissioner,,DEM,Grady Yarbrough,12
+Angelina,29,Railroad Commissioner,,DEM,Grady Yarbrough,21
+Angelina,30,Railroad Commissioner,,DEM,Grady Yarbrough,10
+Angelina,31,Railroad Commissioner,,DEM,Grady Yarbrough,8
+Angelina,32,Railroad Commissioner,,DEM,Grady Yarbrough,2
+Angelina,33,Railroad Commissioner,,DEM,Grady Yarbrough,8
+Angelina,34,Railroad Commissioner,,DEM,Grady Yarbrough,26
+Angelina,35,Railroad Commissioner,,DEM,Grady Yarbrough,37
+Angelina,36,Railroad Commissioner,,DEM,Grady Yarbrough,0
+Angelina,37,Railroad Commissioner,,DEM,Grady Yarbrough,7
+Angelina,38,Railroad Commissioner,,DEM,Grady Yarbrough,4
+Angelina,39,Railroad Commissioner,,DEM,Grady Yarbrough,4
+Angelina,40,Railroad Commissioner,,DEM,Grady Yarbrough,17
+Angelina,1,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,2,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,3,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,4,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,5,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,6,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,7,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,8,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,9,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,10,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,11,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,11B,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,12,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,13,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,14,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,15,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,16,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,17,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,17B,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,18,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,19,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,20,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,21,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,22,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,23,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,24,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,25,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,26,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,27,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,28,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,29,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,30,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,31,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,32,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,33,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,34,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,35,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,36,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,37,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,38,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,39,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,40,Railroad Commissioner,,DEM,OVER VOTES,0
+Angelina,1,Railroad Commissioner,,DEM,UNDER VOTES,8
+Angelina,2,Railroad Commissioner,,DEM,UNDER VOTES,71
+Angelina,3,Railroad Commissioner,,DEM,UNDER VOTES,15
+Angelina,4,Railroad Commissioner,,DEM,UNDER VOTES,37
+Angelina,5,Railroad Commissioner,,DEM,UNDER VOTES,27
+Angelina,6,Railroad Commissioner,,DEM,UNDER VOTES,3
+Angelina,7,Railroad Commissioner,,DEM,UNDER VOTES,7
+Angelina,8,Railroad Commissioner,,DEM,UNDER VOTES,4
+Angelina,9,Railroad Commissioner,,DEM,UNDER VOTES,3
+Angelina,10,Railroad Commissioner,,DEM,UNDER VOTES,30
+Angelina,11,Railroad Commissioner,,DEM,UNDER VOTES,9
+Angelina,11B,Railroad Commissioner,,DEM,UNDER VOTES,9
+Angelina,12,Railroad Commissioner,,DEM,UNDER VOTES,7
+Angelina,13,Railroad Commissioner,,DEM,UNDER VOTES,8
+Angelina,14,Railroad Commissioner,,DEM,UNDER VOTES,30
+Angelina,15,Railroad Commissioner,,DEM,UNDER VOTES,6
+Angelina,16,Railroad Commissioner,,DEM,UNDER VOTES,31
+Angelina,17,Railroad Commissioner,,DEM,UNDER VOTES,12
+Angelina,17B,Railroad Commissioner,,DEM,UNDER VOTES,5
+Angelina,18,Railroad Commissioner,,DEM,UNDER VOTES,8
+Angelina,19,Railroad Commissioner,,DEM,UNDER VOTES,32
+Angelina,20,Railroad Commissioner,,DEM,UNDER VOTES,130
+Angelina,21,Railroad Commissioner,,DEM,UNDER VOTES,5
+Angelina,22,Railroad Commissioner,,DEM,UNDER VOTES,12
+Angelina,23,Railroad Commissioner,,DEM,UNDER VOTES,1
+Angelina,24,Railroad Commissioner,,DEM,UNDER VOTES,19
+Angelina,25,Railroad Commissioner,,DEM,UNDER VOTES,28
+Angelina,26,Railroad Commissioner,,DEM,UNDER VOTES,8
+Angelina,27,Railroad Commissioner,,DEM,UNDER VOTES,6
+Angelina,28,Railroad Commissioner,,DEM,UNDER VOTES,8
+Angelina,29,Railroad Commissioner,,DEM,UNDER VOTES,12
+Angelina,30,Railroad Commissioner,,DEM,UNDER VOTES,7
+Angelina,31,Railroad Commissioner,,DEM,UNDER VOTES,5
+Angelina,32,Railroad Commissioner,,DEM,UNDER VOTES,0
+Angelina,33,Railroad Commissioner,,DEM,UNDER VOTES,5
+Angelina,34,Railroad Commissioner,,DEM,UNDER VOTES,27
+Angelina,35,Railroad Commissioner,,DEM,UNDER VOTES,19
+Angelina,36,Railroad Commissioner,,DEM,UNDER VOTES,0
+Angelina,37,Railroad Commissioner,,DEM,UNDER VOTES,5
+Angelina,38,Railroad Commissioner,,DEM,UNDER VOTES,1
+Angelina,39,Railroad Commissioner,,DEM,UNDER VOTES,12
+Angelina,40,Railroad Commissioner,,DEM,UNDER VOTES,13
+Angelina,1,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,20
+Angelina,2,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,164
+Angelina,3,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,58
+Angelina,4,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,45
+Angelina,5,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,86
+Angelina,6,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,18
+Angelina,7,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,16
+Angelina,8,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,21
+Angelina,9,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,10
+Angelina,10,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,72
+Angelina,11,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,40
+Angelina,11B,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,34
+Angelina,12,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,28
+Angelina,13,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,23
+Angelina,14,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,83
+Angelina,15,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,10
+Angelina,16,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,91
+Angelina,17,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,44
+Angelina,17B,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,10
+Angelina,18,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,27
+Angelina,19,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,71
+Angelina,20,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,195
+Angelina,21,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,49
+Angelina,22,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,41
+Angelina,23,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,15
+Angelina,24,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,60
+Angelina,25,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,52
+Angelina,26,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,43
+Angelina,27,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,11
+Angelina,28,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,33
+Angelina,29,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,40
+Angelina,30,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,12
+Angelina,31,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,12
+Angelina,32,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,2
+Angelina,33,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,18
+Angelina,34,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,66
+Angelina,35,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,62
+Angelina,36,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,0
+Angelina,37,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,22
+Angelina,38,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,11
+Angelina,39,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,18
+Angelina,40,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,39
+Angelina,1,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,2,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,3,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,4,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,5,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,6,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,7,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,8,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,9,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,10,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,11,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,11B,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,12,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,13,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,14,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,15,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,16,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,17,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,17B,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,18,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,19,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,20,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,21,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,22,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,23,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,24,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,25,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,26,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,27,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,28,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,29,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,30,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,31,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,32,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,33,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,34,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,35,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,36,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,37,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,38,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,39,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,40,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0
+Angelina,1,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,12
+Angelina,2,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,103
+Angelina,3,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,19
+Angelina,4,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,51
+Angelina,5,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,44
+Angelina,6,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,3
+Angelina,7,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,8
+Angelina,8,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,4
+Angelina,9,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,6
+Angelina,10,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,39
+Angelina,11,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,12
+Angelina,11B,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,14
+Angelina,12,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,11
+Angelina,13,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,14
+Angelina,14,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,32
+Angelina,15,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,6
+Angelina,16,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,44
+Angelina,17,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,20
+Angelina,17B,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,8
+Angelina,18,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,9
+Angelina,19,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,29
+Angelina,20,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,180
+Angelina,21,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,13
+Angelina,22,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,19
+Angelina,23,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,3
+Angelina,24,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,19
+Angelina,25,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,39
+Angelina,26,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,14
+Angelina,27,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,7
+Angelina,28,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,8
+Angelina,29,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,15
+Angelina,30,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,11
+Angelina,31,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,9
+Angelina,32,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,2
+Angelina,33,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,8
+Angelina,34,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,30
+Angelina,35,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,29
+Angelina,36,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,0
+Angelina,37,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,7
+Angelina,38,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,3
+Angelina,39,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,13
+Angelina,40,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,15
+Angelina,1,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,20
+Angelina,2,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,166
+Angelina,3,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,48
+Angelina,4,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,46
+Angelina,5,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,93
+Angelina,6,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,18
+Angelina,7,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,15
+Angelina,8,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,22
+Angelina,9,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,11
+Angelina,10,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,75
+Angelina,11,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,34
+Angelina,11B,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,32
+Angelina,12,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,28
+Angelina,13,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,24
+Angelina,14,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,83
+Angelina,15,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,12
+Angelina,16,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,101
+Angelina,17,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,44
+Angelina,17B,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,11
+Angelina,18,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,29
+Angelina,19,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,72
+Angelina,20,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,197
+Angelina,21,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,49
+Angelina,22,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,37
+Angelina,23,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,16
+Angelina,24,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,57
+Angelina,25,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,53
+Angelina,26,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,39
+Angelina,27,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,11
+Angelina,28,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,36
+Angelina,29,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,38
+Angelina,30,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,11
+Angelina,31,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,15
+Angelina,32,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,2
+Angelina,33,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,19
+Angelina,34,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,65
+Angelina,35,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,64
+Angelina,36,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,0
+Angelina,37,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,21
+Angelina,38,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,11
+Angelina,39,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,18
+Angelina,40,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,40
+Angelina,1,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,2,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,3,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,4,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,5,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,6,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,7,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,8,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,9,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,10,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,11,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,11B,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,12,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,13,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,14,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,15,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,16,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,17,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,17B,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,18,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,19,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,20,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,21,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,22,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,23,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,24,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,25,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,26,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,27,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,28,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,29,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,30,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,31,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,32,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,33,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,34,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,35,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,36,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,37,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,38,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,39,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,40,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0
+Angelina,1,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,12
+Angelina,2,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,102
+Angelina,3,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,29
+Angelina,4,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,50
+Angelina,5,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,37
+Angelina,6,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,3
+Angelina,7,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,9
+Angelina,8,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,3
+Angelina,9,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,5
+Angelina,10,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,36
+Angelina,11,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,18
+Angelina,11B,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,16
+Angelina,12,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,11
+Angelina,13,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,13
+Angelina,14,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,32
+Angelina,15,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,4
+Angelina,16,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,34
+Angelina,17,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,20
+Angelina,17B,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,7
+Angelina,18,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,7
+Angelina,19,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,28
+Angelina,20,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,178
+Angelina,21,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,13
+Angelina,22,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,23
+Angelina,23,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,2
+Angelina,24,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,22
+Angelina,25,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,38
+Angelina,26,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,18
+Angelina,27,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,7
+Angelina,28,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,5
+Angelina,29,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,17
+Angelina,30,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,12
+Angelina,31,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,6
+Angelina,32,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,2
+Angelina,33,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,7
+Angelina,34,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,31
+Angelina,35,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,27
+Angelina,36,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,0
+Angelina,37,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,8
+Angelina,38,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,3
+Angelina,39,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,13
+Angelina,40,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,14
+Angelina,1,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,19
+Angelina,2,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,163
+Angelina,3,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,51
+Angelina,4,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,46
+Angelina,5,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,93
+Angelina,6,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,17
+Angelina,7,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,15
+Angelina,8,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,21
+Angelina,9,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,13
+Angelina,10,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,70
+Angelina,11,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,35
+Angelina,11B,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,33
+Angelina,12,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,27
+Angelina,13,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,22
+Angelina,14,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,81
+Angelina,15,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,9
+Angelina,16,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,90
+Angelina,17,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,45
+Angelina,17B,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,9
+Angelina,18,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,28
+Angelina,19,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,71
+Angelina,20,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,195
+Angelina,21,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,53
+Angelina,22,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,37
+Angelina,23,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,15
+Angelina,24,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,59
+Angelina,25,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,54
+Angelina,26,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,43
+Angelina,27,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,10
+Angelina,28,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,33
+Angelina,29,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,38
+Angelina,30,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,12
+Angelina,31,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,11
+Angelina,32,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,2
+Angelina,33,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,17
+Angelina,34,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,68
+Angelina,35,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,61
+Angelina,36,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,0
+Angelina,37,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,21
+Angelina,38,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,11
+Angelina,39,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,15
+Angelina,40,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,38
+Angelina,1,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,2,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,3,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,4,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,5,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,6,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,7,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,8,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,9,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,10,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,11,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,11B,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,12,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,13,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,14,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,15,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,16,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,17,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,17B,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,18,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,19,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,20,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,21,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,22,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,23,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,24,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,25,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,26,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,27,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,28,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,29,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,30,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,31,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,32,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,33,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,34,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,35,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,36,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,37,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,38,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,39,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,40,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0
+Angelina,1,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,13
+Angelina,2,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,105
+Angelina,3,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,26
+Angelina,4,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,50
+Angelina,5,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,37
+Angelina,6,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,4
+Angelina,7,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,9
+Angelina,8,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,4
+Angelina,9,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,3
+Angelina,10,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,41
+Angelina,11,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,17
+Angelina,11B,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,15
+Angelina,12,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,12
+Angelina,13,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,15
+Angelina,14,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,34
+Angelina,15,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,7
+Angelina,16,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,45
+Angelina,17,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,19
+Angelina,17B,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,9
+Angelina,18,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,8
+Angelina,19,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,29
+Angelina,20,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,180
+Angelina,21,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,9
+Angelina,22,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,23
+Angelina,23,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,3
+Angelina,24,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,20
+Angelina,25,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,37
+Angelina,26,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,14
+Angelina,27,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,8
+Angelina,28,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,8
+Angelina,29,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,17
+Angelina,30,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,11
+Angelina,31,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,10
+Angelina,32,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,2
+Angelina,33,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,9
+Angelina,34,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,28
+Angelina,35,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,30
+Angelina,36,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,0
+Angelina,37,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,8
+Angelina,38,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,3
+Angelina,39,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,16
+Angelina,40,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,16
+Angelina,1,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",20
+Angelina,2,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",166
+Angelina,3,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",51
+Angelina,4,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",46
+Angelina,5,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",84
+Angelina,6,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",18
+Angelina,7,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",15
+Angelina,8,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",22
+Angelina,9,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",9
+Angelina,10,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",72
+Angelina,11,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",33
+Angelina,11B,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",33
+Angelina,12,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",27
+Angelina,13,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",23
+Angelina,14,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",83
+Angelina,15,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",9
+Angelina,16,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",93
+Angelina,17,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",45
+Angelina,17B,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",10
+Angelina,18,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",25
+Angelina,19,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",73
+Angelina,20,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",196
+Angelina,21,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",49
+Angelina,22,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",38
+Angelina,23,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",15
+Angelina,24,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",58
+Angelina,25,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",54
+Angelina,26,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",41
+Angelina,27,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",10
+Angelina,28,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",33
+Angelina,29,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",35
+Angelina,30,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",12
+Angelina,31,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",11
+Angelina,32,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",2
+Angelina,33,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",20
+Angelina,34,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",66
+Angelina,35,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",62
+Angelina,36,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",0
+Angelina,37,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",22
+Angelina,38,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",11
+Angelina,39,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",17
+Angelina,40,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",39
+Angelina,1,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,2,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,3,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,4,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,5,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,6,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,7,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,8,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,9,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,10,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,11,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,11B,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,12,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,13,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,14,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,15,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,16,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,17,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,17B,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,18,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,19,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,20,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,21,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,22,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,23,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,24,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,25,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,26,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,27,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,28,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,29,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,30,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,31,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,32,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,33,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,34,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,35,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,36,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,37,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,38,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,39,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,40,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0
+Angelina,1,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,12
+Angelina,2,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,102
+Angelina,3,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,26
+Angelina,4,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,50
+Angelina,5,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,46
+Angelina,6,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,3
+Angelina,7,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,9
+Angelina,8,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,3
+Angelina,9,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,7
+Angelina,10,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,39
+Angelina,11,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,19
+Angelina,11B,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,15
+Angelina,12,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,12
+Angelina,13,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,14
+Angelina,14,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,32
+Angelina,15,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,7
+Angelina,16,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,42
+Angelina,17,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,19
+Angelina,17B,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,8
+Angelina,18,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,11
+Angelina,19,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,27
+Angelina,20,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,179
+Angelina,21,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,13
+Angelina,22,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,22
+Angelina,23,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,3
+Angelina,24,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,21
+Angelina,25,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,37
+Angelina,26,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,16
+Angelina,27,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,8
+Angelina,28,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,8
+Angelina,29,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,20
+Angelina,30,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,11
+Angelina,31,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,10
+Angelina,32,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,2
+Angelina,33,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,6
+Angelina,34,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,30
+Angelina,35,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,29
+Angelina,36,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,0
+Angelina,37,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,7
+Angelina,38,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,3
+Angelina,39,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,14
+Angelina,40,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,15
+Angelina,1,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,21
+Angelina,2,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,165
+Angelina,3,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,49
+Angelina,4,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,52
+Angelina,5,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,91
+Angelina,6,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,17
+Angelina,7,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,17
+Angelina,8,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,21
+Angelina,9,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,12
+Angelina,10,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,71
+Angelina,11,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,36
+Angelina,11B,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,34
+Angelina,12,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,28
+Angelina,13,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,22
+Angelina,14,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,80
+Angelina,15,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,10
+Angelina,16,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,99
+Angelina,17,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,47
+Angelina,17B,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,11
+Angelina,18,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,28
+Angelina,19,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,73
+Angelina,20,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,199
+Angelina,21,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,48
+Angelina,22,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,39
+Angelina,23,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,16
+Angelina,24,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,56
+Angelina,25,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,51
+Angelina,26,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,41
+Angelina,27,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,10
+Angelina,28,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,33
+Angelina,29,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,39
+Angelina,30,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,12
+Angelina,31,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,11
+Angelina,32,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,2
+Angelina,33,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,18
+Angelina,34,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,69
+Angelina,35,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,63
+Angelina,36,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,0
+Angelina,37,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,22
+Angelina,38,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,10
+Angelina,39,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,16
+Angelina,40,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,36
+Angelina,1,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,2,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,3,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,4,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,5,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,6,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,7,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,8,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,9,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,10,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,11,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,11B,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,12,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,13,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,14,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,15,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,16,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,17,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,17B,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,18,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,19,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,20,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,21,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,22,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,23,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,24,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,25,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,26,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,27,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,28,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,29,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,30,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,31,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,32,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,33,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,34,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,35,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,36,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,37,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,38,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,39,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,40,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0
+Angelina,1,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,11
+Angelina,2,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,103
+Angelina,3,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,28
+Angelina,4,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,44
+Angelina,5,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,39
+Angelina,6,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,4
+Angelina,7,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,7
+Angelina,8,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,4
+Angelina,9,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,4
+Angelina,10,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,40
+Angelina,11,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,16
+Angelina,11B,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,14
+Angelina,12,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,11
+Angelina,13,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,15
+Angelina,14,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,35
+Angelina,15,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,6
+Angelina,16,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,36
+Angelina,17,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,17
+Angelina,17B,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,7
+Angelina,18,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,8
+Angelina,19,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,27
+Angelina,20,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,176
+Angelina,21,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,14
+Angelina,22,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,21
+Angelina,23,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,2
+Angelina,24,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,23
+Angelina,25,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,40
+Angelina,26,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,16
+Angelina,27,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,8
+Angelina,28,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,8
+Angelina,29,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,16
+Angelina,30,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,11
+Angelina,31,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,10
+Angelina,32,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,2
+Angelina,33,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,8
+Angelina,34,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,27
+Angelina,35,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,28
+Angelina,36,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,0
+Angelina,37,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,7
+Angelina,38,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,4
+Angelina,39,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,15
+Angelina,40,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,18
+Angelina,1,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,19
+Angelina,2,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,164
+Angelina,3,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,52
+Angelina,4,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,53
+Angelina,5,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,87
+Angelina,6,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,17
+Angelina,7,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,15
+Angelina,8,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,22
+Angelina,9,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,9
+Angelina,10,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,68
+Angelina,11,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,39
+Angelina,11B,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,33
+Angelina,12,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,28
+Angelina,13,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,22
+Angelina,14,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,81
+Angelina,15,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,11
+Angelina,16,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,89
+Angelina,17,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,48
+Angelina,17B,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,8
+Angelina,18,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,28
+Angelina,19,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,74
+Angelina,20,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,213
+Angelina,21,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,49
+Angelina,22,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,42
+Angelina,23,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,15
+Angelina,24,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,55
+Angelina,25,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,52
+Angelina,26,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,40
+Angelina,27,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,9
+Angelina,28,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,34
+Angelina,29,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,38
+Angelina,30,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,11
+Angelina,31,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,13
+Angelina,32,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,2
+Angelina,33,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,20
+Angelina,34,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,64
+Angelina,35,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,63
+Angelina,36,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,0
+Angelina,37,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,22
+Angelina,38,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,11
+Angelina,39,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,18
+Angelina,40,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,38
+Angelina,1,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,2,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,3,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,4,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,5,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,6,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,7,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,8,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,9,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,10,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,11,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,11B,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,12,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,13,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,14,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,15,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,16,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,17,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,17B,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,18,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,19,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,20,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,21,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,22,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,23,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,24,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,25,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,26,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,27,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,28,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,29,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,30,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,31,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,32,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,33,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,34,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,35,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,36,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,37,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,38,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,39,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,40,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0
+Angelina,1,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,13
+Angelina,2,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,104
+Angelina,3,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,25
+Angelina,4,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,43
+Angelina,5,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,43
+Angelina,6,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,4
+Angelina,7,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,9
+Angelina,8,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,3
+Angelina,9,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,7
+Angelina,10,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,43
+Angelina,11,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,13
+Angelina,11B,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,15
+Angelina,12,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,11
+Angelina,13,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,15
+Angelina,14,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,34
+Angelina,15,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,5
+Angelina,16,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,46
+Angelina,17,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,16
+Angelina,17B,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,10
+Angelina,18,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,8
+Angelina,19,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,26
+Angelina,20,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,162
+Angelina,21,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,13
+Angelina,22,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,18
+Angelina,23,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,3
+Angelina,24,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,24
+Angelina,25,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,39
+Angelina,26,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,17
+Angelina,27,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,9
+Angelina,28,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,7
+Angelina,29,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,17
+Angelina,30,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,12
+Angelina,31,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,8
+Angelina,32,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,2
+Angelina,33,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,6
+Angelina,34,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,32
+Angelina,35,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,28
+Angelina,36,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,0
+Angelina,37,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,7
+Angelina,38,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,3
+Angelina,39,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,13
+Angelina,40,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,16
+Angelina,1,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,21
+Angelina,2,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,168
+Angelina,3,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,47
+Angelina,4,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,51
+Angelina,5,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,93
+Angelina,6,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,17
+Angelina,7,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,16
+Angelina,8,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,21
+Angelina,9,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,13
+Angelina,10,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,76
+Angelina,11,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,34
+Angelina,11B,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,33
+Angelina,12,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,27
+Angelina,13,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,23
+Angelina,14,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,77
+Angelina,15,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,10
+Angelina,16,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,96
+Angelina,17,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,45
+Angelina,17B,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,10
+Angelina,18,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,28
+Angelina,19,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,70
+Angelina,20,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,212
+Angelina,21,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,51
+Angelina,22,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,39
+Angelina,23,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,15
+Angelina,24,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,52
+Angelina,25,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,53
+Angelina,26,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,42
+Angelina,27,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,8
+Angelina,28,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,34
+Angelina,29,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,39
+Angelina,30,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,10
+Angelina,31,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,13
+Angelina,32,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,3
+Angelina,33,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,18
+Angelina,34,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,63
+Angelina,35,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,62
+Angelina,36,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,0
+Angelina,37,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,21
+Angelina,38,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,12
+Angelina,39,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,16
+Angelina,40,"Member, State Board of Education, District 9",,DEM,Amanda M. Rudolph,40
+Angelina,1,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,2,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,3,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,4,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,5,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,6,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,7,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,8,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,9,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,10,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,11,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,11B,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,12,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,13,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,14,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,15,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,16,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,17,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,17B,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,18,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,19,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,20,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,21,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,22,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,23,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,24,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,25,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,26,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,27,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,28,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,29,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,30,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,31,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,32,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,33,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,34,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,35,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,36,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,37,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,38,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,39,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,40,"Member, State Board of Education, District 9",,DEM,OVER VOTES,0
+Angelina,1,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,11
+Angelina,2,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,99
+Angelina,3,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,30
+Angelina,4,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,45
+Angelina,5,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,37
+Angelina,6,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,4
+Angelina,7,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,8
+Angelina,8,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,4
+Angelina,9,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,3
+Angelina,10,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,35
+Angelina,11,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,18
+Angelina,11B,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,15
+Angelina,12,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,12
+Angelina,13,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,14
+Angelina,14,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,38
+Angelina,15,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,6
+Angelina,16,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,39
+Angelina,17,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,19
+Angelina,17B,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,8
+Angelina,18,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,8
+Angelina,19,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,30
+Angelina,20,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,163
+Angelina,21,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,11
+Angelina,22,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,21
+Angelina,23,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,3
+Angelina,24,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,27
+Angelina,25,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,38
+Angelina,26,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,15
+Angelina,27,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,10
+Angelina,28,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,7
+Angelina,29,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,16
+Angelina,30,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,13
+Angelina,31,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,8
+Angelina,32,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,1
+Angelina,33,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,8
+Angelina,34,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,33
+Angelina,35,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,29
+Angelina,36,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,0
+Angelina,37,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,8
+Angelina,38,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,2
+Angelina,39,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,15
+Angelina,40,"Member, State Board of Education, District 9",,DEM,UNDER VOTES,14
+Angelina,1,"County Commissioner, Precinct No. 3",,DEM,George Cartwright,23
+Angelina,3,"County Commissioner, Precinct No. 3",,DEM,George Cartwright,56
+Angelina,11,"County Commissioner, Precinct No. 3",,DEM,George Cartwright,40
+Angelina,11B,"County Commissioner, Precinct No. 3",,DEM,George Cartwright,37
+Angelina,12,"County Commissioner, Precinct No. 3",,DEM,George Cartwright,30
+Angelina,26,"County Commissioner, Precinct No. 3",,DEM,George Cartwright,43
+Angelina,30,"County Commissioner, Precinct No. 3",,DEM,George Cartwright,11
+Angelina,33,"County Commissioner, Precinct No. 3",,DEM,George Cartwright,21
+Angelina,35,"County Commissioner, Precinct No. 3",,DEM,George Cartwright,59
+Angelina,37,"County Commissioner, Precinct No. 3",,DEM,George Cartwright,22
+Angelina,40,"County Commissioner, Precinct No. 3",,DEM,George Cartwright,42
+Angelina,1,"County Commissioner, Precinct No. 3",,DEM,OVER VOTES,0
+Angelina,3,"County Commissioner, Precinct No. 3",,DEM,OVER VOTES,0
+Angelina,11,"County Commissioner, Precinct No. 3",,DEM,OVER VOTES,0
+Angelina,11B,"County Commissioner, Precinct No. 3",,DEM,OVER VOTES,0
+Angelina,12,"County Commissioner, Precinct No. 3",,DEM,OVER VOTES,0
+Angelina,26,"County Commissioner, Precinct No. 3",,DEM,OVER VOTES,0
+Angelina,30,"County Commissioner, Precinct No. 3",,DEM,OVER VOTES,0
+Angelina,33,"County Commissioner, Precinct No. 3",,DEM,OVER VOTES,0
+Angelina,35,"County Commissioner, Precinct No. 3",,DEM,OVER VOTES,0
+Angelina,37,"County Commissioner, Precinct No. 3",,DEM,OVER VOTES,0
+Angelina,40,"County Commissioner, Precinct No. 3",,DEM,OVER VOTES,0
+Angelina,1,"County Commissioner, Precinct No. 3",,DEM,UNDER VOTES,9
+Angelina,3,"County Commissioner, Precinct No. 3",,DEM,UNDER VOTES,21
+Angelina,11,"County Commissioner, Precinct No. 3",,DEM,UNDER VOTES,12
+Angelina,11B,"County Commissioner, Precinct No. 3",,DEM,UNDER VOTES,11
+Angelina,12,"County Commissioner, Precinct No. 3",,DEM,UNDER VOTES,9
+Angelina,26,"County Commissioner, Precinct No. 3",,DEM,UNDER VOTES,14
+Angelina,30,"County Commissioner, Precinct No. 3",,DEM,UNDER VOTES,12
+Angelina,33,"County Commissioner, Precinct No. 3",,DEM,UNDER VOTES,5
+Angelina,35,"County Commissioner, Precinct No. 3",,DEM,UNDER VOTES,32
+Angelina,37,"County Commissioner, Precinct No. 3",,DEM,UNDER VOTES,7
+Angelina,40,"County Commissioner, Precinct No. 3",,DEM,UNDER VOTES,12
+Angelina,1,County Chairman,,DEM,Shirley Layton,21
+Angelina,2,County Chairman,,DEM,Shirley Layton,173
+Angelina,3,County Chairman,,DEM,Shirley Layton,45
+Angelina,4,County Chairman,,DEM,Shirley Layton,54
+Angelina,5,County Chairman,,DEM,Shirley Layton,94
+Angelina,6,County Chairman,,DEM,Shirley Layton,15
+Angelina,7,County Chairman,,DEM,Shirley Layton,15
+Angelina,8,County Chairman,,DEM,Shirley Layton,22
+Angelina,9,County Chairman,,DEM,Shirley Layton,13
+Angelina,10,County Chairman,,DEM,Shirley Layton,74
+Angelina,11,County Chairman,,DEM,Shirley Layton,40
+Angelina,11B,County Chairman,,DEM,Shirley Layton,29
+Angelina,12,County Chairman,,DEM,Shirley Layton,28
+Angelina,13,County Chairman,,DEM,Shirley Layton,26
+Angelina,14,County Chairman,,DEM,Shirley Layton,84
+Angelina,15,County Chairman,,DEM,Shirley Layton,11
+Angelina,16,County Chairman,,DEM,Shirley Layton,98
+Angelina,17,County Chairman,,DEM,Shirley Layton,48
+Angelina,17B,County Chairman,,DEM,Shirley Layton,11
+Angelina,18,County Chairman,,DEM,Shirley Layton,26
+Angelina,19,County Chairman,,DEM,Shirley Layton,76
+Angelina,20,County Chairman,,DEM,Shirley Layton,220
+Angelina,21,County Chairman,,DEM,Shirley Layton,51
+Angelina,22,County Chairman,,DEM,Shirley Layton,41
+Angelina,23,County Chairman,,DEM,Shirley Layton,15
+Angelina,24,County Chairman,,DEM,Shirley Layton,56
+Angelina,25,County Chairman,,DEM,Shirley Layton,53
+Angelina,26,County Chairman,,DEM,Shirley Layton,40
+Angelina,27,County Chairman,,DEM,Shirley Layton,10
+Angelina,28,County Chairman,,DEM,Shirley Layton,33
+Angelina,29,County Chairman,,DEM,Shirley Layton,40
+Angelina,30,County Chairman,,DEM,Shirley Layton,11
+Angelina,31,County Chairman,,DEM,Shirley Layton,14
+Angelina,32,County Chairman,,DEM,Shirley Layton,2
+Angelina,33,County Chairman,,DEM,Shirley Layton,16
+Angelina,34,County Chairman,,DEM,Shirley Layton,65
+Angelina,35,County Chairman,,DEM,Shirley Layton,63
+Angelina,36,County Chairman,,DEM,Shirley Layton,0
+Angelina,37,County Chairman,,DEM,Shirley Layton,22
+Angelina,38,County Chairman,,DEM,Shirley Layton,11
+Angelina,39,County Chairman,,DEM,Shirley Layton,18
+Angelina,40,County Chairman,,DEM,Shirley Layton,40
+Angelina,1,County Chairman,,DEM,OVER VOTES,0
+Angelina,2,County Chairman,,DEM,OVER VOTES,0
+Angelina,3,County Chairman,,DEM,OVER VOTES,0
+Angelina,4,County Chairman,,DEM,OVER VOTES,0
+Angelina,5,County Chairman,,DEM,OVER VOTES,0
+Angelina,6,County Chairman,,DEM,OVER VOTES,0
+Angelina,7,County Chairman,,DEM,OVER VOTES,0
+Angelina,8,County Chairman,,DEM,OVER VOTES,0
+Angelina,9,County Chairman,,DEM,OVER VOTES,0
+Angelina,10,County Chairman,,DEM,OVER VOTES,0
+Angelina,11,County Chairman,,DEM,OVER VOTES,0
+Angelina,11B,County Chairman,,DEM,OVER VOTES,0
+Angelina,12,County Chairman,,DEM,OVER VOTES,0
+Angelina,13,County Chairman,,DEM,OVER VOTES,0
+Angelina,14,County Chairman,,DEM,OVER VOTES,0
+Angelina,15,County Chairman,,DEM,OVER VOTES,0
+Angelina,16,County Chairman,,DEM,OVER VOTES,0
+Angelina,17,County Chairman,,DEM,OVER VOTES,0
+Angelina,17B,County Chairman,,DEM,OVER VOTES,0
+Angelina,18,County Chairman,,DEM,OVER VOTES,0
+Angelina,19,County Chairman,,DEM,OVER VOTES,0
+Angelina,20,County Chairman,,DEM,OVER VOTES,0
+Angelina,21,County Chairman,,DEM,OVER VOTES,0
+Angelina,22,County Chairman,,DEM,OVER VOTES,0
+Angelina,23,County Chairman,,DEM,OVER VOTES,0
+Angelina,24,County Chairman,,DEM,OVER VOTES,0
+Angelina,25,County Chairman,,DEM,OVER VOTES,0
+Angelina,26,County Chairman,,DEM,OVER VOTES,0
+Angelina,27,County Chairman,,DEM,OVER VOTES,0
+Angelina,28,County Chairman,,DEM,OVER VOTES,0
+Angelina,29,County Chairman,,DEM,OVER VOTES,0
+Angelina,30,County Chairman,,DEM,OVER VOTES,0
+Angelina,31,County Chairman,,DEM,OVER VOTES,0
+Angelina,32,County Chairman,,DEM,OVER VOTES,0
+Angelina,33,County Chairman,,DEM,OVER VOTES,0
+Angelina,34,County Chairman,,DEM,OVER VOTES,0
+Angelina,35,County Chairman,,DEM,OVER VOTES,0
+Angelina,36,County Chairman,,DEM,OVER VOTES,0
+Angelina,37,County Chairman,,DEM,OVER VOTES,0
+Angelina,38,County Chairman,,DEM,OVER VOTES,0
+Angelina,39,County Chairman,,DEM,OVER VOTES,0
+Angelina,40,County Chairman,,DEM,OVER VOTES,0
+Angelina,1,County Chairman,,DEM,UNDER VOTES,11
+Angelina,2,County Chairman,,DEM,UNDER VOTES,95
+Angelina,3,County Chairman,,DEM,UNDER VOTES,32
+Angelina,4,County Chairman,,DEM,UNDER VOTES,42
+Angelina,5,County Chairman,,DEM,UNDER VOTES,36
+Angelina,6,County Chairman,,DEM,UNDER VOTES,6
+Angelina,7,County Chairman,,DEM,UNDER VOTES,9
+Angelina,8,County Chairman,,DEM,UNDER VOTES,3
+Angelina,9,County Chairman,,DEM,UNDER VOTES,3
+Angelina,10,County Chairman,,DEM,UNDER VOTES,37
+Angelina,11,County Chairman,,DEM,UNDER VOTES,12
+Angelina,11B,County Chairman,,DEM,UNDER VOTES,19
+Angelina,12,County Chairman,,DEM,UNDER VOTES,11
+Angelina,13,County Chairman,,DEM,UNDER VOTES,11
+Angelina,14,County Chairman,,DEM,UNDER VOTES,31
+Angelina,15,County Chairman,,DEM,UNDER VOTES,5
+Angelina,16,County Chairman,,DEM,UNDER VOTES,37
+Angelina,17,County Chairman,,DEM,UNDER VOTES,16
+Angelina,17B,County Chairman,,DEM,UNDER VOTES,7
+Angelina,18,County Chairman,,DEM,UNDER VOTES,10
+Angelina,19,County Chairman,,DEM,UNDER VOTES,24
+Angelina,20,County Chairman,,DEM,UNDER VOTES,155
+Angelina,21,County Chairman,,DEM,UNDER VOTES,11
+Angelina,22,County Chairman,,DEM,UNDER VOTES,19
+Angelina,23,County Chairman,,DEM,UNDER VOTES,3
+Angelina,24,County Chairman,,DEM,UNDER VOTES,23
+Angelina,25,County Chairman,,DEM,UNDER VOTES,38
+Angelina,26,County Chairman,,DEM,UNDER VOTES,17
+Angelina,27,County Chairman,,DEM,UNDER VOTES,8
+Angelina,28,County Chairman,,DEM,UNDER VOTES,8
+Angelina,29,County Chairman,,DEM,UNDER VOTES,15
+Angelina,30,County Chairman,,DEM,UNDER VOTES,12
+Angelina,31,County Chairman,,DEM,UNDER VOTES,7
+Angelina,32,County Chairman,,DEM,UNDER VOTES,2
+Angelina,33,County Chairman,,DEM,UNDER VOTES,10
+Angelina,34,County Chairman,,DEM,UNDER VOTES,31
+Angelina,35,County Chairman,,DEM,UNDER VOTES,28
+Angelina,36,County Chairman,,DEM,UNDER VOTES,0
+Angelina,37,County Chairman,,DEM,UNDER VOTES,7
+Angelina,38,County Chairman,,DEM,UNDER VOTES,3
+Angelina,39,County Chairman,,DEM,UNDER VOTES,13
+Angelina,40,County Chairman,,DEM,UNDER VOTES,14
+Angelina,1,Referenda Item #1,,DEM,Yes,29
+Angelina,2,Referenda Item #1,,DEM,Yes,228
+Angelina,3,Referenda Item #1,,DEM,Yes,60
+Angelina,4,Referenda Item #1,,DEM,Yes,76
+Angelina,5,Referenda Item #1,,DEM,Yes,104
+Angelina,6,Referenda Item #1,,DEM,Yes,19
+Angelina,7,Referenda Item #1,,DEM,Yes,19
+Angelina,8,Referenda Item #1,,DEM,Yes,21
+Angelina,9,Referenda Item #1,,DEM,Yes,13
+Angelina,10,Referenda Item #1,,DEM,Yes,103
+Angelina,11,Referenda Item #1,,DEM,Yes,42
+Angelina,11B,Referenda Item #1,,DEM,Yes,39
+Angelina,12,Referenda Item #1,,DEM,Yes,32
+Angelina,13,Referenda Item #1,,DEM,Yes,31
+Angelina,14,Referenda Item #1,,DEM,Yes,103
+Angelina,15,Referenda Item #1,,DEM,Yes,13
+Angelina,16,Referenda Item #1,,DEM,Yes,107
+Angelina,17,Referenda Item #1,,DEM,Yes,50
+Angelina,17B,Referenda Item #1,,DEM,Yes,12
+Angelina,18,Referenda Item #1,,DEM,Yes,32
+Angelina,19,Referenda Item #1,,DEM,Yes,82
+Angelina,20,Referenda Item #1,,DEM,Yes,284
+Angelina,21,Referenda Item #1,,DEM,Yes,52
+Angelina,22,Referenda Item #1,,DEM,Yes,45
+Angelina,23,Referenda Item #1,,DEM,Yes,17
+Angelina,24,Referenda Item #1,,DEM,Yes,62
+Angelina,25,Referenda Item #1,,DEM,Yes,74
+Angelina,26,Referenda Item #1,,DEM,Yes,46
+Angelina,27,Referenda Item #1,,DEM,Yes,12
+Angelina,28,Referenda Item #1,,DEM,Yes,37
+Angelina,29,Referenda Item #1,,DEM,Yes,41
+Angelina,30,Referenda Item #1,,DEM,Yes,18
+Angelina,31,Referenda Item #1,,DEM,Yes,16
+Angelina,32,Referenda Item #1,,DEM,Yes,4
+Angelina,33,Referenda Item #1,,DEM,Yes,19
+Angelina,34,Referenda Item #1,,DEM,Yes,81
+Angelina,35,Referenda Item #1,,DEM,Yes,80
+Angelina,36,Referenda Item #1,,DEM,Yes,0
+Angelina,37,Referenda Item #1,,DEM,Yes,25
+Angelina,38,Referenda Item #1,,DEM,Yes,12
+Angelina,39,Referenda Item #1,,DEM,Yes,22
+Angelina,40,Referenda Item #1,,DEM,Yes,47
+Angelina,1,Referenda Item #1,,DEM,No,3
+Angelina,2,Referenda Item #1,,DEM,No,13
+Angelina,3,Referenda Item #1,,DEM,No,12
+Angelina,4,Referenda Item #1,,DEM,No,8
+Angelina,5,Referenda Item #1,,DEM,No,16
+Angelina,6,Referenda Item #1,,DEM,No,1
+Angelina,7,Referenda Item #1,,DEM,No,4
+Angelina,8,Referenda Item #1,,DEM,No,4
+Angelina,9,Referenda Item #1,,DEM,No,1
+Angelina,10,Referenda Item #1,,DEM,No,4
+Angelina,11,Referenda Item #1,,DEM,No,6
+Angelina,11B,Referenda Item #1,,DEM,No,4
+Angelina,12,Referenda Item #1,,DEM,No,5
+Angelina,13,Referenda Item #1,,DEM,No,3
+Angelina,14,Referenda Item #1,,DEM,No,5
+Angelina,15,Referenda Item #1,,DEM,No,2
+Angelina,16,Referenda Item #1,,DEM,No,11
+Angelina,17,Referenda Item #1,,DEM,No,7
+Angelina,17B,Referenda Item #1,,DEM,No,1
+Angelina,18,Referenda Item #1,,DEM,No,2
+Angelina,19,Referenda Item #1,,DEM,No,11
+Angelina,20,Referenda Item #1,,DEM,No,22
+Angelina,21,Referenda Item #1,,DEM,No,7
+Angelina,22,Referenda Item #1,,DEM,No,12
+Angelina,23,Referenda Item #1,,DEM,No,1
+Angelina,24,Referenda Item #1,,DEM,No,12
+Angelina,25,Referenda Item #1,,DEM,No,7
+Angelina,26,Referenda Item #1,,DEM,No,6
+Angelina,27,Referenda Item #1,,DEM,No,0
+Angelina,28,Referenda Item #1,,DEM,No,3
+Angelina,29,Referenda Item #1,,DEM,No,9
+Angelina,30,Referenda Item #1,,DEM,No,3
+Angelina,31,Referenda Item #1,,DEM,No,3
+Angelina,32,Referenda Item #1,,DEM,No,0
+Angelina,33,Referenda Item #1,,DEM,No,4
+Angelina,34,Referenda Item #1,,DEM,No,5
+Angelina,35,Referenda Item #1,,DEM,No,5
+Angelina,36,Referenda Item #1,,DEM,No,0
+Angelina,37,Referenda Item #1,,DEM,No,4
+Angelina,38,Referenda Item #1,,DEM,No,1
+Angelina,39,Referenda Item #1,,DEM,No,2
+Angelina,40,Referenda Item #1,,DEM,No,4
+Angelina,1,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,2,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,3,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,4,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,5,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,6,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,7,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,8,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,9,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,10,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,11,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,11B,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,12,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,13,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,14,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,15,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,16,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,17,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,17B,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,18,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,19,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,20,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,21,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,22,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,23,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,24,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,25,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,26,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,27,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,28,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,29,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,30,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,31,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,32,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,33,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,34,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,35,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,36,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,37,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,38,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,39,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,40,Referenda Item #1,,DEM,OVER VOTES,0
+Angelina,1,Referenda Item #1,,DEM,UNDER VOTES,0
+Angelina,2,Referenda Item #1,,DEM,UNDER VOTES,27
+Angelina,3,Referenda Item #1,,DEM,UNDER VOTES,5
+Angelina,4,Referenda Item #1,,DEM,UNDER VOTES,12
+Angelina,5,Referenda Item #1,,DEM,UNDER VOTES,10
+Angelina,6,Referenda Item #1,,DEM,UNDER VOTES,1
+Angelina,7,Referenda Item #1,,DEM,UNDER VOTES,1
+Angelina,8,Referenda Item #1,,DEM,UNDER VOTES,0
+Angelina,9,Referenda Item #1,,DEM,UNDER VOTES,2
+Angelina,10,Referenda Item #1,,DEM,UNDER VOTES,4
+Angelina,11,Referenda Item #1,,DEM,UNDER VOTES,4
+Angelina,11B,Referenda Item #1,,DEM,UNDER VOTES,5
+Angelina,12,Referenda Item #1,,DEM,UNDER VOTES,2
+Angelina,13,Referenda Item #1,,DEM,UNDER VOTES,3
+Angelina,14,Referenda Item #1,,DEM,UNDER VOTES,7
+Angelina,15,Referenda Item #1,,DEM,UNDER VOTES,1
+Angelina,16,Referenda Item #1,,DEM,UNDER VOTES,17
+Angelina,17,Referenda Item #1,,DEM,UNDER VOTES,7
+Angelina,17B,Referenda Item #1,,DEM,UNDER VOTES,5
+Angelina,18,Referenda Item #1,,DEM,UNDER VOTES,2
+Angelina,19,Referenda Item #1,,DEM,UNDER VOTES,7
+Angelina,20,Referenda Item #1,,DEM,UNDER VOTES,69
+Angelina,21,Referenda Item #1,,DEM,UNDER VOTES,3
+Angelina,22,Referenda Item #1,,DEM,UNDER VOTES,3
+Angelina,23,Referenda Item #1,,DEM,UNDER VOTES,0
+Angelina,24,Referenda Item #1,,DEM,UNDER VOTES,5
+Angelina,25,Referenda Item #1,,DEM,UNDER VOTES,10
+Angelina,26,Referenda Item #1,,DEM,UNDER VOTES,5
+Angelina,27,Referenda Item #1,,DEM,UNDER VOTES,6
+Angelina,28,Referenda Item #1,,DEM,UNDER VOTES,1
+Angelina,29,Referenda Item #1,,DEM,UNDER VOTES,5
+Angelina,30,Referenda Item #1,,DEM,UNDER VOTES,2
+Angelina,31,Referenda Item #1,,DEM,UNDER VOTES,2
+Angelina,32,Referenda Item #1,,DEM,UNDER VOTES,0
+Angelina,33,Referenda Item #1,,DEM,UNDER VOTES,3
+Angelina,34,Referenda Item #1,,DEM,UNDER VOTES,10
+Angelina,35,Referenda Item #1,,DEM,UNDER VOTES,6
+Angelina,36,Referenda Item #1,,DEM,UNDER VOTES,0
+Angelina,37,Referenda Item #1,,DEM,UNDER VOTES,0
+Angelina,38,Referenda Item #1,,DEM,UNDER VOTES,1
+Angelina,39,Referenda Item #1,,DEM,UNDER VOTES,7
+Angelina,40,Referenda Item #1,,DEM,UNDER VOTES,3
+Angelina,1,Referenda Item #2,,DEM,Yes,27
+Angelina,2,Referenda Item #2,,DEM,Yes,223
+Angelina,3,Referenda Item #2,,DEM,Yes,65
+Angelina,4,Referenda Item #2,,DEM,Yes,73
+Angelina,5,Referenda Item #2,,DEM,Yes,109
+Angelina,6,Referenda Item #2,,DEM,Yes,19
+Angelina,7,Referenda Item #2,,DEM,Yes,18
+Angelina,8,Referenda Item #2,,DEM,Yes,23
+Angelina,9,Referenda Item #2,,DEM,Yes,14
+Angelina,10,Referenda Item #2,,DEM,Yes,97
+Angelina,11,Referenda Item #2,,DEM,Yes,38
+Angelina,11B,Referenda Item #2,,DEM,Yes,42
+Angelina,12,Referenda Item #2,,DEM,Yes,30
+Angelina,13,Referenda Item #2,,DEM,Yes,30
+Angelina,14,Referenda Item #2,,DEM,Yes,101
+Angelina,15,Referenda Item #2,,DEM,Yes,15
+Angelina,16,Referenda Item #2,,DEM,Yes,104
+Angelina,17,Referenda Item #2,,DEM,Yes,48
+Angelina,17B,Referenda Item #2,,DEM,Yes,13
+Angelina,18,Referenda Item #2,,DEM,Yes,31
+Angelina,19,Referenda Item #2,,DEM,Yes,87
+Angelina,20,Referenda Item #2,,DEM,Yes,283
+Angelina,21,Referenda Item #2,,DEM,Yes,54
+Angelina,22,Referenda Item #2,,DEM,Yes,51
+Angelina,23,Referenda Item #2,,DEM,Yes,18
+Angelina,24,Referenda Item #2,,DEM,Yes,72
+Angelina,25,Referenda Item #2,,DEM,Yes,70
+Angelina,26,Referenda Item #2,,DEM,Yes,44
+Angelina,27,Referenda Item #2,,DEM,Yes,14
+Angelina,28,Referenda Item #2,,DEM,Yes,40
+Angelina,29,Referenda Item #2,,DEM,Yes,42
+Angelina,30,Referenda Item #2,,DEM,Yes,17
+Angelina,31,Referenda Item #2,,DEM,Yes,17
+Angelina,32,Referenda Item #2,,DEM,Yes,4
+Angelina,33,Referenda Item #2,,DEM,Yes,20
+Angelina,34,Referenda Item #2,,DEM,Yes,85
+Angelina,35,Referenda Item #2,,DEM,Yes,80
+Angelina,36,Referenda Item #2,,DEM,Yes,0
+Angelina,37,Referenda Item #2,,DEM,Yes,24
+Angelina,38,Referenda Item #2,,DEM,Yes,14
+Angelina,39,Referenda Item #2,,DEM,Yes,22
+Angelina,40,Referenda Item #2,,DEM,Yes,48
+Angelina,1,Referenda Item #2,,DEM,No,4
+Angelina,2,Referenda Item #2,,DEM,No,14
+Angelina,3,Referenda Item #2,,DEM,No,8
+Angelina,4,Referenda Item #2,,DEM,No,6
+Angelina,5,Referenda Item #2,,DEM,No,8
+Angelina,6,Referenda Item #2,,DEM,No,1
+Angelina,7,Referenda Item #2,,DEM,No,5
+Angelina,8,Referenda Item #2,,DEM,No,2
+Angelina,9,Referenda Item #2,,DEM,No,1
+Angelina,10,Referenda Item #2,,DEM,No,6
+Angelina,11,Referenda Item #2,,DEM,No,10
+Angelina,11B,Referenda Item #2,,DEM,No,2
+Angelina,12,Referenda Item #2,,DEM,No,5
+Angelina,13,Referenda Item #2,,DEM,No,4
+Angelina,14,Referenda Item #2,,DEM,No,3
+Angelina,15,Referenda Item #2,,DEM,No,0
+Angelina,16,Referenda Item #2,,DEM,No,13
+Angelina,17,Referenda Item #2,,DEM,No,7
+Angelina,17B,Referenda Item #2,,DEM,No,2
+Angelina,18,Referenda Item #2,,DEM,No,3
+Angelina,19,Referenda Item #2,,DEM,No,3
+Angelina,20,Referenda Item #2,,DEM,No,17
+Angelina,21,Referenda Item #2,,DEM,No,5
+Angelina,22,Referenda Item #2,,DEM,No,7
+Angelina,23,Referenda Item #2,,DEM,No,0
+Angelina,24,Referenda Item #2,,DEM,No,2
+Angelina,25,Referenda Item #2,,DEM,No,11
+Angelina,26,Referenda Item #2,,DEM,No,6
+Angelina,27,Referenda Item #2,,DEM,No,0
+Angelina,28,Referenda Item #2,,DEM,No,1
+Angelina,29,Referenda Item #2,,DEM,No,5
+Angelina,30,Referenda Item #2,,DEM,No,4
+Angelina,31,Referenda Item #2,,DEM,No,2
+Angelina,32,Referenda Item #2,,DEM,No,0
+Angelina,33,Referenda Item #2,,DEM,No,3
+Angelina,34,Referenda Item #2,,DEM,No,1
+Angelina,35,Referenda Item #2,,DEM,No,3
+Angelina,36,Referenda Item #2,,DEM,No,0
+Angelina,37,Referenda Item #2,,DEM,No,5
+Angelina,38,Referenda Item #2,,DEM,No,0
+Angelina,39,Referenda Item #2,,DEM,No,1
+Angelina,40,Referenda Item #2,,DEM,No,2
+Angelina,1,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,2,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,3,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,4,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,5,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,6,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,7,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,8,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,9,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,10,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,11,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,11B,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,12,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,13,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,14,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,15,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,16,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,17,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,17B,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,18,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,19,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,20,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,21,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,22,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,23,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,24,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,25,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,26,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,27,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,28,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,29,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,30,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,31,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,32,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,33,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,34,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,35,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,36,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,37,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,38,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,39,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,40,Referenda Item #2,,DEM,OVER VOTES,0
+Angelina,1,Referenda Item #2,,DEM,UNDER VOTES,1
+Angelina,2,Referenda Item #2,,DEM,UNDER VOTES,31
+Angelina,3,Referenda Item #2,,DEM,UNDER VOTES,4
+Angelina,4,Referenda Item #2,,DEM,UNDER VOTES,17
+Angelina,5,Referenda Item #2,,DEM,UNDER VOTES,13
+Angelina,6,Referenda Item #2,,DEM,UNDER VOTES,1
+Angelina,7,Referenda Item #2,,DEM,UNDER VOTES,1
+Angelina,8,Referenda Item #2,,DEM,UNDER VOTES,0
+Angelina,9,Referenda Item #2,,DEM,UNDER VOTES,1
+Angelina,10,Referenda Item #2,,DEM,UNDER VOTES,8
+Angelina,11,Referenda Item #2,,DEM,UNDER VOTES,4
+Angelina,11B,Referenda Item #2,,DEM,UNDER VOTES,4
+Angelina,12,Referenda Item #2,,DEM,UNDER VOTES,4
+Angelina,13,Referenda Item #2,,DEM,UNDER VOTES,3
+Angelina,14,Referenda Item #2,,DEM,UNDER VOTES,11
+Angelina,15,Referenda Item #2,,DEM,UNDER VOTES,1
+Angelina,16,Referenda Item #2,,DEM,UNDER VOTES,18
+Angelina,17,Referenda Item #2,,DEM,UNDER VOTES,9
+Angelina,17B,Referenda Item #2,,DEM,UNDER VOTES,3
+Angelina,18,Referenda Item #2,,DEM,UNDER VOTES,2
+Angelina,19,Referenda Item #2,,DEM,UNDER VOTES,10
+Angelina,20,Referenda Item #2,,DEM,UNDER VOTES,75
+Angelina,21,Referenda Item #2,,DEM,UNDER VOTES,3
+Angelina,22,Referenda Item #2,,DEM,UNDER VOTES,2
+Angelina,23,Referenda Item #2,,DEM,UNDER VOTES,0
+Angelina,24,Referenda Item #2,,DEM,UNDER VOTES,5
+Angelina,25,Referenda Item #2,,DEM,UNDER VOTES,10
+Angelina,26,Referenda Item #2,,DEM,UNDER VOTES,7
+Angelina,27,Referenda Item #2,,DEM,UNDER VOTES,4
+Angelina,28,Referenda Item #2,,DEM,UNDER VOTES,0
+Angelina,29,Referenda Item #2,,DEM,UNDER VOTES,8
+Angelina,30,Referenda Item #2,,DEM,UNDER VOTES,2
+Angelina,31,Referenda Item #2,,DEM,UNDER VOTES,2
+Angelina,32,Referenda Item #2,,DEM,UNDER VOTES,0
+Angelina,33,Referenda Item #2,,DEM,UNDER VOTES,3
+Angelina,34,Referenda Item #2,,DEM,UNDER VOTES,10
+Angelina,35,Referenda Item #2,,DEM,UNDER VOTES,8
+Angelina,36,Referenda Item #2,,DEM,UNDER VOTES,0
+Angelina,37,Referenda Item #2,,DEM,UNDER VOTES,0
+Angelina,38,Referenda Item #2,,DEM,UNDER VOTES,0
+Angelina,39,Referenda Item #2,,DEM,UNDER VOTES,8
+Angelina,40,Referenda Item #2,,DEM,UNDER VOTES,4
+Angelina,1,Referenda Item #3,,DEM,Yes,27
+Angelina,2,Referenda Item #3,,DEM,Yes,199
+Angelina,3,Referenda Item #3,,DEM,Yes,52
+Angelina,4,Referenda Item #3,,DEM,Yes,68
+Angelina,5,Referenda Item #3,,DEM,Yes,98
+Angelina,6,Referenda Item #3,,DEM,Yes,17
+Angelina,7,Referenda Item #3,,DEM,Yes,21
+Angelina,8,Referenda Item #3,,DEM,Yes,23
+Angelina,9,Referenda Item #3,,DEM,Yes,13
+Angelina,10,Referenda Item #3,,DEM,Yes,94
+Angelina,11,Referenda Item #3,,DEM,Yes,42
+Angelina,11B,Referenda Item #3,,DEM,Yes,35
+Angelina,12,Referenda Item #3,,DEM,Yes,34
+Angelina,13,Referenda Item #3,,DEM,Yes,29
+Angelina,14,Referenda Item #3,,DEM,Yes,98
+Angelina,15,Referenda Item #3,,DEM,Yes,14
+Angelina,16,Referenda Item #3,,DEM,Yes,109
+Angelina,17,Referenda Item #3,,DEM,Yes,44
+Angelina,17B,Referenda Item #3,,DEM,Yes,12
+Angelina,18,Referenda Item #3,,DEM,Yes,31
+Angelina,19,Referenda Item #3,,DEM,Yes,87
+Angelina,20,Referenda Item #3,,DEM,Yes,243
+Angelina,21,Referenda Item #3,,DEM,Yes,48
+Angelina,22,Referenda Item #3,,DEM,Yes,45
+Angelina,23,Referenda Item #3,,DEM,Yes,17
+Angelina,24,Referenda Item #3,,DEM,Yes,64
+Angelina,25,Referenda Item #3,,DEM,Yes,72
+Angelina,26,Referenda Item #3,,DEM,Yes,42
+Angelina,27,Referenda Item #3,,DEM,Yes,10
+Angelina,28,Referenda Item #3,,DEM,Yes,37
+Angelina,29,Referenda Item #3,,DEM,Yes,40
+Angelina,30,Referenda Item #3,,DEM,Yes,17
+Angelina,31,Referenda Item #3,,DEM,Yes,15
+Angelina,32,Referenda Item #3,,DEM,Yes,4
+Angelina,33,Referenda Item #3,,DEM,Yes,22
+Angelina,34,Referenda Item #3,,DEM,Yes,87
+Angelina,35,Referenda Item #3,,DEM,Yes,75
+Angelina,36,Referenda Item #3,,DEM,Yes,0
+Angelina,37,Referenda Item #3,,DEM,Yes,23
+Angelina,38,Referenda Item #3,,DEM,Yes,13
+Angelina,39,Referenda Item #3,,DEM,Yes,19
+Angelina,40,Referenda Item #3,,DEM,Yes,45
+Angelina,1,Referenda Item #3,,DEM,No,5
+Angelina,2,Referenda Item #3,,DEM,No,34
+Angelina,3,Referenda Item #3,,DEM,No,17
+Angelina,4,Referenda Item #3,,DEM,No,9
+Angelina,5,Referenda Item #3,,DEM,No,17
+Angelina,6,Referenda Item #3,,DEM,No,2
+Angelina,7,Referenda Item #3,,DEM,No,2
+Angelina,8,Referenda Item #3,,DEM,No,2
+Angelina,9,Referenda Item #3,,DEM,No,2
+Angelina,10,Referenda Item #3,,DEM,No,6
+Angelina,11,Referenda Item #3,,DEM,No,6
+Angelina,11B,Referenda Item #3,,DEM,No,8
+Angelina,12,Referenda Item #3,,DEM,No,2
+Angelina,13,Referenda Item #3,,DEM,No,5
+Angelina,14,Referenda Item #3,,DEM,No,8
+Angelina,15,Referenda Item #3,,DEM,No,1
+Angelina,16,Referenda Item #3,,DEM,No,10
+Angelina,17,Referenda Item #3,,DEM,No,11
+Angelina,17B,Referenda Item #3,,DEM,No,2
+Angelina,18,Referenda Item #3,,DEM,No,3
+Angelina,19,Referenda Item #3,,DEM,No,7
+Angelina,20,Referenda Item #3,,DEM,No,52
+Angelina,21,Referenda Item #3,,DEM,No,10
+Angelina,22,Referenda Item #3,,DEM,No,14
+Angelina,23,Referenda Item #3,,DEM,No,1
+Angelina,24,Referenda Item #3,,DEM,No,9
+Angelina,25,Referenda Item #3,,DEM,No,8
+Angelina,26,Referenda Item #3,,DEM,No,9
+Angelina,27,Referenda Item #3,,DEM,No,2
+Angelina,28,Referenda Item #3,,DEM,No,4
+Angelina,29,Referenda Item #3,,DEM,No,9
+Angelina,30,Referenda Item #3,,DEM,No,5
+Angelina,31,Referenda Item #3,,DEM,No,4
+Angelina,32,Referenda Item #3,,DEM,No,0
+Angelina,33,Referenda Item #3,,DEM,No,4
+Angelina,34,Referenda Item #3,,DEM,No,3
+Angelina,35,Referenda Item #3,,DEM,No,9
+Angelina,36,Referenda Item #3,,DEM,No,0
+Angelina,37,Referenda Item #3,,DEM,No,5
+Angelina,38,Referenda Item #3,,DEM,No,0
+Angelina,39,Referenda Item #3,,DEM,No,2
+Angelina,40,Referenda Item #3,,DEM,No,5
+Angelina,1,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,2,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,3,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,4,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,5,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,6,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,7,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,8,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,9,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,10,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,11,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,11B,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,12,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,13,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,14,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,15,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,16,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,17,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,17B,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,18,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,19,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,20,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,21,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,22,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,23,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,24,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,25,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,26,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,27,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,28,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,29,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,30,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,31,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,32,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,33,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,34,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,35,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,36,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,37,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,38,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,39,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,40,Referenda Item #3,,DEM,OVER VOTES,0
+Angelina,1,Referenda Item #3,,DEM,UNDER VOTES,0
+Angelina,2,Referenda Item #3,,DEM,UNDER VOTES,35
+Angelina,3,Referenda Item #3,,DEM,UNDER VOTES,8
+Angelina,4,Referenda Item #3,,DEM,UNDER VOTES,19
+Angelina,5,Referenda Item #3,,DEM,UNDER VOTES,15
+Angelina,6,Referenda Item #3,,DEM,UNDER VOTES,2
+Angelina,7,Referenda Item #3,,DEM,UNDER VOTES,1
+Angelina,8,Referenda Item #3,,DEM,UNDER VOTES,0
+Angelina,9,Referenda Item #3,,DEM,UNDER VOTES,1
+Angelina,10,Referenda Item #3,,DEM,UNDER VOTES,11
+Angelina,11,Referenda Item #3,,DEM,UNDER VOTES,4
+Angelina,11B,Referenda Item #3,,DEM,UNDER VOTES,5
+Angelina,12,Referenda Item #3,,DEM,UNDER VOTES,3
+Angelina,13,Referenda Item #3,,DEM,UNDER VOTES,3
+Angelina,14,Referenda Item #3,,DEM,UNDER VOTES,9
+Angelina,15,Referenda Item #3,,DEM,UNDER VOTES,1
+Angelina,16,Referenda Item #3,,DEM,UNDER VOTES,16
+Angelina,17,Referenda Item #3,,DEM,UNDER VOTES,9
+Angelina,17B,Referenda Item #3,,DEM,UNDER VOTES,4
+Angelina,18,Referenda Item #3,,DEM,UNDER VOTES,2
+Angelina,19,Referenda Item #3,,DEM,UNDER VOTES,6
+Angelina,20,Referenda Item #3,,DEM,UNDER VOTES,80
+Angelina,21,Referenda Item #3,,DEM,UNDER VOTES,4
+Angelina,22,Referenda Item #3,,DEM,UNDER VOTES,1
+Angelina,23,Referenda Item #3,,DEM,UNDER VOTES,0
+Angelina,24,Referenda Item #3,,DEM,UNDER VOTES,6
+Angelina,25,Referenda Item #3,,DEM,UNDER VOTES,11
+Angelina,26,Referenda Item #3,,DEM,UNDER VOTES,6
+Angelina,27,Referenda Item #3,,DEM,UNDER VOTES,6
+Angelina,28,Referenda Item #3,,DEM,UNDER VOTES,0
+Angelina,29,Referenda Item #3,,DEM,UNDER VOTES,6
+Angelina,30,Referenda Item #3,,DEM,UNDER VOTES,1
+Angelina,31,Referenda Item #3,,DEM,UNDER VOTES,2
+Angelina,32,Referenda Item #3,,DEM,UNDER VOTES,0
+Angelina,33,Referenda Item #3,,DEM,UNDER VOTES,0
+Angelina,34,Referenda Item #3,,DEM,UNDER VOTES,6
+Angelina,35,Referenda Item #3,,DEM,UNDER VOTES,7
+Angelina,36,Referenda Item #3,,DEM,UNDER VOTES,0
+Angelina,37,Referenda Item #3,,DEM,UNDER VOTES,1
+Angelina,38,Referenda Item #3,,DEM,UNDER VOTES,1
+Angelina,39,Referenda Item #3,,DEM,UNDER VOTES,10
+Angelina,40,Referenda Item #3,,DEM,UNDER VOTES,4
+Angelina,1,Referenda Item #4,,DEM,Yes,30
+Angelina,2,Referenda Item #4,,DEM,Yes,232
+Angelina,3,Referenda Item #4,,DEM,Yes,61
+Angelina,4,Referenda Item #4,,DEM,Yes,71
+Angelina,5,Referenda Item #4,,DEM,Yes,100
+Angelina,6,Referenda Item #4,,DEM,Yes,20
+Angelina,7,Referenda Item #4,,DEM,Yes,21
+Angelina,8,Referenda Item #4,,DEM,Yes,25
+Angelina,9,Referenda Item #4,,DEM,Yes,13
+Angelina,10,Referenda Item #4,,DEM,Yes,91
+Angelina,11,Referenda Item #4,,DEM,Yes,43
+Angelina,11B,Referenda Item #4,,DEM,Yes,38
+Angelina,12,Referenda Item #4,,DEM,Yes,31
+Angelina,13,Referenda Item #4,,DEM,Yes,31
+Angelina,14,Referenda Item #4,,DEM,Yes,96
+Angelina,15,Referenda Item #4,,DEM,Yes,14
+Angelina,16,Referenda Item #4,,DEM,Yes,109
+Angelina,17,Referenda Item #4,,DEM,Yes,45
+Angelina,17B,Referenda Item #4,,DEM,Yes,13
+Angelina,18,Referenda Item #4,,DEM,Yes,31
+Angelina,19,Referenda Item #4,,DEM,Yes,78
+Angelina,20,Referenda Item #4,,DEM,Yes,305
+Angelina,21,Referenda Item #4,,DEM,Yes,48
+Angelina,22,Referenda Item #4,,DEM,Yes,49
+Angelina,23,Referenda Item #4,,DEM,Yes,18
+Angelina,24,Referenda Item #4,,DEM,Yes,66
+Angelina,25,Referenda Item #4,,DEM,Yes,76
+Angelina,26,Referenda Item #4,,DEM,Yes,43
+Angelina,27,Referenda Item #4,,DEM,Yes,14
+Angelina,28,Referenda Item #4,,DEM,Yes,37
+Angelina,29,Referenda Item #4,,DEM,Yes,43
+Angelina,30,Referenda Item #4,,DEM,Yes,20
+Angelina,31,Referenda Item #4,,DEM,Yes,20
+Angelina,32,Referenda Item #4,,DEM,Yes,4
+Angelina,33,Referenda Item #4,,DEM,Yes,24
+Angelina,34,Referenda Item #4,,DEM,Yes,81
+Angelina,35,Referenda Item #4,,DEM,Yes,75
+Angelina,36,Referenda Item #4,,DEM,Yes,0
+Angelina,37,Referenda Item #4,,DEM,Yes,21
+Angelina,38,Referenda Item #4,,DEM,Yes,11
+Angelina,39,Referenda Item #4,,DEM,Yes,20
+Angelina,40,Referenda Item #4,,DEM,Yes,49
+Angelina,1,Referenda Item #4,,DEM,No,1
+Angelina,2,Referenda Item #4,,DEM,No,13
+Angelina,3,Referenda Item #4,,DEM,No,9
+Angelina,4,Referenda Item #4,,DEM,No,7
+Angelina,5,Referenda Item #4,,DEM,No,18
+Angelina,6,Referenda Item #4,,DEM,No,0
+Angelina,7,Referenda Item #4,,DEM,No,1
+Angelina,8,Referenda Item #4,,DEM,No,0
+Angelina,9,Referenda Item #4,,DEM,No,2
+Angelina,10,Referenda Item #4,,DEM,No,9
+Angelina,11,Referenda Item #4,,DEM,No,4
+Angelina,11B,Referenda Item #4,,DEM,No,4
+Angelina,12,Referenda Item #4,,DEM,No,3
+Angelina,13,Referenda Item #4,,DEM,No,2
+Angelina,14,Referenda Item #4,,DEM,No,8
+Angelina,15,Referenda Item #4,,DEM,No,1
+Angelina,16,Referenda Item #4,,DEM,No,16
+Angelina,17,Referenda Item #4,,DEM,No,8
+Angelina,17B,Referenda Item #4,,DEM,No,1
+Angelina,18,Referenda Item #4,,DEM,No,4
+Angelina,19,Referenda Item #4,,DEM,No,14
+Angelina,20,Referenda Item #4,,DEM,No,19
+Angelina,21,Referenda Item #4,,DEM,No,9
+Angelina,22,Referenda Item #4,,DEM,No,7
+Angelina,23,Referenda Item #4,,DEM,No,0
+Angelina,24,Referenda Item #4,,DEM,No,8
+Angelina,25,Referenda Item #4,,DEM,No,6
+Angelina,26,Referenda Item #4,,DEM,No,7
+Angelina,27,Referenda Item #4,,DEM,No,0
+Angelina,28,Referenda Item #4,,DEM,No,3
+Angelina,29,Referenda Item #4,,DEM,No,4
+Angelina,30,Referenda Item #4,,DEM,No,2
+Angelina,31,Referenda Item #4,,DEM,No,0
+Angelina,32,Referenda Item #4,,DEM,No,0
+Angelina,33,Referenda Item #4,,DEM,No,2
+Angelina,34,Referenda Item #4,,DEM,No,10
+Angelina,35,Referenda Item #4,,DEM,No,6
+Angelina,36,Referenda Item #4,,DEM,No,0
+Angelina,37,Referenda Item #4,,DEM,No,4
+Angelina,38,Referenda Item #4,,DEM,No,2
+Angelina,39,Referenda Item #4,,DEM,No,2
+Angelina,40,Referenda Item #4,,DEM,No,1
+Angelina,1,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,2,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,3,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,4,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,5,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,6,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,7,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,8,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,9,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,10,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,11,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,11B,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,12,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,13,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,14,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,15,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,16,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,17,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,17B,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,18,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,19,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,20,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,21,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,22,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,23,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,24,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,25,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,26,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,27,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,28,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,29,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,30,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,31,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,32,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,33,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,34,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,35,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,36,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,37,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,38,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,39,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,40,Referenda Item #4,,DEM,OVER VOTES,0
+Angelina,1,Referenda Item #4,,DEM,UNDER VOTES,1
+Angelina,2,Referenda Item #4,,DEM,UNDER VOTES,23
+Angelina,3,Referenda Item #4,,DEM,UNDER VOTES,7
+Angelina,4,Referenda Item #4,,DEM,UNDER VOTES,18
+Angelina,5,Referenda Item #4,,DEM,UNDER VOTES,12
+Angelina,6,Referenda Item #4,,DEM,UNDER VOTES,1
+Angelina,7,Referenda Item #4,,DEM,UNDER VOTES,2
+Angelina,8,Referenda Item #4,,DEM,UNDER VOTES,0
+Angelina,9,Referenda Item #4,,DEM,UNDER VOTES,1
+Angelina,10,Referenda Item #4,,DEM,UNDER VOTES,11
+Angelina,11,Referenda Item #4,,DEM,UNDER VOTES,5
+Angelina,11B,Referenda Item #4,,DEM,UNDER VOTES,6
+Angelina,12,Referenda Item #4,,DEM,UNDER VOTES,5
+Angelina,13,Referenda Item #4,,DEM,UNDER VOTES,4
+Angelina,14,Referenda Item #4,,DEM,UNDER VOTES,11
+Angelina,15,Referenda Item #4,,DEM,UNDER VOTES,1
+Angelina,16,Referenda Item #4,,DEM,UNDER VOTES,10
+Angelina,17,Referenda Item #4,,DEM,UNDER VOTES,11
+Angelina,17B,Referenda Item #4,,DEM,UNDER VOTES,4
+Angelina,18,Referenda Item #4,,DEM,UNDER VOTES,1
+Angelina,19,Referenda Item #4,,DEM,UNDER VOTES,8
+Angelina,20,Referenda Item #4,,DEM,UNDER VOTES,51
+Angelina,21,Referenda Item #4,,DEM,UNDER VOTES,5
+Angelina,22,Referenda Item #4,,DEM,UNDER VOTES,4
+Angelina,23,Referenda Item #4,,DEM,UNDER VOTES,0
+Angelina,24,Referenda Item #4,,DEM,UNDER VOTES,5
+Angelina,25,Referenda Item #4,,DEM,UNDER VOTES,9
+Angelina,26,Referenda Item #4,,DEM,UNDER VOTES,7
+Angelina,27,Referenda Item #4,,DEM,UNDER VOTES,4
+Angelina,28,Referenda Item #4,,DEM,UNDER VOTES,1
+Angelina,29,Referenda Item #4,,DEM,UNDER VOTES,8
+Angelina,30,Referenda Item #4,,DEM,UNDER VOTES,1
+Angelina,31,Referenda Item #4,,DEM,UNDER VOTES,1
+Angelina,32,Referenda Item #4,,DEM,UNDER VOTES,0
+Angelina,33,Referenda Item #4,,DEM,UNDER VOTES,0
+Angelina,34,Referenda Item #4,,DEM,UNDER VOTES,5
+Angelina,35,Referenda Item #4,,DEM,UNDER VOTES,10
+Angelina,36,Referenda Item #4,,DEM,UNDER VOTES,0
+Angelina,37,Referenda Item #4,,DEM,UNDER VOTES,4
+Angelina,38,Referenda Item #4,,DEM,UNDER VOTES,1
+Angelina,39,Referenda Item #4,,DEM,UNDER VOTES,9
+Angelina,40,Referenda Item #4,,DEM,UNDER VOTES,4
+Angelina,1,Referenda Item #5,,DEM,Yes,22
+Angelina,2,Referenda Item #5,,DEM,Yes,165
+Angelina,3,Referenda Item #5,,DEM,Yes,54
+Angelina,4,Referenda Item #5,,DEM,Yes,54
+Angelina,5,Referenda Item #5,,DEM,Yes,81
+Angelina,6,Referenda Item #5,,DEM,Yes,13
+Angelina,7,Referenda Item #5,,DEM,Yes,14
+Angelina,8,Referenda Item #5,,DEM,Yes,19
+Angelina,9,Referenda Item #5,,DEM,Yes,13
+Angelina,10,Referenda Item #5,,DEM,Yes,71
+Angelina,11,Referenda Item #5,,DEM,Yes,33
+Angelina,11B,Referenda Item #5,,DEM,Yes,28
+Angelina,12,Referenda Item #5,,DEM,Yes,29
+Angelina,13,Referenda Item #5,,DEM,Yes,26
+Angelina,14,Referenda Item #5,,DEM,Yes,83
+Angelina,15,Referenda Item #5,,DEM,Yes,10
+Angelina,16,Referenda Item #5,,DEM,Yes,83
+Angelina,17,Referenda Item #5,,DEM,Yes,35
+Angelina,17B,Referenda Item #5,,DEM,Yes,8
+Angelina,18,Referenda Item #5,,DEM,Yes,26
+Angelina,19,Referenda Item #5,,DEM,Yes,70
+Angelina,20,Referenda Item #5,,DEM,Yes,191
+Angelina,21,Referenda Item #5,,DEM,Yes,47
+Angelina,22,Referenda Item #5,,DEM,Yes,41
+Angelina,23,Referenda Item #5,,DEM,Yes,12
+Angelina,24,Referenda Item #5,,DEM,Yes,51
+Angelina,25,Referenda Item #5,,DEM,Yes,51
+Angelina,26,Referenda Item #5,,DEM,Yes,34
+Angelina,27,Referenda Item #5,,DEM,Yes,10
+Angelina,28,Referenda Item #5,,DEM,Yes,27
+Angelina,29,Referenda Item #5,,DEM,Yes,35
+Angelina,30,Referenda Item #5,,DEM,Yes,18
+Angelina,31,Referenda Item #5,,DEM,Yes,15
+Angelina,32,Referenda Item #5,,DEM,Yes,2
+Angelina,33,Referenda Item #5,,DEM,Yes,20
+Angelina,34,Referenda Item #5,,DEM,Yes,79
+Angelina,35,Referenda Item #5,,DEM,Yes,72
+Angelina,36,Referenda Item #5,,DEM,Yes,0
+Angelina,37,Referenda Item #5,,DEM,Yes,16
+Angelina,38,Referenda Item #5,,DEM,Yes,9
+Angelina,39,Referenda Item #5,,DEM,Yes,16
+Angelina,40,Referenda Item #5,,DEM,Yes,42
+Angelina,1,Referenda Item #5,,DEM,No,10
+Angelina,2,Referenda Item #5,,DEM,No,83
+Angelina,3,Referenda Item #5,,DEM,No,19
+Angelina,4,Referenda Item #5,,DEM,No,29
+Angelina,5,Referenda Item #5,,DEM,No,40
+Angelina,6,Referenda Item #5,,DEM,No,8
+Angelina,7,Referenda Item #5,,DEM,No,9
+Angelina,8,Referenda Item #5,,DEM,No,6
+Angelina,9,Referenda Item #5,,DEM,No,2
+Angelina,10,Referenda Item #5,,DEM,No,34
+Angelina,11,Referenda Item #5,,DEM,No,17
+Angelina,11B,Referenda Item #5,,DEM,No,14
+Angelina,12,Referenda Item #5,,DEM,No,7
+Angelina,13,Referenda Item #5,,DEM,No,9
+Angelina,14,Referenda Item #5,,DEM,No,22
+Angelina,15,Referenda Item #5,,DEM,No,6
+Angelina,16,Referenda Item #5,,DEM,No,45
+Angelina,17,Referenda Item #5,,DEM,No,23
+Angelina,17B,Referenda Item #5,,DEM,No,5
+Angelina,18,Referenda Item #5,,DEM,No,9
+Angelina,19,Referenda Item #5,,DEM,No,22
+Angelina,20,Referenda Item #5,,DEM,No,136
+Angelina,21,Referenda Item #5,,DEM,No,14
+Angelina,22,Referenda Item #5,,DEM,No,19
+Angelina,23,Referenda Item #5,,DEM,No,6
+Angelina,24,Referenda Item #5,,DEM,No,24
+Angelina,25,Referenda Item #5,,DEM,No,34
+Angelina,26,Referenda Item #5,,DEM,No,18
+Angelina,27,Referenda Item #5,,DEM,No,6
+Angelina,28,Referenda Item #5,,DEM,No,14
+Angelina,29,Referenda Item #5,,DEM,No,14
+Angelina,30,Referenda Item #5,,DEM,No,4
+Angelina,31,Referenda Item #5,,DEM,No,5
+Angelina,32,Referenda Item #5,,DEM,No,2
+Angelina,33,Referenda Item #5,,DEM,No,5
+Angelina,34,Referenda Item #5,,DEM,No,14
+Angelina,35,Referenda Item #5,,DEM,No,13
+Angelina,36,Referenda Item #5,,DEM,No,0
+Angelina,37,Referenda Item #5,,DEM,No,13
+Angelina,38,Referenda Item #5,,DEM,No,4
+Angelina,39,Referenda Item #5,,DEM,No,8
+Angelina,40,Referenda Item #5,,DEM,No,8
+Angelina,1,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,2,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,3,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,4,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,5,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,6,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,7,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,8,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,9,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,10,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,11,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,11B,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,12,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,13,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,14,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,15,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,16,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,17,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,17B,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,18,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,19,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,20,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,21,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,22,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,23,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,24,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,25,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,26,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,27,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,28,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,29,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,30,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,31,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,32,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,33,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,34,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,35,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,36,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,37,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,38,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,39,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,40,Referenda Item #5,,DEM,OVER VOTES,0
+Angelina,1,Referenda Item #5,,DEM,UNDER VOTES,0
+Angelina,2,Referenda Item #5,,DEM,UNDER VOTES,20
+Angelina,3,Referenda Item #5,,DEM,UNDER VOTES,4
+Angelina,4,Referenda Item #5,,DEM,UNDER VOTES,13
+Angelina,5,Referenda Item #5,,DEM,UNDER VOTES,9
+Angelina,6,Referenda Item #5,,DEM,UNDER VOTES,0
+Angelina,7,Referenda Item #5,,DEM,UNDER VOTES,1
+Angelina,8,Referenda Item #5,,DEM,UNDER VOTES,0
+Angelina,9,Referenda Item #5,,DEM,UNDER VOTES,1
+Angelina,10,Referenda Item #5,,DEM,UNDER VOTES,6
+Angelina,11,Referenda Item #5,,DEM,UNDER VOTES,2
+Angelina,11B,Referenda Item #5,,DEM,UNDER VOTES,6
+Angelina,12,Referenda Item #5,,DEM,UNDER VOTES,3
+Angelina,13,Referenda Item #5,,DEM,UNDER VOTES,2
+Angelina,14,Referenda Item #5,,DEM,UNDER VOTES,10
+Angelina,15,Referenda Item #5,,DEM,UNDER VOTES,0
+Angelina,16,Referenda Item #5,,DEM,UNDER VOTES,7
+Angelina,17,Referenda Item #5,,DEM,UNDER VOTES,6
+Angelina,17B,Referenda Item #5,,DEM,UNDER VOTES,5
+Angelina,18,Referenda Item #5,,DEM,UNDER VOTES,1
+Angelina,19,Referenda Item #5,,DEM,UNDER VOTES,8
+Angelina,20,Referenda Item #5,,DEM,UNDER VOTES,48
+Angelina,21,Referenda Item #5,,DEM,UNDER VOTES,1
+Angelina,22,Referenda Item #5,,DEM,UNDER VOTES,0
+Angelina,23,Referenda Item #5,,DEM,UNDER VOTES,0
+Angelina,24,Referenda Item #5,,DEM,UNDER VOTES,4
+Angelina,25,Referenda Item #5,,DEM,UNDER VOTES,6
+Angelina,26,Referenda Item #5,,DEM,UNDER VOTES,5
+Angelina,27,Referenda Item #5,,DEM,UNDER VOTES,2
+Angelina,28,Referenda Item #5,,DEM,UNDER VOTES,0
+Angelina,29,Referenda Item #5,,DEM,UNDER VOTES,6
+Angelina,30,Referenda Item #5,,DEM,UNDER VOTES,1
+Angelina,31,Referenda Item #5,,DEM,UNDER VOTES,1
+Angelina,32,Referenda Item #5,,DEM,UNDER VOTES,0
+Angelina,33,Referenda Item #5,,DEM,UNDER VOTES,1
+Angelina,34,Referenda Item #5,,DEM,UNDER VOTES,3
+Angelina,35,Referenda Item #5,,DEM,UNDER VOTES,6
+Angelina,36,Referenda Item #5,,DEM,UNDER VOTES,0
+Angelina,37,Referenda Item #5,,DEM,UNDER VOTES,0
+Angelina,38,Referenda Item #5,,DEM,UNDER VOTES,1
+Angelina,39,Referenda Item #5,,DEM,UNDER VOTES,7
+Angelina,40,Referenda Item #5,,DEM,UNDER VOTES,4
+Angelina,1,Referenda Item #6,,DEM,Yes,26
+Angelina,2,Referenda Item #6,,DEM,Yes,209
+Angelina,3,Referenda Item #6,,DEM,Yes,55
+Angelina,4,Referenda Item #6,,DEM,Yes,67
+Angelina,5,Referenda Item #6,,DEM,Yes,106
+Angelina,6,Referenda Item #6,,DEM,Yes,20
+Angelina,7,Referenda Item #6,,DEM,Yes,18
+Angelina,8,Referenda Item #6,,DEM,Yes,19
+Angelina,9,Referenda Item #6,,DEM,Yes,15
+Angelina,10,Referenda Item #6,,DEM,Yes,88
+Angelina,11,Referenda Item #6,,DEM,Yes,33
+Angelina,11B,Referenda Item #6,,DEM,Yes,28
+Angelina,12,Referenda Item #6,,DEM,Yes,34
+Angelina,13,Referenda Item #6,,DEM,Yes,26
+Angelina,14,Referenda Item #6,,DEM,Yes,93
+Angelina,15,Referenda Item #6,,DEM,Yes,13
+Angelina,16,Referenda Item #6,,DEM,Yes,112
+Angelina,17,Referenda Item #6,,DEM,Yes,43
+Angelina,17B,Referenda Item #6,,DEM,Yes,9
+Angelina,18,Referenda Item #6,,DEM,Yes,32
+Angelina,19,Referenda Item #6,,DEM,Yes,83
+Angelina,20,Referenda Item #6,,DEM,Yes,270
+Angelina,21,Referenda Item #6,,DEM,Yes,52
+Angelina,22,Referenda Item #6,,DEM,Yes,36
+Angelina,23,Referenda Item #6,,DEM,Yes,14
+Angelina,24,Referenda Item #6,,DEM,Yes,59
+Angelina,25,Referenda Item #6,,DEM,Yes,70
+Angelina,26,Referenda Item #6,,DEM,Yes,43
+Angelina,27,Referenda Item #6,,DEM,Yes,13
+Angelina,28,Referenda Item #6,,DEM,Yes,35
+Angelina,29,Referenda Item #6,,DEM,Yes,32
+Angelina,30,Referenda Item #6,,DEM,Yes,15
+Angelina,31,Referenda Item #6,,DEM,Yes,18
+Angelina,32,Referenda Item #6,,DEM,Yes,4
+Angelina,33,Referenda Item #6,,DEM,Yes,22
+Angelina,34,Referenda Item #6,,DEM,Yes,84
+Angelina,35,Referenda Item #6,,DEM,Yes,72
+Angelina,36,Referenda Item #6,,DEM,Yes,0
+Angelina,37,Referenda Item #6,,DEM,Yes,22
+Angelina,38,Referenda Item #6,,DEM,Yes,13
+Angelina,39,Referenda Item #6,,DEM,Yes,23
+Angelina,40,Referenda Item #6,,DEM,Yes,38
+Angelina,1,Referenda Item #6,,DEM,No,5
+Angelina,2,Referenda Item #6,,DEM,No,33
+Angelina,3,Referenda Item #6,,DEM,No,14
+Angelina,4,Referenda Item #6,,DEM,No,13
+Angelina,5,Referenda Item #6,,DEM,No,17
+Angelina,6,Referenda Item #6,,DEM,No,0
+Angelina,7,Referenda Item #6,,DEM,No,5
+Angelina,8,Referenda Item #6,,DEM,No,6
+Angelina,9,Referenda Item #6,,DEM,No,0
+Angelina,10,Referenda Item #6,,DEM,No,15
+Angelina,11,Referenda Item #6,,DEM,No,15
+Angelina,11B,Referenda Item #6,,DEM,No,15
+Angelina,12,Referenda Item #6,,DEM,No,3
+Angelina,13,Referenda Item #6,,DEM,No,7
+Angelina,14,Referenda Item #6,,DEM,No,13
+Angelina,15,Referenda Item #6,,DEM,No,3
+Angelina,16,Referenda Item #6,,DEM,No,13
+Angelina,17,Referenda Item #6,,DEM,No,17
+Angelina,17B,Referenda Item #6,,DEM,No,4
+Angelina,18,Referenda Item #6,,DEM,No,3
+Angelina,19,Referenda Item #6,,DEM,No,11
+Angelina,20,Referenda Item #6,,DEM,No,46
+Angelina,21,Referenda Item #6,,DEM,No,8
+Angelina,22,Referenda Item #6,,DEM,No,18
+Angelina,23,Referenda Item #6,,DEM,No,3
+Angelina,24,Referenda Item #6,,DEM,No,15
+Angelina,25,Referenda Item #6,,DEM,No,15
+Angelina,26,Referenda Item #6,,DEM,No,8
+Angelina,27,Referenda Item #6,,DEM,No,0
+Angelina,28,Referenda Item #6,,DEM,No,6
+Angelina,29,Referenda Item #6,,DEM,No,14
+Angelina,30,Referenda Item #6,,DEM,No,7
+Angelina,31,Referenda Item #6,,DEM,No,2
+Angelina,32,Referenda Item #6,,DEM,No,0
+Angelina,33,Referenda Item #6,,DEM,No,3
+Angelina,34,Referenda Item #6,,DEM,No,9
+Angelina,35,Referenda Item #6,,DEM,No,13
+Angelina,36,Referenda Item #6,,DEM,No,0
+Angelina,37,Referenda Item #6,,DEM,No,6
+Angelina,38,Referenda Item #6,,DEM,No,0
+Angelina,39,Referenda Item #6,,DEM,No,0
+Angelina,40,Referenda Item #6,,DEM,No,9
+Angelina,1,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,2,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,3,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,4,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,5,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,6,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,7,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,8,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,9,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,10,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,11,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,11B,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,12,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,13,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,14,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,15,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,16,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,17,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,17B,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,18,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,19,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,20,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,21,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,22,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,23,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,24,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,25,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,26,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,27,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,28,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,29,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,30,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,31,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,32,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,33,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,34,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,35,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,36,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,37,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,38,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,39,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,40,Referenda Item #6,,DEM,OVER VOTES,0
+Angelina,1,Referenda Item #6,,DEM,UNDER VOTES,1
+Angelina,2,Referenda Item #6,,DEM,UNDER VOTES,26
+Angelina,3,Referenda Item #6,,DEM,UNDER VOTES,8
+Angelina,4,Referenda Item #6,,DEM,UNDER VOTES,16
+Angelina,5,Referenda Item #6,,DEM,UNDER VOTES,7
+Angelina,6,Referenda Item #6,,DEM,UNDER VOTES,1
+Angelina,7,Referenda Item #6,,DEM,UNDER VOTES,1
+Angelina,8,Referenda Item #6,,DEM,UNDER VOTES,0
+Angelina,9,Referenda Item #6,,DEM,UNDER VOTES,1
+Angelina,10,Referenda Item #6,,DEM,UNDER VOTES,8
+Angelina,11,Referenda Item #6,,DEM,UNDER VOTES,4
+Angelina,11B,Referenda Item #6,,DEM,UNDER VOTES,5
+Angelina,12,Referenda Item #6,,DEM,UNDER VOTES,2
+Angelina,13,Referenda Item #6,,DEM,UNDER VOTES,4
+Angelina,14,Referenda Item #6,,DEM,UNDER VOTES,9
+Angelina,15,Referenda Item #6,,DEM,UNDER VOTES,0
+Angelina,16,Referenda Item #6,,DEM,UNDER VOTES,10
+Angelina,17,Referenda Item #6,,DEM,UNDER VOTES,4
+Angelina,17B,Referenda Item #6,,DEM,UNDER VOTES,5
+Angelina,18,Referenda Item #6,,DEM,UNDER VOTES,1
+Angelina,19,Referenda Item #6,,DEM,UNDER VOTES,6
+Angelina,20,Referenda Item #6,,DEM,UNDER VOTES,59
+Angelina,21,Referenda Item #6,,DEM,UNDER VOTES,2
+Angelina,22,Referenda Item #6,,DEM,UNDER VOTES,6
+Angelina,23,Referenda Item #6,,DEM,UNDER VOTES,1
+Angelina,24,Referenda Item #6,,DEM,UNDER VOTES,5
+Angelina,25,Referenda Item #6,,DEM,UNDER VOTES,6
+Angelina,26,Referenda Item #6,,DEM,UNDER VOTES,6
+Angelina,27,Referenda Item #6,,DEM,UNDER VOTES,5
+Angelina,28,Referenda Item #6,,DEM,UNDER VOTES,0
+Angelina,29,Referenda Item #6,,DEM,UNDER VOTES,9
+Angelina,30,Referenda Item #6,,DEM,UNDER VOTES,1
+Angelina,31,Referenda Item #6,,DEM,UNDER VOTES,1
+Angelina,32,Referenda Item #6,,DEM,UNDER VOTES,0
+Angelina,33,Referenda Item #6,,DEM,UNDER VOTES,1
+Angelina,34,Referenda Item #6,,DEM,UNDER VOTES,3
+Angelina,35,Referenda Item #6,,DEM,UNDER VOTES,6
+Angelina,36,Referenda Item #6,,DEM,UNDER VOTES,0
+Angelina,37,Referenda Item #6,,DEM,UNDER VOTES,1
+Angelina,38,Referenda Item #6,,DEM,UNDER VOTES,1
+Angelina,39,Referenda Item #6,,DEM,UNDER VOTES,8
+Angelina,40,Referenda Item #6,,DEM,UNDER VOTES,7


### PR DESCRIPTION
The .ASC file in the sources repository was missing half the Republican primary races and all the Democratic primary races.
I had to use OCR on the canvass report to parse these results, and there were handwritten corrections that I incorporated as well.
I've verified that totals for each race add up to what was printed on the top of the canvass report.

The second page of the canvass report, with the results for the Republican presidential primary election, was missing, and I could not locate it; as such, that data is not present in this PR.