### PR TITLE
Add precinct-level results for the 2016 primaries in Lipscomb County

### DIFF
--- a/2016/20160301__tx__primary__lipscomb__precinct.csv
+++ b/2016/20160301__tx__primary__lipscomb__precinct.csv
@@ -1,0 +1,1161 @@
+county,precinct,office,district,party,candidate,votes,early_voting,election_day
+Lipscomb,202,Registered Voters - Total,,,,304,,
+Lipscomb,202,Ballots Cast - Total,,,,88,10,78
+Lipscomb,202,President,,REP,OVER VOTES,0,0,0
+Lipscomb,202,President,,REP,UNDER VOTES,2,0,2
+Lipscomb,202,President,,REP,Jeb Bush,1,1,0
+Lipscomb,202,President,,REP,Carly Fiorina,0,0,0
+Lipscomb,202,President,,REP,Donald J. Trump,26,2,24
+Lipscomb,202,President,,REP,Rick Santorum,0,0,0
+Lipscomb,202,President,,REP,Lindsey Graham,0,0,0
+Lipscomb,202,President,,REP,Rand Paul,0,0,0
+Lipscomb,202,President,,REP,Elizabeth Gray,0,0,0
+Lipscomb,202,President,,REP,Ted Cruz,46,6,40
+Lipscomb,202,President,,REP,Chris Christie,0,0,0
+Lipscomb,202,President,,REP,Ben Carson,4,0,4
+Lipscomb,202,President,,REP,Mike Huckabee,0,0,0
+Lipscomb,202,President,,REP,John R. Kasich,0,0,0
+Lipscomb,202,President,,REP,Marco Rubio,8,1,7
+Lipscomb,202,President,,REP,Uncommitted,1,0,1
+Lipscomb,202,U.S. House,13,REP,OVER VOTES,0,0,0
+Lipscomb,202,U.S. House,13,REP,UNDER VOTES,13,2,11
+Lipscomb,202,U.S. House,13,REP,Mac Thornberry,75,8,67
+Lipscomb,202,Railroad Commissioner,,REP,OVER VOTES,0,0,0
+Lipscomb,202,Railroad Commissioner,,REP,UNDER VOTES,28,1,27
+Lipscomb,202,Railroad Commissioner,,REP,John Greytok,6,0,6
+Lipscomb,202,Railroad Commissioner,,REP,Ron Hale,13,2,11
+Lipscomb,202,Railroad Commissioner,,REP,Lance N. Christian,5,1,4
+Lipscomb,202,Railroad Commissioner,,REP,Gary Gates,18,3,15
+Lipscomb,202,Railroad Commissioner,,REP,Weston Martinez,1,0,1
+Lipscomb,202,Railroad Commissioner,,REP,Doug Jeffrey,7,3,4
+Lipscomb,202,Railroad Commissioner,,REP,Wayne Christian,10,0,10
+Lipscomb,202,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0,0,0
+Lipscomb,202,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,21,1,20
+Lipscomb,202,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,41,4,37
+Lipscomb,202,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,26,5,21
+Lipscomb,202,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0,0,0
+Lipscomb,202,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,31,1,30
+Lipscomb,202,"Justice, Supreme Court, Place 5",,REP,Paul Green,36,6,30
+Lipscomb,202,"Justice, Supreme Court, Place 5",,REP,Rick Green,21,3,18
+Lipscomb,202,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0,0,0
+Lipscomb,202,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,26,1,25
+Lipscomb,202,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,22,4,18
+Lipscomb,202,"Justice, Supreme Court, Place 9",,REP,Joe Pool,40,5,35
+Lipscomb,202,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0,0,0
+Lipscomb,202,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,32,3,29
+Lipscomb,202,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,24,4,20
+Lipscomb,202,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,21,1,20
+Lipscomb,202,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,11,2,9
+Lipscomb,202,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0,0,0
+Lipscomb,202,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,30,3,27
+Lipscomb,202,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,15,2,13
+Lipscomb,202,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,3,0,3
+Lipscomb,202,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,25,5,20
+Lipscomb,202,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,15,0,15
+Lipscomb,202,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0,0,0
+Lipscomb,202,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,34,3,31
+Lipscomb,202,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,31,5,26
+Lipscomb,202,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,23,2,21
+Lipscomb,202,"Member, State Board of Education, District 15",,REP,OVER VOTES,0,0,0
+Lipscomb,202,"Member, State Board of Education, District 15",,REP,UNDER VOTES,31,2,29
+Lipscomb,202,"Member, State Board of Education, District 15",,REP,Marty Rowley,57,8,49
+Lipscomb,202,State Representative,88,REP,OVER VOTES,0,0,0
+Lipscomb,202,State Representative,88,REP,UNDER VOTES,11,0,11
+Lipscomb,202,State Representative,88,REP,Ken King,77,10,67
+Lipscomb,202,"Justice, 7th Court of Appeals District, Place 4",,REP,OVER VOTES,0,0,0
+Lipscomb,202,"Justice, 7th Court of Appeals District, Place 4",,REP,UNDER VOTES,28,1,27
+Lipscomb,202,"Justice, 7th Court of Appeals District, Place 4",,REP,Jim Campbell,60,9,51
+Lipscomb,202,"District Attorney, 31st Judicial District",,REP,OVER VOTES,0,0,0
+Lipscomb,202,"District Attorney, 31st Judicial District",,REP,UNDER VOTES,26,1,25
+Lipscomb,202,"District Attorney, 31st Judicial District",,REP,Franklin McDonough,62,9,53
+Lipscomb,202,County Attorney,,REP,OVER VOTES,0,0,0
+Lipscomb,202,County Attorney,,REP,UNDER VOTES,17,0,17
+Lipscomb,202,County Attorney,,REP,Matthew Bartosiewicz,71,10,61
+Lipscomb,202,Sheriff,,REP,OVER VOTES,0,0,0
+Lipscomb,202,Sheriff,,REP,UNDER VOTES,1,0,1
+Lipscomb,202,Sheriff,,REP,Dave Thomas,20,2,18
+Lipscomb,202,Sheriff,,REP,Kenneth M. Eggleston,31,3,28
+Lipscomb,202,Sheriff,,REP,James Robertson,28,3,25
+Lipscomb,202,Sheriff,,REP,Don Bolar,8,2,6
+Lipscomb,202,Tax Assessor-Collector,,REP,OVER VOTES,0,0,0
+Lipscomb,202,Tax Assessor-Collector,,REP,UNDER VOTES,17,0,17
+Lipscomb,202,Tax Assessor-Collector,,REP,Sharla Bradshaw,71,10,61
+Lipscomb,202,County Treasurer - Unexpired Term,,REP,OVER VOTES,0,0,0
+Lipscomb,202,County Treasurer - Unexpired Term,,REP,UNDER VOTES,0,0,0
+Lipscomb,202,County Treasurer - Unexpired Term,,REP,Ramona Schilling,25,2,23
+Lipscomb,202,County Treasurer - Unexpired Term,,REP,Kimberly L. Long,63,8,55
+Lipscomb,202,County Chairman,,REP,OVER VOTES,0,0,0
+Lipscomb,202,County Chairman,,REP,UNDER VOTES,16,1,15
+Lipscomb,202,County Chairman,,REP,Diana Hoover,72,9,63
+Lipscomb,202,President,,DEM,OVER VOTES,0,0,0
+Lipscomb,202,President,,DEM,UNDER VOTES,0,0,0
+Lipscomb,202,President,,DEM,Keith Judd,0,0,0
+Lipscomb,202,President,,DEM,Willie L. Wilson,0,0,0
+Lipscomb,202,President,,DEM,"Roque ""Rocky"" De La Fuente",0,0,0
+Lipscomb,202,President,,DEM,Star Locke,0,0,0
+Lipscomb,202,President,,DEM,Calvis L. Hawes,0,0,0
+Lipscomb,202,President,,DEM,Bernie Sanders,0,0,0
+Lipscomb,202,President,,DEM,Hillary Clinton,0,0,0
+Lipscomb,202,President,,DEM,Martin J. O'Malley,0,0,0
+Lipscomb,202,Railroad Commissioner,,DEM,OVER VOTES,0,0,0
+Lipscomb,202,Railroad Commissioner,,DEM,UNDER VOTES,0,0,0
+Lipscomb,202,Railroad Commissioner,,DEM,Cody Garrett,0,0,0
+Lipscomb,202,Railroad Commissioner,,DEM,Lon Burnam,0,0,0
+Lipscomb,202,Railroad Commissioner,,DEM,Grady Yarbrough,0,0,0
+Lipscomb,202,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0,0,0
+Lipscomb,202,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,0,0,0
+Lipscomb,202,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,0,0,0
+Lipscomb,202,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0,0,0
+Lipscomb,202,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,0,0,0
+Lipscomb,202,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,0,0,0
+Lipscomb,202,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0,0,0
+Lipscomb,202,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,0,0,0
+Lipscomb,202,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,0,0,0
+Lipscomb,202,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0,0,0
+Lipscomb,202,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,0,0,0
+Lipscomb,202,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",0,0,0
+Lipscomb,202,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0,0,0
+Lipscomb,202,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,0,0,0
+Lipscomb,202,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,0,0,0
+Lipscomb,202,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0,0,0
+Lipscomb,202,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,0,0,0
+Lipscomb,202,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,0,0,0
+Lipscomb,202,County Chairman,,DEM,OVER VOTES,0,0,0
+Lipscomb,202,County Chairman,,DEM,UNDER VOTES,0,0,0
+Lipscomb,202,County Chairman,,DEM,Virginia Scott,0,0,0
+Lipscomb,202,Proposition 1,,DEM,OVER VOTES,0,0,0
+Lipscomb,202,Proposition 1,,DEM,UNDER VOTES,0,0,0
+Lipscomb,202,Proposition 1,,DEM,For,0,0,0
+Lipscomb,202,Proposition 1,,DEM,Against,0,0,0
+Lipscomb,202,Proposition 2,,DEM,OVER VOTES,0,0,0
+Lipscomb,202,Proposition 2,,DEM,UNDER VOTES,0,0,0
+Lipscomb,202,Proposition 2,,DEM,For,0,0,0
+Lipscomb,202,Proposition 2,,DEM,Against,0,0,0
+Lipscomb,202,Proposition 3,,DEM,OVER VOTES,0,0,0
+Lipscomb,202,Proposition 3,,DEM,UNDER VOTES,0,0,0
+Lipscomb,202,Proposition 3,,DEM,For,0,0,0
+Lipscomb,202,Proposition 3,,DEM,Against,0,0,0
+Lipscomb,202,Proposition 4,,DEM,OVER VOTES,0,0,0
+Lipscomb,202,Proposition 4,,DEM,UNDER VOTES,0,0,0
+Lipscomb,202,Proposition 4,,DEM,For,0,0,0
+Lipscomb,202,Proposition 4,,DEM,Against,0,0,0
+Lipscomb,202,Proposition 5,,DEM,OVER VOTES,0,0,0
+Lipscomb,202,Proposition 5,,DEM,UNDER VOTES,0,0,0
+Lipscomb,202,Proposition 5,,DEM,For,0,0,0
+Lipscomb,202,Proposition 5,,DEM,Against,0,0,0
+Lipscomb,202,Proposition 6,,DEM,OVER VOTES,0,0,0
+Lipscomb,202,Proposition 6,,DEM,UNDER VOTES,0,0,0
+Lipscomb,202,Proposition 6,,DEM,For,0,0,0
+Lipscomb,202,Proposition 6,,DEM,Against,0,0,0
+Lipscomb,202,Proposition 1,,REP,OVER VOTES,0,0,0
+Lipscomb,202,Proposition 1,,REP,UNDER VOTES,5,0,5
+Lipscomb,202,Proposition 1,,REP,YES,60,8,52
+Lipscomb,202,Proposition 1,,REP,NO,23,2,21
+Lipscomb,202,Proposition 2,,REP,OVER VOTES,0,0,0
+Lipscomb,202,Proposition 2,,REP,UNDER VOTES,4,0,4
+Lipscomb,202,Proposition 2,,REP,YES,61,5,56
+Lipscomb,202,Proposition 2,,REP,NO,23,5,18
+Lipscomb,202,Proposition 3,,REP,OVER VOTES,0,0,0
+Lipscomb,202,Proposition 3,,REP,UNDER VOTES,5,1,4
+Lipscomb,202,Proposition 3,,REP,YES,69,7,62
+Lipscomb,202,Proposition 3,,REP,NO,14,2,12
+Lipscomb,202,Proposition 4,,REP,OVER VOTES,0,0,0
+Lipscomb,202,Proposition 4,,REP,UNDER VOTES,6,1,5
+Lipscomb,202,Proposition 4,,REP,YES,79,9,70
+Lipscomb,202,Proposition 4,,REP,NO,3,0,3
+Lipscomb,303,Registered Voters - Total,,,,840,,
+Lipscomb,303,Ballots Cast - Total,,,,292,78,214
+Lipscomb,303,President,,REP,OVER VOTES,0,0,0
+Lipscomb,303,President,,REP,UNDER VOTES,10,5,5
+Lipscomb,303,President,,REP,Jeb Bush,6,6,0
+Lipscomb,303,President,,REP,Carly Fiorina,0,0,0
+Lipscomb,303,President,,REP,Donald J. Trump,87,15,72
+Lipscomb,303,President,,REP,Rick Santorum,1,1,0
+Lipscomb,303,President,,REP,Lindsey Graham,0,0,0
+Lipscomb,303,President,,REP,Rand Paul,2,1,1
+Lipscomb,303,President,,REP,Elizabeth Gray,0,0,0
+Lipscomb,303,President,,REP,Ted Cruz,131,37,94
+Lipscomb,303,President,,REP,Chris Christie,0,0,0
+Lipscomb,303,President,,REP,Ben Carson,15,2,13
+Lipscomb,303,President,,REP,Mike Huckabee,2,0,2
+Lipscomb,303,President,,REP,John R. Kasich,9,1,8
+Lipscomb,303,President,,REP,Marco Rubio,15,2,13
+Lipscomb,303,President,,REP,Uncommitted,7,5,2
+Lipscomb,303,U.S. House,13,REP,OVER VOTES,0,0,0
+Lipscomb,303,U.S. House,13,REP,UNDER VOTES,40,14,26
+Lipscomb,303,U.S. House,13,REP,Mac Thornberry,245,61,184
+Lipscomb,303,Railroad Commissioner,,REP,OVER VOTES,0,0,0
+Lipscomb,303,Railroad Commissioner,,REP,UNDER VOTES,87,24,63
+Lipscomb,303,Railroad Commissioner,,REP,John Greytok,26,2,24
+Lipscomb,303,Railroad Commissioner,,REP,Ron Hale,41,4,37
+Lipscomb,303,Railroad Commissioner,,REP,Lance N. Christian,30,15,15
+Lipscomb,303,Railroad Commissioner,,REP,Gary Gates,35,14,21
+Lipscomb,303,Railroad Commissioner,,REP,Weston Martinez,12,5,7
+Lipscomb,303,Railroad Commissioner,,REP,Doug Jeffrey,13,2,11
+Lipscomb,303,Railroad Commissioner,,REP,Wayne Christian,41,9,32
+Lipscomb,303,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0,0,0
+Lipscomb,303,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,81,28,53
+Lipscomb,303,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,104,28,76
+Lipscomb,303,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,100,19,81
+Lipscomb,303,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0,0,0
+Lipscomb,303,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,86,30,56
+Lipscomb,303,"Justice, Supreme Court, Place 5",,REP,Paul Green,128,26,102
+Lipscomb,303,"Justice, Supreme Court, Place 5",,REP,Rick Green,71,19,52
+Lipscomb,303,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0,0,0
+Lipscomb,303,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,82,29,53
+Lipscomb,303,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,84,16,68
+Lipscomb,303,"Justice, Supreme Court, Place 9",,REP,Joe Pool,119,30,89
+Lipscomb,303,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0,0,0
+Lipscomb,303,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,90,28,62
+Lipscomb,303,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,77,21,56
+Lipscomb,303,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,80,18,62
+Lipscomb,303,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,38,8,30
+Lipscomb,303,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0,0,0
+Lipscomb,303,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,91,29,62
+Lipscomb,303,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,33,5,28
+Lipscomb,303,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,20,7,13
+Lipscomb,303,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,94,22,72
+Lipscomb,303,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,47,12,35
+Lipscomb,303,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0,0,0
+Lipscomb,303,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,93,29,64
+Lipscomb,303,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,116,28,88
+Lipscomb,303,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,76,18,58
+Lipscomb,303,"Member, State Board of Education, District 15",,REP,OVER VOTES,0,0,0
+Lipscomb,303,"Member, State Board of Education, District 15",,REP,UNDER VOTES,91,27,64
+Lipscomb,303,"Member, State Board of Education, District 15",,REP,Marty Rowley,194,48,146
+Lipscomb,303,State Representative,88,REP,OVER VOTES,0,0,0
+Lipscomb,303,State Representative,88,REP,UNDER VOTES,62,14,48
+Lipscomb,303,State Representative,88,REP,Ken King,223,61,162
+Lipscomb,303,"Justice, 7th Court of Appeals District, Place 4",,REP,OVER VOTES,0,0,0
+Lipscomb,303,"Justice, 7th Court of Appeals District, Place 4",,REP,UNDER VOTES,92,27,65
+Lipscomb,303,"Justice, 7th Court of Appeals District, Place 4",,REP,Jim Campbell,193,48,145
+Lipscomb,303,"District Attorney, 31st Judicial District",,REP,OVER VOTES,0,0,0
+Lipscomb,303,"District Attorney, 31st Judicial District",,REP,UNDER VOTES,87,29,58
+Lipscomb,303,"District Attorney, 31st Judicial District",,REP,Franklin McDonough,198,46,152
+Lipscomb,303,County Attorney,,REP,OVER VOTES,0,0,0
+Lipscomb,303,County Attorney,,REP,UNDER VOTES,63,19,44
+Lipscomb,303,County Attorney,,REP,Matthew Bartosiewicz,222,56,166
+Lipscomb,303,Sheriff,,REP,OVER VOTES,0,0,0
+Lipscomb,303,Sheriff,,REP,UNDER VOTES,2,1,1
+Lipscomb,303,Sheriff,,REP,Dave Thomas,61,11,50
+Lipscomb,303,Sheriff,,REP,Kenneth M. Eggleston,147,33,114
+Lipscomb,303,Sheriff,,REP,James Robertson,56,18,38
+Lipscomb,303,Sheriff,,REP,Don Bolar,19,12,7
+Lipscomb,303,Tax Assessor-Collector,,REP,OVER VOTES,0,0,0
+Lipscomb,303,Tax Assessor-Collector,,REP,UNDER VOTES,56,19,37
+Lipscomb,303,Tax Assessor-Collector,,REP,Sharla Bradshaw,229,56,173
+Lipscomb,303,County Treasurer - Unexpired Term,,REP,OVER VOTES,0,0,0
+Lipscomb,303,County Treasurer - Unexpired Term,,REP,UNDER VOTES,4,1,3
+Lipscomb,303,County Treasurer - Unexpired Term,,REP,Ramona Schilling,161,51,110
+Lipscomb,303,County Treasurer - Unexpired Term,,REP,Kimberly L. Long,120,23,97
+Lipscomb,303,"County Commissioner, Precinct 3",,REP,OVER VOTES,0,0,0
+Lipscomb,303,"County Commissioner, Precinct 3",,REP,UNDER VOTES,2,0,2
+Lipscomb,303,"County Commissioner, Precinct 3",,REP,Lynn Blau,115,27,88
+Lipscomb,303,"County Commissioner, Precinct 3",,REP,Scotty Mark Schilling,168,48,120
+Lipscomb,303,County Chairman,,REP,OVER VOTES,0,0,0
+Lipscomb,303,County Chairman,,REP,UNDER VOTES,57,18,39
+Lipscomb,303,County Chairman,,REP,Diana Hoover,228,57,171
+Lipscomb,303,President,,DEM,OVER VOTES,0,0,0
+Lipscomb,303,President,,DEM,UNDER VOTES,0,0,0
+Lipscomb,303,President,,DEM,Keith Judd,0,0,0
+Lipscomb,303,President,,DEM,Willie L. Wilson,0,0,0
+Lipscomb,303,President,,DEM,"Roque ""Rocky"" De La Fuente",0,0,0
+Lipscomb,303,President,,DEM,Star Locke,0,0,0
+Lipscomb,303,President,,DEM,Calvis L. Hawes,0,0,0
+Lipscomb,303,President,,DEM,Bernie Sanders,1,0,1
+Lipscomb,303,President,,DEM,Hillary Clinton,6,3,3
+Lipscomb,303,President,,DEM,Martin J. O'Malley,0,0,0
+Lipscomb,303,Railroad Commissioner,,DEM,OVER VOTES,0,0,0
+Lipscomb,303,Railroad Commissioner,,DEM,UNDER VOTES,3,3,0
+Lipscomb,303,Railroad Commissioner,,DEM,Cody Garrett,1,0,1
+Lipscomb,303,Railroad Commissioner,,DEM,Lon Burnam,1,0,1
+Lipscomb,303,Railroad Commissioner,,DEM,Grady Yarbrough,2,0,2
+Lipscomb,303,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0,0,0
+Lipscomb,303,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,3,3,0
+Lipscomb,303,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,4,0,4
+Lipscomb,303,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0,0,0
+Lipscomb,303,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,4,3,1
+Lipscomb,303,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,3,0,3
+Lipscomb,303,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0,0,0
+Lipscomb,303,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,2,2,0
+Lipscomb,303,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,5,1,4
+Lipscomb,303,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0,0,0
+Lipscomb,303,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,2,2,0
+Lipscomb,303,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",5,1,4
+Lipscomb,303,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0,0,0
+Lipscomb,303,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,2,2,0
+Lipscomb,303,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,5,1,4
+Lipscomb,303,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0,0,0
+Lipscomb,303,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,2,2,0
+Lipscomb,303,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,5,1,4
+Lipscomb,303,County Chairman,,DEM,OVER VOTES,0,0,0
+Lipscomb,303,County Chairman,,DEM,UNDER VOTES,2,2,0
+Lipscomb,303,County Chairman,,DEM,Virginia Scott,5,1,4
+Lipscomb,303,Proposition 1,,DEM,OVER VOTES,0,0,0
+Lipscomb,303,Proposition 1,,DEM,UNDER VOTES,0,0,0
+Lipscomb,303,Proposition 1,,DEM,For,6,3,3
+Lipscomb,303,Proposition 1,,DEM,Against,1,0,1
+Lipscomb,303,Proposition 2,,DEM,OVER VOTES,0,0,0
+Lipscomb,303,Proposition 2,,DEM,UNDER VOTES,1,1,0
+Lipscomb,303,Proposition 2,,DEM,For,5,2,3
+Lipscomb,303,Proposition 2,,DEM,Against,1,0,1
+Lipscomb,303,Proposition 3,,DEM,OVER VOTES,0,0,0
+Lipscomb,303,Proposition 3,,DEM,UNDER VOTES,0,0,0
+Lipscomb,303,Proposition 3,,DEM,For,6,3,3
+Lipscomb,303,Proposition 3,,DEM,Against,1,0,1
+Lipscomb,303,Proposition 4,,DEM,OVER VOTES,0,0,0
+Lipscomb,303,Proposition 4,,DEM,UNDER VOTES,0,0,0
+Lipscomb,303,Proposition 4,,DEM,For,7,3,4
+Lipscomb,303,Proposition 4,,DEM,Against,0,0,0
+Lipscomb,303,Proposition 5,,DEM,OVER VOTES,0,0,0
+Lipscomb,303,Proposition 5,,DEM,UNDER VOTES,0,0,0
+Lipscomb,303,Proposition 5,,DEM,For,6,3,3
+Lipscomb,303,Proposition 5,,DEM,Against,1,0,1
+Lipscomb,303,Proposition 6,,DEM,OVER VOTES,0,0,0
+Lipscomb,303,Proposition 6,,DEM,UNDER VOTES,1,1,0
+Lipscomb,303,Proposition 6,,DEM,For,4,2,2
+Lipscomb,303,Proposition 6,,DEM,Against,2,0,2
+Lipscomb,303,Proposition 1,,REP,OVER VOTES,0,0,0
+Lipscomb,303,Proposition 1,,REP,UNDER VOTES,34,13,21
+Lipscomb,303,Proposition 1,,REP,YES,158,43,115
+Lipscomb,303,Proposition 1,,REP,NO,93,19,74
+Lipscomb,303,Proposition 2,,REP,OVER VOTES,0,0,0
+Lipscomb,303,Proposition 2,,REP,UNDER VOTES,32,15,17
+Lipscomb,303,Proposition 2,,REP,YES,138,34,104
+Lipscomb,303,Proposition 2,,REP,NO,115,26,89
+Lipscomb,303,Proposition 3,,REP,OVER VOTES,0,0,0
+Lipscomb,303,Proposition 3,,REP,UNDER VOTES,32,11,21
+Lipscomb,303,Proposition 3,,REP,YES,198,54,144
+Lipscomb,303,Proposition 3,,REP,NO,55,10,45
+Lipscomb,303,Proposition 4,,REP,OVER VOTES,0,0,0
+Lipscomb,303,Proposition 4,,REP,UNDER VOTES,38,12,26
+Lipscomb,303,Proposition 4,,REP,YES,217,57,160
+Lipscomb,303,Proposition 4,,REP,NO,30,6,24
+Lipscomb,404,Registered Voters - Total,,,,778,,
+Lipscomb,404,Ballots Cast - Total,,,,220,54,166
+Lipscomb,404,President,,REP,OVER VOTES,0,0,0
+Lipscomb,404,President,,REP,UNDER VOTES,11,2,9
+Lipscomb,404,President,,REP,Jeb Bush,3,3,0
+Lipscomb,404,President,,REP,Carly Fiorina,0,0,0
+Lipscomb,404,President,,REP,Donald J. Trump,74,14,60
+Lipscomb,404,President,,REP,Rick Santorum,0,0,0
+Lipscomb,404,President,,REP,Lindsey Graham,0,0,0
+Lipscomb,404,President,,REP,Rand Paul,0,0,0
+Lipscomb,404,President,,REP,Elizabeth Gray,0,0,0
+Lipscomb,404,President,,REP,Ted Cruz,75,16,59
+Lipscomb,404,President,,REP,Chris Christie,0,0,0
+Lipscomb,404,President,,REP,Ben Carson,18,5,13
+Lipscomb,404,President,,REP,Mike Huckabee,1,1,0
+Lipscomb,404,President,,REP,John R. Kasich,5,0,5
+Lipscomb,404,President,,REP,Marco Rubio,16,6,10
+Lipscomb,404,President,,REP,Uncommitted,6,0,6
+Lipscomb,404,U.S. House,13,REP,OVER VOTES,0,0,0
+Lipscomb,404,U.S. House,13,REP,UNDER VOTES,47,7,40
+Lipscomb,404,U.S. House,13,REP,Mac Thornberry,162,40,122
+Lipscomb,404,Railroad Commissioner,,REP,OVER VOTES,0,0,0
+Lipscomb,404,Railroad Commissioner,,REP,UNDER VOTES,80,17,63
+Lipscomb,404,Railroad Commissioner,,REP,John Greytok,11,1,10
+Lipscomb,404,Railroad Commissioner,,REP,Ron Hale,20,5,15
+Lipscomb,404,Railroad Commissioner,,REP,Lance N. Christian,18,5,13
+Lipscomb,404,Railroad Commissioner,,REP,Gary Gates,39,9,30
+Lipscomb,404,Railroad Commissioner,,REP,Weston Martinez,4,2,2
+Lipscomb,404,Railroad Commissioner,,REP,Doug Jeffrey,14,3,11
+Lipscomb,404,Railroad Commissioner,,REP,Wayne Christian,23,5,18
+Lipscomb,404,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0,0,0
+Lipscomb,404,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,68,12,56
+Lipscomb,404,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,76,18,58
+Lipscomb,404,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,65,17,48
+Lipscomb,404,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0,0,0
+Lipscomb,404,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,79,15,64
+Lipscomb,404,"Justice, Supreme Court, Place 5",,REP,Paul Green,88,21,67
+Lipscomb,404,"Justice, Supreme Court, Place 5",,REP,Rick Green,42,11,31
+Lipscomb,404,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0,0,0
+Lipscomb,404,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,70,13,57
+Lipscomb,404,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,60,20,40
+Lipscomb,404,"Justice, Supreme Court, Place 9",,REP,Joe Pool,79,14,65
+Lipscomb,404,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0,0,0
+Lipscomb,404,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,83,14,69
+Lipscomb,404,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,43,9,34
+Lipscomb,404,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,55,14,41
+Lipscomb,404,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,28,10,18
+Lipscomb,404,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0,0,0
+Lipscomb,404,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,80,13,67
+Lipscomb,404,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,18,3,15
+Lipscomb,404,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,14,7,7
+Lipscomb,404,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,47,9,38
+Lipscomb,404,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,50,15,35
+Lipscomb,404,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0,0,0
+Lipscomb,404,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,91,16,75
+Lipscomb,404,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,71,16,55
+Lipscomb,404,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,47,15,32
+Lipscomb,404,"Member, State Board of Education, District 15",,REP,OVER VOTES,0,0,0
+Lipscomb,404,"Member, State Board of Education, District 15",,REP,UNDER VOTES,93,13,80
+Lipscomb,404,"Member, State Board of Education, District 15",,REP,Marty Rowley,116,34,82
+Lipscomb,404,State Representative,88,REP,OVER VOTES,0,0,0
+Lipscomb,404,State Representative,88,REP,UNDER VOTES,62,6,56
+Lipscomb,404,State Representative,88,REP,Ken King,147,41,106
+Lipscomb,404,"Justice, 7th Court of Appeals District, Place 4",,REP,OVER VOTES,0,0,0
+Lipscomb,404,"Justice, 7th Court of Appeals District, Place 4",,REP,UNDER VOTES,95,14,81
+Lipscomb,404,"Justice, 7th Court of Appeals District, Place 4",,REP,Jim Campbell,114,33,81
+Lipscomb,404,"District Attorney, 31st Judicial District",,REP,OVER VOTES,0,0,0
+Lipscomb,404,"District Attorney, 31st Judicial District",,REP,UNDER VOTES,88,11,77
+Lipscomb,404,"District Attorney, 31st Judicial District",,REP,Franklin McDonough,121,36,85
+Lipscomb,404,County Attorney,,REP,OVER VOTES,0,0,0
+Lipscomb,404,County Attorney,,REP,UNDER VOTES,75,8,67
+Lipscomb,404,County Attorney,,REP,Matthew Bartosiewicz,134,39,95
+Lipscomb,404,Sheriff,,REP,OVER VOTES,0,0,0
+Lipscomb,404,Sheriff,,REP,UNDER VOTES,3,0,3
+Lipscomb,404,Sheriff,,REP,Dave Thomas,13,6,7
+Lipscomb,404,Sheriff,,REP,Kenneth M. Eggleston,139,26,113
+Lipscomb,404,Sheriff,,REP,James Robertson,52,15,37
+Lipscomb,404,Sheriff,,REP,Don Bolar,2,0,2
+Lipscomb,404,Tax Assessor-Collector,,REP,OVER VOTES,0,0,0
+Lipscomb,404,Tax Assessor-Collector,,REP,UNDER VOTES,33,3,30
+Lipscomb,404,Tax Assessor-Collector,,REP,Sharla Bradshaw,176,44,132
+Lipscomb,404,County Treasurer - Unexpired Term,,REP,OVER VOTES,0,0,0
+Lipscomb,404,County Treasurer - Unexpired Term,,REP,UNDER VOTES,15,2,13
+Lipscomb,404,County Treasurer - Unexpired Term,,REP,Ramona Schilling,65,26,39
+Lipscomb,404,County Treasurer - Unexpired Term,,REP,Kimberly L. Long,129,19,110
+Lipscomb,404,County Chairman,,REP,OVER VOTES,0,0,0
+Lipscomb,404,County Chairman,,REP,UNDER VOTES,64,8,56
+Lipscomb,404,County Chairman,,REP,Diana Hoover,145,39,106
+Lipscomb,404,President,,DEM,OVER VOTES,0,0,0
+Lipscomb,404,President,,DEM,UNDER VOTES,0,0,0
+Lipscomb,404,President,,DEM,Keith Judd,0,0,0
+Lipscomb,404,President,,DEM,Willie L. Wilson,0,0,0
+Lipscomb,404,President,,DEM,"Roque ""Rocky"" De La Fuente",1,1,0
+Lipscomb,404,President,,DEM,Star Locke,0,0,0
+Lipscomb,404,President,,DEM,Calvis L. Hawes,0,0,0
+Lipscomb,404,President,,DEM,Bernie Sanders,6,2,4
+Lipscomb,404,President,,DEM,Hillary Clinton,4,4,0
+Lipscomb,404,President,,DEM,Martin J. O'Malley,0,0,0
+Lipscomb,404,Railroad Commissioner,,DEM,OVER VOTES,0,0,0
+Lipscomb,404,Railroad Commissioner,,DEM,UNDER VOTES,0,0,0
+Lipscomb,404,Railroad Commissioner,,DEM,Cody Garrett,1,0,1
+Lipscomb,404,Railroad Commissioner,,DEM,Lon Burnam,4,3,1
+Lipscomb,404,Railroad Commissioner,,DEM,Grady Yarbrough,6,4,2
+Lipscomb,404,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0,0,0
+Lipscomb,404,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,0,0,0
+Lipscomb,404,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,11,7,4
+Lipscomb,404,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0,0,0
+Lipscomb,404,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,0,0,0
+Lipscomb,404,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,11,7,4
+Lipscomb,404,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0,0,0
+Lipscomb,404,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,0,0,0
+Lipscomb,404,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,11,7,4
+Lipscomb,404,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0,0,0
+Lipscomb,404,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,0,0,0
+Lipscomb,404,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",11,7,4
+Lipscomb,404,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0,0,0
+Lipscomb,404,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,0,0,0
+Lipscomb,404,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,11,7,4
+Lipscomb,404,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0,0,0
+Lipscomb,404,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,0,0,0
+Lipscomb,404,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,11,7,4
+Lipscomb,404,County Chairman,,DEM,OVER VOTES,0,0,0
+Lipscomb,404,County Chairman,,DEM,UNDER VOTES,0,0,0
+Lipscomb,404,County Chairman,,DEM,Virginia Scott,11,7,4
+Lipscomb,404,Proposition 1,,DEM,OVER VOTES,0,0,0
+Lipscomb,404,Proposition 1,,DEM,UNDER VOTES,0,0,0
+Lipscomb,404,Proposition 1,,DEM,For,10,6,4
+Lipscomb,404,Proposition 1,,DEM,Against,1,1,0
+Lipscomb,404,Proposition 2,,DEM,OVER VOTES,0,0,0
+Lipscomb,404,Proposition 2,,DEM,UNDER VOTES,0,0,0
+Lipscomb,404,Proposition 2,,DEM,For,11,7,4
+Lipscomb,404,Proposition 2,,DEM,Against,0,0,0
+Lipscomb,404,Proposition 3,,DEM,OVER VOTES,0,0,0
+Lipscomb,404,Proposition 3,,DEM,UNDER VOTES,0,0,0
+Lipscomb,404,Proposition 3,,DEM,For,11,7,4
+Lipscomb,404,Proposition 3,,DEM,Against,0,0,0
+Lipscomb,404,Proposition 4,,DEM,OVER VOTES,0,0,0
+Lipscomb,404,Proposition 4,,DEM,UNDER VOTES,0,0,0
+Lipscomb,404,Proposition 4,,DEM,For,10,7,3
+Lipscomb,404,Proposition 4,,DEM,Against,1,0,1
+Lipscomb,404,Proposition 5,,DEM,OVER VOTES,0,0,0
+Lipscomb,404,Proposition 5,,DEM,UNDER VOTES,0,0,0
+Lipscomb,404,Proposition 5,,DEM,For,11,7,4
+Lipscomb,404,Proposition 5,,DEM,Against,0,0,0
+Lipscomb,404,Proposition 6,,DEM,OVER VOTES,0,0,0
+Lipscomb,404,Proposition 6,,DEM,UNDER VOTES,0,0,0
+Lipscomb,404,Proposition 6,,DEM,For,10,6,4
+Lipscomb,404,Proposition 6,,DEM,Against,1,1,0
+Lipscomb,404,Proposition 1,,REP,OVER VOTES,0,0,0
+Lipscomb,404,Proposition 1,,REP,UNDER VOTES,33,10,23
+Lipscomb,404,Proposition 1,,REP,YES,99,24,75
+Lipscomb,404,Proposition 1,,REP,NO,77,13,64
+Lipscomb,404,Proposition 2,,REP,OVER VOTES,0,0,0
+Lipscomb,404,Proposition 2,,REP,UNDER VOTES,30,11,19
+Lipscomb,404,Proposition 2,,REP,YES,80,15,65
+Lipscomb,404,Proposition 2,,REP,NO,99,21,78
+Lipscomb,404,Proposition 3,,REP,OVER VOTES,0,0,0
+Lipscomb,404,Proposition 3,,REP,UNDER VOTES,36,12,24
+Lipscomb,404,Proposition 3,,REP,YES,132,33,99
+Lipscomb,404,Proposition 3,,REP,NO,41,2,39
+Lipscomb,404,Proposition 4,,REP,OVER VOTES,0,0,0
+Lipscomb,404,Proposition 4,,REP,UNDER VOTES,35,10,25
+Lipscomb,404,Proposition 4,,REP,YES,158,36,122
+Lipscomb,404,Proposition 4,,REP,NO,16,1,15
+Lipscomb,106,Registered Voters - Total,,,,668,,
+Lipscomb,106,Ballots Cast - Total,,,,143,45,98
+Lipscomb,106,President,,REP,OVER VOTES,0,0,0
+Lipscomb,106,President,,REP,UNDER VOTES,1,1,0
+Lipscomb,106,President,,REP,Jeb Bush,4,3,1
+Lipscomb,106,President,,REP,Carly Fiorina,0,0,0
+Lipscomb,106,President,,REP,Donald J. Trump,28,11,17
+Lipscomb,106,President,,REP,Rick Santorum,0,0,0
+Lipscomb,106,President,,REP,Lindsey Graham,0,0,0
+Lipscomb,106,President,,REP,Rand Paul,0,0,0
+Lipscomb,106,President,,REP,Elizabeth Gray,0,0,0
+Lipscomb,106,President,,REP,Ted Cruz,76,18,58
+Lipscomb,106,President,,REP,Chris Christie,0,0,0
+Lipscomb,106,President,,REP,Ben Carson,13,5,8
+Lipscomb,106,President,,REP,Mike Huckabee,0,0,0
+Lipscomb,106,President,,REP,John R. Kasich,1,0,1
+Lipscomb,106,President,,REP,Marco Rubio,14,3,11
+Lipscomb,106,President,,REP,Uncommitted,4,2,2
+Lipscomb,106,U.S. House,13,REP,OVER VOTES,0,0,0
+Lipscomb,106,U.S. House,13,REP,UNDER VOTES,12,5,7
+Lipscomb,106,U.S. House,13,REP,Mac Thornberry,129,38,91
+Lipscomb,106,Railroad Commissioner,,REP,OVER VOTES,0,0,0
+Lipscomb,106,Railroad Commissioner,,REP,UNDER VOTES,45,20,25
+Lipscomb,106,Railroad Commissioner,,REP,John Greytok,20,4,16
+Lipscomb,106,Railroad Commissioner,,REP,Ron Hale,19,2,17
+Lipscomb,106,Railroad Commissioner,,REP,Lance N. Christian,12,4,8
+Lipscomb,106,Railroad Commissioner,,REP,Gary Gates,22,10,12
+Lipscomb,106,Railroad Commissioner,,REP,Weston Martinez,7,1,6
+Lipscomb,106,Railroad Commissioner,,REP,Doug Jeffrey,5,1,4
+Lipscomb,106,Railroad Commissioner,,REP,Wayne Christian,11,1,10
+Lipscomb,106,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0,0,0
+Lipscomb,106,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,37,17,20
+Lipscomb,106,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,63,15,48
+Lipscomb,106,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,41,11,30
+Lipscomb,106,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0,0,0
+Lipscomb,106,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,41,19,22
+Lipscomb,106,"Justice, Supreme Court, Place 5",,REP,Paul Green,67,15,52
+Lipscomb,106,"Justice, Supreme Court, Place 5",,REP,Rick Green,33,9,24
+Lipscomb,106,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0,0,0
+Lipscomb,106,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,42,19,23
+Lipscomb,106,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,56,17,39
+Lipscomb,106,"Justice, Supreme Court, Place 9",,REP,Joe Pool,43,7,36
+Lipscomb,106,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0,0,0
+Lipscomb,106,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,46,20,26
+Lipscomb,106,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,33,2,31
+Lipscomb,106,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,41,14,27
+Lipscomb,106,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,21,7,14
+Lipscomb,106,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0,0,0
+Lipscomb,106,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,47,20,27
+Lipscomb,106,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,21,3,18
+Lipscomb,106,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,8,5,3
+Lipscomb,106,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,42,9,33
+Lipscomb,106,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,23,6,17
+Lipscomb,106,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0,0,0
+Lipscomb,106,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,47,20,27
+Lipscomb,106,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,51,10,41
+Lipscomb,106,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,43,13,30
+Lipscomb,106,"Member, State Board of Education, District 15",,REP,OVER VOTES,0,0,0
+Lipscomb,106,"Member, State Board of Education, District 15",,REP,UNDER VOTES,43,19,24
+Lipscomb,106,"Member, State Board of Education, District 15",,REP,Marty Rowley,98,24,74
+Lipscomb,106,State Representative,88,REP,OVER VOTES,0,0,0
+Lipscomb,106,State Representative,88,REP,UNDER VOTES,20,7,13
+Lipscomb,106,State Representative,88,REP,Ken King,121,36,85
+Lipscomb,106,"Justice, 7th Court of Appeals District, Place 4",,REP,OVER VOTES,0,0,0
+Lipscomb,106,"Justice, 7th Court of Appeals District, Place 4",,REP,UNDER VOTES,39,18,21
+Lipscomb,106,"Justice, 7th Court of Appeals District, Place 4",,REP,Jim Campbell,102,25,77
+Lipscomb,106,"District Attorney, 31st Judicial District",,REP,OVER VOTES,0,0,0
+Lipscomb,106,"District Attorney, 31st Judicial District",,REP,UNDER VOTES,38,19,19
+Lipscomb,106,"District Attorney, 31st Judicial District",,REP,Franklin McDonough,103,24,79
+Lipscomb,106,County Attorney,,REP,OVER VOTES,0,0,0
+Lipscomb,106,County Attorney,,REP,UNDER VOTES,23,16,7
+Lipscomb,106,County Attorney,,REP,Matthew Bartosiewicz,118,27,91
+Lipscomb,106,Sheriff,,REP,OVER VOTES,0,0,0
+Lipscomb,106,Sheriff,,REP,UNDER VOTES,3,3,0
+Lipscomb,106,Sheriff,,REP,Dave Thomas,39,14,25
+Lipscomb,106,Sheriff,,REP,Kenneth M. Eggleston,53,17,36
+Lipscomb,106,Sheriff,,REP,James Robertson,41,8,33
+Lipscomb,106,Sheriff,,REP,Don Bolar,5,1,4
+Lipscomb,106,Tax Assessor-Collector,,REP,OVER VOTES,0,0,0
+Lipscomb,106,Tax Assessor-Collector,,REP,UNDER VOTES,22,9,13
+Lipscomb,106,Tax Assessor-Collector,,REP,Sharla Bradshaw,119,34,85
+Lipscomb,106,County Treasurer - Unexpired Term,,REP,OVER VOTES,0,0,0
+Lipscomb,106,County Treasurer - Unexpired Term,,REP,UNDER VOTES,6,2,4
+Lipscomb,106,County Treasurer - Unexpired Term,,REP,Ramona Schilling,47,12,35
+Lipscomb,106,County Treasurer - Unexpired Term,,REP,Kimberly L. Long,88,29,59
+Lipscomb,106,"County Commissioner, Precinct 1",,REP,OVER VOTES,0,0,0
+Lipscomb,106,"County Commissioner, Precinct 1",,REP,UNDER VOTES,0,0,0
+Lipscomb,106,"County Commissioner, Precinct 1",,REP,Chaz Rutledge,59,31,28
+Lipscomb,106,"County Commissioner, Precinct 1",,REP,Juan Cantu,82,12,70
+Lipscomb,106,County Chairman,,REP,OVER VOTES,0,0,0
+Lipscomb,106,County Chairman,,REP,UNDER VOTES,21,14,7
+Lipscomb,106,County Chairman,,REP,Diana Hoover,120,29,91
+Lipscomb,106,President,,DEM,OVER VOTES,0,0,0
+Lipscomb,106,President,,DEM,UNDER VOTES,0,0,0
+Lipscomb,106,President,,DEM,Keith Judd,0,0,0
+Lipscomb,106,President,,DEM,Willie L. Wilson,0,0,0
+Lipscomb,106,President,,DEM,"Roque ""Rocky"" De La Fuente",0,0,0
+Lipscomb,106,President,,DEM,Star Locke,0,0,0
+Lipscomb,106,President,,DEM,Calvis L. Hawes,0,0,0
+Lipscomb,106,President,,DEM,Bernie Sanders,0,0,0
+Lipscomb,106,President,,DEM,Hillary Clinton,2,2,0
+Lipscomb,106,President,,DEM,Martin J. O'Malley,0,0,0
+Lipscomb,106,Railroad Commissioner,,DEM,OVER VOTES,0,0,0
+Lipscomb,106,Railroad Commissioner,,DEM,UNDER VOTES,1,1,0
+Lipscomb,106,Railroad Commissioner,,DEM,Cody Garrett,1,1,0
+Lipscomb,106,Railroad Commissioner,,DEM,Lon Burnam,0,0,0
+Lipscomb,106,Railroad Commissioner,,DEM,Grady Yarbrough,0,0,0
+Lipscomb,106,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0,0,0
+Lipscomb,106,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,1,1,0
+Lipscomb,106,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,1,1,0
+Lipscomb,106,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0,0,0
+Lipscomb,106,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,0,0,0
+Lipscomb,106,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,2,2,0
+Lipscomb,106,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0,0,0
+Lipscomb,106,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,0,0,0
+Lipscomb,106,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,2,2,0
+Lipscomb,106,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0,0,0
+Lipscomb,106,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,1,1,0
+Lipscomb,106,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",1,1,0
+Lipscomb,106,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0,0,0
+Lipscomb,106,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,0,0,0
+Lipscomb,106,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,2,2,0
+Lipscomb,106,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0,0,0
+Lipscomb,106,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,1,1,0
+Lipscomb,106,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,1,1,0
+Lipscomb,106,County Chairman,,DEM,OVER VOTES,0,0,0
+Lipscomb,106,County Chairman,,DEM,UNDER VOTES,0,0,0
+Lipscomb,106,County Chairman,,DEM,Virginia Scott,2,2,0
+Lipscomb,106,Proposition 1,,DEM,OVER VOTES,0,0,0
+Lipscomb,106,Proposition 1,,DEM,UNDER VOTES,0,0,0
+Lipscomb,106,Proposition 1,,DEM,For,2,2,0
+Lipscomb,106,Proposition 1,,DEM,Against,0,0,0
+Lipscomb,106,Proposition 2,,DEM,OVER VOTES,0,0,0
+Lipscomb,106,Proposition 2,,DEM,UNDER VOTES,0,0,0
+Lipscomb,106,Proposition 2,,DEM,For,2,2,0
+Lipscomb,106,Proposition 2,,DEM,Against,0,0,0
+Lipscomb,106,Proposition 3,,DEM,OVER VOTES,0,0,0
+Lipscomb,106,Proposition 3,,DEM,UNDER VOTES,0,0,0
+Lipscomb,106,Proposition 3,,DEM,For,2,2,0
+Lipscomb,106,Proposition 3,,DEM,Against,0,0,0
+Lipscomb,106,Proposition 4,,DEM,OVER VOTES,0,0,0
+Lipscomb,106,Proposition 4,,DEM,UNDER VOTES,0,0,0
+Lipscomb,106,Proposition 4,,DEM,For,2,2,0
+Lipscomb,106,Proposition 4,,DEM,Against,0,0,0
+Lipscomb,106,Proposition 5,,DEM,OVER VOTES,0,0,0
+Lipscomb,106,Proposition 5,,DEM,UNDER VOTES,0,0,0
+Lipscomb,106,Proposition 5,,DEM,For,2,2,0
+Lipscomb,106,Proposition 5,,DEM,Against,0,0,0
+Lipscomb,106,Proposition 6,,DEM,OVER VOTES,0,0,0
+Lipscomb,106,Proposition 6,,DEM,UNDER VOTES,0,0,0
+Lipscomb,106,Proposition 6,,DEM,For,2,2,0
+Lipscomb,106,Proposition 6,,DEM,Against,0,0,0
+Lipscomb,106,Proposition 1,,REP,OVER VOTES,0,0,0
+Lipscomb,106,Proposition 1,,REP,UNDER VOTES,12,4,8
+Lipscomb,106,Proposition 1,,REP,YES,86,23,63
+Lipscomb,106,Proposition 1,,REP,NO,43,16,27
+Lipscomb,106,Proposition 2,,REP,OVER VOTES,0,0,0
+Lipscomb,106,Proposition 2,,REP,UNDER VOTES,12,5,7
+Lipscomb,106,Proposition 2,,REP,YES,65,15,50
+Lipscomb,106,Proposition 2,,REP,NO,64,23,41
+Lipscomb,106,Proposition 3,,REP,OVER VOTES,0,0,0
+Lipscomb,106,Proposition 3,,REP,UNDER VOTES,14,5,9
+Lipscomb,106,Proposition 3,,REP,YES,106,31,75
+Lipscomb,106,Proposition 3,,REP,NO,21,7,14
+Lipscomb,106,Proposition 4,,REP,OVER VOTES,0,0,0
+Lipscomb,106,Proposition 4,,REP,UNDER VOTES,12,5,7
+Lipscomb,106,Proposition 4,,REP,YES,122,36,86
+Lipscomb,106,Proposition 4,,REP,NO,7,2,5
+Lipscomb,207,Registered Voters - Total,,,,740,,
+Lipscomb,207,Ballots Cast - Total,,,,198,4,194
+Lipscomb,207,President,,REP,OVER VOTES,0,0,0
+Lipscomb,207,President,,REP,UNDER VOTES,1,0,1
+Lipscomb,207,President,,REP,Jeb Bush,1,0,1
+Lipscomb,207,President,,REP,Carly Fiorina,0,0,0
+Lipscomb,207,President,,REP,Donald J. Trump,36,0,36
+Lipscomb,207,President,,REP,Rick Santorum,0,0,0
+Lipscomb,207,President,,REP,Lindsey Graham,0,0,0
+Lipscomb,207,President,,REP,Rand Paul,0,0,0
+Lipscomb,207,President,,REP,Elizabeth Gray,0,0,0
+Lipscomb,207,President,,REP,Ted Cruz,116,2,114
+Lipscomb,207,President,,REP,Chris Christie,0,0,0
+Lipscomb,207,President,,REP,Ben Carson,12,1,11
+Lipscomb,207,President,,REP,Mike Huckabee,1,0,1
+Lipscomb,207,President,,REP,John R. Kasich,2,0,2
+Lipscomb,207,President,,REP,Marco Rubio,21,0,21
+Lipscomb,207,President,,REP,Uncommitted,2,0,2
+Lipscomb,207,U.S. House,13,REP,OVER VOTES,0,0,0
+Lipscomb,207,U.S. House,13,REP,UNDER VOTES,18,0,18
+Lipscomb,207,U.S. House,13,REP,Mac Thornberry,174,3,171
+Lipscomb,207,Railroad Commissioner,,REP,OVER VOTES,0,0,0
+Lipscomb,207,Railroad Commissioner,,REP,UNDER VOTES,52,1,51
+Lipscomb,207,Railroad Commissioner,,REP,John Greytok,24,0,24
+Lipscomb,207,Railroad Commissioner,,REP,Ron Hale,26,2,24
+Lipscomb,207,Railroad Commissioner,,REP,Lance N. Christian,21,0,21
+Lipscomb,207,Railroad Commissioner,,REP,Gary Gates,27,0,27
+Lipscomb,207,Railroad Commissioner,,REP,Weston Martinez,12,0,12
+Lipscomb,207,Railroad Commissioner,,REP,Doug Jeffrey,10,0,10
+Lipscomb,207,Railroad Commissioner,,REP,Wayne Christian,20,0,20
+Lipscomb,207,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0,0,0
+Lipscomb,207,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,45,1,44
+Lipscomb,207,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,88,0,88
+Lipscomb,207,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,59,2,57
+Lipscomb,207,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0,0,0
+Lipscomb,207,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,44,1,43
+Lipscomb,207,"Justice, Supreme Court, Place 5",,REP,Paul Green,94,1,93
+Lipscomb,207,"Justice, Supreme Court, Place 5",,REP,Rick Green,54,1,53
+Lipscomb,207,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0,0,0
+Lipscomb,207,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,43,1,42
+Lipscomb,207,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,73,0,73
+Lipscomb,207,"Justice, Supreme Court, Place 9",,REP,Joe Pool,76,2,74
+Lipscomb,207,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0,0,0
+Lipscomb,207,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,57,1,56
+Lipscomb,207,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,53,0,53
+Lipscomb,207,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,48,1,47
+Lipscomb,207,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,34,1,33
+Lipscomb,207,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0,0,0
+Lipscomb,207,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,53,1,52
+Lipscomb,207,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,34,0,34
+Lipscomb,207,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,16,0,16
+Lipscomb,207,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,58,1,57
+Lipscomb,207,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,31,1,30
+Lipscomb,207,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0,0,0
+Lipscomb,207,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,59,1,58
+Lipscomb,207,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,81,1,80
+Lipscomb,207,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,52,1,51
+Lipscomb,207,"Member, State Board of Education, District 15",,REP,OVER VOTES,0,0,0
+Lipscomb,207,"Member, State Board of Education, District 15",,REP,UNDER VOTES,55,1,54
+Lipscomb,207,"Member, State Board of Education, District 15",,REP,Marty Rowley,137,2,135
+Lipscomb,207,State Representative,88,REP,OVER VOTES,0,0,0
+Lipscomb,207,State Representative,88,REP,UNDER VOTES,24,0,24
+Lipscomb,207,State Representative,88,REP,Ken King,168,3,165
+Lipscomb,207,"Justice, 7th Court of Appeals District, Place 4",,REP,OVER VOTES,0,0,0
+Lipscomb,207,"Justice, 7th Court of Appeals District, Place 4",,REP,UNDER VOTES,48,1,47
+Lipscomb,207,"Justice, 7th Court of Appeals District, Place 4",,REP,Jim Campbell,144,2,142
+Lipscomb,207,"District Attorney, 31st Judicial District",,REP,OVER VOTES,0,0,0
+Lipscomb,207,"District Attorney, 31st Judicial District",,REP,UNDER VOTES,49,0,49
+Lipscomb,207,"District Attorney, 31st Judicial District",,REP,Franklin McDonough,143,3,140
+Lipscomb,207,County Attorney,,REP,OVER VOTES,0,0,0
+Lipscomb,207,County Attorney,,REP,UNDER VOTES,24,0,24
+Lipscomb,207,County Attorney,,REP,Matthew Bartosiewicz,168,3,165
+Lipscomb,207,Sheriff,,REP,OVER VOTES,0,0,0
+Lipscomb,207,Sheriff,,REP,UNDER VOTES,7,0,7
+Lipscomb,207,Sheriff,,REP,Dave Thomas,39,1,38
+Lipscomb,207,Sheriff,,REP,Kenneth M. Eggleston,69,0,69
+Lipscomb,207,Sheriff,,REP,James Robertson,70,2,68
+Lipscomb,207,Sheriff,,REP,Don Bolar,7,0,7
+Lipscomb,207,Tax Assessor-Collector,,REP,OVER VOTES,0,0,0
+Lipscomb,207,Tax Assessor-Collector,,REP,UNDER VOTES,33,0,33
+Lipscomb,207,Tax Assessor-Collector,,REP,Sharla Bradshaw,159,3,156
+Lipscomb,207,County Treasurer - Unexpired Term,,REP,OVER VOTES,0,0,0
+Lipscomb,207,County Treasurer - Unexpired Term,,REP,UNDER VOTES,9,0,9
+Lipscomb,207,County Treasurer - Unexpired Term,,REP,Ramona Schilling,82,3,79
+Lipscomb,207,County Treasurer - Unexpired Term,,REP,Kimberly L. Long,101,0,101
+Lipscomb,207,County Chairman,,REP,OVER VOTES,0,0,0
+Lipscomb,207,County Chairman,,REP,UNDER VOTES,25,0,25
+Lipscomb,207,County Chairman,,REP,Diana Hoover,167,3,164
+Lipscomb,207,President,,DEM,OVER VOTES,0,0,0
+Lipscomb,207,President,,DEM,UNDER VOTES,0,0,0
+Lipscomb,207,President,,DEM,Keith Judd,0,0,0
+Lipscomb,207,President,,DEM,Willie L. Wilson,0,0,0
+Lipscomb,207,President,,DEM,"Roque ""Rocky"" De La Fuente",0,0,0
+Lipscomb,207,President,,DEM,Star Locke,0,0,0
+Lipscomb,207,President,,DEM,Calvis L. Hawes,0,0,0
+Lipscomb,207,President,,DEM,Bernie Sanders,3,1,2
+Lipscomb,207,President,,DEM,Hillary Clinton,3,0,3
+Lipscomb,207,President,,DEM,Martin J. O'Malley,0,0,0
+Lipscomb,207,Railroad Commissioner,,DEM,OVER VOTES,0,0,0
+Lipscomb,207,Railroad Commissioner,,DEM,UNDER VOTES,1,0,1
+Lipscomb,207,Railroad Commissioner,,DEM,Cody Garrett,4,0,4
+Lipscomb,207,Railroad Commissioner,,DEM,Lon Burnam,0,0,0
+Lipscomb,207,Railroad Commissioner,,DEM,Grady Yarbrough,1,1,0
+Lipscomb,207,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0,0,0
+Lipscomb,207,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,1,0,1
+Lipscomb,207,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,5,1,4
+Lipscomb,207,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0,0,0
+Lipscomb,207,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,1,0,1
+Lipscomb,207,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,5,1,4
+Lipscomb,207,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0,0,0
+Lipscomb,207,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,1,0,1
+Lipscomb,207,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,5,1,4
+Lipscomb,207,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0,0,0
+Lipscomb,207,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,1,0,1
+Lipscomb,207,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",5,1,4
+Lipscomb,207,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0,0,0
+Lipscomb,207,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,1,0,1
+Lipscomb,207,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,5,1,4
+Lipscomb,207,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0,0,0
+Lipscomb,207,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,1,0,1
+Lipscomb,207,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,5,1,4
+Lipscomb,207,County Chairman,,DEM,OVER VOTES,0,0,0
+Lipscomb,207,County Chairman,,DEM,UNDER VOTES,1,0,1
+Lipscomb,207,County Chairman,,DEM,Virginia Scott,5,1,4
+Lipscomb,207,Proposition 1,,DEM,OVER VOTES,0,0,0
+Lipscomb,207,Proposition 1,,DEM,UNDER VOTES,0,0,0
+Lipscomb,207,Proposition 1,,DEM,For,5,1,4
+Lipscomb,207,Proposition 1,,DEM,Against,1,0,1
+Lipscomb,207,Proposition 2,,DEM,OVER VOTES,0,0,0
+Lipscomb,207,Proposition 2,,DEM,UNDER VOTES,0,0,0
+Lipscomb,207,Proposition 2,,DEM,For,6,1,5
+Lipscomb,207,Proposition 2,,DEM,Against,0,0,0
+Lipscomb,207,Proposition 3,,DEM,OVER VOTES,0,0,0
+Lipscomb,207,Proposition 3,,DEM,UNDER VOTES,0,0,0
+Lipscomb,207,Proposition 3,,DEM,For,5,1,4
+Lipscomb,207,Proposition 3,,DEM,Against,1,0,1
+Lipscomb,207,Proposition 4,,DEM,OVER VOTES,0,0,0
+Lipscomb,207,Proposition 4,,DEM,UNDER VOTES,0,0,0
+Lipscomb,207,Proposition 4,,DEM,For,5,0,5
+Lipscomb,207,Proposition 4,,DEM,Against,1,1,0
+Lipscomb,207,Proposition 5,,DEM,OVER VOTES,0,0,0
+Lipscomb,207,Proposition 5,,DEM,UNDER VOTES,0,0,0
+Lipscomb,207,Proposition 5,,DEM,For,6,1,5
+Lipscomb,207,Proposition 5,,DEM,Against,0,0,0
+Lipscomb,207,Proposition 6,,DEM,OVER VOTES,0,0,0
+Lipscomb,207,Proposition 6,,DEM,UNDER VOTES,0,0,0
+Lipscomb,207,Proposition 6,,DEM,For,5,1,4
+Lipscomb,207,Proposition 6,,DEM,Against,1,0,1
+Lipscomb,207,Proposition 1,,REP,OVER VOTES,0,0,0
+Lipscomb,207,Proposition 1,,REP,UNDER VOTES,14,1,13
+Lipscomb,207,Proposition 1,,REP,YES,127,1,126
+Lipscomb,207,Proposition 1,,REP,NO,51,1,50
+Lipscomb,207,Proposition 2,,REP,OVER VOTES,0,0,0
+Lipscomb,207,Proposition 2,,REP,UNDER VOTES,13,1,12
+Lipscomb,207,Proposition 2,,REP,YES,108,1,107
+Lipscomb,207,Proposition 2,,REP,NO,71,1,70
+Lipscomb,207,Proposition 3,,REP,OVER VOTES,0,0,0
+Lipscomb,207,Proposition 3,,REP,UNDER VOTES,14,0,14
+Lipscomb,207,Proposition 3,,REP,YES,146,2,144
+Lipscomb,207,Proposition 3,,REP,NO,32,1,31
+Lipscomb,207,Proposition 4,,REP,OVER VOTES,0,0,0
+Lipscomb,207,Proposition 4,,REP,UNDER VOTES,16,1,15
+Lipscomb,207,Proposition 4,,REP,YES,168,2,166
+Lipscomb,207,Proposition 4,,REP,NO,8,0,8
+Lipscomb,308,Registered Voters - Total,,,,340,,
+Lipscomb,308,Ballots Cast - Total,,,,98,21,77
+Lipscomb,308,President,,REP,OVER VOTES,0,0,0
+Lipscomb,308,President,,REP,UNDER VOTES,4,1,3
+Lipscomb,308,President,,REP,Jeb Bush,2,2,0
+Lipscomb,308,President,,REP,Carly Fiorina,1,0,1
+Lipscomb,308,President,,REP,Donald J. Trump,26,4,22
+Lipscomb,308,President,,REP,Rick Santorum,0,0,0
+Lipscomb,308,President,,REP,Lindsey Graham,0,0,0
+Lipscomb,308,President,,REP,Rand Paul,1,0,1
+Lipscomb,308,President,,REP,Elizabeth Gray,0,0,0
+Lipscomb,308,President,,REP,Ted Cruz,40,10,30
+Lipscomb,308,President,,REP,Chris Christie,0,0,0
+Lipscomb,308,President,,REP,Ben Carson,4,0,4
+Lipscomb,308,President,,REP,Mike Huckabee,1,0,1
+Lipscomb,308,President,,REP,John R. Kasich,0,0,0
+Lipscomb,308,President,,REP,Marco Rubio,14,4,10
+Lipscomb,308,President,,REP,Uncommitted,2,0,2
+Lipscomb,308,U.S. House,13,REP,OVER VOTES,0,0,0
+Lipscomb,308,U.S. House,13,REP,UNDER VOTES,18,3,15
+Lipscomb,308,U.S. House,13,REP,Mac Thornberry,77,18,59
+Lipscomb,308,Railroad Commissioner,,REP,OVER VOTES,0,0,0
+Lipscomb,308,Railroad Commissioner,,REP,UNDER VOTES,29,8,21
+Lipscomb,308,Railroad Commissioner,,REP,John Greytok,12,0,12
+Lipscomb,308,Railroad Commissioner,,REP,Ron Hale,17,4,13
+Lipscomb,308,Railroad Commissioner,,REP,Lance N. Christian,8,1,7
+Lipscomb,308,Railroad Commissioner,,REP,Gary Gates,14,4,10
+Lipscomb,308,Railroad Commissioner,,REP,Weston Martinez,1,0,1
+Lipscomb,308,Railroad Commissioner,,REP,Doug Jeffrey,5,1,4
+Lipscomb,308,Railroad Commissioner,,REP,Wayne Christian,9,3,6
+Lipscomb,308,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0,0,0
+Lipscomb,308,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,28,7,21
+Lipscomb,308,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,41,12,29
+Lipscomb,308,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,26,2,24
+Lipscomb,308,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0,0,0
+Lipscomb,308,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,32,9,23
+Lipscomb,308,"Justice, Supreme Court, Place 5",,REP,Paul Green,39,6,33
+Lipscomb,308,"Justice, Supreme Court, Place 5",,REP,Rick Green,24,6,18
+Lipscomb,308,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0,0,0
+Lipscomb,308,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,31,8,23
+Lipscomb,308,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,22,4,18
+Lipscomb,308,"Justice, Supreme Court, Place 9",,REP,Joe Pool,42,9,33
+Lipscomb,308,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0,0,0
+Lipscomb,308,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,33,9,24
+Lipscomb,308,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,25,2,23
+Lipscomb,308,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,27,8,19
+Lipscomb,308,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,10,2,8
+Lipscomb,308,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0,0,0
+Lipscomb,308,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,33,8,25
+Lipscomb,308,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,11,2,9
+Lipscomb,308,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,6,0,6
+Lipscomb,308,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,32,8,24
+Lipscomb,308,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,13,3,10
+Lipscomb,308,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0,0,0
+Lipscomb,308,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,35,9,26
+Lipscomb,308,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,38,9,29
+Lipscomb,308,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,22,3,19
+Lipscomb,308,"Member, State Board of Education, District 15",,REP,OVER VOTES,0,0,0
+Lipscomb,308,"Member, State Board of Education, District 15",,REP,UNDER VOTES,30,6,24
+Lipscomb,308,"Member, State Board of Education, District 15",,REP,Marty Rowley,65,15,50
+Lipscomb,308,State Representative,88,REP,OVER VOTES,0,0,0
+Lipscomb,308,State Representative,88,REP,UNDER VOTES,17,6,11
+Lipscomb,308,State Representative,88,REP,Ken King,78,15,63
+Lipscomb,308,"Justice, 7th Court of Appeals District, Place 4",,REP,OVER VOTES,0,0,0
+Lipscomb,308,"Justice, 7th Court of Appeals District, Place 4",,REP,UNDER VOTES,35,7,28
+Lipscomb,308,"Justice, 7th Court of Appeals District, Place 4",,REP,Jim Campbell,60,14,46
+Lipscomb,308,"District Attorney, 31st Judicial District",,REP,OVER VOTES,0,0,0
+Lipscomb,308,"District Attorney, 31st Judicial District",,REP,UNDER VOTES,32,5,27
+Lipscomb,308,"District Attorney, 31st Judicial District",,REP,Franklin McDonough,63,16,47
+Lipscomb,308,County Attorney,,REP,OVER VOTES,0,0,0
+Lipscomb,308,County Attorney,,REP,UNDER VOTES,29,9,20
+Lipscomb,308,County Attorney,,REP,Matthew Bartosiewicz,66,12,54
+Lipscomb,308,Sheriff,,REP,OVER VOTES,0,0,0
+Lipscomb,308,Sheriff,,REP,UNDER VOTES,3,2,1
+Lipscomb,308,Sheriff,,REP,Dave Thomas,17,2,15
+Lipscomb,308,Sheriff,,REP,Kenneth M. Eggleston,47,9,38
+Lipscomb,308,Sheriff,,REP,James Robertson,22,8,14
+Lipscomb,308,Sheriff,,REP,Don Bolar,6,0,6
+Lipscomb,308,Tax Assessor-Collector,,REP,OVER VOTES,0,0,0
+Lipscomb,308,Tax Assessor-Collector,,REP,UNDER VOTES,20,1,19
+Lipscomb,308,Tax Assessor-Collector,,REP,Sharla Bradshaw,75,20,55
+Lipscomb,308,County Treasurer - Unexpired Term,,REP,OVER VOTES,0,0,0
+Lipscomb,308,County Treasurer - Unexpired Term,,REP,UNDER VOTES,2,0,2
+Lipscomb,308,County Treasurer - Unexpired Term,,REP,Ramona Schilling,36,12,24
+Lipscomb,308,County Treasurer - Unexpired Term,,REP,Kimberly L. Long,57,9,48
+Lipscomb,308,"County Commissioner, Precinct 3",,REP,OVER VOTES,0,0,0
+Lipscomb,308,"County Commissioner, Precinct 3",,REP,UNDER VOTES,4,2,2
+Lipscomb,308,"County Commissioner, Precinct 3",,REP,Lynn Blau,32,9,23
+Lipscomb,308,"County Commissioner, Precinct 3",,REP,Scotty Mark Schilling,59,10,49
+Lipscomb,308,County Chairman,,REP,OVER VOTES,0,0,0
+Lipscomb,308,County Chairman,,REP,UNDER VOTES,25,4,21
+Lipscomb,308,County Chairman,,REP,Diana Hoover,70,17,53
+Lipscomb,308,President,,DEM,OVER VOTES,0,0,0
+Lipscomb,308,President,,DEM,UNDER VOTES,0,0,0
+Lipscomb,308,President,,DEM,Keith Judd,0,0,0
+Lipscomb,308,President,,DEM,Willie L. Wilson,0,0,0
+Lipscomb,308,President,,DEM,"Roque ""Rocky"" De La Fuente",0,0,0
+Lipscomb,308,President,,DEM,Star Locke,0,0,0
+Lipscomb,308,President,,DEM,Calvis L. Hawes,0,0,0
+Lipscomb,308,President,,DEM,Bernie Sanders,1,0,1
+Lipscomb,308,President,,DEM,Hillary Clinton,2,0,2
+Lipscomb,308,President,,DEM,Martin J. O'Malley,0,0,0
+Lipscomb,308,Railroad Commissioner,,DEM,OVER VOTES,0,0,0
+Lipscomb,308,Railroad Commissioner,,DEM,UNDER VOTES,2,0,2
+Lipscomb,308,Railroad Commissioner,,DEM,Cody Garrett,1,0,1
+Lipscomb,308,Railroad Commissioner,,DEM,Lon Burnam,0,0,0
+Lipscomb,308,Railroad Commissioner,,DEM,Grady Yarbrough,0,0,0
+Lipscomb,308,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0,0,0
+Lipscomb,308,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,1,0,1
+Lipscomb,308,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,2,0,2
+Lipscomb,308,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0,0,0
+Lipscomb,308,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,1,0,1
+Lipscomb,308,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,2,0,2
+Lipscomb,308,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0,0,0
+Lipscomb,308,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,1,0,1
+Lipscomb,308,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,2,0,2
+Lipscomb,308,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0,0,0
+Lipscomb,308,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,1,0,1
+Lipscomb,308,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",2,0,2
+Lipscomb,308,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0,0,0
+Lipscomb,308,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,1,0,1
+Lipscomb,308,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,2,0,2
+Lipscomb,308,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0,0,0
+Lipscomb,308,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,1,0,1
+Lipscomb,308,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,2,0,2
+Lipscomb,308,County Chairman,,DEM,OVER VOTES,0,0,0
+Lipscomb,308,County Chairman,,DEM,UNDER VOTES,1,0,1
+Lipscomb,308,County Chairman,,DEM,Virginia Scott,2,0,2
+Lipscomb,308,Proposition 1,,DEM,OVER VOTES,0,0,0
+Lipscomb,308,Proposition 1,,DEM,UNDER VOTES,1,0,1
+Lipscomb,308,Proposition 1,,DEM,For,1,0,1
+Lipscomb,308,Proposition 1,,DEM,Against,1,0,1
+Lipscomb,308,Proposition 2,,DEM,OVER VOTES,0,0,0
+Lipscomb,308,Proposition 2,,DEM,UNDER VOTES,1,0,1
+Lipscomb,308,Proposition 2,,DEM,For,2,0,2
+Lipscomb,308,Proposition 2,,DEM,Against,0,0,0
+Lipscomb,308,Proposition 3,,DEM,OVER VOTES,0,0,0
+Lipscomb,308,Proposition 3,,DEM,UNDER VOTES,1,0,1
+Lipscomb,308,Proposition 3,,DEM,For,2,0,2
+Lipscomb,308,Proposition 3,,DEM,Against,0,0,0
+Lipscomb,308,Proposition 4,,DEM,OVER VOTES,0,0,0
+Lipscomb,308,Proposition 4,,DEM,UNDER VOTES,1,0,1
+Lipscomb,308,Proposition 4,,DEM,For,1,0,1
+Lipscomb,308,Proposition 4,,DEM,Against,1,0,1
+Lipscomb,308,Proposition 5,,DEM,OVER VOTES,0,0,0
+Lipscomb,308,Proposition 5,,DEM,UNDER VOTES,1,0,1
+Lipscomb,308,Proposition 5,,DEM,For,2,0,2
+Lipscomb,308,Proposition 5,,DEM,Against,0,0,0
+Lipscomb,308,Proposition 6,,DEM,OVER VOTES,0,0,0
+Lipscomb,308,Proposition 6,,DEM,UNDER VOTES,1,0,1
+Lipscomb,308,Proposition 6,,DEM,For,2,0,2
+Lipscomb,308,Proposition 6,,DEM,Against,0,0,0
+Lipscomb,308,Proposition 1,,REP,OVER VOTES,0,0,0
+Lipscomb,308,Proposition 1,,REP,UNDER VOTES,6,1,5
+Lipscomb,308,Proposition 1,,REP,YES,56,16,40
+Lipscomb,308,Proposition 1,,REP,NO,33,4,29
+Lipscomb,308,Proposition 2,,REP,OVER VOTES,0,0,0
+Lipscomb,308,Proposition 2,,REP,UNDER VOTES,5,1,4
+Lipscomb,308,Proposition 2,,REP,YES,48,9,39
+Lipscomb,308,Proposition 2,,REP,NO,42,11,31
+Lipscomb,308,Proposition 3,,REP,OVER VOTES,0,0,0
+Lipscomb,308,Proposition 3,,REP,UNDER VOTES,10,3,7
+Lipscomb,308,Proposition 3,,REP,YES,65,13,52
+Lipscomb,308,Proposition 3,,REP,NO,20,5,15
+Lipscomb,308,Proposition 4,,REP,OVER VOTES,0,0,0
+Lipscomb,308,Proposition 4,,REP,UNDER VOTES,7,1,6
+Lipscomb,308,Proposition 4,,REP,YES,77,17,60
+Lipscomb,308,Proposition 4,,REP,NO,11,3,8
+Lipscomb,409,Registered Voters - Total,,,,286,,
+Lipscomb,409,Ballots Cast - Total,,,,60,3,57
+Lipscomb,409,President,,REP,OVER VOTES,0,0,0
+Lipscomb,409,President,,REP,UNDER VOTES,1,0,1
+Lipscomb,409,President,,REP,Jeb Bush,0,0,0
+Lipscomb,409,President,,REP,Carly Fiorina,0,0,0
+Lipscomb,409,President,,REP,Donald J. Trump,10,1,9
+Lipscomb,409,President,,REP,Rick Santorum,0,0,0
+Lipscomb,409,President,,REP,Lindsey Graham,0,0,0
+Lipscomb,409,President,,REP,Rand Paul,0,0,0
+Lipscomb,409,President,,REP,Elizabeth Gray,0,0,0
+Lipscomb,409,President,,REP,Ted Cruz,31,0,31
+Lipscomb,409,President,,REP,Chris Christie,0,0,0
+Lipscomb,409,President,,REP,Ben Carson,1,0,1
+Lipscomb,409,President,,REP,Mike Huckabee,0,0,0
+Lipscomb,409,President,,REP,John R. Kasich,2,1,1
+Lipscomb,409,President,,REP,Marco Rubio,9,0,9
+Lipscomb,409,President,,REP,Uncommitted,1,1,0
+Lipscomb,409,U.S. House,13,REP,OVER VOTES,0,0,0
+Lipscomb,409,U.S. House,13,REP,UNDER VOTES,7,0,7
+Lipscomb,409,U.S. House,13,REP,Mac Thornberry,48,3,45
+Lipscomb,409,Railroad Commissioner,,REP,OVER VOTES,0,0,0
+Lipscomb,409,Railroad Commissioner,,REP,UNDER VOTES,16,0,16
+Lipscomb,409,Railroad Commissioner,,REP,John Greytok,3,0,3
+Lipscomb,409,Railroad Commissioner,,REP,Ron Hale,5,0,5
+Lipscomb,409,Railroad Commissioner,,REP,Lance N. Christian,3,0,3
+Lipscomb,409,Railroad Commissioner,,REP,Gary Gates,10,1,9
+Lipscomb,409,Railroad Commissioner,,REP,Weston Martinez,5,2,3
+Lipscomb,409,Railroad Commissioner,,REP,Doug Jeffrey,6,0,6
+Lipscomb,409,Railroad Commissioner,,REP,Wayne Christian,7,0,7
+Lipscomb,409,"Justice, Supreme Court, Place 3",,REP,OVER VOTES,0,0,0
+Lipscomb,409,"Justice, Supreme Court, Place 3",,REP,UNDER VOTES,11,0,11
+Lipscomb,409,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,29,3,26
+Lipscomb,409,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,15,0,15
+Lipscomb,409,"Justice, Supreme Court, Place 5",,REP,OVER VOTES,0,0,0
+Lipscomb,409,"Justice, Supreme Court, Place 5",,REP,UNDER VOTES,16,0,16
+Lipscomb,409,"Justice, Supreme Court, Place 5",,REP,Paul Green,25,0,25
+Lipscomb,409,"Justice, Supreme Court, Place 5",,REP,Rick Green,14,3,11
+Lipscomb,409,"Justice, Supreme Court, Place 9",,REP,OVER VOTES,0,0,0
+Lipscomb,409,"Justice, Supreme Court, Place 9",,REP,UNDER VOTES,14,0,14
+Lipscomb,409,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,23,3,20
+Lipscomb,409,"Justice, Supreme Court, Place 9",,REP,Joe Pool,18,0,18
+Lipscomb,409,"Judge, Court of Criminal Appeals, Place 2",,REP,OVER VOTES,0,0,0
+Lipscomb,409,"Judge, Court of Criminal Appeals, Place 2",,REP,UNDER VOTES,18,0,18
+Lipscomb,409,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,12,1,11
+Lipscomb,409,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,15,2,13
+Lipscomb,409,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,10,0,10
+Lipscomb,409,"Judge, Court of Criminal Appeals, Place 5",,REP,OVER VOTES,0,0,0
+Lipscomb,409,"Judge, Court of Criminal Appeals, Place 5",,REP,UNDER VOTES,17,0,17
+Lipscomb,409,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,9,0,9
+Lipscomb,409,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,2,1,1
+Lipscomb,409,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,20,2,18
+Lipscomb,409,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,7,0,7
+Lipscomb,409,"Judge, Court of Criminal Appeals, Place 6",,REP,OVER VOTES,0,0,0
+Lipscomb,409,"Judge, Court of Criminal Appeals, Place 6",,REP,UNDER VOTES,18,0,18
+Lipscomb,409,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,27,2,25
+Lipscomb,409,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,10,1,9
+Lipscomb,409,"Member, State Board of Education, District 15",,REP,OVER VOTES,0,0,0
+Lipscomb,409,"Member, State Board of Education, District 15",,REP,UNDER VOTES,17,0,17
+Lipscomb,409,"Member, State Board of Education, District 15",,REP,Marty Rowley,38,3,35
+Lipscomb,409,State Representative,88,REP,OVER VOTES,0,0,0
+Lipscomb,409,State Representative,88,REP,UNDER VOTES,5,0,5
+Lipscomb,409,State Representative,88,REP,Ken King,50,3,47
+Lipscomb,409,"Justice, 7th Court of Appeals District, Place 4",,REP,OVER VOTES,0,0,0
+Lipscomb,409,"Justice, 7th Court of Appeals District, Place 4",,REP,UNDER VOTES,16,0,16
+Lipscomb,409,"Justice, 7th Court of Appeals District, Place 4",,REP,Jim Campbell,39,3,36
+Lipscomb,409,"District Attorney, 31st Judicial District",,REP,OVER VOTES,0,0,0
+Lipscomb,409,"District Attorney, 31st Judicial District",,REP,UNDER VOTES,15,0,15
+Lipscomb,409,"District Attorney, 31st Judicial District",,REP,Franklin McDonough,40,3,37
+Lipscomb,409,County Attorney,,REP,OVER VOTES,0,0,0
+Lipscomb,409,County Attorney,,REP,UNDER VOTES,2,0,2
+Lipscomb,409,County Attorney,,REP,Matthew Bartosiewicz,53,3,50
+Lipscomb,409,Sheriff,,REP,OVER VOTES,0,0,0
+Lipscomb,409,Sheriff,,REP,UNDER VOTES,2,0,2
+Lipscomb,409,Sheriff,,REP,Dave Thomas,7,0,7
+Lipscomb,409,Sheriff,,REP,Kenneth M. Eggleston,26,0,26
+Lipscomb,409,Sheriff,,REP,James Robertson,19,3,16
+Lipscomb,409,Sheriff,,REP,Don Bolar,1,0,1
+Lipscomb,409,Tax Assessor-Collector,,REP,OVER VOTES,0,0,0
+Lipscomb,409,Tax Assessor-Collector,,REP,UNDER VOTES,11,0,11
+Lipscomb,409,Tax Assessor-Collector,,REP,Sharla Bradshaw,44,3,41
+Lipscomb,409,County Treasurer - Unexpired Term,,REP,OVER VOTES,0,0,0
+Lipscomb,409,County Treasurer - Unexpired Term,,REP,UNDER VOTES,2,0,2
+Lipscomb,409,County Treasurer - Unexpired Term,,REP,Ramona Schilling,18,1,17
+Lipscomb,409,County Treasurer - Unexpired Term,,REP,Kimberly L. Long,35,2,33
+Lipscomb,409,County Chairman,,REP,OVER VOTES,0,0,0
+Lipscomb,409,County Chairman,,REP,UNDER VOTES,5,0,5
+Lipscomb,409,County Chairman,,REP,Diana Hoover,50,3,47
+Lipscomb,409,President,,DEM,OVER VOTES,0,0,0
+Lipscomb,409,President,,DEM,UNDER VOTES,0,0,0
+Lipscomb,409,President,,DEM,Keith Judd,0,0,0
+Lipscomb,409,President,,DEM,Willie L. Wilson,0,0,0
+Lipscomb,409,President,,DEM,"Roque ""Rocky"" De La Fuente",0,0,0
+Lipscomb,409,President,,DEM,Star Locke,0,0,0
+Lipscomb,409,President,,DEM,Calvis L. Hawes,0,0,0
+Lipscomb,409,President,,DEM,Bernie Sanders,0,0,0
+Lipscomb,409,President,,DEM,Hillary Clinton,5,0,5
+Lipscomb,409,President,,DEM,Martin J. O'Malley,0,0,0
+Lipscomb,409,Railroad Commissioner,,DEM,OVER VOTES,0,0,0
+Lipscomb,409,Railroad Commissioner,,DEM,UNDER VOTES,1,0,1
+Lipscomb,409,Railroad Commissioner,,DEM,Cody Garrett,2,0,2
+Lipscomb,409,Railroad Commissioner,,DEM,Lon Burnam,2,0,2
+Lipscomb,409,Railroad Commissioner,,DEM,Grady Yarbrough,0,0,0
+Lipscomb,409,"Justice, Supreme Court, Place 3",,DEM,OVER VOTES,0,0,0
+Lipscomb,409,"Justice, Supreme Court, Place 3",,DEM,UNDER VOTES,2,0,2
+Lipscomb,409,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,3,0,3
+Lipscomb,409,"Justice, Supreme Court, Place 5",,DEM,OVER VOTES,0,0,0
+Lipscomb,409,"Justice, Supreme Court, Place 5",,DEM,UNDER VOTES,1,0,1
+Lipscomb,409,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,4,0,4
+Lipscomb,409,"Justice, Supreme Court, Place 9",,DEM,OVER VOTES,0,0,0
+Lipscomb,409,"Justice, Supreme Court, Place 9",,DEM,UNDER VOTES,2,0,2
+Lipscomb,409,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,3,0,3
+Lipscomb,409,"Judge, Court of Criminal Appeals, Place 2",,DEM,OVER VOTES,0,0,0
+Lipscomb,409,"Judge, Court of Criminal Appeals, Place 2",,DEM,UNDER VOTES,2,0,2
+Lipscomb,409,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",3,0,3
+Lipscomb,409,"Judge, Court of Criminal Appeals, Place 5",,DEM,OVER VOTES,0,0,0
+Lipscomb,409,"Judge, Court of Criminal Appeals, Place 5",,DEM,UNDER VOTES,1,0,1
+Lipscomb,409,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,4,0,4
+Lipscomb,409,"Judge, Court of Criminal Appeals, Place 6",,DEM,OVER VOTES,0,0,0
+Lipscomb,409,"Judge, Court of Criminal Appeals, Place 6",,DEM,UNDER VOTES,2,0,2
+Lipscomb,409,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,3,0,3
+Lipscomb,409,County Chairman,,DEM,OVER VOTES,0,0,0
+Lipscomb,409,County Chairman,,DEM,UNDER VOTES,2,0,2
+Lipscomb,409,County Chairman,,DEM,Virginia Scott,3,0,3
+Lipscomb,409,Proposition 1,,DEM,OVER VOTES,0,0,0
+Lipscomb,409,Proposition 1,,DEM,UNDER VOTES,1,0,1
+Lipscomb,409,Proposition 1,,DEM,For,4,0,4
+Lipscomb,409,Proposition 1,,DEM,Against,0,0,0
+Lipscomb,409,Proposition 2,,DEM,OVER VOTES,0,0,0
+Lipscomb,409,Proposition 2,,DEM,UNDER VOTES,1,0,1
+Lipscomb,409,Proposition 2,,DEM,For,4,0,4
+Lipscomb,409,Proposition 2,,DEM,Against,0,0,0
+Lipscomb,409,Proposition 3,,DEM,OVER VOTES,0,0,0
+Lipscomb,409,Proposition 3,,DEM,UNDER VOTES,0,0,0
+Lipscomb,409,Proposition 3,,DEM,For,3,0,3
+Lipscomb,409,Proposition 3,,DEM,Against,2,0,2
+Lipscomb,409,Proposition 4,,DEM,OVER VOTES,0,0,0
+Lipscomb,409,Proposition 4,,DEM,UNDER VOTES,0,0,0
+Lipscomb,409,Proposition 4,,DEM,For,4,0,4
+Lipscomb,409,Proposition 4,,DEM,Against,1,0,1
+Lipscomb,409,Proposition 5,,DEM,OVER VOTES,0,0,0
+Lipscomb,409,Proposition 5,,DEM,UNDER VOTES,0,0,0
+Lipscomb,409,Proposition 5,,DEM,For,2,0,2
+Lipscomb,409,Proposition 5,,DEM,Against,3,0,3
+Lipscomb,409,Proposition 6,,DEM,OVER VOTES,0,0,0
+Lipscomb,409,Proposition 6,,DEM,UNDER VOTES,0,0,0
+Lipscomb,409,Proposition 6,,DEM,For,5,0,5
+Lipscomb,409,Proposition 6,,DEM,Against,0,0,0
+Lipscomb,409,Proposition 1,,REP,OVER VOTES,0,0,0
+Lipscomb,409,Proposition 1,,REP,UNDER VOTES,6,0,6
+Lipscomb,409,Proposition 1,,REP,YES,25,1,24
+Lipscomb,409,Proposition 1,,REP,NO,24,2,22
+Lipscomb,409,Proposition 2,,REP,OVER VOTES,0,0,0
+Lipscomb,409,Proposition 2,,REP,UNDER VOTES,4,0,4
+Lipscomb,409,Proposition 2,,REP,YES,27,1,26
+Lipscomb,409,Proposition 2,,REP,NO,24,2,22
+Lipscomb,409,Proposition 3,,REP,OVER VOTES,0,0,0
+Lipscomb,409,Proposition 3,,REP,UNDER VOTES,2,0,2
+Lipscomb,409,Proposition 3,,REP,YES,42,3,39
+Lipscomb,409,Proposition 3,,REP,NO,11,0,11
+Lipscomb,409,Proposition 4,,REP,OVER VOTES,0,0,0
+Lipscomb,409,Proposition 4,,REP,UNDER VOTES,4,0,4
+Lipscomb,409,Proposition 4,,REP,YES,49,3,46
+Lipscomb,409,Proposition 4,,REP,NO,2,0,2


### PR DESCRIPTION
This one was strange - halfway through the source file, the race names all became "Justice, Supreme Court, Place {3,4,5,6,7,8...}", as if Excel's Auto Fill feature were used.
I matched candidate names with the correct races. Thank goodness for VLOOKUP.