### PR TITLE
Add precinct-level results for the 2016 primaries in Armstrong County

### DIFF
--- a/2016/20160301__tx__primary__armstrong__precinct.csv
+++ b/2016/20160301__tx__primary__armstrong__precinct.csv
@@ -1,0 +1,726 @@
+county,precinct,office,district,party,candidate,votes,early_voting,election_day
+Armstrong,101,President,,DEM,"Roque ""Rocky"" De La Fuenta",0,0,0
+Armstrong,201,President,,DEM,"Roque ""Rocky"" De La Fuenta",0,0,0
+Armstrong,301,President,,DEM,"Roque ""Rocky"" De La Fuenta",0,0,0
+Armstrong,303,President,,DEM,"Roque ""Rocky"" De La Fuenta",0,0,0
+Armstrong,401,President,,DEM,"Roque ""Rocky"" De La Fuenta",0,0,0
+Armstrong,402,President,,DEM,"Roque ""Rocky"" De La Fuenta",0,0,0
+Armstrong,Mail,President,,DEM,"Roque ""Rocky"" De La Fuenta",0,0,0
+Armstrong,101,President,,DEM,Hillary Clinton,2,1,1
+Armstrong,201,President,,DEM,Hillary Clinton,0,0,0
+Armstrong,301,President,,DEM,Hillary Clinton,0,0,0
+Armstrong,303,President,,DEM,Hillary Clinton,0,0,0
+Armstrong,401,President,,DEM,Hillary Clinton,0,0,0
+Armstrong,402,President,,DEM,Hillary Clinton,0,0,0
+Armstrong,Mail,President,,DEM,Hillary Clinton,0,0,0
+Armstrong,101,President,,DEM,Martin J. O'Malley,0,0,0
+Armstrong,201,President,,DEM,Martin J. O'Malley,0,0,0
+Armstrong,301,President,,DEM,Martin J. O'Malley,0,0,0
+Armstrong,303,President,,DEM,Martin J. O'Malley,0,0,0
+Armstrong,401,President,,DEM,Martin J. O'Malley,0,0,0
+Armstrong,402,President,,DEM,Martin J. O'Malley,0,0,0
+Armstrong,Mail,President,,DEM,Martin J. O'Malley,0,0,0
+Armstrong,101,President,,DEM,Star Locke,0,0,0
+Armstrong,201,President,,DEM,Star Locke,0,0,0
+Armstrong,301,President,,DEM,Star Locke,0,0,0
+Armstrong,303,President,,DEM,Star Locke,0,0,0
+Armstrong,401,President,,DEM,Star Locke,0,0,0
+Armstrong,402,President,,DEM,Star Locke,0,0,0
+Armstrong,Mail,President,,DEM,Star Locke,0,0,0
+Armstrong,101,President,,DEM,Calvis L. Hawes,0,0,0
+Armstrong,201,President,,DEM,Calvis L. Hawes,0,0,0
+Armstrong,301,President,,DEM,Calvis L. Hawes,0,0,0
+Armstrong,303,President,,DEM,Calvis L. Hawes,0,0,0
+Armstrong,401,President,,DEM,Calvis L. Hawes,0,0,0
+Armstrong,402,President,,DEM,Calvis L. Hawes,0,0,0
+Armstrong,Mail,President,,DEM,Calvis L. Hawes,0,0,0
+Armstrong,101,President,,DEM,Bernie Sanders,2,1,1
+Armstrong,201,President,,DEM,Bernie Sanders,0,0,0
+Armstrong,301,President,,DEM,Bernie Sanders,0,0,0
+Armstrong,303,President,,DEM,Bernie Sanders,0,0,0
+Armstrong,401,President,,DEM,Bernie Sanders,0,0,0
+Armstrong,402,President,,DEM,Bernie Sanders,1,0,1
+Armstrong,Mail,President,,DEM,Bernie Sanders,0,0,0
+Armstrong,101,President,,DEM,Willie L. Wilson,0,0,0
+Armstrong,201,President,,DEM,Willie L. Wilson,0,0,0
+Armstrong,301,President,,DEM,Willie L. Wilson,0,0,0
+Armstrong,303,President,,DEM,Willie L. Wilson,0,0,0
+Armstrong,401,President,,DEM,Willie L. Wilson,0,0,0
+Armstrong,402,President,,DEM,Willie L. Wilson,0,0,0
+Armstrong,Mail,President,,DEM,Willie L. Wilson,0,0,0
+Armstrong,101,President,,DEM,Keith Judd,0,0,0
+Armstrong,201,President,,DEM,Keith Judd,0,0,0
+Armstrong,301,President,,DEM,Keith Judd,0,0,0
+Armstrong,303,President,,DEM,Keith Judd,0,0,0
+Armstrong,401,President,,DEM,Keith Judd,0,0,0
+Armstrong,402,President,,DEM,Keith Judd,0,0,0
+Armstrong,Mail,President,,DEM,Keith Judd,0,0,0
+Armstrong,101,Railroad Commissioner,,DEM,Lon Burnam,1,0,1
+Armstrong,201,Railroad Commissioner,,DEM,Lon Burnam,0,0,0
+Armstrong,301,Railroad Commissioner,,DEM,Lon Burnam,0,0,0
+Armstrong,303,Railroad Commissioner,,DEM,Lon Burnam,0,0,0
+Armstrong,401,Railroad Commissioner,,DEM,Lon Burnam,0,0,0
+Armstrong,402,Railroad Commissioner,,DEM,Lon Burnam,0,0,0
+Armstrong,Mail,Railroad Commissioner,,DEM,Lon Burnam,0,0,0
+Armstrong,101,Railroad Commissioner,,DEM,Cody Garrett,0,0,0
+Armstrong,201,Railroad Commissioner,,DEM,Cody Garrett,1,1,0
+Armstrong,301,Railroad Commissioner,,DEM,Cody Garrett,0,0,0
+Armstrong,303,Railroad Commissioner,,DEM,Cody Garrett,0,0,0
+Armstrong,401,Railroad Commissioner,,DEM,Cody Garrett,0,0,0
+Armstrong,402,Railroad Commissioner,,DEM,Cody Garrett,0,0,0
+Armstrong,Mail,Railroad Commissioner,,DEM,Cody Garrett,0,0,0
+Armstrong,101,Railroad Commissioner,,DEM,Grady Yarbrough,2,1,1
+Armstrong,201,Railroad Commissioner,,DEM,Grady Yarbrough,1,1,0
+Armstrong,301,Railroad Commissioner,,DEM,Grady Yarbrough,0,0,0
+Armstrong,303,Railroad Commissioner,,DEM,Grady Yarbrough,0,0,0
+Armstrong,401,Railroad Commissioner,,DEM,Grady Yarbrough,0,0,0
+Armstrong,402,Railroad Commissioner,,DEM,Grady Yarbrough,0,0,0
+Armstrong,Mail,Railroad Commissioner,,DEM,Grady Yarbrough,0,0,0
+Armstrong,101,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,1,0,1
+Armstrong,201,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,2,2,0
+Armstrong,301,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,0,0,0
+Armstrong,303,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,0,0,0
+Armstrong,401,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,0,0,0
+Armstrong,402,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,1,0,1
+Armstrong,Mail,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,0,0,0
+Armstrong,101,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,2,1,1
+Armstrong,201,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,3,3,0
+Armstrong,301,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,0,0,0
+Armstrong,303,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,0,0,0
+Armstrong,401,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,0,0,0
+Armstrong,402,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,1,0,1
+Armstrong,Mail,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,0,0,0
+Armstrong,101,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,3,1,2
+Armstrong,201,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,3,3,0
+Armstrong,301,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,0,0,0
+Armstrong,303,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,0,0,0
+Armstrong,401,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,0,0,0
+Armstrong,402,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,1,0,1
+Armstrong,Mail,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,0,0,0
+Armstrong,101,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",2,1,1
+Armstrong,201,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",2,2,0
+Armstrong,301,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",0,0,0
+Armstrong,303,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",0,0,0
+Armstrong,401,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",0,0,0
+Armstrong,402,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",1,0,1
+Armstrong,Mail,"Judge, Court of Criminal Appeals, Place 2",,DEM,"Lawrence ""Larry"" Meyers",0,0,0
+Armstrong,101,"Judge, Court of Criminal Appeals,Place 5",,DEM,Betsy Johnson,2,1,1
+Armstrong,201,"Judge, Court of Criminal Appeals,Place 5",,DEM,Betsy Johnson,3,3,0
+Armstrong,301,"Judge, Court of Criminal Appeals,Place 5",,DEM,Betsy Johnson,0,0,0
+Armstrong,303,"Judge, Court of Criminal Appeals,Place 5",,DEM,Betsy Johnson,0,0,0
+Armstrong,401,"Judge, Court of Criminal Appeals,Place 5",,DEM,Betsy Johnson,0,0,0
+Armstrong,402,"Judge, Court of Criminal Appeals,Place 5",,DEM,Betsy Johnson,1,0,1
+Armstrong,Mail,"Judge, Court of Criminal Appeals,Place 5",,DEM,Betsy Johnson,0,0,0
+Armstrong,101,"Judge, Court of Criminal Appeals,Place 6",,DEM,Robert Burns,2,1,1
+Armstrong,201,"Judge, Court of Criminal Appeals,Place 6",,DEM,Robert Burns,2,2,0
+Armstrong,301,"Judge, Court of Criminal Appeals,Place 6",,DEM,Robert Burns,0,0,0
+Armstrong,303,"Judge, Court of Criminal Appeals,Place 6",,DEM,Robert Burns,0,0,0
+Armstrong,401,"Judge, Court of Criminal Appeals,Place 6",,DEM,Robert Burns,0,0,0
+Armstrong,402,"Judge, Court of Criminal Appeals,Place 6",,DEM,Robert Burns,1,0,1
+Armstrong,Mail,"Judge, Court of Criminal Appeals,Place 6",,DEM,Robert Burns,0,0,0
+Armstrong,101,Referenda 1,,DEM,For,2,1,1
+Armstrong,201,Referenda 1,,DEM,For,0,0,0
+Armstrong,301,Referenda 1,,DEM,For,0,0,0
+Armstrong,303,Referenda 1,,DEM,For,0,0,0
+Armstrong,401,Referenda 1,,DEM,For,0,0,0
+Armstrong,402,Referenda 1,,DEM,For,0,0,0
+Armstrong,Mail,Referenda 1,,DEM,For,0,0,0
+Armstrong,101,Referenda 1,,DEM,Against,2,1,1
+Armstrong,201,Referenda 1,,DEM,Against,2,2,0
+Armstrong,301,Referenda 1,,DEM,Against,0,0,0
+Armstrong,303,Referenda 1,,DEM,Against,0,0,0
+Armstrong,401,Referenda 1,,DEM,Against,0,0,0
+Armstrong,402,Referenda 1,,DEM,Against,1,0,1
+Armstrong,Mail,Referenda 1,,DEM,Against,0,0,0
+Armstrong,101,Referenda 2,,DEM,For,3,2,1
+Armstrong,201,Referenda 2,,DEM,For,3,3,0
+Armstrong,301,Referenda 2,,DEM,For,0,0,0
+Armstrong,303,Referenda 2,,DEM,For,0,0,0
+Armstrong,401,Referenda 2,,DEM,For,0,0,0
+Armstrong,402,Referenda 2,,DEM,For,1,0,1
+Armstrong,Mail,Referenda 2,,DEM,For,0,0,0
+Armstrong,101,Referenda 2,,DEM,Against,1,0,1
+Armstrong,201,Referenda 2,,DEM,Against,0,0,0
+Armstrong,301,Referenda 2,,DEM,Against,0,0,0
+Armstrong,303,Referenda 2,,DEM,Against,0,0,0
+Armstrong,401,Referenda 2,,DEM,Against,0,0,0
+Armstrong,402,Referenda 2,,DEM,Against,0,0,0
+Armstrong,Mail,Referenda 2,,DEM,Against,0,0,0
+Armstrong,101,Referenda 3,,DEM,For,3,2,1
+Armstrong,201,Referenda 3,,DEM,For,3,3,0
+Armstrong,301,Referenda 3,,DEM,For,0,0,0
+Armstrong,303,Referenda 3,,DEM,For,0,0,0
+Armstrong,401,Referenda 3,,DEM,For,0,0,0
+Armstrong,402,Referenda 3,,DEM,For,1,0,1
+Armstrong,Mail,Referenda 3,,DEM,For,0,0,0
+Armstrong,101,Referenda 3,,DEM,Against,1,0,1
+Armstrong,201,Referenda 3,,DEM,Against,0,0,0
+Armstrong,301,Referenda 3,,DEM,Against,0,0,0
+Armstrong,303,Referenda 3,,DEM,Against,0,0,0
+Armstrong,401,Referenda 3,,DEM,Against,0,0,0
+Armstrong,402,Referenda 3,,DEM,Against,0,0,0
+Armstrong,Mail,Referenda 3,,DEM,Against,0,0,0
+Armstrong,101,Referenda 4,,DEM,For,3,2,1
+Armstrong,201,Referenda 4,,DEM,For,3,3,0
+Armstrong,301,Referenda 4,,DEM,For,0,0,0
+Armstrong,303,Referenda 4,,DEM,For,0,0,0
+Armstrong,401,Referenda 4,,DEM,For,0,0,0
+Armstrong,402,Referenda 4,,DEM,For,1,0,1
+Armstrong,Mail,Referenda 4,,DEM,For,0,0,0
+Armstrong,101,Referenda 4,,DEM,Against,1,0,1
+Armstrong,201,Referenda 4,,DEM,Against,0,0,0
+Armstrong,301,Referenda 4,,DEM,Against,0,0,0
+Armstrong,303,Referenda 4,,DEM,Against,0,0,0
+Armstrong,401,Referenda 4,,DEM,Against,0,0,0
+Armstrong,402,Referenda 4,,DEM,Against,0,0,0
+Armstrong,Mail,Referenda 4,,DEM,Against,0,0,0
+Armstrong,101,Referenda 5,,DEM,For,3,1,2
+Armstrong,201,Referenda 5,,DEM,For,3,3,0
+Armstrong,301,Referenda 5,,DEM,For,0,0,0
+Armstrong,303,Referenda 5,,DEM,For,0,0,0
+Armstrong,401,Referenda 5,,DEM,For,0,0,0
+Armstrong,402,Referenda 5,,DEM,For,1,0,1
+Armstrong,Mail,Referenda 5,,DEM,For,0,0,0
+Armstrong,101,Referenda 5,,DEM,Against,1,1,0
+Armstrong,201,Referenda 5,,DEM,Against,0,0,0
+Armstrong,301,Referenda 5,,DEM,Against,0,0,0
+Armstrong,303,Referenda 5,,DEM,Against,0,0,0
+Armstrong,401,Referenda 5,,DEM,Against,0,0,0
+Armstrong,402,Referenda 5,,DEM,Against,0,0,0
+Armstrong,Mail,Referenda 5,,DEM,Against,0,0,0
+Armstrong,101,Referenda 6,,DEM,For,4,2,2
+Armstrong,201,Referenda 6,,DEM,For,2,2,0
+Armstrong,301,Referenda 6,,DEM,For,0,0,0
+Armstrong,303,Referenda 6,,DEM,For,0,0,0
+Armstrong,401,Referenda 6,,DEM,For,0,0,0
+Armstrong,402,Referenda 6,,DEM,For,1,0,1
+Armstrong,Mail,Referenda 6,,DEM,For,0,0,0
+Armstrong,101,Referenda 6,,DEM,Against,0,0,0
+Armstrong,201,Referenda 6,,DEM,Against,1,1,0
+Armstrong,301,Referenda 6,,DEM,Against,0,0,0
+Armstrong,303,Referenda 6,,DEM,Against,0,0,0
+Armstrong,401,Referenda 6,,DEM,Against,0,0,0
+Armstrong,402,Referenda 6,,DEM,Against,0,0,0
+Armstrong,Mail,Referenda 6,,DEM,Against,0,0,0
+Armstrong,101,President,,REP,Donald J. Trump,41,16,25
+Armstrong,201,President,,REP,Donald J. Trump,34,12,22
+Armstrong,202,President,,REP,Donald J. Trump,8,4,4
+Armstrong,301,President,,REP,Donald J. Trump,43,16,27
+Armstrong,303,President,,REP,Donald J. Trump,9,0,9
+Armstrong,401,President,,REP,Donald J. Trump,24,13,11
+Armstrong,402,President,,REP,Donald J. Trump,29,6,23
+Armstrong,404,President,,REP,Donald J. Trump,2,0,2
+Armstrong,Mail,President,,REP,Donald J. Trump,7,0,0
+Armstrong,101,President,,REP,Chris Christie,2,2,0
+Armstrong,201,President,,REP,Chris Christie,0,0,0
+Armstrong,202,President,,REP,Chris Christie,0,0,0
+Armstrong,301,President,,REP,Chris Christie,1,0,1
+Armstrong,303,President,,REP,Chris Christie,0,0,0
+Armstrong,401,President,,REP,Chris Christie,0,0,0
+Armstrong,402,President,,REP,Chris Christie,1,0,1
+Armstrong,404,President,,REP,Chris Christie,0,0,0
+Armstrong,Mail,President,,REP,Chris Christie,0,0,0
+Armstrong,101,President,,REP,Jeb Bush,3,0,3
+Armstrong,201,President,,REP,Jeb Bush,2,2,0
+Armstrong,202,President,,REP,Jeb Bush,0,0,0
+Armstrong,301,President,,REP,Jeb Bush,2,0,2
+Armstrong,303,President,,REP,Jeb Bush,1,1,0
+Armstrong,401,President,,REP,Jeb Bush,2,2,0
+Armstrong,402,President,,REP,Jeb Bush,1,0,1
+Armstrong,404,President,,REP,Jeb Bush,0,0,0
+Armstrong,Mail,President,,REP,Jeb Bush,0,0,0
+Armstrong,101,President,,REP,Rand Paul,2,0,2
+Armstrong,201,President,,REP,Rand Paul,1,0,1
+Armstrong,202,President,,REP,Rand Paul,0,0,0
+Armstrong,301,President,,REP,Rand Paul,1,0,1
+Armstrong,303,President,,REP,Rand Paul,0,0,0
+Armstrong,401,President,,REP,Rand Paul,0,0,0
+Armstrong,402,President,,REP,Rand Paul,0,0,0
+Armstrong,404,President,,REP,Rand Paul,0,0,0
+Armstrong,Mail,President,,REP,Rand Paul,0,0,0
+Armstrong,101,President,,REP,Mike Huckabee,0,0,0
+Armstrong,201,President,,REP,Mike Huckabee,0,0,0
+Armstrong,202,President,,REP,Mike Huckabee,0,0,0
+Armstrong,301,President,,REP,Mike Huckabee,2,1,1
+Armstrong,303,President,,REP,Mike Huckabee,0,0,0
+Armstrong,401,President,,REP,Mike Huckabee,0,0,0
+Armstrong,402,President,,REP,Mike Huckabee,0,0,0
+Armstrong,404,President,,REP,Mike Huckabee,0,0,0
+Armstrong,Mail,President,,REP,Mike Huckabee,0,0,0
+Armstrong,101,President,,REP,Rick Santorum,0,0,0
+Armstrong,201,President,,REP,Rick Santorum,0,0,0
+Armstrong,202,President,,REP,Rick Santorum,0,0,0
+Armstrong,301,President,,REP,Rick Santorum,0,0,0
+Armstrong,303,President,,REP,Rick Santorum,0,0,0
+Armstrong,401,President,,REP,Rick Santorum,0,0,0
+Armstrong,402,President,,REP,Rick Santorum,0,0,0
+Armstrong,404,President,,REP,Rick Santorum,0,0,0
+Armstrong,Mail,President,,REP,Rick Santorum,0,0,0
+Armstrong,101,President,,REP,Elizabeth Gray,0,0,0
+Armstrong,201,President,,REP,Elizabeth Gray,0,0,0
+Armstrong,202,President,,REP,Elizabeth Gray,0,0,0
+Armstrong,301,President,,REP,Elizabeth Gray,0,0,0
+Armstrong,303,President,,REP,Elizabeth Gray,0,0,0
+Armstrong,401,President,,REP,Elizabeth Gray,0,0,0
+Armstrong,402,President,,REP,Elizabeth Gray,0,0,0
+Armstrong,404,President,,REP,Elizabeth Gray,0,0,0
+Armstrong,Mail,President,,REP,Elizabeth Gray,0,0,0
+Armstrong,101,President,,REP,Ben Carson,17,5,12
+Armstrong,201,President,,REP,Ben Carson,2,1,1
+Armstrong,202,President,,REP,Ben Carson,4,2,2
+Armstrong,301,President,,REP,Ben Carson,14,8,6
+Armstrong,303,President,,REP,Ben Carson,0,0,0
+Armstrong,401,President,,REP,Ben Carson,12,2,10
+Armstrong,402,President,,REP,Ben Carson,10,0,10
+Armstrong,404,President,,REP,Ben Carson,0,0,0
+Armstrong,Mail,President,,REP,Ben Carson,1,0,0
+Armstrong,101,President,,REP,John R. Kasich,3,2,1
+Armstrong,201,President,,REP,John R. Kasich,3,1,2
+Armstrong,202,President,,REP,John R. Kasich,2,1,1
+Armstrong,301,President,,REP,John R. Kasich,1,0,1
+Armstrong,303,President,,REP,John R. Kasich,2,0,2
+Armstrong,401,President,,REP,John R. Kasich,2,2,0
+Armstrong,402,President,,REP,John R. Kasich,1,0,1
+Armstrong,404,President,,REP,John R. Kasich,0,0,0
+Armstrong,Mail,President,,REP,John R. Kasich,1,0,0
+Armstrong,101,President,,REP,Ted Cruz,96,40,56
+Armstrong,201,President,,REP,Ted Cruz,56,16,40
+Armstrong,202,President,,REP,Ted Cruz,19,9,10
+Armstrong,301,President,,REP,Ted Cruz,92,31,61
+Armstrong,303,President,,REP,Ted Cruz,18,0,18
+Armstrong,401,President,,REP,Ted Cruz,45,18,27
+Armstrong,402,President,,REP,Ted Cruz,35,6,29
+Armstrong,404,President,,REP,Ted Cruz,13,5,8
+Armstrong,Mail,President,,REP,Ted Cruz,6,0,0
+Armstrong,101,President,,REP,Marco Rubio,7,2,5
+Armstrong,201,President,,REP,Marco Rubio,4,1,3
+Armstrong,202,President,,REP,Marco Rubio,6,2,4
+Armstrong,301,President,,REP,Marco Rubio,17,6,11
+Armstrong,303,President,,REP,Marco Rubio,1,0,1
+Armstrong,401,President,,REP,Marco Rubio,13,7,6
+Armstrong,402,President,,REP,Marco Rubio,5,0,5
+Armstrong,404,President,,REP,Marco Rubio,4,2,2
+Armstrong,Mail,President,,REP,Marco Rubio,1,0,0
+Armstrong,101,President,,REP,Carly Fiorina,0,0,0
+Armstrong,201,President,,REP,Carly Fiorina,0,0,0
+Armstrong,202,President,,REP,Carly Fiorina,0,0,0
+Armstrong,301,President,,REP,Carly Fiorina,0,0,0
+Armstrong,303,President,,REP,Carly Fiorina,0,0,0
+Armstrong,401,President,,REP,Carly Fiorina,0,0,0
+Armstrong,402,President,,REP,Carly Fiorina,0,0,0
+Armstrong,404,President,,REP,Carly Fiorina,0,0,0
+Armstrong,Mail,President,,REP,Carly Fiorina,0,0,0
+Armstrong,101,President,,REP,Lindsey Graham,8,3,5
+Armstrong,201,President,,REP,Lindsey Graham,3,1,2
+Armstrong,202,President,,REP,Lindsey Graham,1,0,1
+Armstrong,301,President,,REP,Lindsey Graham,6,4,2
+Armstrong,303,President,,REP,Lindsey Graham,1,0,1
+Armstrong,401,President,,REP,Lindsey Graham,2,2,0
+Armstrong,402,President,,REP,Lindsey Graham,3,0,3
+Armstrong,404,President,,REP,Lindsey Graham,0,0,0
+Armstrong,Mail,President,,REP,Lindsey Graham,0,0,0
+Armstrong,101,President,,REP,Uncommitted,6,5,1
+Armstrong,201,President,,REP,Uncommitted,0,0,0
+Armstrong,202,President,,REP,Uncommitted,1,0,1
+Armstrong,301,President,,REP,Uncommitted,4,1,3
+Armstrong,303,President,,REP,Uncommitted,2,0,2
+Armstrong,401,President,,REP,Uncommitted,1,0,1
+Armstrong,402,President,,REP,Uncommitted,1,0,1
+Armstrong,404,President,,REP,Uncommitted,0,0,0
+Armstrong,Mail,President,,REP,Uncommitted,5,0,0
+Armstrong,101,U.S. House,13,REP,Mac Thornberry,152,61,91
+Armstrong,201,U.S. House,13,REP,Mac Thornberry,86,30,56
+Armstrong,202,U.S. House,13,REP,Mac Thornberry,32,15,17
+Armstrong,301,U.S. House,13,REP,Mac Thornberry,150,53,97
+Armstrong,303,U.S. House,13,REP,Mac Thornberry,26,1,25
+Armstrong,401,U.S. House,13,REP,Mac Thornberry,81,34,47
+Armstrong,402,U.S. House,13,REP,Mac Thornberry,74,8,66
+Armstrong,404,U.S. House,13,REP,Mac Thornberry,15,6,9
+Armstrong,Mail,U.S. House,13,REP,Mac Thornberry,20,0,0
+Armstrong,101,Railroad Commissioner,,REP,Ron Hale,43,19,24
+Armstrong,201,Railroad Commissioner,,REP,Ron Hale,24,7,17
+Armstrong,202,Railroad Commissioner,,REP,Ron Hale,8,2,6
+Armstrong,301,Railroad Commissioner,,REP,Ron Hale,41,13,28
+Armstrong,303,Railroad Commissioner,,REP,Ron Hale,7,0,7
+Armstrong,401,Railroad Commissioner,,REP,Ron Hale,15,8,7
+Armstrong,402,Railroad Commissioner,,REP,Ron Hale,21,3,18
+Armstrong,404,Railroad Commissioner,,REP,Ron Hale,1,0,1
+Armstrong,Mail,Railroad Commissioner,,REP,Ron Hale,4,0,0
+Armstrong,101,Railroad Commissioner,,REP,John Greytok,4,1,3
+Armstrong,201,Railroad Commissioner,,REP,John Greytok,2,1,1
+Armstrong,202,Railroad Commissioner,,REP,John Greytok,0,0,0
+Armstrong,301,Railroad Commissioner,,REP,John Greytok,5,4,1
+Armstrong,303,Railroad Commissioner,,REP,John Greytok,0,0,0
+Armstrong,401,Railroad Commissioner,,REP,John Greytok,9,5,4
+Armstrong,402,Railroad Commissioner,,REP,John Greytok,2,0,2
+Armstrong,404,Railroad Commissioner,,REP,John Greytok,3,1,2
+Armstrong,Mail,Railroad Commissioner,,REP,John Greytok,1,0,0
+Armstrong,101,Railroad Commissioner,,REP,Doug Jeffrey,15,7,8
+Armstrong,201,Railroad Commissioner,,REP,Doug Jeffrey,3,0,3
+Armstrong,202,Railroad Commissioner,,REP,Doug Jeffrey,2,1,1
+Armstrong,301,Railroad Commissioner,,REP,Doug Jeffrey,11,3,8
+Armstrong,303,Railroad Commissioner,,REP,Doug Jeffrey,1,0,1
+Armstrong,401,Railroad Commissioner,,REP,Doug Jeffrey,4,1,3
+Armstrong,402,Railroad Commissioner,,REP,Doug Jeffrey,4,0,4
+Armstrong,404,Railroad Commissioner,,REP,Doug Jeffrey,2,0,2
+Armstrong,Mail,Railroad Commissioner,,REP,Doug Jeffrey,5,0,0
+Armstrong,101,Railroad Commissioner,,REP,Gary Gates,23,6,17
+Armstrong,201,Railroad Commissioner,,REP,Gary Gates,11,5,6
+Armstrong,202,Railroad Commissioner,,REP,Gary Gates,3,2,1
+Armstrong,301,Railroad Commissioner,,REP,Gary Gates,26,7,19
+Armstrong,303,Railroad Commissioner,,REP,Gary Gates,4,0,4
+Armstrong,401,Railroad Commissioner,,REP,Gary Gates,13,4,9
+Armstrong,402,Railroad Commissioner,,REP,Gary Gates,16,3,13
+Armstrong,404,Railroad Commissioner,,REP,Gary Gates,2,2,0
+Armstrong,Mail,Railroad Commissioner,,REP,Gary Gates,1,0,0
+Armstrong,101,Railroad Commissioner,,REP,Weston Martinez,4,0,4
+Armstrong,201,Railroad Commissioner,,REP,Weston Martinez,2,0,2
+Armstrong,202,Railroad Commissioner,,REP,Weston Martinez,1,0,1
+Armstrong,301,Railroad Commissioner,,REP,Weston Martinez,5,2,3
+Armstrong,303,Railroad Commissioner,,REP,Weston Martinez,1,0,1
+Armstrong,401,Railroad Commissioner,,REP,Weston Martinez,2,1,1
+Armstrong,402,Railroad Commissioner,,REP,Weston Martinez,3,0,3
+Armstrong,404,Railroad Commissioner,,REP,Weston Martinez,1,1,0
+Armstrong,Mail,Railroad Commissioner,,REP,Weston Martinez,0,0,0
+Armstrong,101,Railroad Commissioner,,REP,Lance N. Christian,16,8,8
+Armstrong,201,Railroad Commissioner,,REP,Lance N. Christian,5,2,3
+Armstrong,202,Railroad Commissioner,,REP,Lance N. Christian,1,1,0
+Armstrong,301,Railroad Commissioner,,REP,Lance N. Christian,17,4,13
+Armstrong,303,Railroad Commissioner,,REP,Lance N. Christian,2,0,2
+Armstrong,401,Railroad Commissioner,,REP,Lance N. Christian,13,5,8
+Armstrong,402,Railroad Commissioner,,REP,Lance N. Christian,9,2,7
+Armstrong,404,Railroad Commissioner,,REP,Lance N. Christian,1,0,1
+Armstrong,Mail,Railroad Commissioner,,REP,Lance N. Christian,2,0,0
+Armstrong,101,Railroad Commissioner,,REP,Wayne Christian,26,14,12
+Armstrong,201,Railroad Commissioner,,REP,Wayne Christian,16,8,8
+Armstrong,202,Railroad Commissioner,,REP,Wayne Christian,4,3,1
+Armstrong,301,Railroad Commissioner,,REP,Wayne Christian,22,12,10
+Armstrong,303,Railroad Commissioner,,REP,Wayne Christian,6,0,6
+Armstrong,401,Railroad Commissioner,,REP,Wayne Christian,15,7,8
+Armstrong,402,Railroad Commissioner,,REP,Wayne Christian,5,1,4
+Armstrong,404,Railroad Commissioner,,REP,Wayne Christian,6,1,5
+Armstrong,Mail,Railroad Commissioner,,REP,Wayne Christian,1,0,0
+Armstrong,101,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,73,29,44
+Armstrong,201,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,46,12,34
+Armstrong,202,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,16,8,8
+Armstrong,301,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,71,26,45
+Armstrong,303,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,13,0,13
+Armstrong,401,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,38,16,22
+Armstrong,402,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,37,5,32
+Armstrong,404,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,7,1,6
+Armstrong,Mail,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,4,0,0
+Armstrong,101,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,58,26,32
+Armstrong,201,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,24,14,10
+Armstrong,202,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,8,4,4
+Armstrong,301,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,60,21,39
+Armstrong,303,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,12,0,12
+Armstrong,401,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,36,17,19
+Armstrong,402,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,21,2,19
+Armstrong,404,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,8,4,4
+Armstrong,Mail,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,10,0,0
+Armstrong,101,"Justice, Supreme Court, Place 5",,REP,Rick Green,79,34,45
+Armstrong,201,"Justice, Supreme Court, Place 5",,REP,Rick Green,41,16,25
+Armstrong,202,"Justice, Supreme Court, Place 5",,REP,Rick Green,11,4,7
+Armstrong,301,"Justice, Supreme Court, Place 5",,REP,Rick Green,65,28,37
+Armstrong,303,"Justice, Supreme Court, Place 5",,REP,Rick Green,12,0,12
+Armstrong,401,"Justice, Supreme Court, Place 5",,REP,Rick Green,37,16,21
+Armstrong,402,"Justice, Supreme Court, Place 5",,REP,Rick Green,37,6,31
+Armstrong,404,"Justice, Supreme Court, Place 5",,REP,Rick Green,11,4,7
+Armstrong,Mail,"Justice, Supreme Court, Place 5",,REP,Rick Green,6,0,0
+Armstrong,101,"Justice, Supreme Court, Place 5",,REP,Paul Green,45,18,27
+Armstrong,201,"Justice, Supreme Court, Place 5",,REP,Paul Green,21,7,14
+Armstrong,202,"Justice, Supreme Court, Place 5",,REP,Paul Green,7,5,2
+Armstrong,301,"Justice, Supreme Court, Place 5",,REP,Paul Green,58,15,43
+Armstrong,303,"Justice, Supreme Court, Place 5",,REP,Paul Green,12,0,12
+Armstrong,401,"Justice, Supreme Court, Place 5",,REP,Paul Green,29,14,15
+Armstrong,402,"Justice, Supreme Court, Place 5",,REP,Paul Green,19,1,18
+Armstrong,404,"Justice, Supreme Court, Place 5",,REP,Paul Green,4,1,3
+Armstrong,Mail,"Justice, Supreme Court, Place 5",,REP,Paul Green,9,0,0
+Armstrong,101,"Justice, Supreme Court, Place 9",,REP,Joe Pool,94,41,53
+Armstrong,201,"Justice, Supreme Court, Place 9",,REP,Joe Pool,48,20,28
+Armstrong,202,"Justice, Supreme Court, Place 9",,REP,Joe Pool,16,7,9
+Armstrong,301,"Justice, Supreme Court, Place 9",,REP,Joe Pool,77,29,48
+Armstrong,303,"Justice, Supreme Court, Place 9",,REP,Joe Pool,17,0,17
+Armstrong,401,"Justice, Supreme Court, Place 9",,REP,Joe Pool,46,22,24
+Armstrong,402,"Justice, Supreme Court, Place 9",,REP,Joe Pool,39,5,34
+Armstrong,404,"Justice, Supreme Court, Place 9",,REP,Joe Pool,7,3,4
+Armstrong,Mail,"Justice, Supreme Court, Place 9",,REP,Joe Pool,9,0,0
+Armstrong,101,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,31,11,20
+Armstrong,201,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,18,5,13
+Armstrong,202,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,4,3,1
+Armstrong,301,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,51,15,36
+Armstrong,303,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,8,0,8
+Armstrong,401,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,23,9,14
+Armstrong,402,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,18,2,16
+Armstrong,404,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,6,2,4
+Armstrong,Mail,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,6,0,0
+Armstrong,101,"Judge, Court of Criminal Appeals,  Place 2",,REP,Chris Oldner,49,21,28
+Armstrong,201,"Judge, Court of Criminal Appeals,  Place 2",,REP,Chris Oldner,24,9,15
+Armstrong,202,"Judge, Court of Criminal Appeals,  Place 2",,REP,Chris Oldner,6,3,3
+Armstrong,301,"Judge, Court of Criminal Appeals,  Place 2",,REP,Chris Oldner,49,17,32
+Armstrong,303,"Judge, Court of Criminal Appeals,  Place 2",,REP,Chris Oldner,8,0,8
+Armstrong,401,"Judge, Court of Criminal Appeals,  Place 2",,REP,Chris Oldner,24,12,12
+Armstrong,402,"Judge, Court of Criminal Appeals,  Place 2",,REP,Chris Oldner,21,3,18
+Armstrong,404,"Judge, Court of Criminal Appeals,  Place 2",,REP,Chris Oldner,5,1,4
+Armstrong,Mail,"Judge, Court of Criminal Appeals,  Place 2",,REP,Chris Oldner,4,0,0
+Armstrong,101,"Judge, Court of Criminal Appeals,  Place 2",,REP,Mary Lou Keel,44,15,29
+Armstrong,201,"Judge, Court of Criminal Appeals,  Place 2",,REP,Mary Lou Keel,25,12,13
+Armstrong,202,"Judge, Court of Criminal Appeals,  Place 2",,REP,Mary Lou Keel,8,5,3
+Armstrong,301,"Judge, Court of Criminal Appeals,  Place 2",,REP,Mary Lou Keel,48,17,31
+Armstrong,303,"Judge, Court of Criminal Appeals,  Place 2",,REP,Mary Lou Keel,11,0,11
+Armstrong,401,"Judge, Court of Criminal Appeals,  Place 2",,REP,Mary Lou Keel,23,7,16
+Armstrong,402,"Judge, Court of Criminal Appeals,  Place 2",,REP,Mary Lou Keel,28,4,24
+Armstrong,404,"Judge, Court of Criminal Appeals,  Place 2",,REP,Mary Lou Keel,3,2,1
+Armstrong,Mail,"Judge, Court of Criminal Appeals,  Place 2",,REP,Mary Lou Keel,8,0,0
+Armstrong,101,"Judge, Court of Criminal Appeals,  Place 2",,REP,Ray Wheless,27,14,13
+Armstrong,201,"Judge, Court of Criminal Appeals,  Place 2",,REP,Ray Wheless,13,4,9
+Armstrong,202,"Judge, Court of Criminal Appeals,  Place 2",,REP,Ray Wheless,6,3,3
+Armstrong,301,"Judge, Court of Criminal Appeals,  Place 2",,REP,Ray Wheless,19,5,14
+Armstrong,303,"Judge, Court of Criminal Appeals,  Place 2",,REP,Ray Wheless,4,0,4
+Armstrong,401,"Judge, Court of Criminal Appeals,  Place 2",,REP,Ray Wheless,20,11,9
+Armstrong,402,"Judge, Court of Criminal Appeals,  Place 2",,REP,Ray Wheless,9,1,8
+Armstrong,404,"Judge, Court of Criminal Appeals,  Place 2",,REP,Ray Wheless,5,2,3
+Armstrong,Mail,"Judge, Court of Criminal Appeals,  Place 2",,REP,Ray Wheless,2,0,0
+Armstrong,101,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,22,7,15
+Armstrong,201,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,8,4,4
+Armstrong,202,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,2,0,2
+Armstrong,301,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,28,8,20
+Armstrong,303,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,3,0,3
+Armstrong,401,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,21,10,11
+Armstrong,402,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,7,2,5
+Armstrong,404,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,1,0,1
+Armstrong,Mail,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,2,0,0
+Armstrong,101,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,30,13,17
+Armstrong,201,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,17,8,9
+Armstrong,202,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,5,2,3
+Armstrong,301,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,15,7,8
+Armstrong,303,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,4,0,4
+Armstrong,401,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,12,5,7
+Armstrong,402,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,7,2,5
+Armstrong,404,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,5,2,3
+Armstrong,Mail,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,5,0,0
+Armstrong,101,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,59,26,33
+Armstrong,201,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,29,10,19
+Armstrong,202,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,8,5,3
+Armstrong,301,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,58,22,36
+Armstrong,303,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,14,0,14
+Armstrong,401,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,30,13,17
+Armstrong,402,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,35,2,33
+Armstrong,404,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,8,3,5
+Armstrong,Mail,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,7,0,0
+Armstrong,101,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,10,5,5
+Armstrong,201,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,8,1,7
+Armstrong,202,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,4,3,1
+Armstrong,301,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,15,4,11
+Armstrong,303,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,1,0,1
+Armstrong,401,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,4,2,2
+Armstrong,402,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,7,1,6
+Armstrong,404,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,0,0,0
+Armstrong,Mail,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,1,0,0
+Armstrong,101,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,69,25,44
+Armstrong,201,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,36,13,23
+Armstrong,202,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,9,2,7
+Armstrong,301,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,65,23,42
+Armstrong,303,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,13,0,13
+Armstrong,401,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,43,19,24
+Armstrong,402,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,37,5,32
+Armstrong,404,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,9,4,5
+Armstrong,Mail,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,9,0,0
+Armstrong,101,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,50,26,24
+Armstrong,201,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,23,12,11
+Armstrong,202,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,8,6,2
+Armstrong,301,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,45,15,30
+Armstrong,303,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,9,0,9
+Armstrong,401,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,23,11,12
+Armstrong,402,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,18,2,16
+Armstrong,404,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,5,1,4
+Armstrong,Mail,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,5,0,0
+Armstrong,101,"Member, State Board of Education, District 15",,REP,Marty Rowley,121,49,72
+Armstrong,201,"Member, State Board of Education, District 15",,REP,Marty Rowley,60,22,38
+Armstrong,202,"Member, State Board of Education, District 15",,REP,Marty Rowley,19,9,10
+Armstrong,301,"Member, State Board of Education, District 15",,REP,Marty Rowley,119,45,74
+Armstrong,303,"Member, State Board of Education, District 15",,REP,Marty Rowley,26,0,26
+Armstrong,401,"Member, State Board of Education, District 15",,REP,Marty Rowley,63,26,37
+Armstrong,402,"Member, State Board of Education, District 15",,REP,Marty Rowley,52,4,48
+Armstrong,404,"Member, State Board of Education, District 15",,REP,Marty Rowley,14,5,9
+Armstrong,Mail,"Member, State Board of Education, District 15",,REP,Marty Rowley,15,0,0
+Armstrong,101,State Representative,88,REP,Ken King,127,52,75
+Armstrong,201,State Representative,88,REP,Ken King,71,24,47
+Armstrong,202,State Representative,88,REP,Ken King,21,12,9
+Armstrong,301,State Representative,88,REP,Ken King,132,50,82
+Armstrong,303,State Representative,88,REP,Ken King,25,0,25
+Armstrong,401,State Representative,88,REP,Ken King,73,33,40
+Armstrong,402,State Representative,88,REP,Ken King,57,6,51
+Armstrong,404,State Representative,88,REP,Ken King,13,5,8
+Armstrong,Mail,State Representative,88,REP,Ken King,14,0,0
+Armstrong,101,"Justice, 7th Court of Appeals District, Place 4",,REP,Jim Campbell,117,46,71
+Armstrong,201,"Justice, 7th Court of Appeals District, Place 4",,REP,Jim Campbell,59,21,38
+Armstrong,202,"Justice, 7th Court of Appeals District, Place 4",,REP,Jim Campbell,18,10,8
+Armstrong,301,"Justice, 7th Court of Appeals District, Place 4",,REP,Jim Campbell,118,44,74
+Armstrong,303,"Justice, 7th Court of Appeals District, Place 4",,REP,Jim Campbell,25,0,25
+Armstrong,401,"Justice, 7th Court of Appeals District, Place 4",,REP,Jim Campbell,62,27,35
+Armstrong,402,"Justice, 7th Court of Appeals District, Place 4",,REP,Jim Campbell,54,5,49
+Armstrong,404,"Justice, 7th Court of Appeals District, Place 4",,REP,Jim Campbell,13,5,8
+Armstrong,Mail,"Justice, 7th Court of Appeals District, Place 4",,REP,Jim Campbell,14,0,0
+Armstrong,101,"District Attorney, 47th Judicial District",,REP,Steven Denny,52,24,28
+Armstrong,201,"District Attorney, 47th Judicial District",,REP,Steven Denny,27,4,23
+Armstrong,202,"District Attorney, 47th Judicial District",,REP,Steven Denny,12,10,2
+Armstrong,301,"District Attorney, 47th Judicial District",,REP,Steven Denny,29,4,25
+Armstrong,303,"District Attorney, 47th Judicial District",,REP,Steven Denny,11,1,10
+Armstrong,401,"District Attorney, 47th Judicial District",,REP,Steven Denny,27,15,12
+Armstrong,402,"District Attorney, 47th Judicial District",,REP,Steven Denny,12,2,10
+Armstrong,404,"District Attorney, 47th Judicial District",,REP,Steven Denny,7,3,4
+Armstrong,Mail,"District Attorney, 47th Judicial District",,REP,Steven Denny,8,0,0
+Armstrong,101,"District Attorney, 47th Judicial District",,REP,Randall C. Sims,124,49,75
+Armstrong,201,"District Attorney, 47th Judicial District",,REP,Randall C. Sims,73,30,43
+Armstrong,202,"District Attorney, 47th Judicial District",,REP,Randall C. Sims,24,7,17
+Armstrong,301,"District Attorney, 47th Judicial District",,REP,Randall C. Sims,143,61,82
+Armstrong,303,"District Attorney, 47th Judicial District",,REP,Randall C. Sims,19,0,19
+Armstrong,401,"District Attorney, 47th Judicial District",,REP,Randall C. Sims,67,27,40
+Armstrong,402,"District Attorney, 47th Judicial District",,REP,Randall C. Sims,63,9,54
+Armstrong,404,"District Attorney, 47th Judicial District",,REP,Randall C. Sims,11,4,7
+Armstrong,Mail,"District Attorney, 47th Judicial District",,REP,Randall C. Sims,13,0,0
+Armstrong,101,Sheriff,,REP,Nathan McKee,102,41,61
+Armstrong,201,Sheriff,,REP,Nathan McKee,47,15,32
+Armstrong,202,Sheriff,,REP,Nathan McKee,18,8,10
+Armstrong,301,Sheriff,,REP,Nathan McKee,116,46,70
+Armstrong,303,Sheriff,,REP,Nathan McKee,7,1,6
+Armstrong,401,Sheriff,,REP,Nathan McKee,42,19,23
+Armstrong,402,Sheriff,,REP,Nathan McKee,35,4,31
+Armstrong,404,Sheriff,,REP,Nathan McKee,9,4,5
+Armstrong,Mail,Sheriff,,REP,Nathan McKee,7,0,0
+Armstrong,101,Sheriff,,REP,Fleta Barnett,83,35,48
+Armstrong,201,Sheriff,,REP,Fleta Barnett,62,21,41
+Armstrong,202,Sheriff,,REP,Fleta Barnett,20,10,10
+Armstrong,301,Sheriff,,REP,Fleta Barnett,66,21,45
+Armstrong,303,Sheriff,,REP,Fleta Barnett,26,0,26
+Armstrong,401,Sheriff,,REP,Fleta Barnett,60,26,34
+Armstrong,402,Sheriff,,REP,Fleta Barnett,46,6,40
+Armstrong,404,Sheriff,,REP,Fleta Barnett,10,3,7
+Armstrong,Mail,Sheriff,,REP,Fleta Barnett,13,0,0
+Armstrong,101,County Tax Assessor-Collector,,REP,Crystal Hernandez,150,59,91
+Armstrong,201,County Tax Assessor-Collector,,REP,Crystal Hernandez,81,32,49
+Armstrong,202,County Tax Assessor-Collector,,REP,Crystal Hernandez,24,12,12
+Armstrong,301,County Tax Assessor-Collector,,REP,Crystal Hernandez,146,50,96
+Armstrong,303,County Tax Assessor-Collector,,REP,Crystal Hernandez,26,0,26
+Armstrong,401,County Tax Assessor-Collector,,REP,Crystal Hernandez,74,30,44
+Armstrong,402,County Tax Assessor-Collector,,REP,Crystal Hernandez,64,8,56
+Armstrong,404,County Tax Assessor-Collector,,REP,Crystal Hernandez,14,7,7
+Armstrong,Mail,County Tax Assessor-Collector,,REP,Crystal Hernandez,16,0,0
+Armstrong,101,"County Commissioner, Precinct No. 1",,REP,Adam Ensey,112,49,63
+Armstrong,201,"County Commissioner, Precinct No. 1",,REP,Adam Ensey,0,0,0
+Armstrong,202,"County Commissioner, Precinct No. 1",,REP,Adam Ensey,0,0,0
+Armstrong,301,"County Commissioner, Precinct No. 1",,REP,Adam Ensey,0,0,0
+Armstrong,303,"County Commissioner, Precinct No. 1",,REP,Adam Ensey,0,0,0
+Armstrong,401,"County Commissioner, Precinct No. 1",,REP,Adam Ensey,0,0,0
+Armstrong,402,"County Commissioner, Precinct No. 1",,REP,Adam Ensey,0,0,0
+Armstrong,404,"County Commissioner, Precinct No. 1",,REP,Adam Ensey,0,0,0
+Armstrong,Mail,"County Commissioner, Precinct No. 1",,REP,Adam Ensey,0,0,0
+Armstrong,101,"County Commissioner, Precinct No. 1",,REP,David Fields,68,27,41
+Armstrong,201,"County Commissioner, Precinct No. 1",,REP,David Fields,0,0,0
+Armstrong,202,"County Commissioner, Precinct No. 1",,REP,David Fields,0,0,0
+Armstrong,301,"County Commissioner, Precinct No. 1",,REP,David Fields,0,0,0
+Armstrong,303,"County Commissioner, Precinct No. 1",,REP,David Fields,0,0,0
+Armstrong,401,"County Commissioner, Precinct No. 1",,REP,David Fields,0,0,0
+Armstrong,402,"County Commissioner, Precinct No. 1",,REP,David Fields,0,0,0
+Armstrong,404,"County Commissioner, Precinct No. 1",,REP,David Fields,0,0,0
+Armstrong,Mail,"County Commissioner, Precinct No. 1",,REP,David Fields,0,0,0
+Armstrong,101,"County Commissioner, Precinct No. 3",,REP,Robert Harris,0,0,0
+Armstrong,201,"County Commissioner, Precinct No. 3",,REP,Robert Harris,0,0,0
+Armstrong,202,"County Commissioner, Precinct No. 3",,REP,Robert Harris,0,0,0
+Armstrong,301,"County Commissioner, Precinct No. 3",,REP,Robert Harris,92,33,59
+Armstrong,303,"County Commissioner, Precinct No. 3",,REP,Robert Harris,4,0,4
+Armstrong,401,"County Commissioner, Precinct No. 3",,REP,Robert Harris,0,0,0
+Armstrong,402,"County Commissioner, Precinct No. 3",,REP,Robert Harris,0,0,0
+Armstrong,404,"County Commissioner, Precinct No. 3",,REP,Robert Harris,0,0,0
+Armstrong,Mail,"County Commissioner, Precinct No. 3",,REP,Robert Harris,0,0,0
+Armstrong,101,"County Commissioner, Precinct No. 3",,REP,Tom Ferris,0,0,0
+Armstrong,201,"County Commissioner, Precinct No. 3",,REP,Tom Ferris,0,0,0
+Armstrong,202,"County Commissioner, Precinct No. 3",,REP,Tom Ferris,0,0,0
+Armstrong,301,"County Commissioner, Precinct No. 3",,REP,Tom Ferris,42,20,22
+Armstrong,303,"County Commissioner, Precinct No. 3",,REP,Tom Ferris,8,1,7
+Armstrong,401,"County Commissioner, Precinct No. 3",,REP,Tom Ferris,0,0,0
+Armstrong,402,"County Commissioner, Precinct No. 3",,REP,Tom Ferris,0,0,0
+Armstrong,404,"County Commissioner, Precinct No. 3",,REP,Tom Ferris,0,0,0
+Armstrong,Mail,"County Commissioner, Precinct No. 3",,REP,Tom Ferris,0,0,0
+Armstrong,101,"County Commissioner, Precinct No. 3",,REP,Jered Meeks,0,0,0
+Armstrong,201,"County Commissioner, Precinct No. 3",,REP,Jered Meeks,0,0,0
+Armstrong,202,"County Commissioner, Precinct No. 3",,REP,Jered Meeks,0,0,0
+Armstrong,301,"County Commissioner, Precinct No. 3",,REP,Jered Meeks,31,8,23
+Armstrong,303,"County Commissioner, Precinct No. 3",,REP,Jered Meeks,22,0,22
+Armstrong,401,"County Commissioner, Precinct No. 3",,REP,Jered Meeks,0,0,0
+Armstrong,402,"County Commissioner, Precinct No. 3",,REP,Jered Meeks,0,0,0
+Armstrong,404,"County Commissioner, Precinct No. 3",,REP,Jered Meeks,0,0,0
+Armstrong,Mail,"County Commissioner, Precinct No. 3",,REP,Jered Meeks,0,0,0
+Armstrong,101,Proposition 1,,REP,Yes,122,50,72
+Armstrong,201,Proposition 1,,REP,Yes,67,22,45
+Armstrong,202,Proposition 1,,REP,Yes,18,8,10
+Armstrong,301,Proposition 1,,REP,Yes,119,47,72
+Armstrong,303,Proposition 1,,REP,Yes,24,0,24
+Armstrong,401,Proposition 1,,REP,Yes,69,27,42
+Armstrong,402,Proposition 1,,REP,Yes,46,6,40
+Armstrong,404,Proposition 1,,REP,Yes,13,5,8
+Armstrong,Mail,Proposition 1,,REP,Yes,15,0,0
+Armstrong,101,Proposition 1,,REP,No,47,19,28
+Armstrong,201,Proposition 1,,REP,No,21,11,10
+Armstrong,202,Proposition 1,,REP,No,14,8,6
+Armstrong,301,Proposition 1,,REP,No,44,13,31
+Armstrong,303,Proposition 1,,REP,No,8,1,7
+Armstrong,401,Proposition 1,,REP,No,22,12,10
+Armstrong,402,Proposition 1,,REP,No,25,3,22
+Armstrong,404,Proposition 1,,REP,No,4,1,3
+Armstrong,Mail,Proposition 1,,REP,No,3,0,0
+Armstrong,101,Proposition 2,,REP,Yes,99,42,57
+Armstrong,201,Proposition 2,,REP,Yes,47,18,29
+Armstrong,202,Proposition 2,,REP,Yes,17,10,7
+Armstrong,301,Proposition 2,,REP,Yes,100,36,64
+Armstrong,303,Proposition 2,,REP,Yes,13,1,12
+Armstrong,401,Proposition 2,,REP,Yes,50,24,26
+Armstrong,402,Proposition 2,,REP,Yes,38,4,34
+Armstrong,404,Proposition 2,,REP,Yes,13,3,10
+Armstrong,Mail,Proposition 2,,REP,Yes,13,0,0
+Armstrong,101,Proposition 2,,REP,No,76,29,47
+Armstrong,201,Proposition 2,,REP,No,45,14,31
+Armstrong,202,Proposition 2,,REP,No,18,7,11
+Armstrong,301,Proposition 2,,REP,No,63,22,41
+Armstrong,303,Proposition 2,,REP,No,20,0,20
+Armstrong,401,Proposition 2,,REP,No,48,20,28
+Armstrong,402,Proposition 2,,REP,No,36,4,32
+Armstrong,404,Proposition 2,,REP,No,5,4,1
+Armstrong,Mail,Proposition 2,,REP,No,7,0,0
+Armstrong,101,Proposition 3,,REP,Yes,125,53,72
+Armstrong,201,Proposition 3,,REP,Yes,64,22,42
+Armstrong,202,Proposition 3,,REP,Yes,28,15,13
+Armstrong,301,Proposition 3,,REP,Yes,119,43,76
+Armstrong,303,Proposition 3,,REP,Yes,24,1,23
+Armstrong,401,Proposition 3,,REP,Yes,71,33,38
+Armstrong,402,Proposition 3,,REP,Yes,59,7,52
+Armstrong,404,Proposition 3,,REP,Yes,15,5,10
+Armstrong,Mail,Proposition 3,,REP,Yes,16,0,0
+Armstrong,101,Proposition 3,,REP,No,45,15,30
+Armstrong,201,Proposition 3,,REP,No,22,9,13
+Armstrong,202,Proposition 3,,REP,No,4,1,3
+Armstrong,301,Proposition 3,,REP,No,39,15,24
+Armstrong,303,Proposition 3,,REP,No,8,0,8
+Armstrong,401,Proposition 3,,REP,No,24,9,15
+Armstrong,402,Proposition 3,,REP,No,14,2,12
+Armstrong,404,Proposition 3,,REP,No,3,2,1
+Armstrong,Mail,Proposition 3,,REP,No,1,0,0
+Armstrong,101,Proposition 4,,REP,Yes,163,64,99
+Armstrong,201,Proposition 4,,REP,Yes,82,29,53
+Armstrong,202,Proposition 4,,REP,Yes,29,15,14
+Armstrong,301,Proposition 4,,REP,Yes,158,62,96
+Armstrong,303,Proposition 4,,REP,Yes,29,0,29
+Armstrong,401,Proposition 4,,REP,Yes,87,39,48
+Armstrong,402,Proposition 4,,REP,Yes,69,9,60
+Armstrong,404,Proposition 4,,REP,Yes,17,6,11
+Armstrong,Mail,Proposition 4,,REP,Yes,18,0,0
+Armstrong,101,Proposition 4,,REP,No,7,5,2
+Armstrong,201,Proposition 4,,REP,No,6,4,2
+Armstrong,202,Proposition 4,,REP,No,3,1,2
+Armstrong,301,Proposition 4,,REP,No,64,58,6
+Armstrong,303,Proposition 4,,REP,No,3,0,3
+Armstrong,401,Proposition 4,,REP,No,6,2,4
+Armstrong,402,Proposition 4,,REP,No,4,0,4
+Armstrong,404,Proposition 4,,REP,No,1,1,0
+Armstrong,Mail,Proposition 4,,REP,No,0,0,0


### PR DESCRIPTION
The Democratic primary results are a mess: two precincts are missing from the data, and none of the totals match the SoS's data. It would appear that only early vote results were reported to the SoS. The 3 poor Election Day Democratic voters apparently, therefore, were not counted.
The source file did not differentiate mail/absentee ballots by precinct; I created a separate entry per race with precinct "Mail".