### PR TITLE
Add precinct-level results for the 2016 primaries in Coleman County

### DIFF
--- a/2016/20160301__tx__primary__coleman__precinct.csv
+++ b/2016/20160301__tx__primary__coleman__precinct.csv
@@ -1,0 +1,447 @@
+county,precinct,office,district,party,candidate,votes,early_voting,election_day
+Coleman,1,Registered Voters - Total,,,,1488,,
+Coleman,1,President,,DEM,Hillary Clinton,9,4,5
+Coleman,1,President,,DEM,Star Locke,0,0,0
+Coleman,1,President,,DEM,Martin J. O'Malley,0,0,0
+Coleman,1,President,,DEM,Calvis L. Hawes,0,0,0
+Coleman,1,President,,DEM,Keith Judd,0,0,0
+Coleman,1,President,,DEM,"Roque ""Rocky"" De La Fuente",0,0,0
+Coleman,1,President,,DEM,Bernie Sanders,7,3,4
+Coleman,1,President,,DEM,Willie L. Wilson,0,0,0
+Coleman,1,Railroad Commissioner,,DEM,Grady Yarbrough,5,2,3
+Coleman,1,Railroad Commissioner,,DEM,Cody Garrett,5,3,2
+Coleman,1,Railroad Commissioner,,DEM,Lon Burnam,2,1,1
+Coleman,1,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,12,7,5
+Coleman,1,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,13,7,6
+Coleman,1,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,13,7,6
+Coleman,1,"Judge, Court of Criminal Appeals, Place 2",,DEM,Lawrence Meyers,13,7,6
+Coleman,1,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,13,7,6
+Coleman,1,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,13,7,6
+Coleman,1,Referenda Item #1,,DEM,Yes,14,7,7
+Coleman,1,Referenda Item #1,,DEM,No,2,0,2
+Coleman,1,Referenda Item #2,,DEM,Yes,14,7,7
+Coleman,1,Referenda Item #2,,DEM,No,2,0,2
+Coleman,1,Referenda Item #3,,DEM,Yes,15,7,8
+Coleman,1,Referenda Item #3,,DEM,No,1,0,1
+Coleman,1,Referenda Item #4,,DEM,Yes,12,5,7
+Coleman,1,Referenda Item #4,,DEM,No,3,1,2
+Coleman,1,Referenda Item #5,,DEM,Yes,11,6,5
+Coleman,1,Referenda Item #5,,DEM,No,5,1,4
+Coleman,1,Referenda Item #6,,DEM,Yes,14,7,7
+Coleman,1,Referenda Item #6,,DEM,No,2,0,2
+Coleman,2,Registered Voters - Total,,,,1112,,
+Coleman,2,President,,DEM,Hillary Clinton,22,5,17
+Coleman,2,President,,DEM,Star Locke,0,0,0
+Coleman,2,President,,DEM,Martin J. O'Malley,0,0,0
+Coleman,2,President,,DEM,Calvis L. Hawes,0,0,0
+Coleman,2,President,,DEM,Keith Judd,0,0,0
+Coleman,2,President,,DEM,"Roque ""Rocky"" De La Fuente",0,0,0
+Coleman,2,President,,DEM,Bernie Sanders,21,6,15
+Coleman,2,President,,DEM,Willie L. Wilson,0,0,0
+Coleman,2,Railroad Commissioner,,DEM,Grady Yarbrough,19,4,15
+Coleman,2,Railroad Commissioner,,DEM,Cody Garrett,10,3,7
+Coleman,2,Railroad Commissioner,,DEM,Lon Burnam,8,2,6
+Coleman,2,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,34,8,26
+Coleman,2,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,32,6,26
+Coleman,2,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,32,7,25
+Coleman,2,"Judge, Court of Criminal Appeals, Place 2",,DEM,Lawrence Meyers,34,8,26
+Coleman,2,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,33,7,26
+Coleman,2,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,32,7,25
+Coleman,2,Referenda Item #1,,DEM,Yes,40,10,30
+Coleman,2,Referenda Item #1,,DEM,No,2,0,2
+Coleman,2,Referenda Item #2,,DEM,Yes,36,10,26
+Coleman,2,Referenda Item #2,,DEM,No,5,1,4
+Coleman,2,Referenda Item #3,,DEM,Yes,37,11,26
+Coleman,2,Referenda Item #3,,DEM,No,5,0,5
+Coleman,2,Referenda Item #4,,DEM,Yes,33,8,25
+Coleman,2,Referenda Item #4,,DEM,No,5,1,4
+Coleman,2,Referenda Item #5,,DEM,Yes,31,10,21
+Coleman,2,Referenda Item #5,,DEM,No,9,1,8
+Coleman,2,Referenda Item #6,,DEM,Yes,35,10,25
+Coleman,2,Referenda Item #6,,DEM,No,6,1,5
+Coleman,2e,Registered Voters - Total,,,,407,,
+Coleman,2e,President,,DEM,Hillary Clinton,8,2,6
+Coleman,2e,President,,DEM,Star Locke,0,0,0
+Coleman,2e,President,,DEM,Martin J. O'Malley,0,0,0
+Coleman,2e,President,,DEM,Calvis L. Hawes,0,0,0
+Coleman,2e,President,,DEM,Keith Judd,0,0,0
+Coleman,2e,President,,DEM,"Roque ""Rocky"" De La Fuente",0,0,0
+Coleman,2e,President,,DEM,Bernie Sanders,5,4,1
+Coleman,2e,President,,DEM,Willie L. Wilson,0,0,0
+Coleman,2e,Railroad Commissioner,,DEM,Grady Yarbrough,4,3,1
+Coleman,2e,Railroad Commissioner,,DEM,Cody Garrett,3,2,1
+Coleman,2e,Railroad Commissioner,,DEM,Lon Burnam,3,0,3
+Coleman,2e,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,7,4,3
+Coleman,2e,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,11,6,5
+Coleman,2e,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,8,4,4
+Coleman,2e,"Judge, Court of Criminal Appeals, Place 2",,DEM,Lawrence Meyers,9,4,5
+Coleman,2e,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,7,4,3
+Coleman,2e,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,10,5,5
+Coleman,2e,Referenda Item #1,,DEM,Yes,11,5,6
+Coleman,2e,Referenda Item #1,,DEM,No,1,0,1
+Coleman,2e,Referenda Item #2,,DEM,Yes,12,5,7
+Coleman,2e,Referenda Item #2,,DEM,No,0,0,0
+Coleman,2e,Referenda Item #3,,DEM,Yes,10,4,6
+Coleman,2e,Referenda Item #3,,DEM,No,1,0,1
+Coleman,2e,Referenda Item #4,,DEM,Yes,12,5,7
+Coleman,2e,Referenda Item #4,,DEM,No,0,0,0
+Coleman,2e,Referenda Item #5,,DEM,Yes,9,5,4
+Coleman,2e,Referenda Item #5,,DEM,No,3,1,2
+Coleman,2e,Referenda Item #6,,DEM,Yes,11,5,6
+Coleman,2e,Referenda Item #6,,DEM,No,0,0,0
+Coleman,3,Registered Voters - Total,,,,1331,,
+Coleman,3,President,,DEM,Hillary Clinton,18,13,5
+Coleman,3,President,,DEM,Star Locke,0,0,0
+Coleman,3,President,,DEM,Martin J. O'Malley,1,0,1
+Coleman,3,President,,DEM,Calvis L. Hawes,0,0,0
+Coleman,3,President,,DEM,Keith Judd,0,0,0
+Coleman,3,President,,DEM,"Roque ""Rocky"" De La Fuente",0,0,0
+Coleman,3,President,,DEM,Bernie Sanders,7,1,6
+Coleman,3,President,,DEM,Willie L. Wilson,0,0,0
+Coleman,3,Railroad Commissioner,,DEM,Grady Yarbrough,13,7,6
+Coleman,3,Railroad Commissioner,,DEM,Cody Garrett,6,5,1
+Coleman,3,Railroad Commissioner,,DEM,Lon Burnam,1,0,1
+Coleman,3,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,17,11,6
+Coleman,3,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,15,9,6
+Coleman,3,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,17,9,8
+Coleman,3,"Judge, Court of Criminal Appeals, Place 2",,DEM,Lawrence Meyers,19,10,9
+Coleman,3,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,17,8,9
+Coleman,3,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,18,9,9
+Coleman,3,Referenda Item #1,,DEM,Yes,19,11,8
+Coleman,3,Referenda Item #1,,DEM,No,3,2,1
+Coleman,3,Referenda Item #2,,DEM,Yes,19,11,8
+Coleman,3,Referenda Item #2,,DEM,No,3,3,0
+Coleman,3,Referenda Item #3,,DEM,Yes,20,11,9
+Coleman,3,Referenda Item #3,,DEM,No,2,2,0
+Coleman,3,Referenda Item #4,,DEM,Yes,20,12,8
+Coleman,3,Referenda Item #4,,DEM,No,2,2,0
+Coleman,3,Referenda Item #5,,DEM,Yes,18,12,6
+Coleman,3,Referenda Item #5,,DEM,No,5,2,3
+Coleman,3,Referenda Item #6,,DEM,Yes,19,10,9
+Coleman,3,Referenda Item #6,,DEM,No,4,4,0
+Coleman,4,Registered Voters - Total,,,,1512,,
+Coleman,4,President,,DEM,Hillary Clinton,18,5,13
+Coleman,4,President,,DEM,Star Locke,0,0,0
+Coleman,4,President,,DEM,Martin J. O'Malley,0,0,0
+Coleman,4,President,,DEM,Calvis L. Hawes,0,0,0
+Coleman,4,President,,DEM,Keith Judd,0,0,0
+Coleman,4,President,,DEM,"Roque ""Rocky"" De La Fuente",0,0,0
+Coleman,4,President,,DEM,Bernie Sanders,9,6,3
+Coleman,4,President,,DEM,Willie L. Wilson,0,0,0
+Coleman,4,Railroad Commissioner,,DEM,Grady Yarbrough,12,7,5
+Coleman,4,Railroad Commissioner,,DEM,Cody Garrett,1,0,1
+Coleman,4,Railroad Commissioner,,DEM,Lon Burnam,2,1,1
+Coleman,4,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,14,7,7
+Coleman,4,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,15,7,8
+Coleman,4,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,13,7,6
+Coleman,4,"Judge, Court of Criminal Appeals, Place 2",,DEM,Lawrence Meyers,13,7,6
+Coleman,4,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,14,7,7
+Coleman,4,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,12,7,5
+Coleman,4,Referenda Item #1,,DEM,Yes,15,7,8
+Coleman,4,Referenda Item #1,,DEM,No,4,2,2
+Coleman,4,Referenda Item #2,,DEM,Yes,14,7,7
+Coleman,4,Referenda Item #2,,DEM,No,4,2,2
+Coleman,4,Referenda Item #3,,DEM,Yes,16,8,8
+Coleman,4,Referenda Item #3,,DEM,No,3,1,2
+Coleman,4,Referenda Item #4,,DEM,Yes,14,7,7
+Coleman,4,Referenda Item #4,,DEM,No,4,2,2
+Coleman,4,Referenda Item #5,,DEM,Yes,14,8,6
+Coleman,4,Referenda Item #5,,DEM,No,7,2,5
+Coleman,4,Referenda Item #6,,DEM,Yes,18,8,10
+Coleman,4,Referenda Item #6,,DEM,No,4,2,2
+Coleman,1,President,,REP,Ted Cruz,295,137,158
+Coleman,1,President,,REP,Carly Fiorina,0,0,0
+Coleman,1,President,,REP,Elizabeth Gray,0,0,0
+Coleman,1,President,,REP,Mike Huckabee,6,4,2
+Coleman,1,President,,REP,John R. Kasich,6,5,1
+Coleman,1,President,,REP,Donald J. Trump,173,102,71
+Coleman,1,President,,REP,Rand Paul,3,2,1
+Coleman,1,President,,REP,Marco Rubio,53,31,22
+Coleman,1,President,,REP,Jeb Bush,6,4,2
+Coleman,1,President,,REP,Ben Carson,22,15,7
+Coleman,1,President,,REP,Lindsey Graham,0,0,0
+Coleman,1,President,,REP,Rick Santorum,0,0,0
+Coleman,1,President,,REP,Chris Christie,1,0,1
+Coleman,1,President,,REP,Uncommitted,12,7,5
+Coleman,1,U.S. House,11,REP,Mike Conaway,471,253,218
+Coleman,1,Railroad Commissioner,,REP,Weston Martinez,64,34,30
+Coleman,1,Railroad Commissioner,,REP,Doug Jeffrey,47,23,24
+Coleman,1,Railroad Commissioner,,REP,Lance N. Christian,71,35,36
+Coleman,1,Railroad Commissioner,,REP,Gary Gates,90,62,28
+Coleman,1,Railroad Commissioner,,REP,Ron Hale,56,24,32
+Coleman,1,Railroad Commissioner,,REP,John Greytok,13,5,8
+Coleman,1,Railroad Commissioner,,REP,Wayne Christian,89,49,40
+Coleman,1,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,270,135,135
+Coleman,1,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,192,111,81
+Coleman,1,"Justice, Supreme Court, Place 5",,REP,Rick Green,266,124,142
+Coleman,1,"Justice, Supreme Court, Place 5",,REP,Paul Green,172,108,64
+Coleman,1,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,207,108,99
+Coleman,1,"Justice, Supreme Court, Place 9",,REP,Joe Pool,245,130,115
+Coleman,1,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,161,79,82
+Coleman,1,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,154,95,59
+Coleman,1,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,102,45,57
+Coleman,1,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,112,58,54
+Coleman,1,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,168,85,83
+Coleman,1,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,58,26,32
+Coleman,1,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,72,46,26
+Coleman,1,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,243,121,122
+Coleman,1,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,153,87,66
+Coleman,1,"Member, State Board of Education, District 15",,REP,Marty Rowley,415,221,194
+Coleman,1,State Senator,28,REP,Charles Perry,425,227,198
+Coleman,1,State Representative,60,REP,Kevin Downing,273,119,154
+Coleman,1,State Representative,60,REP,Mike Lang,248,155,93
+Coleman,1,"Justice, 11th Court of Appeals District, Place 3",,REP,John Bailey,437,233,204
+Coleman,1,"District Judge, 42nd Judicial District",,REP,James Eidson,448,239,209
+Coleman,1,District Attorney,,REP,Heath Hemphill,492,268,224
+Coleman,1,Sheriff,,REP,Les Cogdill,430,231,199
+Coleman,1,Sheriff,,REP,Steve Vail,120,68,52
+Coleman,1,County Attorney,,REP,Joe Lee Rose,455,244,211
+Coleman,1,Tax-Assessor- Collector,,REP,Jamie Trammell,497,269,228
+Coleman,1,"County Comissioner, Precinct 1",,REP,Mark Williams,482,257,225
+Coleman,1,Constable,,REP,R.E. Eddie Jones,148,88,60
+Coleman,1,Constable,,REP,Joe D. Watson,378,200,178
+Coleman,1,Proposition #1,,REP,Yes,394,214,180
+Coleman,1,Proposition #1,,REP,No,139,70,69
+Coleman,1,Proposition #2,,REP,Yes,302,157,145
+Coleman,1,Proposition #2,,REP,No,235,126,109
+Coleman,1,Proposition #3,,REP,Yes,454,235,219
+Coleman,1,Proposition #3,,REP,No,75,43,32
+Coleman,1,Proposition #4,,REP,Yes,501,261,240
+Coleman,1,Proposition #4,,REP,No,26,15,11
+Coleman,2,President,,REP,Ted Cruz,198,77,121
+Coleman,2,President,,REP,Carly Fiorina,2,1,1
+Coleman,2,President,,REP,Elizabeth Gray,2,1,1
+Coleman,2,President,,REP,Mike Huckabee,2,1,1
+Coleman,2,President,,REP,John R. Kasich,4,0,4
+Coleman,2,President,,REP,Donald J. Trump,115,42,73
+Coleman,2,President,,REP,Rand Paul,1,0,1
+Coleman,2,President,,REP,Marco Rubio,26,13,13
+Coleman,2,President,,REP,Jeb Bush,6,6,0
+Coleman,2,President,,REP,Ben Carson,39,12,27
+Coleman,2,President,,REP,Lindsey Graham,0,0,0
+Coleman,2,President,,REP,Rick Santorum,0,0,0
+Coleman,2,President,,REP,Chris Christie,0,0,0
+Coleman,2,President,,REP,Uncommitted,4,2,2
+Coleman,2,U.S. House,11,REP,Mike Conaway,309,120,189
+Coleman,2,Railroad Commissioner,,REP,Weston Martinez,42,21,21
+Coleman,2,Railroad Commissioner,,REP,Doug Jeffrey,41,10,31
+Coleman,2,Railroad Commissioner,,REP,Lance N. Christian,50,18,32
+Coleman,2,Railroad Commissioner,,REP,Gary Gates,72,35,37
+Coleman,2,Railroad Commissioner,,REP,Ron Hale,44,15,29
+Coleman,2,Railroad Commissioner,,REP,John Greytok,11,6,5
+Coleman,2,Railroad Commissioner,,REP,Wayne Christian,54,21,33
+Coleman,2,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,189,73,116
+Coleman,2,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,142,57,85
+Coleman,2,"Justice, Supreme Court, Place 5",,REP,Rick Green,200,74,126
+Coleman,2,"Justice, Supreme Court, Place 5",,REP,Paul Green,114,48,66
+Coleman,2,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,154,70,84
+Coleman,2,"Justice, Supreme Court, Place 9",,REP,Joe Pool,158,54,104
+Coleman,2,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,129,55,74
+Coleman,2,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,119,42,77
+Coleman,2,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,57,22,35
+Coleman,2,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,76,23,53
+Coleman,2,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,136,51,85
+Coleman,2,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,40,23,17
+Coleman,2,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,55,25,30
+Coleman,2,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,176,70,106
+Coleman,2,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,116,44,72
+Coleman,2,"Member, State Board of Education, District 15",,REP,Marty Rowley,287,122,165
+Coleman,2,State Senator,28,REP,Charles Perry,291,119,172
+Coleman,2,State Representative,60,REP,Kevin Downing,182,72,110
+Coleman,2,State Representative,60,REP,Mike Lang,172,66,106
+Coleman,2,"Justice, 11th Court of Appeals District, Place 3",,REP,John Bailey,288,121,167
+Coleman,2,"District Judge, 42nd Judicial District",,REP,James Eidson,286,118,168
+Coleman,2,District Attorney,,REP,Heath Hemphill,303,122,181
+Coleman,2,Sheriff,,REP,Les Cogdill,262,101,161
+Coleman,2,Sheriff,,REP,Steve Vail,107,44,63
+Coleman,2,County Attorney,,REP,Joe Lee Rose,293,119,174
+Coleman,2,Tax-Assessor- Collector,,REP,Jamie Trammell,322,128,194
+Coleman,2,Constable,,REP,R.E. Eddie Jones,193,69,124
+Coleman,2,Constable,,REP,Joe D. Watson,177,78,99
+Coleman,2,Proposition #1,,REP,Yes,293,115,178
+Coleman,2,Proposition #1,,REP,No,83,29,54
+Coleman,2,Proposition #2,,REP,Yes,233,87,146
+Coleman,2,Proposition #2,,REP,No,145,58,87
+Coleman,2,Proposition #3,,REP,Yes,320,129,191
+Coleman,2,Proposition #3,,REP,No,53,18,35
+Coleman,2,Proposition #4,,REP,Yes,356,139,217
+Coleman,2,Proposition #4,,REP,No,14,6,8
+Coleman,2E,Registered Voters - Total,,,,407,,
+Coleman,2E,President,,REP,Ted Cruz,85,33,52
+Coleman,2E,President,,REP,Carly Fiorina,0,0,0
+Coleman,2E,President,,REP,Elizabeth Gray,0,0,0
+Coleman,2E,President,,REP,Mike Huckabee,0,0,0
+Coleman,2E,President,,REP,John R. Kasich,3,2,1
+Coleman,2E,President,,REP,Donald J. Trump,55,28,27
+Coleman,2E,President,,REP,Rand Paul,0,0,0
+Coleman,2E,President,,REP,Marco Rubio,20,6,14
+Coleman,2E,President,,REP,Jeb Bush,1,0,1
+Coleman,2E,President,,REP,Ben Carson,11,5,6
+Coleman,2E,President,,REP,Lindsey Graham,0,0,0
+Coleman,2E,President,,REP,Rick Santorum,0,0,0
+Coleman,2E,President,,REP,Chris Christie,0,0,0
+Coleman,2E,President,,REP,Uncommitted,5,2,3
+Coleman,2E,U.S. House,11,REP,Mike Conaway,143,62,81
+Coleman,2E,Railroad Commissioner,,REP,Weston Martinez,16,3,13
+Coleman,2E,Railroad Commissioner,,REP,Doug Jeffrey,18,7,11
+Coleman,2E,Railroad Commissioner,,REP,Lance N. Christian,23,6,17
+Coleman,2E,Railroad Commissioner,,REP,Gary Gates,22,12,10
+Coleman,2E,Railroad Commissioner,,REP,Ron Hale,14,6,8
+Coleman,2E,Railroad Commissioner,,REP,John Greytok,10,5,5
+Coleman,2E,Railroad Commissioner,,REP,Wayne Christian,27,12,15
+Coleman,2E,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,85,29,56
+Coleman,2E,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,53,27,26
+Coleman,2E,"Justice, Supreme Court, Place 5",,REP,Rick Green,67,29,38
+Coleman,2E,"Justice, Supreme Court, Place 5",,REP,Paul Green,58,22,36
+Coleman,2E,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,62,22,40
+Coleman,2E,"Justice, Supreme Court, Place 9",,REP,Joe Pool,63,29,34
+Coleman,2E,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,60,17,43
+Coleman,2E,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,40,23,17
+Coleman,2E,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,20,8,12
+Coleman,2E,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,40,12,28
+Coleman,2E,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,51,24,27
+Coleman,2E,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,11,6,5
+Coleman,2E,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,21,7,14
+Coleman,2E,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,69,22,47
+Coleman,2E,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,53,27,26
+Coleman,2E,"Member, State Board of Education, District 15",,REP,Marty Rowley,127,54,73
+Coleman,2E,State Senator,28,REP,Charles Perry,126,53,73
+Coleman,2E,State Representative,60,REP,Kevin Downing,80,18,62
+Coleman,2E,State Representative,60,REP,Mike Lang,80,47,33
+Coleman,2E,"Justice, 11th Court of Appeals District, Place 3",,REP,John Bailey,128,54,74
+Coleman,2E,"District Judge, 42nd Judicial District",,REP,James Eidson,134,60,74
+Coleman,2E,District Attorney,,REP,Heath Hemphill,159,68,91
+Coleman,2E,Sheriff,,REP,Les Cogdill,149,59,90
+Coleman,2E,Sheriff,,REP,Steve Vail,30,16,14
+Coleman,2E,County Attorney,,REP,Joe Lee Rose,149,59,90
+Coleman,2E,Tax-Assessor- Collector,,REP,Jamie Trammell,158,67,91
+Coleman,2E,Constable,,REP,R.E. Eddie Jones,38,15,23
+Coleman,2E,Constable,,REP,Joe D. Watson,132,56,76
+Coleman,2E,Proposition #1,,REP,Yes,123,57,66
+Coleman,2E,Proposition #1,,REP,No,40,10,30
+Coleman,2E,Proposition #2,,REP,Yes,98,37,61
+Coleman,2E,Proposition #2,,REP,No,67,33,34
+Coleman,2E,Proposition #3,,REP,Yes,140,61,79
+Coleman,2E,Proposition #3,,REP,No,22,6,16
+Coleman,2E,Proposition #4,,REP,Yes,152,67,85
+Coleman,2E,Proposition #4,,REP,No,8,1,7
+Coleman,3,President,,REP,Ted Cruz,241,128,113
+Coleman,3,President,,REP,Carly Fiorina,0,0,0
+Coleman,3,President,,REP,Elizabeth Gray,0,0,0
+Coleman,3,President,,REP,Mike Huckabee,2,0,2
+Coleman,3,President,,REP,John R. Kasich,11,8,3
+Coleman,3,President,,REP,Donald J. Trump,188,106,82
+Coleman,3,President,,REP,Rand Paul,1,1,0
+Coleman,3,President,,REP,Marco Rubio,59,39,20
+Coleman,3,President,,REP,Jeb Bush,8,5,3
+Coleman,3,President,,REP,Ben Carson,21,12,9
+Coleman,3,President,,REP,Lindsey Graham,1,1,0
+Coleman,3,President,,REP,Rick Santorum,0,0,0
+Coleman,3,President,,REP,Chris Christie,0,0,0
+Coleman,3,President,,REP,Uncommitted,5,3,2
+Coleman,3,U.S. House,11,REP,Mike Conaway,431,244,187
+Coleman,3,Railroad Commissioner,,REP,Weston Martinez,57,31,26
+Coleman,3,Railroad Commissioner,,REP,Doug Jeffrey,58,34,24
+Coleman,3,Railroad Commissioner,,REP,Lance N. Christian,73,41,32
+Coleman,3,Railroad Commissioner,,REP,Gary Gates,96,64,32
+Coleman,3,Railroad Commissioner,,REP,Ron Hale,58,28,30
+Coleman,3,Railroad Commissioner,,REP,John Greytok,14,9,5
+Coleman,3,Railroad Commissioner,,REP,Wayne Christian,66,38,28
+Coleman,3,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,233,139,94
+Coleman,3,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,207,110,97
+Coleman,3,"Justice, Supreme Court, Place 5",,REP,Rick Green,228,129,99
+Coleman,3,"Justice, Supreme Court, Place 5",,REP,Paul Green,172,100,72
+Coleman,3,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,185,118,67
+Coleman,3,"Justice, Supreme Court, Place 9",,REP,Joe Pool,221,118,103
+Coleman,3,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,146,93,53
+Coleman,3,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,152,82,70
+Coleman,3,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,92,47,45
+Coleman,3,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,138,79,59
+Coleman,3,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,156,92,64
+Coleman,3,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,55,36,19
+Coleman,3,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,50,25,25
+Coleman,3,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,215,120,95
+Coleman,3,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,170,97,73
+Coleman,3,"Member, State Board of Education, District 15",,REP,Marty Rowley,367,204,163
+Coleman,3,State Senator,28,REP,Charles Perry,369,212,157
+Coleman,3,State Representative,60,REP,Kevin Downing,258,139,119
+Coleman,3,State Representative,60,REP,Mike Lang,230,142,88
+Coleman,3,"Justice, 11th Court of Appeals District, Place 3",,REP,John Bailey,369,208,161
+Coleman,3,"District Judge, 42nd Judicial District",,REP,James Eidson,391,223,168
+Coleman,3,District Attorney,,REP,Heath Hemphill,428,240,188
+Coleman,3,Sheriff,,REP,Les Cogdill,431,241,190
+Coleman,3,Sheriff,,REP,Steve Vail,94,57,37
+Coleman,3,County Attorney,,REP,Joe Lee Rose,395,219,176
+Coleman,3,Tax-Assessor- Collector,,REP,Jamie Trammell,444,250,194
+Coleman,3,"County Comissioner, Precinct 3",,REP,Rodney Cole,63,40,23
+Coleman,3,"County Comissioner, Precinct 3",,REP,Davey Thweatt,164,95,69
+Coleman,3,"County Comissioner, Precinct 3",,REP,Scotty Lawrence,240,124,116
+Coleman,3,"County Comissioner, Precinct 3",,REP,Mark Martinez,62,37,25
+Coleman,3,Constable,,REP,R.E. Eddie Jones,175,108,67
+Coleman,3,Constable,,REP,Joe D. Watson,328,178,150
+Coleman,3,Proposition #1,,REP,Yes,365,198,167
+Coleman,3,Proposition #1,,REP,No,127,81,46
+Coleman,3,Proposition #2,,REP,Yes,254,145,109
+Coleman,3,Proposition #2,,REP,No,248,138,110
+Coleman,3,Proposition #3,,REP,Yes,391,223,168
+Coleman,3,Proposition #3,,REP,No,98,54,44
+Coleman,3,Proposition #4,,REP,Yes,454,254,200
+Coleman,3,Proposition #4,,REP,No,28,18,10
+Coleman,4,President,,REP,Ted Cruz,315,175,140
+Coleman,4,President,,REP,Carly Fiorina,1,1,0
+Coleman,4,President,,REP,Elizabeth Gray,0,0,0
+Coleman,4,President,,REP,Mike Huckabee,2,2,0
+Coleman,4,President,,REP,John R. Kasich,11,7,4
+Coleman,4,President,,REP,Donald J. Trump,193,115,78
+Coleman,4,President,,REP,Rand Paul,0,0,0
+Coleman,4,President,,REP,Marco Rubio,64,39,25
+Coleman,4,President,,REP,Jeb Bush,9,6,3
+Coleman,4,President,,REP,Ben Carson,32,20,12
+Coleman,4,President,,REP,Lindsey Graham,1,1,0
+Coleman,4,President,,REP,Rick Santorum,0,0,0
+Coleman,4,President,,REP,Chris Christie,0,0,0
+Coleman,4,President,,REP,Uncommitted,4,2,2
+Coleman,4,U.S. House,11,REP,Mike Conaway,520,311,209
+Coleman,4,Railroad Commissioner,,REP,Weston Martinez,48,22,26
+Coleman,4,Railroad Commissioner,,REP,Doug Jeffrey,54,34,20
+Coleman,4,Railroad Commissioner,,REP,Lance N. Christian,60,34,26
+Coleman,4,Railroad Commissioner,,REP,Gary Gates,111,70,41
+Coleman,4,Railroad Commissioner,,REP,Ron Hale,77,44,33
+Coleman,4,Railroad Commissioner,,REP,John Greytok,23,13,10
+Coleman,4,Railroad Commissioner,,REP,Wayne Christian,88,59,29
+Coleman,4,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,260,151,109
+Coleman,4,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,240,147,93
+Coleman,4,"Justice, Supreme Court, Place 5",,REP,Rick Green,293,167,126
+Coleman,4,"Justice, Supreme Court, Place 5",,REP,Paul Green,166,109,57
+Coleman,4,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,224,141,83
+Coleman,4,"Justice, Supreme Court, Place 9",,REP,Joe Pool,241,138,103
+Coleman,4,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,157,85,72
+Coleman,4,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,191,127,64
+Coleman,4,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,100,58,42
+Coleman,4,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,123,64,59
+Coleman,4,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,163,93,70
+Coleman,4,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,56,33,23
+Coleman,4,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,114,89,25
+Coleman,4,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,259,154,105
+Coleman,4,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,172,109,63
+Coleman,4,"Member, State Board of Education, District 15",,REP,Marty Rowley,440,264,176
+Coleman,4,State Senator,28,REP,Charles Perry,455,272,183
+Coleman,4,State Representative,60,REP,Kevin Downing,260,125,135
+Coleman,4,State Representative,60,REP,Mike Lang,320,219,101
+Coleman,4,"Justice, 11th Court of Appeals District, Place 3",,REP,John Bailey,455,270,185
+Coleman,4,"District Judge, 42nd Judicial District",,REP,James Eidson,476,284,192
+Coleman,4,District Attorney,,REP,Heath Hemphill,537,318,219
+Coleman,4,Sheriff,,REP,Les Cogdill,477,269,208
+Coleman,4,Sheriff,,REP,Steve Vail,142,95,47
+Coleman,4,County Attorney,,REP,Joe Lee Rose,504,296,208
+Coleman,4,Tax-Assessor- Collector,,REP,Jamie Trammell,541,323,218
+Coleman,4,Constable,,REP,R.E. Eddie Jones,174,103,71
+Coleman,4,Constable,,REP,Joe D. Watson,410,247,163
+Coleman,4,Proposition #1,,REP,Yes,450,260,190
+Coleman,4,Proposition #1,,REP,No,136,84,52
+Coleman,4,Proposition #2,,REP,Yes,317,164,153
+Coleman,4,Proposition #2,,REP,No,270,183,87
+Coleman,4,Proposition #3,,REP,Yes,496,297,199
+Coleman,4,Proposition #3,,REP,No,86,46,40
+Coleman,4,Proposition #4,,REP,Yes,566,336,230
+Coleman,4,Proposition #4,,REP,No,19,9,10


### PR DESCRIPTION
Verified Cruz, HRC, DJT, Railroad Commissioner totals.
Amusingly, the county had misspelled "Hillary Clinton" as "Hilary Clinton", which threw me for a loop momentarily. It's fixed in this PR, though.