### PR TITLE
Add precinct-level results for the 2016 primaries in Howard County

### DIFF
--- a/2016/20160301__tx__primary__howard__precinct.csv
+++ b/2016/20160301__tx__primary__howard__precinct.csv
@@ -1,0 +1,1141 @@
+county,precinct,office,district,party,candidate,votes,early_voting,election_day
+Howard,"11,12,12a,13,14,16",President,,REP,Rick Santorum,1,1,0
+Howard,"103,104,105",President,,REP,Rick Santorum,0,0,0
+Howard,"24,25,26",President,,REP,Rick Santorum,0,0,0
+Howard,205,President,,REP,Rick Santorum,0,0,0
+Howard,"207,207c",President,,REP,Rick Santorum,0,0,0
+Howard,208,President,,REP,Rick Santorum,0,0,0
+Howard,"32,33,34,35",President,,REP,Rick Santorum,1,0,1
+Howard,304,President,,REP,Rick Santorum,0,0,0
+Howard,"42,45,46",President,,REP,Rick Santorum,1,0,1
+Howard,"404,405",President,,REP,Rick Santorum,0,0,0
+Howard,"408,",President,,REP,Rick Santorum,0,0,0
+Howard,409,President,,REP,Rick Santorum,1,0,1
+Howard,"11,12,12a,13,14,16",President,,REP,Jeb Bush,8,5,3
+Howard,"103,104,105",President,,REP,Jeb Bush,1,1,0
+Howard,"24,25,26",President,,REP,Jeb Bush,13,10,3
+Howard,205,President,,REP,Jeb Bush,6,5,1
+Howard,"207,207c",President,,REP,Jeb Bush,7,2,5
+Howard,208,President,,REP,Jeb Bush,2,2,0
+Howard,"32,33,34,35",President,,REP,Jeb Bush,14,11,3
+Howard,304,President,,REP,Jeb Bush,0,0,0
+Howard,"42,45,46",President,,REP,Jeb Bush,7,5,2
+Howard,"404,405",President,,REP,Jeb Bush,3,1,2
+Howard,"408,",President,,REP,Jeb Bush,0,0,0
+Howard,409,President,,REP,Jeb Bush,2,1,1
+Howard,"11,12,12a,13,14,16",President,,REP,Carly Fiorina,0,0,0
+Howard,"103,104,105",President,,REP,Carly Fiorina,0,0,0
+Howard,"24,25,26",President,,REP,Carly Fiorina,1,1,0
+Howard,205,President,,REP,Carly Fiorina,0,0,0
+Howard,"207,207c",President,,REP,Carly Fiorina,0,0,0
+Howard,208,President,,REP,Carly Fiorina,0,0,0
+Howard,"32,33,34,35",President,,REP,Carly Fiorina,0,0,0
+Howard,304,President,,REP,Carly Fiorina,0,0,0
+Howard,"42,45,46",President,,REP,Carly Fiorina,0,0,0
+Howard,"404,405",President,,REP,Carly Fiorina,0,0,0
+Howard,"408,",President,,REP,Carly Fiorina,0,0,0
+Howard,409,President,,REP,Carly Fiorina,0,0,0
+Howard,"11,12,12a,13,14,16",President,,REP,Ben Carson,14,2,12
+Howard,"103,104,105",President,,REP,Ben Carson,3,3,0
+Howard,"24,25,26",President,,REP,Ben Carson,49,21,28
+Howard,205,President,,REP,Ben Carson,19,8,11
+Howard,"207,207c",President,,REP,Ben Carson,7,4,3
+Howard,208,President,,REP,Ben Carson,2,2,0
+Howard,"32,33,34,35",President,,REP,Ben Carson,31,12,19
+Howard,304,President,,REP,Ben Carson,14,5,9
+Howard,"42,45,46",President,,REP,Ben Carson,33,13,20
+Howard,"404,405",President,,REP,Ben Carson,17,3,14
+Howard,"408,",President,,REP,Ben Carson,0,0,0
+Howard,409,President,,REP,Ben Carson,10,1,9
+Howard,"11,12,12a,13,14,16",President,,REP,Donald Trump,75,31,44
+Howard,"103,104,105",President,,REP,Donald Trump,35,27,8
+Howard,"24,25,26",President,,REP,Donald Trump,138,66,72
+Howard,205,President,,REP,Donald Trump,141,79,62
+Howard,"207,207c",President,,REP,Donald Trump,151,55,96
+Howard,208,President,,REP,Donald Trump,1,1,0
+Howard,"32,33,34,35",President,,REP,Donald Trump,245,128,117
+Howard,304,President,,REP,Donald Trump,48,25,23
+Howard,"42,45,46",President,,REP,Donald Trump,116,52,64
+Howard,"404,405",President,,REP,Donald Trump,83,33,50
+Howard,"408,",President,,REP,Donald Trump,7,3,4
+Howard,409,President,,REP,Donald Trump,52,15,37
+Howard,"11,12,12a,13,14,16",President,,REP,Marco Rubio,52,30,22
+Howard,"103,104,105",President,,REP,Marco Rubio,10,7,3
+Howard,"24,25,26",President,,REP,Marco Rubio,76,46,30
+Howard,205,President,,REP,Marco Rubio,50,29,21
+Howard,"207,207c",President,,REP,Marco Rubio,68,19,49
+Howard,208,President,,REP,Marco Rubio,5,3,2
+Howard,"32,33,34,35",President,,REP,Marco Rubio,116,55,61
+Howard,304,President,,REP,Marco Rubio,13,7,6
+Howard,"42,45,46",President,,REP,Marco Rubio,54,24,30
+Howard,"404,405",President,,REP,Marco Rubio,14,8,6
+Howard,"408,",President,,REP,Marco Rubio,2,2,0
+Howard,409,President,,REP,Marco Rubio,22,5,17
+Howard,"11,12,12a,13,14,16",President,,REP,Rand Paul,2,1,1
+Howard,"103,104,105",President,,REP,Rand Paul,0,0,0
+Howard,"24,25,26",President,,REP,Rand Paul,1,0,1
+Howard,205,President,,REP,Rand Paul,1,1,0
+Howard,"207,207c",President,,REP,Rand Paul,0,0,0
+Howard,208,President,,REP,Rand Paul,0,0,0
+Howard,"32,33,34,35",President,,REP,Rand Paul,1,1,0
+Howard,304,President,,REP,Rand Paul,0,0,0
+Howard,"42,45,46",President,,REP,Rand Paul,1,0,1
+Howard,"404,405",President,,REP,Rand Paul,0,0,0
+Howard,"408,",President,,REP,Rand Paul,0,0,0
+Howard,409,President,,REP,Rand Paul,1,1,0
+Howard,"11,12,12a,13,14,16",President,,REP,Mike Huckabee,1,1,0
+Howard,"103,104,105",President,,REP,Mike Huckabee,1,0,1
+Howard,"24,25,26",President,,REP,Mike Huckabee,1,1,0
+Howard,205,President,,REP,Mike Huckabee,0,0,0
+Howard,"207,207c",President,,REP,Mike Huckabee,3,2,1
+Howard,208,President,,REP,Mike Huckabee,2,1,1
+Howard,"32,33,34,35",President,,REP,Mike Huckabee,5,2,3
+Howard,304,President,,REP,Mike Huckabee,1,0,1
+Howard,"42,45,46",President,,REP,Mike Huckabee,0,0,0
+Howard,"404,405",President,,REP,Mike Huckabee,0,0,0
+Howard,"408,",President,,REP,Mike Huckabee,0,0,0
+Howard,409,President,,REP,Mike Huckabee,1,0,1
+Howard,"11,12,12a,13,14,16",President,,REP,Lindsey Graham,0,0,0
+Howard,"103,104,105",President,,REP,Lindsey Graham,0,0,0
+Howard,"24,25,26",President,,REP,Lindsey Graham,0,0,0
+Howard,205,President,,REP,Lindsey Graham,0,0,0
+Howard,"207,207c",President,,REP,Lindsey Graham,1,0,1
+Howard,208,President,,REP,Lindsey Graham,0,0,0
+Howard,"32,33,34,35",President,,REP,Lindsey Graham,0,0,0
+Howard,304,President,,REP,Lindsey Graham,0,0,0
+Howard,"42,45,46",President,,REP,Lindsey Graham,0,0,0
+Howard,"404,405",President,,REP,Lindsey Graham,0,0,0
+Howard,"408,",President,,REP,Lindsey Graham,0,0,0
+Howard,409,President,,REP,Lindsey Graham,0,0,0
+Howard,"11,12,12a,13,14,16",President,,REP,John R Kasich,7,3,4
+Howard,"103,104,105",President,,REP,John R Kasich,1,1,0
+Howard,"24,25,26",President,,REP,John R Kasich,7,4,3
+Howard,205,President,,REP,John R Kasich,10,7,3
+Howard,"207,207c",President,,REP,John R Kasich,9,5,4
+Howard,208,President,,REP,John R Kasich,3,0,3
+Howard,"32,33,34,35",President,,REP,John R Kasich,17,12,5
+Howard,304,President,,REP,John R Kasich,3,2,1
+Howard,"42,45,46",President,,REP,John R Kasich,3,0,3
+Howard,"404,405",President,,REP,John R Kasich,3,3,0
+Howard,"408,",President,,REP,John R Kasich,1,1,0
+Howard,409,President,,REP,John R Kasich,1,1,0
+Howard,"11,12,12a,13,14,17",President,,REP,Chris Christie,2,2,0
+Howard,"103,104,106",President,,REP,Chris Christie,0,0,0
+Howard,24.25.26,President,,REP,Chris Christie,0,0,0
+Howard,205,President,,REP,Chris Christie,0,0,0
+Howard,"207,207c",President,,REP,Chris Christie,1,0,1
+Howard,208,President,,REP,Chris Christie,0,0,0
+Howard,"32,33,34,36",President,,REP,Chris Christie,4,3,1
+Howard,304,President,,REP,Chris Christie,0,0,0
+Howard,"42,45,47",President,,REP,Chris Christie,0,0,0
+Howard,"404,405",President,,REP,Chris Christie,0,0,0
+Howard,"408,",President,,REP,Chris Christie,0,0,0
+Howard,409,President,,REP,Chris Christie,0,0,0
+Howard,"11,12,12a,13,14,17",President,,REP,Elizabeth Gray,0,0,0
+Howard,"103,104,106",President,,REP,Elizabeth Gray,0,0,0
+Howard,"24,25,27",President,,REP,Elizabeth Gray,0,0,0
+Howard,205,President,,REP,Elizabeth Gray,0,0,0
+Howard,"207,207c",President,,REP,Elizabeth Gray,0,0,0
+Howard,208,President,,REP,Elizabeth Gray,0,0,0
+Howard,"32,33,34,36",President,,REP,Elizabeth Gray,0,0,0
+Howard,304,President,,REP,Elizabeth Gray,0,0,0
+Howard,"42,45,46",President,,REP,Elizabeth Gray,0,0,0
+Howard,"404, 405",President,,REP,Elizabeth Gray,0,0,0
+Howard,"408,",President,,REP,Elizabeth Gray,0,0,0
+Howard,409,President,,REP,Elizabeth Gray,0,0,0
+Howard,"11,12,12a,13,14,18",President,,REP,Ted Cruz,109,39,70
+Howard,"103,104,107",President,,REP,Ted Cruz,56,20,36
+Howard,"24,25,28",President,,REP,Ted Cruz,338,139,199
+Howard,207,President,,REP,Ted Cruz,225,101,124
+Howard,"207,207c",President,,REP,Ted Cruz,246,59,187
+Howard,208,President,,REP,Ted Cruz,16,2,14
+Howard,"32,33,34,35",President,,REP,Ted Cruz,350,159,191
+Howard,304,President,,REP,Ted Cruz,80,27,53
+Howard,"42,45,48",President,,REP,Ted Cruz,180,65,115
+Howard,"404, 405",President,,REP,Ted Cruz,137,52,85
+Howard,"408,",President,,REP,Ted Cruz,15,5,10
+Howard,409,President,,REP,Ted Cruz,75,23,52
+Howard,"11,12,12a,13,14,16",President,,REP,Uncommitted,7,5,2
+Howard,"103, 104, 105",President,,REP,Uncommitted,1,1,0
+Howard,"24,25,26",President,,REP,Uncommitted,8,4,4
+Howard,207,President,,REP,Uncommitted,3,1,2
+Howard,"207,207c",President,,REP,Uncommitted,4,1,3
+Howard,208,President,,REP,Uncommitted,0,0,0
+Howard,"32,33,34,35",President,,REP,Uncommitted,11,11,0
+Howard,304,President,,REP,Uncommitted,1,1,0
+Howard,"42,45,48",President,,REP,Uncommitted,5,5,0
+Howard,"404, 405",President,,REP,Uncommitted,3,3,0
+Howard,"408,",President,,REP,Uncommitted,0,0,0
+Howard,409,President,,REP,Uncommitted,2,1,1
+Howard,"11,12,12a,13,14,16",U.S. House,19,REP,Jason Corley,14,4,10
+Howard,"103,104,108",U.S. House,19,REP,Jason Corley,4,2,2
+Howard,"24,25,29",U.S. House,19,REP,Jason Corley,38,15,23
+Howard,208,U.S. House,19,REP,Jason Corley,25,11,14
+Howard,"207,207c",U.S. House,19,REP,Jason Corley,40,10,30
+Howard,211,U.S. House,19,REP,Jason Corley,2,1,1
+Howard,"32,33,34,35",U.S. House,19,REP,Jason Corley,49,16,33
+Howard,304,U.S. House,19,REP,Jason Corley,8,0,8
+Howard,"42,45,46",U.S. House,19,REP,Jason Corley,22,8,14
+Howard,"405,405",U.S. House,19,REP,Jason Corley,16,4,12
+Howard,408,U.S. House,19,REP,Jason Corley,0,0,0
+Howard,409,U.S. House,19,REP,Jason Corley,8,2,6
+Howard,"11,12,12a,13,14,16",U.S. House,19,REP,Donald R May,22,10,12
+Howard,"103,104,108",U.S. House,19,REP,Donald R May  ,12,5,7
+Howard,"24,25,29",U.S. House,19,REP,Donald R May,88,46,42
+Howard,205,U.S. House,19,REP,Donald R May  ,77,46,31
+Howard,"207,207c",U.S. House,19,REP,Donald R May,75,28,47
+Howard,208,U.S. House,19,REP,Donald R May  ,3,0,3
+Howard,"32,33,34,35",U.S. House,19,REP,Donald R May,119,57,62
+Howard,304,U.S. House,19,REP,Donald R May  ,29,12,17
+Howard,"42,45,46",U.S. House,19,REP,Donald R May,56,32,24
+Howard,"405,405",U.S. House,19,REP,Donald R May  ,34,15,19
+Howard,408,U.S. House,19,REP,Donald R May,3,1,2
+Howard,409,U.S. House,19,REP,Donald R May  ,27,6,21
+Howard,"11,12,12a,13,14,16",U.S. House,19,REP,DeRenda Warren,13,5,8
+Howard,"103,104,108",U.S. House,19,REP,DeRenda Warren,8,5,3
+Howard,"24,25,29",U.S. House,19,REP,DeRenda Warren,27,20,7
+Howard,205,U.S. House,19,REP,DeRenda Warren,12,5,7
+Howard,"207,207c",U.S. House,19,REP,DeRenda Warren,7,3,4
+Howard,208,U.S. House,19,REP,DeRenda Warren,0,0,0
+Howard,"32,33,34,35",U.S. House,19,REP,DeRenda Warren,35,24,11
+Howard,304,U.S. House,19,REP,DeRenda Warren,7,6,1
+Howard,"42,45,46",U.S. House,19,REP,DeRenda Warren,10,7,3
+Howard,"405,405",U.S. House,19,REP,DeRenda Warren,9,4,5
+Howard,408,U.S. House,19,REP,DeRenda Warren,1,0,1
+Howard,409,U.S. House,19,REP,DeRenda Warren,8,1,7
+Howard,"11,12,12a,13,14,19",U.S. House,19,REP,Michael Bob Starr,32,18,14
+Howard,"103,104,108",U.S. House,19,REP,Michael Bob Starr,8,6,2
+Howard,"24,25,29",U.S. House,19,REP,Michael Bob Starr,62,29,33
+Howard,205,U.S. House,19,REP,Michael Bob Starr,33,23,10
+Howard,"207,207c",U.S. House,19,REP,Michael Bob Starr,58,19,39
+Howard,208,U.S. House,19,REP,Michael Bob Starr,1,1,0
+Howard,"32,33,34,35",U.S. House,19,REP,Michael Bob Starr,82,44,38
+Howard,304,U.S. House,19,REP,Michael Bob Starr,21,11,10
+Howard,"42,45,46",U.S. House,19,REP,Michael Bob Starr,30,10,20
+Howard,"405,405",U.S. House,19,REP,Michael Bob Starr,22,12,10
+Howard,408,U.S. House,19,REP,Michael Bob Starr,2,2,0
+Howard,409,U.S. House,19,REP,Michael Bob Starr,22,4,18
+Howard,"11,12,12a,13,14,19",U.S. House,19,REP,Glen Robertson,66,29,37
+Howard,"103,104,108",U.S. House,19,REP,Glen Robertson,26,17,9
+Howard,"24,25,29",U.S. House,19,REP,Glen Robertson,142,76,66
+Howard,205,U.S. House,19,REP,Glen Robertson,97,61,36
+Howard,"207,207c",U.S. House,19,REP,Glen Robertson,94,39,55
+Howard,208,U.S. House,19,REP,Glen Robertson,4,2,2
+Howard,"32,33,34,35",U.S. House,19,REP,Glen Robertson,180,115,65
+Howard,304,U.S. House,19,REP,Glen Robertson,26,11,15
+Howard,"42,45,46",U.S. House,19,REP,Glen Robertson,80,45,35
+Howard,"405,405",U.S. House,19,REP,Glen Robertson,45,18,27
+Howard,408,U.S. House,19,REP,Glen Robertson,9,3,6
+Howard,409,U.S. House,19,REP,Glen Robertson,38,19,19
+Howard,"11,12,12a,13,14,19",U.S. House,19,REP,Jodey Arrington,31,13,18
+Howard,"103,104,108",U.S. House,19,REP,Jodey Arrington,21,9,12
+Howard,"24,25,29",U.S. House,19,REP,Jodey Arrington,100,32,68
+Howard,205,U.S. House,19,REP,Jodey Arrington,64,20,44
+Howard,"207,207c",U.S. House,19,REP,Jodey Arrington,53,12,41
+Howard,208,U.S. House,19,REP,Jodey Arrington,8,3,5
+Howard,"32,33,34,35",U.S. House,19,REP,Jodey Arrington,109,51,58
+Howard,304,U.S. House,19,REP,Jodey Arrington,17,5,12
+Howard,"42,45,46",U.S. House,19,REP,Jodey Arrington,54,16,38
+Howard,"405,405",U.S. House,19,REP,Jodey Arrington,35,12,23
+Howard,408,U.S. House,19,REP,Jodey Arrington,4,3,1
+Howard,409,U.S. House,19,REP,Jodey Arrington,19,4,15
+Howard,"11,12,12a,13,14,19",U.S. House,19,REP,John C Key,9,3,6
+Howard,"103,104,108",U.S. House,19,REP,John C Key,1,0,1
+Howard,"24,25,29",U.S. House,19,REP,John C Key,16,9,7
+Howard,205,U.S. House,19,REP,John C Key,15,8,7
+Howard,"207,207c",U.S. House,19,REP,John C Key,12,1,11
+Howard,208,U.S. House,19,REP,John C Key,3,1,2
+Howard,"32,33,34,35",U.S. House,19,REP,John C Key,29,11,18
+Howard,304,U.S. House,19,REP,John C Key,5,1,4
+Howard,"42,45,46",U.S. House,19,REP,John C Key,16,11,5
+Howard,"405,405",U.S. House,19,REP,John C Key,13,9,4
+Howard,408,U.S. House,19,REP,John C Key,1,0,1
+Howard,409,U.S. House,19,REP,John C Key,2,1,1
+Howard,"11,12,12a,13,14,19",U.S. House,19,REP,Greg Garrett,32,15,17
+Howard,"103,104,108",U.S. House,19,REP,Greg Garrett,5,2,3
+Howard,"24,25,29",U.S. House,19,REP,Greg Garrett,44,21,23
+Howard,205,U.S. House,19,REP,Greg Garrett,43,16,27
+Howard,"207,207c",U.S. House,19,REP,Greg Garrett,40,7,33
+Howard,208,U.S. House,19,REP,Greg Garrett,5,1,4
+Howard,"32,33,34,35",U.S. House,19,REP,Greg Garrett,64,17,47
+Howard,304,U.S. House,19,REP,Greg Garrett,19,7,12
+Howard,"42,45,46",U.S. House,19,REP,Greg Garrett,46,8,38
+Howard,"405,405",U.S. House,19,REP,Greg Garrett,38,5,33
+Howard,408,U.S. House,19,REP,Greg Garrett,1,1,0
+Howard,409,U.S. House,19,REP,Greg Garrett,8,2,6
+Howard,"11,12,12a,13,14,19",U.S. House,19,REP,Don Parrish ,10,5,5
+Howard,"103,104,108",U.S. House,19,REP,Don Parrish ,1,0,1
+Howard,"24,25,29",U.S. House,19,REP,Don Parrish ,29,7,22
+Howard,205,U.S. House,19,REP,Don Parrish ,13,4,9
+Howard,"207,207c",U.S. House,19,REP,Don Parrish ,35,7,28
+Howard,208,U.S. House,19,REP,Don Parrish ,2,0,2
+Howard,"32,33,34,35",U.S. House,19,REP,Don Parrish ,31,13,18
+Howard,304,U.S. House,19,REP,Don Parrish ,10,5,5
+Howard,"42,45,46",U.S. House,19,REP,Don Parrish ,19,6,13
+Howard,"405,405",U.S. House,19,REP,Don Parrish ,20,10,10
+Howard,408,U.S. House,19,REP,Don Parrish ,2,0,2
+Howard,409,U.S. House,19,REP,Don Parrish ,13,2,11
+Howard,"11,12,12a,13,14,19",Railroad Commissioner,,REP,Weston Martinez,71,39,32
+Howard,"103,104,108",Railroad Commissioner,,REP,Weston Martinez,4,3,1
+Howard,"24,25,29",Railroad Commissioner,,REP,Weston Martinez,47,19,28
+Howard,205,Railroad Commissioner,,REP,Weston Martinez,23,7,16
+Howard,"207,207c",Railroad Commissioner,,REP,Weston Martinez,34,4,30
+Howard,208,Railroad Commissioner,,REP,Weston Martinez,4,0,4
+Howard,"32,33,34,35",Railroad Commissioner,,REP,Weston Martinez,77,22,55
+Howard,304,Railroad Commissioner,,REP,Weston Martinez,9,2,7
+Howard,"42,45,46",Railroad Commissioner,,REP,Weston Martinez,44,13,31
+Howard,"405,405",Railroad Commissioner,,REP,Weston Martinez,22,9,13
+Howard,408,Railroad Commissioner,,REP,Weston Martinez,1,1,0
+Howard,409,Railroad Commissioner,,REP,Weston Martinez,12,1,11
+Howard,"11,12,12a,13,14,19",Railroad Commissioner,,REP,John Greytok,11,6,5
+Howard,"103,104,108",Railroad Commissioner,,REP,John Greytok,4,0,4
+Howard,"24,25,29",Railroad Commissioner,,REP,John Greytok,23,11,12
+Howard,205,Railroad Commissioner,,REP,John Greytok,19,10,9
+Howard,"207,207c",Railroad Commissioner,,REP,John Greytok,24,10,14
+Howard,208,Railroad Commissioner,,REP,John Greytok,1,1,0
+Howard,"32,33,34,35",Railroad Commissioner,,REP,John Greytok,33,19,14
+Howard,304,Railroad Commissioner,,REP,John Greytok,13,4,9
+Howard,"42,45,46",Railroad Commissioner,,REP,John Greytok,16,6,10
+Howard,"405,405",Railroad Commissioner,,REP,John Greytok,17,7,10
+Howard,408,Railroad Commissioner,,REP,John Greytok,1,0,1
+Howard,409,Railroad Commissioner,,REP,John Greytok,9,2,7
+Howard,"11,12,12a,13,14,19",Railroad Commissioner,,REP,Ron Hale,35,10,25
+Howard,"103,104,108",Railroad Commissioner,,REP,Ron Hale,14,9,5
+Howard,"24,25,29",Railroad Commissioner,,REP,Ron Hale,97,43,54
+Howard,205,Railroad Commissioner,,REP,Ron Hale,76,42,34
+Howard,"207,207c",Railroad Commissioner,,REP,Ron Hale,83,20,63
+Howard,208,Railroad Commissioner,,REP,Ron Hale,3,0,3
+Howard,"32,33,34,35",Railroad Commissioner,,REP,Ron Hale,118,60,58
+Howard,304,Railroad Commissioner,,REP,Ron Hale,29,9,20
+Howard,"42,45,46",Railroad Commissioner,,REP,Ron Hale,72,28,44
+Howard,"405,405",Railroad Commissioner,,REP,Ron Hale,36,12,24
+Howard,408,Railroad Commissioner,,REP,Ron Hale,3,2,1
+Howard,409,Railroad Commissioner,,REP,Ron Hale,32,5,27
+Howard,"11,12,12a,13,14,19",Railroad Commissioner,,REP,Doug Jeffery,24,11,13
+Howard,"103,104,108",Railroad Commissioner,,REP,Doug Jeffery,8,3,5
+Howard,"24,25,29",Railroad Commissioner,,REP,Doug Jeffery,57,22,35
+Howard,205,Railroad Commissioner,,REP,Doug Jeffery,41,20,21
+Howard,"207,207c",Railroad Commissioner,,REP,Doug Jeffery,39,6,33
+Howard,208,Railroad Commissioner,,REP,Doug Jeffery,3,0,3
+Howard,"32,33,34,35",Railroad Commissioner,,REP,Doug Jeffery,80,45,35
+Howard,304,Railroad Commissioner,,REP,Doug Jeffery,14,3,11
+Howard,"42,45,46",Railroad Commissioner,,REP,Doug Jeffery,33,13,20
+Howard,"405,405",Railroad Commissioner,,REP,Doug Jeffery,24,7,17
+Howard,408,Railroad Commissioner,,REP,Doug Jeffery,0,0,0
+Howard,409,Railroad Commissioner,,REP,Doug Jeffery,19,10,9
+Howard,"11,12,12a,13,14,19",Railroad Commissioner,,REP,Wayne Christian,33,14,19
+Howard,"103,104,108",Railroad Commissioner,,REP,Wayne Christian,21,9,12
+Howard,"24,25,29",Railroad Commissioner,,REP,Wayne Christian,110,46,64
+Howard,205,Railroad Commissioner,,REP,Wayne Christian,71,40,31
+Howard,"207,207c",Railroad Commissioner,,REP,Wayne Christian,70,22,48
+Howard,208,Railroad Commissioner,,REP,Wayne Christian,10,5,5
+Howard,"32,33,34,35",Railroad Commissioner,,REP,Wayne Christian,118,47,71
+Howard,304,Railroad Commissioner,,REP,Wayne Christian,26,12,14
+Howard,"42,45,46",Railroad Commissioner,,REP,Wayne Christian,49,25,24
+Howard,"405,405",Railroad Commissioner,,REP,Wayne Christian,35,15,20
+Howard,408,Railroad Commissioner,,REP,Wayne Christian,8,2,6
+Howard,409,Railroad Commissioner,,REP,Wayne Christian,18,4,14
+Howard,"11,12,12a,13,14,19",Railroad Commissioner,,REP,Gary Gates,25,12,13
+Howard,"103,104,108",Railroad Commissioner,,REP,Gary Gates,13,8,5
+Howard,"24,25,29",Railroad Commissioner,,REP,Gary Gates,94,53,41
+Howard,205,Railroad Commissioner,,REP,Gary Gates,63,30,33
+Howard,"207,207c",Railroad Commissioner,,REP,Gary Gates,74,29,45
+Howard,208,Railroad Commissioner,,REP,Gary Gates,2,2,0
+Howard,"32,33,34,35",Railroad Commissioner,,REP,Gary Gates,137,82,55
+Howard,304,Railroad Commissioner,,REP,Gary Gates,30,16,14
+Howard,"42,45,46",Railroad Commissioner,,REP,Gary Gates,63,35,28
+Howard,"405,405",Railroad Commissioner,,REP,Gary Gates,51,20,31
+Howard,408,Railroad Commissioner,,REP,Gary Gates,1,1,0
+Howard,409,Railroad Commissioner,,REP,Gary Gates,31,10,21
+Howard,"11,12,12a,13,14,19",Railroad Commissioner,,REP,Lance N Christian,25,7,18
+Howard,"103,104,108",Railroad Commissioner,,REP,Lance N Christian,8,6,2
+Howard,"24,25,29",Railroad Commissioner,,REP,Lance N Christian,63,30,33
+Howard,205,Railroad Commissioner,,REP,Lance N Christian,48,26,22
+Howard,"207,207c",Railroad Commissioner,,REP,Lance N Christian,54,15,39
+Howard,208,Railroad Commissioner,,REP,Lance N Christian,4,1,3
+Howard,"32,33,34,35",Railroad Commissioner,,REP,Lance N Christian,71,26,45
+Howard,304,Railroad Commissioner,,REP,Lance N Christian,12,6,6
+Howard,"42,45,46",Railroad Commissioner,,REP,Lance N Christian,34,11,23
+Howard,"405,405",Railroad Commissioner,,REP,Lance N Christian,28,14,14
+Howard,408,Railroad Commissioner,,REP,Lance N Christian,5,3,2
+Howard,409,Railroad Commissioner,,REP,Lance N Christian,9,2,7
+Howard,"11,12,12a,13,14,19","Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,133,54,79
+Howard,"103,104,108","Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,29,15,14
+Howard,"24,25,29","Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,274,139,135
+Howard,205,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,173,85,88
+Howard,"207,207c","Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,194,54,140
+Howard,208,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,12,7,5
+Howard,"32,33,34,35","Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,392,205,187
+Howard,304,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,69,31,38
+Howard,"42,45,46","Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,168,73,95
+Howard,"405,405","Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,109,41,68
+Howard,408,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,8,6,2
+Howard,409,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,61,17,44
+Howard,"11,12,12a,13,14,19","Justice, Supreme Court, Place 3",,REP,Michel Massengale,88,42,46
+Howard,"103,104,108","Justice, Supreme Court, Place 3",,REP,Michel Massengale,51,27,24
+Howard,"24,25,29","Justice, Supreme Court, Place 3",,REP,Michel Massengale,244,100,144
+Howard,205,"Justice, Supreme Court, Place 3",,REP,Michel Massengale,168,83,85
+Howard,"207,207c","Justice, Supreme Court, Place 3",,REP,Michel Massengale,188,54,134
+Howard,208,"Justice, Supreme Court, Place 3",,REP,Michel Massengale,15,1,14
+Howard,"32,33,34,35","Justice, Supreme Court, Place 3",,REP,Michel Massengale,264,113,151
+Howard,304,"Justice, Supreme Court, Place 3",,REP,Michel Massengale,68,22,46
+Howard,"42,45,46","Justice, Supreme Court, Place 3",,REP,Michel Massengale,152,61,91
+Howard,"405,405","Justice, Supreme Court, Place 3",,REP,Michel Massengale,110,42,68
+Howard,408,"Justice, Supreme Court, Place 3",,REP,Michel Massengale,11,3,8
+Howard,409,"Justice, Supreme Court, Place 3",,REP,Michel Massengale,74,17,57
+Howard,"11,12,12a,13,14,16","Justice, Supreme Court, Place 5",,REP,Rick Green,130,59,71
+Howard,"103,104,108","Justice, Supreme Court, Place 5",,REP,Rick Green,46,20,26
+Howard,"24,25,29","Justice, Supreme Court, Place 5",,REP,Rick Green,328,137,191
+Howard,205,"Justice, Supreme Court, Place 5",,REP,Rick Green,214,105,109
+Howard,"207,207c","Justice, Supreme Court, Place 5",,REP,Rick Green,246,68,178
+Howard,208,"Justice, Supreme Court, Place 5",,REP,Rick Green,12,5,7
+Howard,"32,33,34,35","Justice, Supreme Court, Place 5",,REP,Rick Green,392,178,214
+Howard,304,"Justice, Supreme Court, Place 5",,REP,Rick Green,83,31,52
+Howard,"42,45,46","Justice, Supreme Court, Place 5",,REP,Rick Green,175,75,100
+Howard,"405,405","Justice, Supreme Court, Place 5",,REP,Rick Green,131,43,88
+Howard,408,"Justice, Supreme Court, Place 5",,REP,Rick Green,9,5,4
+Howard,409,"Justice, Supreme Court, Place 5",,REP,Rick Green,97,23,74
+Howard,"11,12,12a,13,14,16","Justice, Supreme Court, Place 5",,REP,Paul Green,83,41,42
+Howard,"103,104,108","Justice, Supreme Court, Place 5",,REP,Paul Green,29,18,11
+Howard,"24,25,29","Justice, Supreme Court, Place 5",,REP,Paul Green,159,83,76
+Howard,205,"Justice, Supreme Court, Place 5",,REP,Paul Green,116,61,55
+Howard,"207,207c","Justice, Supreme Court, Place 5",,REP,Paul Green,134,40,94
+Howard,208,"Justice, Supreme Court, Place 5",,REP,Paul Green,14,3,11
+Howard,"32,33,34,35","Justice, Supreme Court, Place 5",,REP,Paul Green,224,113,111
+Howard,304,"Justice, Supreme Court, Place 5",,REP,Paul Green,49,21,28
+Howard,"42,45,46","Justice, Supreme Court, Place 5",,REP,Paul Green,120,51,69
+Howard,"405,405","Justice, Supreme Court, Place 5",,REP,Paul Green,76,34,42
+Howard,408,"Justice, Supreme Court, Place 5",,REP,Paul Green,8,5,3
+Howard,409,"Justice, Supreme Court, Place 5",,REP,Paul Green,30,10,20
+Howard,"11,12,12a,13,14,16","Justice, Supreme Court, Place 9",,REP,Eva Guzman,153,74,79
+Howard,"103,104,108","Justice, Supreme Court, Place 9",,REP,Eva Guzman,32,16,16
+Howard,"24,25,29","Justice, Supreme Court, Place 9",,REP,Eva Guzman,252,124,128
+Howard,205,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,155,79,76
+Howard,"207,207c","Justice, Supreme Court, Place 9",,REP,Eva Guzman,141,45,96
+Howard,208,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,19,6,13
+Howard,"32,33,34,35","Justice, Supreme Court, Place 9",,REP,Eva Guzman,318,153,165
+Howard,304,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,52,22,30
+Howard,"42,45,46","Justice, Supreme Court, Place 9",,REP,Eva Guzman,174,72,102
+Howard,"405,405","Justice, Supreme Court, Place 9",,REP,Eva Guzman,85,33,52
+Howard,408,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,11,4,7
+Howard,409,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,65,18,47
+Howard,"11,12,12a,13,14,19","Justice, Supreme Court, Place 9",,REP,Joe Pool,75,32,43
+Howard,"103,104,108","Justice, Supreme Court, Place 9",,REP,Joe Pool,44,24,20
+Howard,"24,25,29","Justice, Supreme Court, Place 9",,REP,Joe Pool,237,102,135
+Howard,205,"Justice, Supreme Court, Place 9",,REP,Joe Pool,176,89,87
+Howard,"207,207c","Justice, Supreme Court, Place 9",,REP,Joe Pool,224,61,163
+Howard,208,"Justice, Supreme Court, Place 9",,REP,Joe Pool,6,2,4
+Howard,"32,33,34,35","Justice, Supreme Court, Place 9",,REP,Joe Pool,315,157,158
+Howard,304,"Justice, Supreme Court, Place 9",,REP,Joe Pool,81,33,48
+Howard,"42,45,46","Justice, Supreme Court, Place 9",,REP,Joe Pool,132,58,74
+Howard,"405,405","Justice, Supreme Court, Place 9",,REP,Joe Pool,123,46,77
+Howard,408,"Justice, Supreme Court, Place 9",,REP,Joe Pool,7,5,2
+Howard,409,"Justice, Supreme Court, Place 9",,REP,Joe Pool,60,19,41
+Howard,"11,12,12a,13,14,19","Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,96,45,51
+Howard,"103,104,108","Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,24,14,10
+Howard,"24,25,29","Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,196,87,109
+Howard,205,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,143,73,70
+Howard,"207,207c","Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,145,43,102
+Howard,208,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,7,3,4
+Howard,"32,33,34,35","Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,287,136,151
+Howard,304,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,51,26,25
+Howard,"42,45,46","Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,136,59,77
+Howard,"405,405","Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,84,31,53
+Howard,408,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,3,2,1
+Howard,409,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,38,10,28
+Howard,"11,12,12a,13,14,19","Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,43,14,29
+Howard,"103,104,108","Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,36,17,19
+Howard,"24,25,29","Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,156,71,85
+Howard,205,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,109,60,49
+Howard,"207,207c","Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,134,41,93
+Howard,208,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,10,2,8
+Howard,"32,33,34,35","Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,166,91,75
+Howard,304,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,41,12,29
+Howard,"42,45,46","Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,84,39,45
+Howard,"405,405","Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,51,24,27
+Howard,408,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,9,4,5
+Howard,409,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,55,18,37
+Howard,"11,12,12a,13,14,19","Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,70,34,36
+Howard,"103,104,108","Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,14,7,7
+Howard,"24,25,29","Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,119,55,64
+Howard,205,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,71,32,39
+Howard,"207,207c","Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,91,20,71
+Howard,208,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,9,3,6
+Howard,"32,33,34,35","Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,153,63,90
+Howard,304,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,39,12,27
+Howard,"42,45,46","Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,76,24,52
+Howard,"405,405","Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,62,23,39
+Howard,408,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,5,3,2
+Howard,409,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,29,5,24
+Howard,"11,12,12a,13,14,19","Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,113,43,70
+Howard,"103,104,105","Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,43,24,19
+Howard,"24,25,29","Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,237,105,132
+Howard,205,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,185,93,92
+Howard,"207,207c","Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,220,63,157
+Howard,208,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,9,4,5
+Howard,"32,33,34,35","Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,352,157,195
+Howard,304,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,70,28,42
+Howard,"42,45,46","Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,172,81,91
+Howard,"405,405","Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,126,49,77
+Howard,408,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,2,1,1
+Howard,409,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,77,23,54
+Howard,"11,12,12a,13,14,19","Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,31,11,20
+Howard,"103,104,108","Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,14,5,9
+Howard,"24,25,29","Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,72,36,36
+Howard,205,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,43,16,27
+Howard,"207,207c","Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,54,13,41
+Howard,208,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,7,0,7
+Howard,"32,33,34,35","Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,77,42,35
+Howard,304,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,23,8,15
+Howard,"42,45,46","Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,43,10,33
+Howard,"405,405","Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,32,12,20
+Howard,408,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,4,1,3
+Howard,409,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,25,5,20
+Howard,"11,12,12a,13,14,19","Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,22,12,10
+Howard,"103,104,108","Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,6,2,4
+Howard,"24,25,29","Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,58,33,25
+Howard,205,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,37,23,14
+Howard,"207,207c","Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,29,10,19
+Howard,208,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,3,2,1
+Howard,"32,33,34,35","Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,56,29,27
+Howard,304,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,12,6,6
+Howard,"42,45,46","Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,29,14,15
+Howard,"405,405","Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,14,6,8
+Howard,408,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,5,2,3
+Howard,409,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,4,0,4
+Howard,"11,12,12a,13,14,19","Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,46,29,17
+Howard,"103,104,108","Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,11,8,3
+Howard,"24,25,29","Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,110,43,67
+Howard,205,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,63,36,27
+Howard,"207,207c","Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,74,18,56
+Howard,208,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,6,2,4
+Howard,"32,33,34,35","Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,125,65,60
+Howard,304,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,24,7,17
+Howard,"42,45,46","Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,64,23,41
+Howard,"405,405","Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,30,12,18
+Howard,408,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,6,5,1
+Howard,409,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,18,4,14
+Howard,"11,12,12a,13,14,19","Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,120,44,76
+Howard,"103,104,108","Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,35,16,19
+Howard,"24,25,29","Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,225,97,128
+Howard,205,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,174,86,88
+Howard,"207,207c","Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,222,61,161
+Howard,208,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,11,3,8
+Howard,"32,33,34,35","Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,343,165,178
+Howard,304,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,79,32,47
+Howard,"42,45,46","Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,149,68,81
+Howard,"405,405","Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,136,49,87
+Howard,408,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,7,4,3
+Howard,409,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,70,17,53
+Howard,"11,12,12a,13,14,19","Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,90,51,39
+Howard,"103,104,108","Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,35,16,19
+Howard,"24,25,29","Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,238,113,125
+Howard,205,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,141,75,66
+Howard,"207,207c","Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,144,38,106
+Howard,208,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,15,5,10
+Howard,"32,33,34,35","Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,258,121,137
+Howard,304,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,49,17,32
+Howard,"42,45,46","Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,150,57,93
+Howard,"405,405","Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,64,25,39
+Howard,408,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,10,6,4
+Howard,409,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,53,13,40
+Howard,"11,12,12a,13,14,19","Member, State Board of Education, District 15",,REP,Marty Rowley,165,74,91
+Howard,"103,104,108","Member, State Board of Education, District 15",,REP,Marty Rowley,58,30,28
+Howard,"24,25,29","Member, State Board of Education, District 15",,REP,Marty Rowley,440,212,228
+Howard,205,"Member, State Board of Education, District 15",,REP,Marty Rowley,299,142,157
+Howard,"207,207c","Member, State Board of Education, District 15",,REP,Marty Rowley,337,93,244
+Howard,208,"Member, State Board of Education, District 15",,REP,Marty Rowley,26,8,18
+Howard,"32,33,34,35","Member, State Board of Education, District 15",,REP,Marty Rowley,567,278,289
+Howard,304,"Member, State Board of Education, District 15",,REP,Marty Rowley,108,43,65
+Howard,"42,45,46","Member, State Board of Education, District 15",,REP,Marty Rowley,273,110,163
+Howard,"405,405","Member, State Board of Education, District 15",,REP,Marty Rowley,168,64,104
+Howard,408,"Member, State Board of Education, District 15",,REP,Marty Rowley,12,5,7
+Howard,409,"Member, State Board of Education, District 15",,REP,Marty Rowley,106,28,78
+Howard,"11,12,12a,13,14,19",State Representative,72,REP,Drew Darby,184,87,97
+Howard,"103,104,108",State Representative,72,REP,Drew Darby,63,36,27
+Howard,"24,25,29",State Representative,72,REP,Drew Darby,480,232,248
+Howard,205,State Representative,72,REP,Drew Darby,320,152,168
+Howard,"207,207c",State Representative,72,REP,Drew Darby,358,103,255
+Howard,208,State Representative,72,REP,Drew Darby,26,8,18
+Howard,"32,33,34,35",State Representative,72,REP,Drew Darby,598,295,303
+Howard,304,State Representative,72,REP,Drew Darby,119,49,70
+Howard,"42,45,46",State Representative,72,REP,Drew Darby,291,126,165
+Howard,"405,405",State Representative,72,REP,Drew Darby,180,69,111
+Howard,408,State Representative,72,REP,Drew Darby,15,7,8
+Howard,409,State Representative,72,REP,Drew Darby,121,35,86
+Howard,"11,12,12a,13,14,19","Justice, 11th Court of Appeals District, Place 3",,REP,John Bailey,172,78,94
+Howard,"103,104,108","Justice, 11th Court of Appeals District, Place 3",,REP,John Bailey,58,31,27
+Howard,"24,25,29","Justice, 11th Court of Appeals District, Place 3",,REP,John Bailey,449,214,235
+Howard,205,"Justice, 11th Court of Appeals District, Place 3",,REP,John Bailey,302,141,161
+Howard,"207,207c","Justice, 11th Court of Appeals District, Place 3",,REP,John Bailey,343,97,246
+Howard,208,"Justice, 11th Court of Appeals District, Place 3",,REP,John Bailey,26,8,18
+Howard,"32,33,34,35","Justice, 11th Court of Appeals District, Place 3",,REP,John Bailey,563,274,289
+Howard,304,"Justice, 11th Court of Appeals District, Place 3",,REP,John Bailey,114,47,67
+Howard,"42,45,46","Justice, 11th Court of Appeals District, Place 3",,REP,John Bailey,272,113,159
+Howard,"405,405","Justice, 11th Court of Appeals District, Place 3",,REP,John Bailey,170,63,107
+Howard,408,"Justice, 11th Court of Appeals District, Place 3",,REP,John Bailey,12,5,7
+Howard,409,"Justice, 11th Court of Appeals District, Place 3",,REP,John Bailey,113,31,82
+Howard,"11,12,12a,13,14,19","District Attorney, 118th Judicial District",,REP,Hardy Wilkerson,180,82,98
+Howard,"103,104,108","District Attorney, 118th Judicial District",,REP,Hardy Wilkerson,68,37,31
+Howard,"24,25,29","District Attorney, 118th Judicial District",,REP,Hardy Wilkerson,479,232,247
+Howard,205,"District Attorney, 118th Judicial District",,REP,Hardy Wilkerson,324,153,171
+Howard,"207,207c","District Attorney, 118th Judicial District",,REP,Hardy Wilkerson,364,105,259
+Howard,208,"District Attorney, 118th Judicial District",,REP,Hardy Wilkerson,26,8,18
+Howard,"32,33,34,35","District Attorney, 118th Judicial District",,REP,Hardy Wilkerson,605,291,314
+Howard,304,"District Attorney, 118th Judicial District",,REP,Hardy Wilkerson,117,49,68
+Howard,"42,45,46","District Attorney, 118th Judicial District",,REP,Hardy Wilkerson,287,121,166
+Howard,"405,405","District Attorney, 118th Judicial District",,REP,Hardy Wilkerson,191,75,116
+Howard,408,"District Attorney, 118th Judicial District",,REP,Hardy Wilkerson,15,7,8
+Howard,409,"District Attorney, 118th Judicial District",,REP,Hardy Wilkerson,117,33,84
+Howard,"11,12,12a,13,14,19",County Attorney,,REP,Joshua Andrew Hamby,189,85,104
+Howard,"103,104,108",County Attorney,,REP,Joshua Andrew Hamby,78,44,34
+Howard,"24,25,29",County Attorney,,REP,Joshua Andrew Hamby,506,248,258
+Howard,205,County Attorney,,REP,Joshua Andrew Hamby,338,160,178
+Howard,"207,207c",County Attorney,,REP,Joshua Andrew Hamby,385,114,271
+Howard,208,County Attorney,,REP,Joshua Andrew Hamby,28,9,19
+Howard,"32,33,34,35",County Attorney,,REP,Joshua Andrew Hamby,631,307,324
+Howard,304,County Attorney,,REP,Joshua Andrew Hamby,125,49,76
+Howard,"42,45,46",County Attorney,,REP,Joshua Andrew Hamby,302,127,175
+Howard,"405,405",County Attorney,,REP,Joshua Andrew Hamby,194,77,117
+Howard,408,County Attorney,,REP,Joshua Andrew Hamby,17,7,10
+Howard,409,County Attorney,,REP,Joshua Andrew Hamby,127,36,91
+Howard,"11,12,12a,13,14,19",Sheriff,,REP,Stan Parker,223,101,122
+Howard,"103,104,108",Sheriff,,REP,Stan Parker,83,45,38
+Howard,"24,25,29",Sheriff,,REP,Stan Parker,537,257,280
+Howard,205,Sheriff,,REP,Stan Parker,368,179,189
+Howard,"207,207c",Sheriff,,REP,Stan Parker,390,116,274
+Howard,208,Sheriff,,REP,Stan Parker,25,8,17
+Howard,"32,33,34,35",Sheriff,,REP,Stan Parker,663,322,341
+Howard,304,Sheriff,,REP,Stan Parker,135,55,80
+Howard,"42,45,46",Sheriff,,REP,Stan Parker,324,137,187
+Howard,"405,405",Sheriff,,REP,Stan Parker,206,82,124
+Howard,408,Sheriff,,REP,Stan Parker,19,8,11
+Howard,409,Sheriff,,REP,Stan Parker,130,39,91
+Howard,"11,12,12a,13,14,19",Tax Assessor-Collector,,REP,Tiffany Sayles Fernandez,191,90,101
+Howard,"103,104,108",Tax Assessor-Collector,,REP,Tiffany Sayles Fernandez,60,31,29
+Howard,"24,25,29",Tax Assessor-Collector,,REP,Tiffany Sayles Fernandez,466,220,246
+Howard,205,Tax Assessor-Collector,,REP,Tiffany Sayles Fernandez,326,157,169
+Howard,"207,207c",Tax Assessor-Collector,,REP,Tiffany Sayles Fernandez,357,106,251
+Howard,208,Tax Assessor-Collector,,REP,Tiffany Sayles Fernandez,24,8,16
+Howard,"32,33,34,35",Tax Assessor-Collector,,REP,Tiffany Sayles Fernandez,602,295,307
+Howard,304,Tax Assessor-Collector,,REP,Tiffany Sayles Fernandez,124,51,73
+Howard,"42,45,46",Tax Assessor-Collector,,REP,Tiffany Sayles Fernandez,296,122,174
+Howard,"405,405",Tax Assessor-Collector,,REP,Tiffany Sayles Fernandez,173,70,103
+Howard,408,Tax Assessor-Collector,,REP,Tiffany Sayles Fernandez,15,6,9
+Howard,409,Tax Assessor-Collector,,REP,Tiffany Sayles Fernandez,118,32,86
+Howard,"11,12,12a,13,14,19","County Commissioner, Precinct 1",,REP,Jesse Bravo,69,36,33
+Howard,"103,104,108","County Commissioner, Precinct 1",,REP,Jesse Bravo,6,5,1
+Howard,"24,25,29","County Commissioner, Precinct 1",,REP,Jesse Bravo,0,0,0
+Howard,205,"County Commissioner, Precinct 1",,REP,Jesse Bravo,0,0,0
+Howard,"207,207c","County Commissioner, Precinct 1",,REP,Jesse Bravo,0,0,0
+Howard,208,"County Commissioner, Precinct 1",,REP,Jesse Bravo,0,0,0
+Howard,"32,33,34,35","County Commissioner, Precinct 1",,REP,Jesse Bravo,0,0,0
+Howard,304,"County Commissioner, Precinct 1",,REP,Jesse Bravo,0,0,0
+Howard,"42,45,46","County Commissioner, Precinct 1",,REP,Jesse Bravo,0,0,0
+Howard,"405,405","County Commissioner, Precinct 1",,REP,Jesse Bravo,0,0,0
+Howard,408,"County Commissioner, Precinct 1",,REP,Jesse Bravo,0,0,0
+Howard,409,"County Commissioner, Precinct 1",,REP,Jesse Bravo,0,0,0
+Howard,"11,12,12a,13,14,19","County Commissioner, Precinct 1",,REP,Oscar M Garcia,118,51,67
+Howard,"103,104,108","County Commissioner, Precinct 1",,REP,Oscar M Garcia,16,7,9
+Howard,"24,25,29","County Commissioner, Precinct 1",,REP,Oscar M Garcia,0,0,0
+Howard,205,"County Commissioner, Precinct 1",,REP,Oscar M Garcia,0,0,0
+Howard,"207,207c","County Commissioner, Precinct 1",,REP,Oscar M Garcia,0,0,0
+Howard,208,"County Commissioner, Precinct 1",,REP,Oscar M Garcia,0,0,0
+Howard,"32,33,34,35","County Commissioner, Precinct 1",,REP,Oscar M Garcia,0,0,0
+Howard,304,"County Commissioner, Precinct 1",,REP,Oscar M Garcia,0,0,0
+Howard,"42,45,46","County Commissioner, Precinct 1",,REP,Oscar M Garcia,0,0,0
+Howard,"405,405","County Commissioner, Precinct 1",,REP,Oscar M Garcia,0,0,0
+Howard,408,"County Commissioner, Precinct 1",,REP,Oscar M Garcia,0,0,0
+Howard,409,"County Commissioner, Precinct 1",,REP,Oscar M Garcia,0,0,0
+Howard,"11,12,12a,13,14,19","County Commissioner, Precinct 1",,REP,Chad Averette,89,46,43
+Howard,"103,104,108","County Commissioner, Precinct 1",,REP,Chad Averette,69,41,28
+Howard,"24,25,29","County Commissioner, Precinct 1",,REP,Chad Averette,0,0,0
+Howard,205,"County Commissioner, Precinct 1",,REP,Chad Averette,0,0,0
+Howard,"207,207c","County Commissioner, Precinct 1",,REP,Chad Averette,0,0,0
+Howard,208,"County Commissioner, Precinct 1",,REP,Chad Averette,0,0,0
+Howard,"32,33,34,35","County Commissioner, Precinct 1",,REP,Chad Averette,0,0,0
+Howard,304,"County Commissioner, Precinct 1",,REP,Chad Averette,0,0,0
+Howard,"42,45,46","County Commissioner, Precinct 1",,REP,Chad Averette,0,0,0
+Howard,"405,405","County Commissioner, Precinct 1",,REP,Chad Averette,0,0,0
+Howard,408,"County Commissioner, Precinct 1",,REP,Chad Averette,0,0,0
+Howard,409,"County Commissioner, Precinct 1",,REP,Chad Averette,0,0,0
+Howard,"11,12,12a,13,14,19","County Commissioner, Precinct 3",,REP,Jimmie Long,0,0,0
+Howard,"103,104,108","County Commissioner, Precinct 3",,REP,Jimmie Long,0,0,0
+Howard,"24,25,29","County Commissioner, Precinct 3",,REP,Jimmie Long,0,0,0
+Howard,205,"County Commissioner, Precinct 3",,REP,Jimmie Long,0,0,0
+Howard,"207,207c","County Commissioner, Precinct 3",,REP,Jimmie Long,0,0,0
+Howard,208,"County Commissioner, Precinct 3",,REP,Jimmie Long,0,0,0
+Howard,"32,33,34,35","County Commissioner, Precinct 3",,REP,Jimmie Long,612,300,312
+Howard,304,"County Commissioner, Precinct 3",,REP,Jimmie Long,125,51,74
+Howard,"42,45,46","County Commissioner, Precinct 3",,REP,Jimmie Long,0,0,0
+Howard,"405,405","County Commissioner, Precinct 3",,REP,Jimmie Long,0,0,0
+Howard,408,"County Commissioner, Precinct 3",,REP,Jimmie Long,0,0,0
+Howard,409,"County Commissioner, Precinct 3",,REP,Jimmie Long,0,0,0
+Howard,"11,12,12a,13,14,19","Justice of the Peace Precinct 1, Place 1",,REP,Bennie Green,223,100,123
+Howard,"103,104,108","Justice of the Peace Precinct 1, Place 1",,REP,Bennie Green,80,42,38
+Howard,"24,25,29","Justice of the Peace Precinct 1, Place 1",,REP,Bennie Green,540,258,282
+Howard,205,"Justice of the Peace Precinct 1, Place 1",,REP,Bennie Green,363,177,186
+Howard,"207,207c","Justice of the Peace Precinct 1, Place 1",,REP,Bennie Green,0,0,0
+Howard,208,"Justice of the Peace Precinct 1, Place 1",,REP,Bennie Green,0,0,0
+Howard,"32,33,34,35","Justice of the Peace Precinct 1, Place 1",,REP,Bennie Green,655,319,336
+Howard,304,"Justice of the Peace Precinct 1, Place 1",,REP,Bennie Green,133,56,77
+Howard,"42,45,46","Justice of the Peace Precinct 1, Place 1",,REP,Bennie Green,333,141,192
+Howard,"405,405","Justice of the Peace Precinct 1, Place 1",,REP,Bennie Green,206,79,127
+Howard,408,"Justice of the Peace Precinct 1, Place 1",,REP,Bennie Green,18,7,11
+Howard,409,"Justice of the Peace Precinct 1, Place 1",,REP,Bennie Green,0,0,0
+Howard,"11,12,12a,13,14,19",Constable Pct 1,,REP,Kneel Stallings,188,86,102
+Howard,"103,104,108",Constable Pct 1,,REP,Kneel Stallings,76,40,36
+Howard,"24,25,29",Constable Pct 1,,REP,Kneel Stallings,486,239,247
+Howard,205,Constable Pct 1,,REP,Kneel Stallings,337,161,176
+Howard,"207,207c",Constable Pct 1,,REP,Kneel Stallings,0,0,0
+Howard,208,Constable Pct 1,,REP,Kneel Stallings,0,0,0
+Howard,"32,33,34,35",Constable Pct 1,,REP,Kneel Stallings,612,297,315
+Howard,304,Constable Pct 1,,REP,Kneel Stallings,124,52,72
+Howard,"42,45,46",Constable Pct 1,,REP,Kneel Stallings,291,121,170
+Howard,"405,405",Constable Pct 1,,REP,Kneel Stallings,185,74,111
+Howard,408,Constable Pct 1,,REP,Kneel Stallings,15,7,8
+Howard,409,Constable Pct 1,,REP,Kneel Stallings,0,0,0
+Howard,"11,12,12a,13,14,19",Proposition 1 ,,REP,For,186,77,109
+Howard,"103,104,108",Proposition 1,,REP,For,70,39,31
+Howard,"24,25,29",Proposition 1,,REP,For,438,213,225
+Howard,205,Proposition 1,,REP,For,326,168,158
+Howard,"207,207c",Proposition 1,,REP,For,334,104,230
+Howard,208,Proposition 1,,REP,For,17,7,10
+Howard,"32,33,34,35",Proposition 1,,REP,For,521,243,278
+Howard,304,Proposition 1,,REP,For,99,34,65
+Howard,"42,45,46",Proposition 1,,REP,For,255,110,145
+Howard,"405,405",Proposition 1,,REP,For,172,72,100
+Howard,408,Proposition 1,,REP,For,17,9,8
+Howard,409,Proposition 1,,REP,For,112,30,82
+Howard,"11,12,12a,13,14,19",Proposition 1,,REP,Against,70,35,35
+Howard,"103,104,108",Proposition 1,,REP,Against,23,12,11
+Howard,"24,25,29",Proposition 1,,REP,Against,163,66,97
+Howard,205,Proposition 1,,REP,Against,101,49,52
+Howard,"207,207c",Proposition 1,,REP,Against,132,32,100
+Howard,208,Proposition 1,,REP,Against,10,2,8
+Howard,"32,33,34,35",Proposition 1,,REP,Against,215,121,94
+Howard,304,Proposition 1,,REP,Against,51,27,24
+Howard,"42,45,46",Proposition 1,,REP,Against,114,46,68
+Howard,"405,405",Proposition 1,,REP,Against,73,27,46
+Howard,408,Proposition 1,,REP,Against,3,1,2
+Howard,409,Proposition 1,,REP,Against,42,12,30
+Howard,"11,12,12a,13,14,19",Proposition 2 ,,REP,For,159,75,84
+Howard,"103,104,108",Proposition 2 ,,REP,For,61,32,29
+Howard,"24,25,29",Proposition 2,,REP,For,377,168,209
+Howard,205,Proposition 2,,REP,For,245,124,121
+Howard,"207,207c",Proposition 2,,REP,For,268,76,192
+Howard,208,Proposition 2,,REP,For,19,6,13
+Howard,"32,33,34,35",Proposition 2,,REP,For,444,214,230
+Howard,304,Proposition 2,,REP,For,103,44,59
+Howard,"42,45,46",Proposition 2,,REP,For,240,104,136
+Howard,"405,405",Proposition 2,,REP,For,146,63,83
+Howard,408,Proposition 2,,REP,For,15,9,6
+Howard,409,Proposition 2,,REP,For,87,27,60
+Howard,"11,12,12a,13,14,19",Proposition 2,,REP,Against,106,44,62
+Howard,"103,104,108",Proposition 2,,REP,Against,37,21,16
+Howard,"24,25,29",Proposition 2,,REP,Against,222,111,111
+Howard,205,Proposition 2,,REP,Against,181,95,86
+Howard,"207,207c",Proposition 2,,REP,Against,193,59,134
+Howard,208,Proposition 2,,REP,Against,10,4,6
+Howard,"32,33,34,35",Proposition 2,,REP,Against,302,156,146
+Howard,304,Proposition 2,,REP,Against,52,21,31
+Howard,"42,45,46",Proposition 2,,REP,Against,141,56,85
+Howard,"405,405",Proposition 2,,REP,Against,95,34,61
+Howard,408,Proposition 2,,REP,Against,7,1,6
+Howard,409,Proposition 2,,REP,Against,66,15,51
+Howard,"11,12,12a,13,14,19",Proposition 3,,REP,For,199,93,106
+Howard,"103,104,108",Proposition 3,,REP,For,81,43,38
+Howard,"24,25,29",Proposition 3,,REP,For,487,233,254
+Howard,205,Proposition 3,,REP,For,359,193,166
+Howard,"207,207c",Proposition 3,,REP,For,360,103,257
+Howard,208,Proposition 3,,REP,For,24,8,16
+Howard,"32,33,34,35",Proposition 3,,REP,For,605,303,302
+Howard,304,Proposition 3,,REP,For,135,59,76
+Howard,"42,45,46",Proposition 3,,REP,For,295,129,166
+Howard,"405,405",Proposition 3,,REP,For,205,81,124
+Howard,408,Proposition 3,,REP,For,20,10,10
+Howard,409,Proposition 3,,REP,For,129,40,89
+Howard,"11,12,12a,13,14,19",Proposition 3,,REP,Against,61,25,36
+Howard,"103,104,108",Proposition 3,,REP,Against,15,9,6
+Howard,"24,25,29",Proposition 3,,REP,Against,114,45,69
+Howard,205,Proposition 3,,REP,Against,62,24,38
+Howard,"207,207c",Proposition 3,,REP,Against,93,30,63
+Howard,208,Proposition 3,,REP,Against,3,1,2
+Howard,"32,33,34,35",Proposition 3,,REP,Against,147,70,77
+Howard,304,Proposition 3,,REP,Against,18,6,12
+Howard,"42,45,46",Proposition 3,,REP,Against,78,31,47
+Howard,"405,405",Proposition 3,,REP,Against,42,18,24
+Howard,408,Proposition 3,,REP,Against,1,0,1
+Howard,409,Proposition 3,,REP,Against,24,4,20
+Howard,"11,12,12a,13,14,19",Proposition 4,,REP,For,236,108,128
+Howard,"103,104,108",Proposition 4,,REP,For,92,51,41
+Howard,"24,25,29",Proposition 4,,REP,For,566,262,304
+Howard,205,Proposition 4,,REP,For,422,219,203
+Howard,"207,207c",Proposition 4,,REP,For,447,132,315
+Howard,208,Proposition 4,,REP,For,26,9,17
+Howard,"32,33,34,35",Proposition 4,,REP,For,705,355,350
+Howard,304,Proposition 4,,REP,For,147,64,83
+Howard,"42,45,46",Proposition 4,,REP,For,362,160,202
+Howard,"405,405",Proposition 4,,REP,For,233,94,139
+Howard,408,Proposition 4,,REP,For,21,10,11
+Howard,409,Proposition 4,,REP,For,148,42,106
+Howard,"11,12,12a,13,14,19",Proposition 4,,REP,Against,21,12,9
+Howard,"103,104,108",Proposition 4,,REP,Against,2,1,1
+Howard,"24,25,29",Proposition 4,,REP,Against,29,13,16
+Howard,205,Proposition 4,,REP,Against,9,2,7
+Howard,"207,207c",Proposition 4,,REP,Against,13,4,9
+Howard,208,Proposition 4,,REP,Against,2,1,1
+Howard,"32,33,34,35",Proposition 4,,REP,Against,30,13,17
+Howard,304,Proposition 4,,REP,Against,4,1,3
+Howard,"42,45,46",Proposition 4,,REP,Against,13,2,11
+Howard,"405,405",Proposition 4,,REP,Against,11,4,7
+Howard,408,Proposition 4,,REP,Against,0,0,0
+Howard,409,Proposition 4,,REP,Against,8,1,7
+Howard,"11,12,12a,13,14,16",President,,DEM,Bernie Sanders,45,8,37
+Howard,"103,104,105",President,,DEM,Bernie Sanders,9,1,8
+Howard,"24,25,26",President,,DEM,Bernie Sanders,26,7,19
+Howard,205,President,,DEM,Bernie Sanders,6,2,4
+Howard,"207,207c",President,,DEM,Bernie Sanders,11,5,6
+Howard,208,President,,DEM,Bernie Sanders,2,1,1
+Howard,"32,33,34,35",President,,DEM,Bernie Sanders,39,10,29
+Howard,304,President,,DEM,Bernie Sanders,1,1,0
+Howard,"42,45,46",President,,DEM,Bernie Sanders,39,15,24
+Howard,"404,405",President,,DEM,Bernie Sanders,8,1,7
+Howard,"408,",President,,DEM,Bernie Sanders,0,0,0
+Howard,409,President,,DEM,Bernie Sanders,6,3,3
+Howard,"11,12,12a,13,14,16",President,,DEM,Star Locke,0,0,0
+Howard,"103,104,105",President,,DEM,Star Locke,0,0,0
+Howard,"24,25,26",President,,DEM,Star Locke,0,0,0
+Howard,205,President,,DEM,Star Locke,0,0,0
+Howard,"207,207c",President,,DEM,Star Locke,0,0,0
+Howard,208,President,,DEM,Star Locke,0,0,0
+Howard,"32,33,34,35",President,,DEM,Star Locke,0,0,0
+Howard,304,President,,DEM,Star Locke,0,0,0
+Howard,"42,45,46",President,,DEM,Star Locke,0,0,0
+Howard,"404,405",President,,DEM,Star Locke,0,0,0
+Howard,"408,",President,,DEM,Star Locke,0,0,0
+Howard,409,President,,DEM,Star Locke,0,0,0
+Howard,"11,12,12a,13,14,16",President,,DEM,Keith Judd,0,0,0
+Howard,"103,104,105",President,,DEM,Keith Judd,0,0,0
+Howard,"24,25,26",President,,DEM,Keith Judd,0,0,0
+Howard,205,President,,DEM,Keith Judd,0,0,0
+Howard,"207,207c",President,,DEM,Keith Judd,2,2,0
+Howard,208,President,,DEM,Keith Judd,0,0,0
+Howard,"32,33,34,35",President,,DEM,Keith Judd,1,1,0
+Howard,304,President,,DEM,Keith Judd,0,0,0
+Howard,"42,45,46",President,,DEM,Keith Judd,0,0,0
+Howard,"404,405",President,,DEM,Keith Judd,0,0,0
+Howard,"408,",President,,DEM,Keith Judd,0,0,0
+Howard,409,President,,DEM,Keith Judd,0,0,0
+Howard,"11,12,12a,13,14,16",President,,DEM,Hillary Clinton,80,23,57
+Howard,"103,104,105",President,,DEM,Hillary Clinton,4,2,2
+Howard,"24,25,26",President,,DEM,Hillary Clinton,59,23,36
+Howard,205,President,,DEM,Hillary Clinton,15,7,8
+Howard,"207,207c",President,,DEM,Hillary Clinton,28,3,25
+Howard,208,President,,DEM,Hillary Clinton,2,2,0
+Howard,"32,33,34,35",President,,DEM,Hillary Clinton,71,28,43
+Howard,304,President,,DEM,Hillary Clinton,10,2,8
+Howard,"42,45,46",President,,DEM,Hillary Clinton,62,25,37
+Howard,"404,405",President,,DEM,Hillary Clinton,16,4,12
+Howard,"408,",President,,DEM,Hillary Clinton,0,0,0
+Howard,409,President,,DEM,Hillary Clinton,4,2,2
+Howard,"11,12,12a,13,14,16",President,,DEM,Willie L Wilson,0,0,0
+Howard,"103,104,105",President,,DEM,Willie L Wilson,0,0,0
+Howard,"24,25,26",President,,DEM,Willie L Wilson,1,1,0
+Howard,205,President,,DEM,Willie L Wilson,0,0,0
+Howard,"207,207c",President,,DEM,Willie L Wilson,0,0,0
+Howard,208,President,,DEM,Willie L Wilson,0,0,0
+Howard,"32,33,34,35",President,,DEM,Willie L Wilson,0,0,0
+Howard,304,President,,DEM,Willie L Wilson,0,0,0
+Howard,"42,45,46",President,,DEM,Willie L Wilson,0,0,0
+Howard,"404,405",President,,DEM,Willie L Wilson,0,0,0
+Howard,"408,",President,,DEM,Willie L Wilson,0,0,0
+Howard,409,President,,DEM,Willie L Wilson,0,0,0
+Howard,"11,12,12a,13,14,16",President,,DEM,"Roque "" Rocky"" DeLaFuente",2,0,2
+Howard,"103,104,105",President,,DEM,"Roque "" Rocky"" DeLaFuente",0,0,0
+Howard,"24,25,26",President,,DEM,"Roque "" Rocky"" DeLaFuente",1,0,1
+Howard,205,President,,DEM,"Roque "" Rocky"" DeLaFuente",0,0,0
+Howard,"207,207c",President,,DEM,"Roque "" Rocky"" DeLaFuente",0,0,0
+Howard,208,President,,DEM,"Roque "" Rocky"" DeLaFuente",0,0,0
+Howard,"32,33,34,35",President,,DEM,"Roque "" Rocky"" DeLaFuente",0,0,0
+Howard,304,President,,DEM,"Roque "" Rocky"" DeLaFuente",0,0,0
+Howard,"42,45,46",President,,DEM,"Roque "" Rocky"" DeLaFuente",0,0,0
+Howard,"404,405",President,,DEM,"Roque "" Rocky"" DeLaFuente",0,0,0
+Howard,"408,",President,,DEM,"Roque "" Rocky"" DeLaFuente",0,0,0
+Howard,409,President,,DEM,"Roque "" Rocky"" DeLaFuente",0,0,0
+Howard,"11,12,12a,13,14,16",President,,DEM,Martin J O'Malley,1,0,1
+Howard,"103,104,105",President,,DEM,Martin J O'Malley,0,0,0
+Howard,"24,25,26",President,,DEM,Martin J O'Malley,1,0,1
+Howard,205,President,,DEM,Martin J O'Malley,0,0,0
+Howard,"207,207c",President,,DEM,Martin J O'Malley,0,0,0
+Howard,208,President,,DEM,Martin J O'Malley,0,0,0
+Howard,"32,33,34,35",President,,DEM,Martin J O'Malley,0,0,0
+Howard,304,President,,DEM,Martin J O'Malley,0,0,0
+Howard,"42,45,46",President,,DEM,Martin J O'Malley,0,0,0
+Howard,"404,405",President,,DEM,Martin J O'Malley,0,0,0
+Howard,"408,",President,,DEM,Martin J O'Malley,0,0,0
+Howard,409,President,,DEM,Martin J O'Malley,0,0,0
+Howard,"11,12,12a,13,14,16",President,,DEM,Calvin L Hawes,0,0,0
+Howard,"103,104,105",President,,DEM,Calvin L Hawes,0,0,0
+Howard,"24,25,26",President,,DEM,Calvin L Hawes,1,0,1
+Howard,205,President,,DEM,Calvin L Hawes,0,0,0
+Howard,"207,207c",President,,DEM,Calvin L Hawes,0,0,0
+Howard,208,President,,DEM,Calvin L Hawes,0,0,0
+Howard,"32,33,34,35",President,,DEM,Calvin L Hawes,1,1,0
+Howard,304,President,,DEM,Calvin L Hawes,0,0,0
+Howard,"42,45,46",President,,DEM,Calvin L Hawes,0,0,0
+Howard,"404,405",President,,DEM,Calvin L Hawes,0,0,0
+Howard,"408,",President,,DEM,Calvin L Hawes,0,0,0
+Howard,409,President,,DEM,Calvin L Hawes,0,0,0
+Howard,"11,12,12a,13,14,16",Railroad Commissioner,,DEM,Cody Garrett,41,9,32
+Howard,"103,104,105",Railroad Commissioner,,DEM,Cody Garrett,7,2,5
+Howard,"24,25,26",Railroad Commissioner,,DEM,Cody Garrett,31,7,24
+Howard,205,Railroad Commissioner,,DEM,Cody Garrett,9,3,6
+Howard,"207,207c",Railroad Commissioner,,DEM,Cody Garrett,20,3,17
+Howard,208,Railroad Commissioner,,DEM,Cody Garrett,2,2,0
+Howard,"32,33,34,35",Railroad Commissioner,,DEM,Cody Garrett,44,8,36
+Howard,304,Railroad Commissioner,,DEM,Cody Garrett,4,0,4
+Howard,"42,45,46",Railroad Commissioner,,DEM,Cody Garrett,37,14,23
+Howard,"404,405",Railroad Commissioner,,DEM,Cody Garrett,8,1,7
+Howard,"408,",Railroad Commissioner,,DEM,Cody Garrett,0,0,0
+Howard,409,Railroad Commissioner,,DEM,Cody Garrett,3,0,3
+Howard,"11,12,12a,13,14,16",Railroad Commissioner,,DEM,Grady Yarbrough,45,16,29
+Howard,"103,104,105",Railroad Commissioner,,DEM,Grady Yarbrough,3,1,2
+Howard,"24,25,26",Railroad Commissioner,,DEM,Grady Yarbrough,26,10,16
+Howard,205,Railroad Commissioner,,DEM,Grady Yarbrough,9,6,3
+Howard,"207,207c",Railroad Commissioner,,DEM,Grady Yarbrough,14,4,10
+Howard,208,Railroad Commissioner,,DEM,Grady Yarbrough,0,0,0
+Howard,"32,33,34,35",Railroad Commissioner,,DEM,Grady Yarbrough,44,17,27
+Howard,304,Railroad Commissioner,,DEM,Grady Yarbrough,4,2,2
+Howard,"42,45,46",Railroad Commissioner,,DEM,Grady Yarbrough,38,18,20
+Howard,"404,405",Railroad Commissioner,,DEM,Grady Yarbrough,8,4,4
+Howard,"408,",Railroad Commissioner,,DEM,Grady Yarbrough,0,0,0
+Howard,409,Railroad Commissioner,,DEM,Grady Yarbrough,4,3,1
+Howard,"11,12,12a,13,14,17",Railroad Commissioner,,DEM,Lon Burnam,15,4,11
+Howard,"103,104,106",Railroad Commissioner,,DEM,Lon Burnam,1,0,1
+Howard,24.25.26,Railroad Commissioner,,DEM,Lon Burnam,16,7,9
+Howard,205,Railroad Commissioner,,DEM,Lon Burnam,1,0,1
+Howard,"207,207c",Railroad Commissioner,,DEM,Lon Burnam,5,3,2
+Howard,208,Railroad Commissioner,,DEM,Lon Burnam,1,0,1
+Howard,"32,33,34,36",Railroad Commissioner,,DEM,Lon Burnam,11,6,5
+Howard,304,Railroad Commissioner,,DEM,Lon Burnam,1,0,1
+Howard,"42,45,47",Railroad Commissioner,,DEM,Lon Burnam,13,5,8
+Howard,"404,405",Railroad Commissioner,,DEM,Lon Burnam,7,0,7
+Howard,"408,",Railroad Commissioner,,DEM,Lon Burnam,0,0,0
+Howard,409,Railroad Commissioner,,DEM,Lon Burnam,2,0,2
+Howard,"11,12,12a,13,14,17","Justice, Supreme Court, Place 3",,DEM,Mike Westergren,76,23,53
+Howard,"103,104,106","Justice, Supreme Court, Place 3",,DEM,Mike Westergren,8,1,7
+Howard,"24,25,27","Justice, Supreme Court, Place 3",,DEM,Mike Westergren,68,25,43
+Howard,205,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,13,5,8
+Howard,"207,207c","Justice, Supreme Court, Place 3",,DEM,Mike Westergren,32,8,24
+Howard,208,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,3,2,1
+Howard,"32,33,34,36","Justice, Supreme Court, Place 3",,DEM,Mike Westergren,83,28,55
+Howard,304,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,9,1,8
+Howard,"42,45,46","Justice, Supreme Court, Place 3",,DEM,Mike Westergren,74,30,44
+Howard,"404, 405","Justice, Supreme Court, Place 3",,DEM,Mike Westergren,15,4,11
+Howard,"408,","Justice, Supreme Court, Place 3",,DEM,Mike Westergren,0,0,0
+Howard,409,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,4,2,2
+Howard,"11,12,12a,13,14,18","Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,89,23,66
+Howard,"103,104,107","Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,9,1,8
+Howard,"24,25,28","Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,74,26,48
+Howard,207,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,13,5,8
+Howard,"207,207c","Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,33,8,25
+Howard,208,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,4,3,1
+Howard,"32,33,34,35","Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,86,28,58
+Howard,304,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,10,2,8
+Howard,"42,45,48","Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,79,30,49
+Howard,"404, 405","Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,17,4,13
+Howard,"408,","Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,0,0,0
+Howard,409,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,3,2,1
+Howard,"11,12,12a,13,14,16","Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,76,22,54
+Howard,"103, 104, 105","Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,8,1,7
+Howard,"24,25,26","Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,68,26,42
+Howard,207,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,15,7,8
+Howard,"207,207c","Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,31,8,23
+Howard,208,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,3,2,1
+Howard,"32,33,34,35","Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,84,29,55
+Howard,304,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,10,2,8
+Howard,"42,45,48","Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,76,31,45
+Howard,"404, 405","Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,15,4,11
+Howard,"408,","Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,0,0,0
+Howard,409,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,5,2,3
+Howard,"11,12,12a,13,14,16","Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawerence ""Larry"" Meyers",77,21,56
+Howard,"103,104,108","Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawerence ""Larry"" Meyers",8,1,7
+Howard,"24,25,29","Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawerence ""Larry"" Meyers",68,26,42
+Howard,208,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawerence ""Larry"" Meyers",13,5,8
+Howard,"207,207c","Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawerence ""Larry"" Meyers",30,8,22
+Howard,211,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawerence ""Larry"" Meyers",3,2,1
+Howard,"32,33,34,35","Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawerence ""Larry"" Meyers",81,25,56
+Howard,304,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawerence ""Larry"" Meyers",10,2,8
+Howard,"42,45,46","Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawerence ""Larry"" Meyers",73,29,44
+Howard,"405,405","Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawerence ""Larry"" Meyers",13,3,10
+Howard,408,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawerence ""Larry"" Meyers",0,0,0
+Howard,409,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawerence ""Larry"" Meyers",4,2,2
+Howard,"11,12,12a,13,14,16","Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,80,22,58
+Howard,"103,104,108","Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,8,1,7
+Howard,"24,25,29","Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,68,26,42
+Howard,205,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,13,5,8
+Howard,"207,207c","Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,30,7,23
+Howard,208,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,3,2,1
+Howard,"32,33,34,35","Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,85,28,57
+Howard,304,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,0,0,0
+Howard,"42,45,46","Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,79,31,48
+Howard,"405,405","Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,14,3,11
+Howard,408,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,0,0,0
+Howard,409,"Judge, Court of Criminal Appeals, Place 5",,DEM,Betsy Johnson,5,2,3
+Howard,"11,12,12a,13,14,16","Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,78,22,56
+Howard,"103,104,108","Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,8,1,7
+Howard,"24,25,29","Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,66,24,42
+Howard,205,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,14,6,8
+Howard,"207,207c","Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,30,7,23
+Howard,208,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,3,2,1
+Howard,"32,33,34,35","Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,81,26,55
+Howard,304,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,9,1,8
+Howard,"42,45,46","Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,71,28,43
+Howard,"405,405","Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,14,3,11
+Howard,408,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,0,0,0
+Howard,409,"Judge, Court of Criminal Appeals, Place 6",,DEM,Robert Burns,4,2,2
+Howard,"11,12,12a,13,14,19",Referenda #1,,DEM,For,112,29,83
+Howard,"103,104,108",Referenda #1,,DEM,For,10,3,7
+Howard,"24,25,29",Referenda #1,,DEM,For,82,31,51
+Howard,205,Referenda #1,,DEM,For,19,9,10
+Howard,"207,207c",Referenda #1,,DEM,For,35,9,26
+Howard,208,Referenda #1,,DEM,For,4,3,1
+Howard,"32,33,34,35",Referenda #1,,DEM,For,95,32,63
+Howard,304,Referenda #1,,DEM,For,10,3,7
+Howard,"42,45,46",Referenda #1,,DEM,For,89,37,52
+Howard,"405,405",Referenda #1,,DEM,For,17,4,13
+Howard,408,Referenda #1,,DEM,For,0,0,0
+Howard,409,Referenda #1,,DEM,For,10,5,5
+Howard,"11,12,12a,13,14,19",Referenda #1,,DEM,Against,8,2,6
+Howard,"103,104,108",Referenda #1,,DEM,Against,2,0,2
+Howard,"24,25,29",Referenda #1,,DEM,Against,6,1,5
+Howard,205,Referenda #1,,DEM,Against,2,0,2
+Howard,"207,207c",Referenda #1,,DEM,Against,3,2,1
+Howard,208,Referenda #1,,DEM,Against,0,0,0
+Howard,"32,33,34,35",Referenda #1,,DEM,Against,13,7,6
+Howard,304,Referenda #1,,DEM,Against,1,0,1
+Howard,"42,45,46",Referenda #1,,DEM,Against,7,3,4
+Howard,"405,405",Referenda #1,,DEM,Against,4,1,3
+Howard,408,Referenda #1,,DEM,Against,0,0,0
+Howard,409,Referenda #1,,DEM,Against,1,0,1
+Howard,"11,12,12a,13,14,19",Referenda #2,,DEM,For,110,29,81
+Howard,"103,104,108",Referenda #2,,DEM,For,11,3,8
+Howard,"24,25,29",Referenda #2,,DEM,For,79,31,48
+Howard,205,Referenda #2,,DEM,For,18,8,10
+Howard,"207,207c",Referenda #2,,DEM,For,38,11,27
+Howard,208,Referenda #2,,DEM,For,3,2,1
+Howard,"32,33,34,35",Referenda #2,,DEM,For,100,35,65
+Howard,304,Referenda #2,,DEM,For,10,3,7
+Howard,"42,45,46",Referenda #2,,DEM,For,89,38,51
+Howard,"405,405",Referenda #2,,DEM,For,20,4,16
+Howard,408,Referenda #2,,DEM,For,0,0,0
+Howard,409,Referenda #2,,DEM,For,7,5,2
+Howard,"11,12,12a,13,14,19",Referenda #2,,DEM,Against,5,1,4
+Howard,"103,104,108",Referenda #2,,DEM,Against,1,0,1
+Howard,"24,25,29",Referenda #2,,DEM,Against,6,1,5
+Howard,205,Referenda #2,,DEM,Against,3,1,2
+Howard,"207,207c",Referenda #2,,DEM,Against,0,0,0
+Howard,208,Referenda #2,,DEM,Against,1,1,0
+Howard,"32,33,34,35",Referenda #2,,DEM,Against,6,4,2
+Howard,304,Referenda #2,,DEM,Against,1,0,1
+Howard,"42,45,46",Referenda #2,,DEM,Against,7,1,6
+Howard,"405,405",Referenda #2,,DEM,Against,2,1,1
+Howard,408,Referenda #2,,DEM,Against,0,0,0
+Howard,409,Referenda #2,,DEM,Against,4,0,4
+Howard,"11,12,12a,13,14,19",Referenda #3,,DEM,For,102,27,75
+Howard,"103,104,108",Referenda #3,,DEM,For,11,3,8
+Howard,"24,25,29",Referenda #3,,DEM,For,80,29,51
+Howard,205,Referenda #3,,DEM,For,16,7,9
+Howard,"207,207c",Referenda #3,,DEM,For,30,7,23
+Howard,208,Referenda #3,,DEM,For,2,1,1
+Howard,"32,33,34,35",Referenda #3,,DEM,For,97,33,64
+Howard,304,Referenda #3,,DEM,For,9,3,6
+Howard,"42,45,46",Referenda #3,,DEM,For,88,34,54
+Howard,"405,405",Referenda #3,,DEM,For,22,5,17
+Howard,408,Referenda #3,,DEM,For,0,0,0
+Howard,409,Referenda #3,,DEM,For,7,5,2
+Howard,"11,12,12a,13,14,19",Referenda #3,,DEM,Against,11,3,8
+Howard,"103,104,108",Referenda #3,,DEM,Against,1,0,1
+Howard,"24,25,29",Referenda #3,,DEM,Against,5,2,3
+Howard,205,Referenda #3,,DEM,Against,5,2,3
+Howard,"207,207c",Referenda #3,,DEM,Against,8,4,4
+Howard,208,Referenda #3,,DEM,Against,2,2,0
+Howard,"32,33,34,35",Referenda #3,,DEM,Against,10,6,4
+Howard,304,Referenda #3,,DEM,Against,2,0,2
+Howard,"42,45,46",Referenda #3,,DEM,Against,9,6,3
+Howard,"405,405",Referenda #3,,DEM,Against,0,0,0
+Howard,408,Referenda #3,,DEM,Against,0,0,0
+Howard,409,Referenda #3,,DEM,Against,4,0,4
+Howard,"11,12,12a,13,14,19",Referenda #4,,DEM,For,103,29,74
+Howard,"103,104,108",Referenda #4,,DEM,For,11,2,9
+Howard,"24,25,29",Referenda #4,,DEM,For,81,32,49
+Howard,205,Referenda #4,,DEM,For,19,9,10
+Howard,"207,207c",Referenda #4,,DEM,For,39,11,28
+Howard,208,Referenda #4,,DEM,For,3,3,0
+Howard,"32,33,34,35",Referenda #4,,DEM,For,88,29,59
+Howard,304,Referenda #4,,DEM,For,8,2,6
+Howard,"42,45,46",Referenda #4,,DEM,For,88,34,54
+Howard,"405,405",Referenda #4,,DEM,For,15,5,10
+Howard,408,Referenda #4,,DEM,For,0,0,0
+Howard,409,Referenda #4,,DEM,For,9,5,4
+Howard,"11,12,12a,13,14,19",Referenda #4,,DEM,Against,9,1,8
+Howard,"103,104,108",Referenda #4,,DEM,Against,2,1,1
+Howard,"24,25,29",Referenda #4,,DEM,Against,5,0,5
+Howard,205,Referenda #4,,DEM,Against,2,0,2
+Howard,"207,207c",Referenda #4,,DEM,Against,0,0,0
+Howard,208,Referenda #4,,DEM,Against,0,0,0
+Howard,"32,33,34,35",Referenda #4,,DEM,Against,16,10,6
+Howard,304,Referenda #4,,DEM,Against,2,1,1
+Howard,"42,45,46",Referenda #4,,DEM,Against,6,4,2
+Howard,"405,405",Referenda #4,,DEM,Against,4,0,4
+Howard,408,Referenda #4,,DEM,Against,0,0,0
+Howard,409,Referenda #4,,DEM,Against,2,0,2
+Howard,"11,12,12a,13,14,19",Referenda #5,,DEM,For,77,22,55
+Howard,"103,104,108",Referenda #5,,DEM,For,8,3,5
+Howard,"24,25,29",Referenda #5,,DEM,For,61,23,38
+Howard,205,Referenda #5,,DEM,For,17,9,8
+Howard,"207,207c",Referenda #5,,DEM,For,25,9,16
+Howard,208,Referenda #5,,DEM,For,3,2,1
+Howard,"32,33,34,35",Referenda #5,,DEM,For,69,24,45
+Howard,304,Referenda #5,,DEM,For,5,1,4
+Howard,"42,45,46",Referenda #5,,DEM,For,72,34,38
+Howard,"405,405",Referenda #5,,DEM,For,20,4,16
+Howard,408,Referenda #5,,DEM,For,0,0,0
+Howard,409,Referenda #5,,DEM,For,7,3,4
+Howard,"11,12,12a,13,14,19",Referenda #5,,DEM,Against,40,8,32
+Howard,"103,104,108",Referenda #5,,DEM,Against,5,0,5
+Howard,"24,25,29",Referenda #5,,DEM,Against,26,9,17
+Howard,205,Referenda #5,,DEM,Against,4,0,4
+Howard,"207,207c",Referenda #5,,DEM,Against,13,2,11
+Howard,208,Referenda #5,,DEM,Against,1,1,0
+Howard,"32,33,34,35",Referenda #5,,DEM,Against,38,14,24
+Howard,304,Referenda #5,,DEM,Against,5,2,3
+Howard,"42,45,46",Referenda #5,,DEM,Against,25,6,19
+Howard,"405,405",Referenda #5,,DEM,Against,3,1,2
+Howard,408,Referenda #5,,DEM,Against,0,0,0
+Howard,409,Referenda #5,,DEM,Against,3,1,2
+Howard,"11,12,12a,13,14,19",Referenda #6 ,,DEM,For,113,29,84
+Howard,"103,104,108",Referenda #6 ,,DEM,For,7,2,5
+Howard,"24,25,29",Referenda #6 ,,DEM,For,82,30,52
+Howard,205,Referenda #6 ,,DEM,For,11,3,8
+Howard,"207,207c",Referenda #6 ,,DEM,For,36,9,27
+Howard,208,Referenda #6 ,,DEM,For,4,3,1
+Howard,"32,33,34,35",Referenda #6 ,,DEM,For,93,33,60
+Howard,304,Referenda #6 ,,DEM,For,10,3,7
+Howard,"42,45,46",Referenda #6 ,,DEM,For,88,37,51
+Howard,"405,405",Referenda #6 ,,DEM,For,18,3,15
+Howard,408,Referenda #6 ,,DEM,For,0,0,0
+Howard,409,Referenda #6 ,,DEM,For,8,5,3
+Howard,"11,12,12a,13,14,19",Referenda #6 ,,DEM,Against,8,1,7
+Howard,"103,104,108",Referenda #6 ,,DEM,Against,6,1,5
+Howard,"24,25,29",Referenda #6 ,,DEM,Against,7,2,5
+Howard,205,Referenda #6 ,,DEM,Against,9,5,4
+Howard,"207,207c",Referenda #6 ,,DEM,Against,3,2,1
+Howard,208,Referenda #6 ,,DEM,Against,0,0,0
+Howard,"32,33,34,35",Referenda #6 ,,DEM,Against,16,6,10
+Howard,304,Referenda #6 ,,DEM,Against,1,0,1
+Howard,"42,45,46",Referenda #6 ,,DEM,Against,9,3,6
+Howard,"405,405",Referenda #6 ,,DEM,Against,4,2,2
+Howard,408,Referenda #6 ,,DEM,Against,0,0,0
+Howard,409,Referenda #6 ,,DEM,Against,3,0,3


### PR DESCRIPTION
The source data file only gave results in blocks of 1-6 precincts. They are as follows:

|Precinct Groups|
|-|
11, 12, 12a, 13, 14, 16
103, 104, 105
24, 25, 26
205
207, 207c
208
32, 33, 34, 35
304
42, 45, 46
404, 405
408
409

