### PR TITLE
Add precinct-level results for the 2016 primaries in Cochran County

### DIFF
--- a/2016/20160301__tx__primary__cochran__precinct.csv
+++ b/2016/20160301__tx__primary__cochran__precinct.csv
@@ -1,0 +1,531 @@
+county,precinct,office,district,party,candidate,votes,early_voting,election_day
+Cochran,101,Registered Voters - Total,,,,477,,
+Cochran,202,Registered Voters - Total,,,,453,,
+Cochran,303,Registered Voters - Total,,,,92,,
+Cochran,306,Registered Voters - Total,,,,386,,
+Cochran,404,Registered Voters - Total,,,,331,,
+Cochran,101,President,,REP,Mike Huckabee,2,2,0
+Cochran,202,President,,REP,Mike Huckabee,1,1,0
+Cochran,303,President,,REP,Mike Huckabee,3,0,3
+Cochran,306,President,,REP,Mike Huckabee,1,0,1
+Cochran,404,President,,REP,Mike Huckabee,1,0,1
+Cochran,101,President,,REP,Lindsey Graham,0,0,0
+Cochran,202,President,,REP,Lindsey Graham,1,0,1
+Cochran,303,President,,REP,Lindsey Graham,0,0,0
+Cochran,306,President,,REP,Lindsey Graham,0,0,0
+Cochran,404,President,,REP,Lindsey Graham,0,0,0
+Cochran,101,President,,REP,Donald J. Trump,48,30,18
+Cochran,202,President,,REP,Donald J. Trump,33,6,27
+Cochran,303,President,,REP,Donald J. Trump,9,4,5
+Cochran,306,President,,REP,Donald J. Trump,44,27,17
+Cochran,404,President,,REP,Donald J. Trump,19,11,8
+Cochran,101,President,,REP,Ben Carson,12,5,7
+Cochran,202,President,,REP,Ben Carson,7,0,7
+Cochran,303,President,,REP,Ben Carson,9,5,4
+Cochran,306,President,,REP,Ben Carson,7,2,5
+Cochran,404,President,,REP,Ben Carson,4,3,1
+Cochran,101,President,,REP,Carly Fiorina,0,0,0
+Cochran,202,President,,REP,Carly Fiorina,1,0,1
+Cochran,303,President,,REP,Carly Fiorina,0,0,0
+Cochran,306,President,,REP,Carly Fiorina,0,0,0
+Cochran,404,President,,REP,Carly Fiorina,0,0,0
+Cochran,101,President,,REP,Chris Christie,0,0,0
+Cochran,202,President,,REP,Chris Christie,0,0,0
+Cochran,303,President,,REP,Chris Christie,0,0,0
+Cochran,306,President,,REP,Chris Christie,0,0,0
+Cochran,404,President,,REP,Chris Christie,1,1,0
+Cochran,101,President,,REP,Rick Santorum,0,0,0
+Cochran,202,President,,REP,Rick Santorum,0,0,0
+Cochran,303,President,,REP,Rick Santorum,0,0,0
+Cochran,306,President,,REP,Rick Santorum,0,0,0
+Cochran,404,President,,REP,Rick Santorum,1,1,0
+Cochran,101,President,,REP,Marco Rubio,39,15,24
+Cochran,202,President,,REP,Marco Rubio,17,3,14
+Cochran,303,President,,REP,Marco Rubio,2,0,2
+Cochran,306,President,,REP,Marco Rubio,40,10,30
+Cochran,404,President,,REP,Marco Rubio,24,8,16
+Cochran,101,President,,REP,John R. Kasich,2,1,1
+Cochran,202,President,,REP,John R. Kasich,3,0,3
+Cochran,303,President,,REP,John R. Kasich,0,0,0
+Cochran,306,President,,REP,John R. Kasich,7,7,0
+Cochran,404,President,,REP,John R. Kasich,3,3,0
+Cochran,101,President,,REP,Rand Paul,1,0,1
+Cochran,202,President,,REP,Rand Paul,1,0,1
+Cochran,303,President,,REP,Rand Paul,0,0,0
+Cochran,306,President,,REP,Rand Paul,0,0,0
+Cochran,404,President,,REP,Rand Paul,1,0,1
+Cochran,101,President,,REP,Jeb Bush,10,7,3
+Cochran,202,President,,REP,Jeb Bush,7,4,3
+Cochran,303,President,,REP,Jeb Bush,1,1,0
+Cochran,306,President,,REP,Jeb Bush,5,4,1
+Cochran,404,President,,REP,Jeb Bush,7,5,2
+Cochran,101,President,,REP,Elizabeth Gray,1,1,0
+Cochran,202,President,,REP,Elizabeth Gray,0,0,0
+Cochran,303,President,,REP,Elizabeth Gray,0,0,0
+Cochran,306,President,,REP,Elizabeth Gray,1,0,1
+Cochran,404,President,,REP,Elizabeth Gray,1,0,1
+Cochran,101,President,,REP,Ted Cruz,104,58,46
+Cochran,202,President,,REP,Ted Cruz,95,11,84
+Cochran,303,President,,REP,Ted Cruz,25,6,19
+Cochran,306,President,,REP,Ted Cruz,89,45,44
+Cochran,404,President,,REP,Ted Cruz,40,19,21
+Cochran,101,President,,REP,Uncommitted,6,3,3
+Cochran,202,President,,REP,Uncommitted,6,2,4
+Cochran,303,President,,REP,Uncommitted,0,0,0
+Cochran,306,President,,REP,Uncommitted,2,2,0
+Cochran,404,President,,REP,Uncommitted,5,2,3
+Cochran,101,President,,DEM,Martin J. O'Malley,0,0,0
+Cochran,202,President,,DEM,Martin J. O'Malley,0,0,0
+Cochran,303,President,,DEM,Martin J. O'Malley,0,0,0
+Cochran,306,President,,DEM,Martin J. O'Malley,0,0,0
+Cochran,404,President,,DEM,Martin J. O'Malley,0,0,0
+Cochran,101,President,,DEM,Star Locke,0,0,0
+Cochran,202,President,,DEM,Star Locke,0,0,0
+Cochran,303,President,,DEM,Star Locke,0,0,0
+Cochran,306,President,,DEM,Star Locke,0,0,0
+Cochran,404,President,,DEM,Star Locke,0,0,0
+Cochran,101,President,,DEM,Hillary Clinton,4,3,1
+Cochran,202,President,,DEM,Hillary Clinton,0,0,0
+Cochran,303,President,,DEM,Hillary Clinton,0,0,0
+Cochran,306,President,,DEM,Hillary Clinton,0,0,0
+Cochran,404,President,,DEM,Hillary Clinton,0,0,0
+Cochran,101,President,,DEM,Bernie Sanders,3,2,1
+Cochran,202,President,,DEM,Bernie Sanders,0,0,0
+Cochran,303,President,,DEM,Bernie Sanders,0,0,0
+Cochran,306,President,,DEM,Bernie Sanders,0,0,0
+Cochran,404,President,,DEM,Bernie Sanders,0,0,0
+Cochran,101,President,,DEM,Keith Judd,0,0,0
+Cochran,202,President,,DEM,Keith Judd,0,0,0
+Cochran,303,President,,DEM,Keith Judd,0,0,0
+Cochran,306,President,,DEM,Keith Judd,0,0,0
+Cochran,404,President,,DEM,Keith Judd,0,0,0
+Cochran,101,President,,DEM,"Roque ""Rocky"" De La Fuente",0,0,0
+Cochran,202,President,,DEM,"Roque ""Rocky"" De La Fuente",0,0,0
+Cochran,303,President,,DEM,"Roque ""Rocky"" De La Fuente",0,0,0
+Cochran,306,President,,DEM,"Roque ""Rocky"" De La Fuente",0,0,0
+Cochran,404,President,,DEM,"Roque ""Rocky"" De La Fuente",0,0,0
+Cochran,101,President,,DEM,Willie L. Wison,0,0,0
+Cochran,202,President,,DEM,Willie L. Wison,0,0,0
+Cochran,303,President,,DEM,Willie L. Wison,0,0,0
+Cochran,306,President,,DEM,Willie L. Wison,0,0,0
+Cochran,404,President,,DEM,Willie L. Wison,0,0,0
+Cochran,101,President,,DEM,Calvis L. Hawes,1,1,0
+Cochran,202,President,,DEM,Calvis L. Hawes,0,0,0
+Cochran,303,President,,DEM,Calvis L. Hawes,0,0,0
+Cochran,306,President,,DEM,Calvis L. Hawes,0,0,0
+Cochran,404,President,,DEM,Calvis L. Hawes,0,0,0
+Cochran,101,U.S. House,19,REP,Michael Bob Star,20,9,11
+Cochran,202,U.S. House,19,REP,Michael Bob Star,26,8,18
+Cochran,303,U.S. House,19,REP,Michael Bob Star,3,2,1
+Cochran,306,U.S. House,19,REP,Michael Bob Star,22,11,11
+Cochran,404,U.S. House,19,REP,Michael Bob Star,7,4,3
+Cochran,101,U.S. House,19,REP,Greg Garrett,32,15,17
+Cochran,202,U.S. House,19,REP,Greg Garrett,20,2,18
+Cochran,303,U.S. House,19,REP,Greg Garrett,3,0,3
+Cochran,306,U.S. House,19,REP,Greg Garrett,28,10,18
+Cochran,404,U.S. House,19,REP,Greg Garrett,18,7,11
+Cochran,101,U.S. House,19,REP,Glen Robertson,52,32,20
+Cochran,202,U.S. House,19,REP,Glen Robertson,42,5,37
+Cochran,303,U.S. House,19,REP,Glen Robertson,24,8,16
+Cochran,306,U.S. House,19,REP,Glen Robertson,49,29,20
+Cochran,404,U.S. House,19,REP,Glen Robertson,36,22,14
+Cochran,101,U.S. House,19,REP,Jason Corley,6,6,0
+Cochran,202,U.S. House,19,REP,Jason Corley,2,0,2
+Cochran,303,U.S. House,19,REP,Jason Corley,0,0,0
+Cochran,306,U.S. House,19,REP,Jason Corley,1,0,1
+Cochran,404,U.S. House,19,REP,Jason Corley,4,0,4
+Cochran,101,U.S. House,19,REP,DaRenda Warren,3,3,0
+Cochran,202,U.S. House,19,REP,DaRenda Warren,8,0,8
+Cochran,303,U.S. House,19,REP,DaRenda Warren,0,0,0
+Cochran,306,U.S. House,19,REP,DaRenda Warren,2,0,2
+Cochran,404,U.S. House,19,REP,DaRenda Warren,2,1,1
+Cochran,101,U.S. House,19,REP,John C. Key,3,2,1
+Cochran,202,U.S. House,19,REP,John C. Key,7,0,7
+Cochran,303,U.S. House,19,REP,John C. Key,0,0,0
+Cochran,306,U.S. House,19,REP,John C. Key,2,1,1
+Cochran,404,U.S. House,19,REP,John C. Key,2,0,2
+Cochran,101,U.S. House,19,REP,Donald R. May,21,9,12
+Cochran,202,U.S. House,19,REP,Donald R. May,21,1,20
+Cochran,303,U.S. House,19,REP,Donald R. May,12,3,9
+Cochran,306,U.S. House,19,REP,Donald R. May,12,5,7
+Cochran,404,U.S. House,19,REP,Donald R. May,4,3,1
+Cochran,101,U.S. House,19,REP,Don Parrish,7,3,4
+Cochran,202,U.S. House,19,REP,Don Parrish,2,0,2
+Cochran,303,U.S. House,19,REP,Don Parrish,2,1,1
+Cochran,306,U.S. House,19,REP,Don Parrish,4,4,0
+Cochran,404,U.S. House,19,REP,Don Parrish,1,0,1
+Cochran,101,U.S. House,19,REP,Jodey Arrington,61,32,29
+Cochran,202,U.S. House,19,REP,Jodey Arrington,42,10,32
+Cochran,303,U.S. House,19,REP,Jodey Arrington,4,2,2
+Cochran,306,U.S. House,19,REP,Jodey Arrington,59,30,29
+Cochran,404,U.S. House,19,REP,Jodey Arrington,24,11,13
+Cochran,101,Railroad Commissioner,,REP,Lance N. Christian,24,15,9
+Cochran,202,Railroad Commissioner,,REP,Lance N. Christian,21,5,16
+Cochran,303,Railroad Commissioner,,REP,Lance N. Christian,6,1,5
+Cochran,306,Railroad Commissioner,,REP,Lance N. Christian,18,9,9
+Cochran,404,Railroad Commissioner,,REP,Lance N. Christian,10,6,4
+Cochran,101,Railroad Commissioner,,REP,Wayne Christian,40,21,19
+Cochran,202,Railroad Commissioner,,REP,Wayne Christian,22,3,19
+Cochran,303,Railroad Commissioner,,REP,Wayne Christian,6,2,4
+Cochran,306,Railroad Commissioner,,REP,Wayne Christian,34,12,22
+Cochran,404,Railroad Commissioner,,REP,Wayne Christian,14,10,4
+Cochran,101,Railroad Commissioner,,REP,Ron Hale,25,13,12
+Cochran,202,Railroad Commissioner,,REP,Ron Hale,24,5,19
+Cochran,303,Railroad Commissioner,,REP,Ron Hale,5,3,2
+Cochran,306,Railroad Commissioner,,REP,Ron Hale,23,12,11
+Cochran,404,Railroad Commissioner,,REP,Ron Hale,7,1,6
+Cochran,101,Railroad Commissioner,,REP,Gary Gates,39,17,22
+Cochran,202,Railroad Commissioner,,REP,Gary Gates,32,6,26
+Cochran,303,Railroad Commissioner,,REP,Gary Gates,10,5,5
+Cochran,306,Railroad Commissioner,,REP,Gary Gates,34,19,15
+Cochran,404,Railroad Commissioner,,REP,Gary Gates,18,7,11
+Cochran,101,Railroad Commissioner,,REP,Weston Martinez,39,22,17
+Cochran,202,Railroad Commissioner,,REP,Weston Martinez,17,0,17
+Cochran,303,Railroad Commissioner,,REP,Weston Martinez,3,0,3
+Cochran,306,Railroad Commissioner,,REP,Weston Martinez,29,16,13
+Cochran,404,Railroad Commissioner,,REP,Weston Martinez,26,14,12
+Cochran,101,Railroad Commissioner,,REP,John Greytok,2,2,0
+Cochran,202,Railroad Commissioner,,REP,John Greytok,6,0,6
+Cochran,303,Railroad Commissioner,,REP,John Greytok,3,0,3
+Cochran,306,Railroad Commissioner,,REP,John Greytok,4,2,2
+Cochran,404,Railroad Commissioner,,REP,John Greytok,1,1,0
+Cochran,101,Railroad Commissioner,,REP,Doug Jeffrey,10,8,2
+Cochran,202,Railroad Commissioner,,REP,Doug Jeffrey,20,4,16
+Cochran,303,Railroad Commissioner,,REP,Doug Jeffrey,5,2,3
+Cochran,306,Railroad Commissioner,,REP,Doug Jeffrey,11,4,7
+Cochran,404,Railroad Commissioner,,REP,Doug Jeffrey,9,2,7
+Cochran,101,Railroad Commissioner,,DEM,Cody Garrett,3,3,0
+Cochran,202,Railroad Commissioner,,DEM,Cody Garrett,0,0,0
+Cochran,303,Railroad Commissioner,,DEM,Cody Garrett,0,0,0
+Cochran,306,Railroad Commissioner,,DEM,Cody Garrett,0,0,0
+Cochran,404,Railroad Commissioner,,DEM,Cody Garrett,0,0,0
+Cochran,101,Railroad Commissioner,,DEM,Grady Yarbrough,3,2,1
+Cochran,202,Railroad Commissioner,,DEM,Grady Yarbrough,0,0,0
+Cochran,303,Railroad Commissioner,,DEM,Grady Yarbrough,0,0,0
+Cochran,306,Railroad Commissioner,,DEM,Grady Yarbrough,0,0,0
+Cochran,404,Railroad Commissioner,,DEM,Grady Yarbrough,0,0,0
+Cochran,101,Railroad Commissioner,,DEM,Lon Burnam,1,1,0
+Cochran,202,Railroad Commissioner,,DEM,Lon Burnam,0,0,0
+Cochran,303,Railroad Commissioner,,DEM,Lon Burnam,0,0,0
+Cochran,306,Railroad Commissioner,,DEM,Lon Burnam,0,0,0
+Cochran,404,Railroad Commissioner,,DEM,Lon Burnam,0,0,0
+Cochran,101,"Justice, Supreme Court, Place 3",,REP,Debra Lehmann,89,46,43
+Cochran,202,"Justice, Supreme Court, Place 3",,REP,Debra Lehmann,58,10,48
+Cochran,303,"Justice, Supreme Court, Place 3",,REP,Debra Lehmann,23,4,19
+Cochran,306,"Justice, Supreme Court, Place 3",,REP,Debra Lehmann,67,29,38
+Cochran,404,"Justice, Supreme Court, Place 3",,REP,Debra Lehmann,47,28,19
+Cochran,101,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,93,51,42
+Cochran,202,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,93,13,80
+Cochran,303,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,19,9,10
+Cochran,306,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,82,46,36
+Cochran,404,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,39,13,26
+Cochran,101,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,5,5,0
+Cochran,202,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,0,0,0
+Cochran,303,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,0,0,0
+Cochran,306,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,0,0,0
+Cochran,404,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,0,0,0
+Cochran,101,"Justice, Supreme Court, Place 5",,REP,Rick Green,115,62,53
+Cochran,202,"Justice, Supreme Court, Place 5",,REP,Rick Green,75,15,60
+Cochran,303,"Justice, Supreme Court, Place 5",,REP,Rick Green,14,6,8
+Cochran,306,"Justice, Supreme Court, Place 5",,REP,Rick Green,78,41,37
+Cochran,404,"Justice, Supreme Court, Place 5",,REP,Rick Green,49,24,25
+Cochran,101,"Justice, Supreme Court, Place 5",,REP,Paul Green,57,30,27
+Cochran,202,"Justice, Supreme Court, Place 5",,REP,Paul Green,66,7,59
+Cochran,303,"Justice, Supreme Court, Place 5",,REP,Paul Green,25,6,19
+Cochran,306,"Justice, Supreme Court, Place 5",,REP,Paul Green,75,34,41
+Cochran,404,"Justice, Supreme Court, Place 5",,REP,Paul Green,33,13,20
+Cochran,101,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,5,5,0
+Cochran,202,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,0,0,0
+Cochran,303,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,0,0,0
+Cochran,306,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,0,0,0
+Cochran,404,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,0,0,0
+Cochran,101,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,111,55,56
+Cochran,202,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,72,5,67
+Cochran,303,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,19,3,16
+Cochran,306,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,91,41,50
+Cochran,404,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,66,32,34
+Cochran,101,"Justice, Supreme Court, Place 9",,REP,Joe Pool,72,45,27
+Cochran,202,"Justice, Supreme Court, Place 9",,REP,Joe Pool,71,17,54
+Cochran,303,"Justice, Supreme Court, Place 9",,REP,Joe Pool,20,9,11
+Cochran,306,"Justice, Supreme Court, Place 9",,REP,Joe Pool,58,34,24
+Cochran,404,"Justice, Supreme Court, Place 9",,REP,Joe Pool,21,8,13
+Cochran,101,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,5,5,0
+Cochran,202,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,0,0,0
+Cochran,303,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,0,0,0
+Cochran,306,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,0,0,0
+Cochran,404,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,0,0,0
+Cochran,101,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,69,39,30
+Cochran,202,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,48,8,40
+Cochran,303,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,16,3,13
+Cochran,306,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,55,30,25
+Cochran,404,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,30,15,15
+Cochran,101,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,61,31,30
+Cochran,202,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,47,7,40
+Cochran,303,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,12,6,6
+Cochran,306,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,54,27,27
+Cochran,404,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,30,15,15
+Cochran,101,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,30,16,14
+Cochran,202,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,36,6,30
+Cochran,303,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,7,2,5
+Cochran,306,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,35,15,20
+Cochran,404,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,18,6,12
+Cochran,101,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",5,5,0
+Cochran,202,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",0,0,0
+Cochran,303,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",0,0,0
+Cochran,306,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",0,0,0
+Cochran,404,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",0,0,0
+Cochran,101,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,48,27,21
+Cochran,202,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,41,9,32
+Cochran,303,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,9,3,6
+Cochran,306,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,36,16,20
+Cochran,404,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,22,8,14
+Cochran,101,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,27,14,13
+Cochran,202,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,13,2,11
+Cochran,303,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,2,0,2
+Cochran,306,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,23,5,18
+Cochran,404,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,10,5,5
+Cochran,101,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,66,33,33
+Cochran,202,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,50,4,46
+Cochran,303,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,19,7,12
+Cochran,306,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,62,34,28
+Cochran,404,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,36,18,18
+Cochran,101,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,22,12,10
+Cochran,202,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,27,5,22
+Cochran,303,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,4,1,3
+Cochran,306,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,24,17,7
+Cochran,404,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,13,6,7
+Cochran,101,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,6,6,0
+Cochran,202,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,0,0,0
+Cochran,303,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,0,0,0
+Cochran,306,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,0,0,0
+Cochran,404,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,0,0,0
+Cochran,101,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,91,49,42
+Cochran,202,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,65,12,53
+Cochran,303,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,26,8,18
+Cochran,306,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,81,40,41
+Cochran,404,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,44,16,28
+Cochran,101,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,71,38,33
+Cochran,202,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,67,10,57
+Cochran,303,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,8,3,5
+Cochran,306,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,65,32,33
+Cochran,404,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,38,21,17
+Cochran,101,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,6,5,1
+Cochran,202,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,0,0,0
+Cochran,303,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,0,0,0
+Cochran,306,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,0,0,0
+Cochran,404,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,0,0,0
+Cochran,101,"Member, State Board of Education, District 15",,REP,Marty Rowley,154,78,76
+Cochran,202,"Member, State Board of Education, District 15",,REP,Marty Rowley,124,20,104
+Cochran,303,"Member, State Board of Education, District 15",,REP,Marty Rowley,32,10,22
+Cochran,306,"Member, State Board of Education, District 15",,REP,Marty Rowley,138,68,70
+Cochran,404,"Member, State Board of Education, District 15",,REP,Marty Rowley,69,31,38
+Cochran,101,State Representative,88,REP,Ken King,160,82,78
+Cochran,202,State Representative,88,REP,Ken King,131,24,107
+Cochran,303,State Representative,88,REP,Ken King,36,12,24
+Cochran,306,State Representative,88,REP,Ken King,147,73,74
+Cochran,404,State Representative,88,REP,Ken King,79,35,44
+Cochran,101,"Justice, 7th Court of Appeals District, Place 4",,REP,Jim Campbell,159,82,77
+Cochran,202,"Justice, 7th Court of Appeals District, Place 4",,REP,Jim Campbell,123,24,99
+Cochran,303,"Justice, 7th Court of Appeals District, Place 4",,REP,Jim Campbell,33,10,23
+Cochran,306,"Justice, 7th Court of Appeals District, Place 4",,REP,Jim Campbell,142,71,71
+Cochran,404,"Justice, 7th Court of Appeals District, Place 4",,REP,Jim Campbell,80,36,44
+Cochran,101,"District Attornery, 286th Judicial District",,REP,Richard Husen,67,45,22
+Cochran,202,"District Attornery, 286th Judicial District",,REP,Richard Husen,65,9,56
+Cochran,303,"District Attornery, 286th Judicial District",,REP,Richard Husen,20,6,14
+Cochran,306,"District Attornery, 286th Judicial District",,REP,Richard Husen,53,25,28
+Cochran,404,"District Attornery, 286th Judicial District",,REP,Richard Husen,31,12,19
+Cochran,101,"District Attornery, 286th Judicial District",,REP,Christopher E. Dennis,125,60,65
+Cochran,202,"District Attornery, 286th Judicial District",,REP,Christopher E. Dennis,91,17,74
+Cochran,303,"District Attornery, 286th Judicial District",,REP,Christopher E. Dennis,21,7,14
+Cochran,306,"District Attornery, 286th Judicial District",,REP,Christopher E. Dennis,110,59,51
+Cochran,404,"District Attornery, 286th Judicial District",,REP,Christopher E. Dennis,61,31,30
+Cochran,101,County Attorney,,REP,"J. Collier Adams, Jr.",173,86,87
+Cochran,202,County Attorney,,REP,"J. Collier Adams, Jr.",130,25,105
+Cochran,303,County Attorney,,REP,"J. Collier Adams, Jr.",38,9,29
+Cochran,306,County Attorney,,REP,"J. Collier Adams, Jr.",141,71,70
+Cochran,404,County Attorney,,REP,"J. Collier Adams, Jr.",86,40,46
+Cochran,101,Sheriff,,REP,Jorge De La Cruz,152,75,77
+Cochran,202,Sheriff,,REP,Jorge De La Cruz,58,8,50
+Cochran,303,Sheriff,,REP,Jorge De La Cruz,24,8,16
+Cochran,306,Sheriff,,REP,Jorge De La Cruz,137,59,78
+Cochran,404,Sheriff,,REP,Jorge De La Cruz,88,42,46
+Cochran,101,Sheriff,,REP,Raymond Weber,80,51,29
+Cochran,202,Sheriff,,REP,Raymond Weber,115,20,95
+Cochran,303,Sheriff,,REP,Raymond Weber,26,8,18
+Cochran,306,Sheriff,,REP,Raymond Weber,63,37,26
+Cochran,404,Sheriff,,REP,Raymond Weber,28,13,15
+Cochran,101,County Tax Assessor-Collector,,REP,Treva Jackson,197,102,95
+Cochran,202,County Tax Assessor-Collector,,REP,Treva Jackson,143,26,117
+Cochran,303,County Tax Assessor-Collector,,REP,Treva Jackson,43,13,30
+Cochran,306,County Tax Assessor-Collector,,REP,Treva Jackson,161,84,77
+Cochran,404,County Tax Assessor-Collector,,REP,Treva Jackson,102,52,50
+Cochran,101,"County Commissioner, Precinct No. 1",,REP,Timothy Roberts,52,25,27
+Cochran,202,"County Commissioner, Precinct No. 1",,REP,Timothy Roberts,0,0,0
+Cochran,303,"County Commissioner, Precinct No. 1",,REP,Timothy Roberts,0,0,0
+Cochran,306,"County Commissioner, Precinct No. 1",,REP,Timothy Roberts,0,0,0
+Cochran,404,"County Commissioner, Precinct No. 1",,REP,Timothy Roberts,0,0,0
+Cochran,101,"County Commissioner, Precinct No. 1",,REP,Gerald Ramsey,32,19,13
+Cochran,202,"County Commissioner, Precinct No. 1",,REP,Gerald Ramsey,0,0,0
+Cochran,303,"County Commissioner, Precinct No. 1",,REP,Gerald Ramsey,0,0,0
+Cochran,306,"County Commissioner, Precinct No. 1",,REP,Gerald Ramsey,0,0,0
+Cochran,404,"County Commissioner, Precinct No. 1",,REP,Gerald Ramsey,0,0,0
+Cochran,101,"County Commissioner, Precinct No. 1",,REP,"Javier ""Harvey"" Velasquez",33,22,11
+Cochran,202,"County Commissioner, Precinct No. 1",,REP,"Javier ""Harvey"" Velasquez",0,0,0
+Cochran,303,"County Commissioner, Precinct No. 1",,REP,"Javier ""Harvey"" Velasquez",0,0,0
+Cochran,306,"County Commissioner, Precinct No. 1",,REP,"Javier ""Harvey"" Velasquez",0,0,0
+Cochran,404,"County Commissioner, Precinct No. 1",,REP,"Javier ""Harvey"" Velasquez",0,0,0
+Cochran,101,"County Commissioner, Precinct No. 1",,REP,Donnie Simpson,22,13,9
+Cochran,202,"County Commissioner, Precinct No. 1",,REP,Donnie Simpson,0,0,0
+Cochran,303,"County Commissioner, Precinct No. 1",,REP,Donnie Simpson,0,0,0
+Cochran,306,"County Commissioner, Precinct No. 1",,REP,Donnie Simpson,0,0,0
+Cochran,404,"County Commissioner, Precinct No. 1",,REP,Donnie Simpson,0,0,0
+Cochran,101,"County Commissioner, Precinct No. 1",,REP,"Richard ""Rick"" Levitt",38,18,20
+Cochran,202,"County Commissioner, Precinct No. 1",,REP,"Richard ""Rick"" Levitt",0,0,0
+Cochran,303,"County Commissioner, Precinct No. 1",,REP,"Richard ""Rick"" Levitt",0,0,0
+Cochran,306,"County Commissioner, Precinct No. 1",,REP,"Richard ""Rick"" Levitt",0,0,0
+Cochran,404,"County Commissioner, Precinct No. 1",,REP,"Richard ""Rick"" Levitt",0,0,0
+Cochran,101,"County Commissioner, Precinct No. 1",,REP,Cody Dewbre,11,5,6
+Cochran,202,"County Commissioner, Precinct No. 1",,REP,Cody Dewbre,0,0,0
+Cochran,303,"County Commissioner, Precinct No. 1",,REP,Cody Dewbre,0,0,0
+Cochran,306,"County Commissioner, Precinct No. 1",,REP,Cody Dewbre,0,0,0
+Cochran,404,"County Commissioner, Precinct No. 1",,REP,Cody Dewbre,0,0,0
+Cochran,101,"County Commissioner, Precinct No. 1",,REP,Kevin Mark Silhan,40,21,19
+Cochran,202,"County Commissioner, Precinct No. 1",,REP,Kevin Mark Silhan,0,0,0
+Cochran,303,"County Commissioner, Precinct No. 1",,REP,Kevin Mark Silhan,0,0,0
+Cochran,306,"County Commissioner, Precinct No. 1",,REP,Kevin Mark Silhan,0,0,0
+Cochran,404,"County Commissioner, Precinct No. 1",,REP,Kevin Mark Silhan,0,0,0
+Cochran,101,"County Commissioner, Precinct No. 3",,REP,Ray O' Brien,0,0,0
+Cochran,202,"County Commissioner, Precinct No. 3",,REP,Ray O' Brien,0,0,0
+Cochran,303,"County Commissioner, Precinct No. 3",,REP,Ray O' Brien,17,6,11
+Cochran,306,"County Commissioner, Precinct No. 3",,REP,Ray O' Brien,37,13,24
+Cochran,404,"County Commissioner, Precinct No. 3",,REP,Ray O' Brien,0,0,0
+Cochran,101,"County Commissioner, Precinct No. 3",,REP,Dennis Lemons,0,0,0
+Cochran,202,"County Commissioner, Precinct No. 3",,REP,Dennis Lemons,0,0,0
+Cochran,303,"County Commissioner, Precinct No. 3",,REP,Dennis Lemons,0,0,0
+Cochran,306,"County Commissioner, Precinct No. 3",,REP,Dennis Lemons,12,4,8
+Cochran,404,"County Commissioner, Precinct No. 3",,REP,Dennis Lemons,0,0,0
+Cochran,101,"County Commissioner, Precinct No. 3",,REP,Chris Campbell,0,0,0
+Cochran,202,"County Commissioner, Precinct No. 3",,REP,Chris Campbell,0,0,0
+Cochran,303,"County Commissioner, Precinct No. 3",,REP,Chris Campbell,1,1,0
+Cochran,306,"County Commissioner, Precinct No. 3",,REP,Chris Campbell,13,5,8
+Cochran,404,"County Commissioner, Precinct No. 3",,REP,Chris Campbell,0,0,0
+Cochran,101,"County Commissioner, Precinct No. 3",,REP,Albert Salas,0,0,0
+Cochran,202,"County Commissioner, Precinct No. 3",,REP,Albert Salas,0,0,0
+Cochran,303,"County Commissioner, Precinct No. 3",,REP,Albert Salas,5,0,5
+Cochran,306,"County Commissioner, Precinct No. 3",,REP,Albert Salas,53,33,20
+Cochran,404,"County Commissioner, Precinct No. 3",,REP,Albert Salas,0,0,0
+Cochran,101,"County Commissioner, Precinct No. 3",,REP,Eric Silhan,0,0,0
+Cochran,202,"County Commissioner, Precinct No. 3",,REP,Eric Silhan,0,0,0
+Cochran,303,"County Commissioner, Precinct No. 3",,REP,Eric Silhan,27,9,18
+Cochran,306,"County Commissioner, Precinct No. 3",,REP,Eric Silhan,89,43,46
+Cochran,404,"County Commissioner, Precinct No. 3",,REP,Eric Silhan,0,0,0
+Cochran,101,Constable,,REP,Esteban (Steven) Franco Vejar,79,43,36
+Cochran,202,Constable,,REP,Esteban (Steven) Franco Vejar,60,3,57
+Cochran,303,Constable,,REP,Esteban (Steven) Franco Vejar,15,6,9
+Cochran,306,Constable,,REP,Esteban (Steven) Franco Vejar,57,23,34
+Cochran,404,Constable,,REP,Esteban (Steven) Franco Vejar,54,27,27
+Cochran,101,Constable,,REP,Ben Bristow,138,75,63
+Cochran,202,Constable,,REP,Ben Bristow,105,23,82
+Cochran,303,Constable,,REP,Ben Bristow,30,8,22
+Cochran,306,Constable,,REP,Ben Bristow,130,70,60
+Cochran,404,Constable,,REP,Ben Bristow,55,28,27
+Cochran,101,Proposition 1,,REP,Yes,126,68,58
+Cochran,202,Proposition 1,,REP,Yes,117,17,100
+Cochran,303,Proposition 1,,REP,Yes,35,11,24
+Cochran,306,Proposition 1,,REP,Yes,103,52,51
+Cochran,404,Proposition 1,,REP,Yes,54,28,26
+Cochran,101,Proposition 1,,REP,No,67,37,30
+Cochran,202,Proposition 1,,REP,No,48,9,39
+Cochran,303,Proposition 1,,REP,No,9,3,6
+Cochran,306,Proposition 1,,REP,No,65,34,31
+Cochran,404,Proposition 1,,REP,No,44,19,25
+Cochran,101,Proposition 2,,REP,Yes,119,58,61
+Cochran,202,Proposition 2,,REP,Yes,100,19,81
+Cochran,303,Proposition 2,,REP,Yes,23,6,17
+Cochran,306,Proposition 2,,REP,Yes,107,56,51
+Cochran,404,Proposition 2,,REP,Yes,69,32,37
+Cochran,101,Proposition 2,,REP,No,76,48,28
+Cochran,202,Proposition 2,,REP,No,65,6,59
+Cochran,303,Proposition 2,,REP,No,23,8,15
+Cochran,306,Proposition 2,,REP,No,65,29,36
+Cochran,404,Proposition 2,,REP,No,33,17,16
+Cochran,101,Proposition 3,,REP,Yes,160,83,77
+Cochran,202,Proposition 3,,REP,Yes,129,17,112
+Cochran,303,Proposition 3,,REP,Yes,37,9,28
+Cochran,306,Proposition 3,,REP,Yes,131,65,66
+Cochran,404,Proposition 3,,REP,Yes,69,37,32
+Cochran,101,Proposition 3,,REP,No,40,25,15
+Cochran,202,Proposition 3,,REP,No,35,9,26
+Cochran,303,Proposition 3,,REP,No,10,6,4
+Cochran,306,Proposition 3,,REP,No,39,21,18
+Cochran,404,Proposition 3,,REP,No,33,11,22
+Cochran,101,Proposition 4,,REP,Yes,172,89,83
+Cochran,202,Proposition 4,,REP,Yes,155,22,133
+Cochran,303,Proposition 4,,REP,Yes,46,14,32
+Cochran,306,Proposition 4,,REP,Yes,154,76,78
+Cochran,404,Proposition 4,,REP,Yes,86,41,45
+Cochran,101,Proposition 4,,REP,No,19,14,5
+Cochran,202,Proposition 4,,REP,No,8,1,7
+Cochran,303,Proposition 4,,REP,No,0,0,0
+Cochran,306,Proposition 4,,REP,No,10,5,5
+Cochran,404,Proposition 4,,REP,No,12,4,8
+Cochran,101,Referenda Item #1,,DEM,For,5,5,0
+Cochran,202,Referenda Item #1,,DEM,For,0,0,0
+Cochran,303,Referenda Item #1,,DEM,For,0,0,0
+Cochran,306,Referenda Item #1,,DEM,For,0,0,0
+Cochran,404,Referenda Item #1,,DEM,For,0,0,0
+Cochran,101,Referenda Item #1,,DEM,Against,2,1,1
+Cochran,202,Referenda Item #1,,DEM,Against,0,0,0
+Cochran,303,Referenda Item #1,,DEM,Against,0,0,0
+Cochran,306,Referenda Item #1,,DEM,Against,0,0,0
+Cochran,404,Referenda Item #1,,DEM,Against,0,0,0
+Cochran,101,Referenda Item #2,,DEM,For,7,6,1
+Cochran,202,Referenda Item #2,,DEM,For,0,0,0
+Cochran,303,Referenda Item #2,,DEM,For,0,0,0
+Cochran,306,Referenda Item #2,,DEM,For,0,0,0
+Cochran,404,Referenda Item #2,,DEM,For,0,0,0
+Cochran,101,Referenda Item #2,,DEM,Against,1,0,1
+Cochran,202,Referenda Item #2,,DEM,Against,0,0,0
+Cochran,303,Referenda Item #2,,DEM,Against,0,0,0
+Cochran,306,Referenda Item #2,,DEM,Against,0,0,0
+Cochran,404,Referenda Item #2,,DEM,Against,0,0,0
+Cochran,101,Referenda Item #3,,DEM,For,6,4,2
+Cochran,202,Referenda Item #3,,DEM,For,0,0,0
+Cochran,303,Referenda Item #3,,DEM,For,0,0,0
+Cochran,306,Referenda Item #3,,DEM,For,0,0,0
+Cochran,404,Referenda Item #3,,DEM,For,0,0,0
+Cochran,101,Referenda Item #3,,DEM,Against,2,2,0
+Cochran,202,Referenda Item #3,,DEM,Against,0,0,0
+Cochran,303,Referenda Item #3,,DEM,Against,0,0,0
+Cochran,306,Referenda Item #3,,DEM,Against,0,0,0
+Cochran,404,Referenda Item #3,,DEM,Against,0,0,0
+Cochran,101,Referenda Item #4,,DEM,For,7,5,2
+Cochran,202,Referenda Item #4,,DEM,For,0,0,0
+Cochran,303,Referenda Item #4,,DEM,For,0,0,0
+Cochran,306,Referenda Item #4,,DEM,For,0,0,0
+Cochran,404,Referenda Item #4,,DEM,For,0,0,0
+Cochran,101,Referenda Item #4,,DEM,Against,0,0,0
+Cochran,202,Referenda Item #4,,DEM,Against,0,0,0
+Cochran,303,Referenda Item #4,,DEM,Against,0,0,0
+Cochran,306,Referenda Item #4,,DEM,Against,0,0,0
+Cochran,404,Referenda Item #4,,DEM,Against,0,0,0
+Cochran,101,Referenda Item #5,,DEM,For,6,4,2
+Cochran,202,Referenda Item #5,,DEM,For,0,0,0
+Cochran,303,Referenda Item #5,,DEM,For,0,0,0
+Cochran,306,Referenda Item #5,,DEM,For,0,0,0
+Cochran,404,Referenda Item #5,,DEM,For,0,0,0
+Cochran,101,Referenda Item #5,,DEM,Against,2,2,0
+Cochran,202,Referenda Item #5,,DEM,Against,0,0,0
+Cochran,303,Referenda Item #5,,DEM,Against,0,0,0
+Cochran,306,Referenda Item #5,,DEM,Against,0,0,0
+Cochran,404,Referenda Item #5,,DEM,Against,0,0,0
+Cochran,101,Referenda Item #6,,DEM,For,6,5,1
+Cochran,202,Referenda Item #6,,DEM,For,0,0,0
+Cochran,303,Referenda Item #6,,DEM,For,0,0,0
+Cochran,306,Referenda Item #6,,DEM,For,0,0,0
+Cochran,404,Referenda Item #6,,DEM,For,0,0,0
+Cochran,101,Referenda Item #6,,DEM,Against,1,1,0
+Cochran,202,Referenda Item #6,,DEM,Against,0,0,0
+Cochran,303,Referenda Item #6,,DEM,Against,0,0,0
+Cochran,306,Referenda Item #6,,DEM,Against,0,0,0
+Cochran,404,Referenda Item #6,,DEM,Against,0,0,0


### PR DESCRIPTION
Verified President totals. Cochran County is so small that simply checking the Presidential totals and results of the Democratic referenda was enough for me to be confident in the correctness of the results.