### PR TITLE
Add precinct-level results for the 2016 primaries in Hill County

### DIFF
--- a/2016/20160301__tx__primary__hill__precinct.csv
+++ b/2016/20160301__tx__primary__hill__precinct.csv
@@ -1,0 +1,3980 @@
+county,precinct,office,district,party,candidate,votes,absentee,early_voting_paper,early_voting_dre,election_day_paper,election_day_dre
+Hill,0002,Registered Voters - Total,,,,1104,,,,,
+Hill,0002,Ballots Cast - Total,,REP,,497,21,101,116,168,91
+Hill,0002,Ballots Cast - Total,,DEM,,52,2,10,7,20,13
+Hill,0002,President,,REP,Ted Cruz,216,10,46,43,77,40
+Hill,0002,President,,REP,Jeb Bush,15,2,4,3,5,1
+Hill,0002,President,,REP,Donald J. Trump,154,4,28,39,55,28
+Hill,0002,President,,REP,Ben Carson,16,1,2,3,4,6
+Hill,0002,President,,REP,Rand Paul,0,0,0,0,0,0
+Hill,0002,President,,REP,Rick Santorum,1,0,0,1,0,0
+Hill,0002,President,,REP,Elizabeth Gray,4,0,0,1,1,2
+Hill,0002,President,,REP,Carly Fiorina,0,0,0,0,0,0
+Hill,0002,President,,REP,Lindsey Graham,1,0,0,0,0,1
+Hill,0002,President,,REP,Marco Rubio,49,2,9,15,13,10
+Hill,0002,President,,REP,John R. Kasich,18,1,6,4,7,0
+Hill,0002,President,,REP,Mike Huckabee,2,0,1,0,1,0
+Hill,0002,President,,REP,Chris Christie,3,0,0,1,0,2
+Hill,0002,President,,REP,Uncommitted,13,1,4,4,4,0
+Hill,0002,President,,REP,Over Votes,0,0,0,0,0,0
+Hill,0002,President,,REP,Under Votes,5,0,1,2,1,1
+Hill,0002,U.S. House,25,REP,Roger Williams,360,16,77,80,125,62
+Hill,0002,U.S. House,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0002,U.S. House,25,REP,Under Votes,137,5,24,36,43,29
+Hill,0002,Railroad Commissioner,25,REP,Gary Gates,131,7,34,28,45,17
+Hill,0002,Railroad Commissioner,25,REP,Lance N. Christian,42,0,7,11,15,9
+Hill,0002,Railroad Commissioner,25,REP,Weston Martinez,29,0,4,5,8,12
+Hill,0002,Railroad Commissioner,25,REP,Wayne Christian,82,6,17,18,28,13
+Hill,0002,Railroad Commissioner,25,REP,Ron Hale,40,1,6,11,12,10
+Hill,0002,Railroad Commissioner,25,REP,Doug Jeffrey,34,0,6,8,13,7
+Hill,0002,Railroad Commissioner,25,REP,John Greytok,14,1,2,6,5,0
+Hill,0002,Railroad Commissioner,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0002,Railroad Commissioner,25,REP,Under Votes,125,6,25,29,42,23
+Hill,0002,"Justice, Supreme Court, Place 3",25,REP,Michael Massengale,195,7,38,44,67,39
+Hill,0002,"Justice, Supreme Court, Place 3",25,REP,Debra Lehrmann,189,11,40,45,60,33
+Hill,0002,"Justice, Supreme Court, Place 3",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0002,"Justice, Supreme Court, Place 3",25,REP,Under Votes,113,3,23,27,41,19
+Hill,0002,"Justice, Supreme Court, Place 5",25,REP,Paul Green,211,5,49,48,71,38
+Hill,0002,"Justice, Supreme Court, Place 5",25,REP,Rick Green,160,10,26,42,50,32
+Hill,0002,"Justice, Supreme Court, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0002,"Justice, Supreme Court, Place 5",25,REP,Under Votes,126,6,26,26,47,21
+Hill,0002,"Justice, Supreme Court, Place 9",25,REP,Joe Pool,189,4,37,47,65,36
+Hill,0002,"Justice, Supreme Court, Place 9",25,REP,Eva Guzman,199,13,42,41,65,38
+Hill,0002,"Justice, Supreme Court, Place 9",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0002,"Justice, Supreme Court, Place 9",25,REP,Under Votes,109,4,22,28,38,17
+Hill,0002,"Judge, Court of Criminal Appeals, Place 2",25,REP,Chris Oldner,112,1,24,32,36,19
+Hill,0002,"Judge, Court of Criminal Appeals, Place 2",25,REP,Ray Wheless,103,3,21,17,40,22
+Hill,0002,"Judge, Court of Criminal Appeals, Place 2",25,REP,Mary Lou Keel,150,12,30,36,44,28
+Hill,0002,"Judge, Court of Criminal Appeals, Place 2",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0002,"Judge, Court of Criminal Appeals, Place 2",25,REP,Under Votes,132,5,26,31,48,22
+Hill,0002,"Judge, Court of Criminal Appeals, Place 5",25,REP,Sid Harle,76,6,16,15,26,13
+Hill,0002,"Judge, Court of Criminal Appeals, Place 5",25,REP,Brent Webster,63,3,14,10,26,10
+Hill,0002,"Judge, Court of Criminal Appeals, Place 5",25,REP,Scott Walker,120,1,22,31,38,28
+Hill,0002,"Judge, Court of Criminal Appeals, Place 5",25,REP,Steve Smith,117,6,23,32,34,22
+Hill,0002,"Judge, Court of Criminal Appeals, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0002,"Judge, Court of Criminal Appeals, Place 5",25,REP,Under Votes,121,5,26,28,44,18
+Hill,0002,"Judge, Court of Criminal Appeals, Place 6",25,REP,Richard Davis,190,3,36,41,61,49
+Hill,0002,"Judge, Court of Criminal Appeals, Place 6",25,REP,Michael E. Keasler,163,11,34,43,57,18
+Hill,0002,"Judge, Court of Criminal Appeals, Place 6",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0002,"Judge, Court of Criminal Appeals, Place 6",25,REP,Under Votes,144,7,31,32,50,24
+Hill,0002,"Member, State Board of Education, District 14",25,REP,Sue Melton-Malone,354,18,71,84,113,68
+Hill,0002,"Member, State Board of Education, District 14",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0002,"Member, State Board of Education, District 14",25,REP,Under Votes,143,3,30,32,55,23
+Hill,0002,State Senator,22,REP,Brian Birdwell,385,19,79,87,126,74
+Hill,0002,State Senator,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0002,State Senator,22,REP,Under Votes,112,2,22,29,42,17
+Hill,0002,State Representative,8,REP,Thomas McNutt,207,11,41,43,78,34
+Hill,0002,State Representative,8,REP,Byron Cook,262,10,53,69,80,50
+Hill,0002,State Representative,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0002,State Representative,8,REP,Under Votes,28,0,7,4,10,7
+Hill,0002,"Justice, 10th Court of Appeals District, Place 3",8,REP,Al Scoggins,323,14,67,77,100,65
+Hill,0002,"Justice, 10th Court of Appeals District, Place 3",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0002,"Justice, 10th Court of Appeals District, Place 3",8,REP,Under Votes,174,7,34,39,68,26
+Hill,0002,"District Attorney, 66th Judicial District",8,REP,Mark F Pratt,411,16,88,96,137,74
+Hill,0002,"District Attorney, 66th Judicial District",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0002,"District Attorney, 66th Judicial District",8,REP,Under Votes,86,5,13,20,31,17
+Hill,0002,County Attorney,8,REP,R David Holmes,378,16,76,91,120,75
+Hill,0002,County Attorney,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0002,County Attorney,8,REP,Under Votes,119,5,25,25,48,16
+Hill,0002,Sheriff,8,REP,Jimmy Johnson,98,5,23,31,27,12
+Hill,0002,Sheriff,8,REP,Dedri Hafer,16,0,1,5,2,8
+Hill,0002,Sheriff,8,REP,Rodney Watson,282,12,62,50,108,50
+Hill,0002,Sheriff,8,REP,Kyle R Cox,33,0,3,14,7,9
+Hill,0002,Sheriff,8,REP,Ronnie Myers,54,4,11,12,19,8
+Hill,0002,Sheriff,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0002,Sheriff,8,REP,Under Votes,14,0,1,4,5,4
+Hill,0002,Tax Assessor-Collector,8,REP,Ray Mabry,215,4,40,54,70,47
+Hill,0002,Tax Assessor-Collector,8,REP,Krissi Hightower,222,15,52,45,77,33
+Hill,0002,Tax Assessor-Collector,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0002,Tax Assessor-Collector,8,REP,Under Votes,60,2,9,17,21,11
+Hill,0002,"Constable, Precinct No. 2",8,REP,Justin Girsh,288,14,62,64,105,43
+Hill,0002,"Constable, Precinct No. 2",8,REP,Curtis R Jones,118,3,21,30,34,30
+Hill,0002,"Constable, Precinct No. 2",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0002,"Constable, Precinct No. 2",8,REP,Under Votes,91,4,18,22,29,18
+Hill,0002,County Chairman,8,REP,Will Orr,378,17,78,83,126,74
+Hill,0002,County Chairman,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0002,County Chairman,8,REP,Under Votes,119,4,23,33,42,17
+Hill,0002,President,8,DEM,Bernie Sanders,16,0,4,1,6,5
+Hill,0002,President,8,DEM,Star Locke,0,0,0,0,0,0
+Hill,0002,President,8,DEM,"Roque ""Rocky"" De La Fuente",0,0,0,0,0,0
+Hill,0002,President,8,DEM,Willie L. Wilson,0,0,0,0,0,0
+Hill,0002,President,8,DEM,Calvis L. Hawes,0,0,0,0,0,0
+Hill,0002,President,8,DEM,Hillary Clinton,36,2,6,6,14,8
+Hill,0002,President,8,DEM,Keith Judd,0,0,0,0,0,0
+Hill,0002,President,8,DEM,Martin J. O'Malley,0,0,0,0,0,0
+Hill,0002,President,8,DEM,Over Votes,0,0,0,0,0,0
+Hill,0002,President,8,DEM,Under Votes,0,0,0,0,0,0
+Hill,0002,U.S. House,25,DEM,Kathi Thomas,41,2,9,5,15,10
+Hill,0002,U.S. House,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0002,U.S. House,25,DEM,Under Votes,11,0,1,2,5,3
+Hill,0002,Railroad Commissioner,25,DEM,Cody Garrett,11,0,1,2,2,6
+Hill,0002,Railroad Commissioner,25,DEM,Lon Burnam,19,2,5,1,8,3
+Hill,0002,Railroad Commissioner,25,DEM,Grady Yarbrough,13,0,2,3,5,3
+Hill,0002,Railroad Commissioner,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0002,Railroad Commissioner,25,DEM,Under Votes,9,0,2,1,5,1
+Hill,0002,"Justice, Supreme Court, Place 3",25,DEM,Mike Westergren,37,2,7,5,14,9
+Hill,0002,"Justice, Supreme Court, Place 3",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0002,"Justice, Supreme Court, Place 3",25,DEM,Under Votes,15,0,3,2,6,4
+Hill,0002,"Justice, Supreme Court, Place 5",25,DEM,Dori Contreras Garza,38,2,7,5,14,10
+Hill,0002,"Justice, Supreme Court, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0002,"Justice, Supreme Court, Place 5",25,DEM,Under Votes,14,0,3,2,6,3
+Hill,0002,"Justice, Supreme Court, Place 9",25,DEM,Savannah Robinson,37,2,7,5,14,9
+Hill,0002,"Justice, Supreme Court, Place 9",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0002,"Justice, Supreme Court, Place 9",25,DEM,Under Votes,15,0,3,2,6,4
+Hill,0002,"Judge, Court of Criminal Appeals, Place 2",25,DEM,"Lawrence ""Larry"" Meyers",36,2,6,5,14,9
+Hill,0002,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0002,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Under Votes,16,0,4,2,6,4
+Hill,0002,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Betsy Johnson,38,2,7,5,14,10
+Hill,0002,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0002,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Under Votes,14,0,3,2,6,3
+Hill,0002,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Robert Burns,38,2,7,5,14,10
+Hill,0002,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0002,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Under Votes,14,0,3,2,6,3
+Hill,0002,State Senator,22,DEM,Michael Collins,32,2,4,5,11,10
+Hill,0002,State Senator,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0002,State Senator,22,DEM,Under Votes,20,0,6,2,9,3
+Hill,0002,County Chairman,22,DEM,Thomas Hanson,37,2,7,6,14,8
+Hill,0002,County Chairman,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0002,County Chairman,22,DEM,Under Votes,15,0,3,1,6,5
+Hill,0002,Precinct Chairman 2,22,DEM,Bruce Vieregge,41,2,8,5,16,10
+Hill,0002,Precinct Chairman 2,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0002,Precinct Chairman 2,22,DEM,Under Votes,11,0,2,2,4,3
+Hill,0002,Proposition 1,22,REP,Yes,317,14,61,85,104,53
+Hill,0002,Proposition 1,22,REP,No,115,4,22,21,37,31
+Hill,0002,Proposition 1,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0002,Proposition 1,22,REP,Under Votes,65,3,18,10,27,7
+Hill,0002,Proposition 2,22,REP,Yes,274,7,51,74,86,56
+Hill,0002,Proposition 2,22,REP,No,183,12,40,35,64,32
+Hill,0002,Proposition 2,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0002,Proposition 2,22,REP,Under Votes,40,2,10,7,18,3
+Hill,0002,Proposition 3,22,REP,Yes,348,16,76,72,123,61
+Hill,0002,Proposition 3,22,REP,No,106,4,14,34,28,26
+Hill,0002,Proposition 3,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0002,Proposition 3,22,REP,Under Votes,43,1,11,10,17,4
+Hill,0002,Proposition 4,22,REP,Yes,415,17,82,99,135,82
+Hill,0002,Proposition 4,22,REP,No,39,2,8,9,14,6
+Hill,0002,Proposition 4,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0002,Proposition 4,22,REP,Under Votes,43,2,11,8,19,3
+Hill,0002,Referenda Item #1,22,DEM,For,47,2,8,7,17,13
+Hill,0002,Referenda Item #1,22,DEM,Against,2,0,1,0,1,0
+Hill,0002,Referenda Item #1,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0002,Referenda Item #1,22,DEM,Under Votes,3,0,1,0,2,0
+Hill,0002,Referenda Item #2,22,DEM,For,44,2,7,7,15,13
+Hill,0002,Referenda Item #2,22,DEM,Against,3,0,1,0,2,0
+Hill,0002,Referenda Item #2,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0002,Referenda Item #2,22,DEM,Under Votes,5,0,2,0,3,0
+Hill,0002,Referenda Item #3,22,DEM,For,42,2,6,7,14,13
+Hill,0002,Referenda Item #3,22,DEM,Against,5,0,2,0,3,0
+Hill,0002,Referenda Item #3,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0002,Referenda Item #3,22,DEM,Under Votes,5,0,2,0,3,0
+Hill,0002,Referenda Item #4,22,DEM,For,42,2,8,5,16,11
+Hill,0002,Referenda Item #4,22,DEM,Against,3,0,0,1,1,1
+Hill,0002,Referenda Item #4,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0002,Referenda Item #4,22,DEM,Under Votes,7,0,2,1,3,1
+Hill,0002,Referenda Item #5,22,DEM,For,37,2,6,6,12,11
+Hill,0002,Referenda Item #5,22,DEM,Against,8,0,2,0,4,2
+Hill,0002,Referenda Item #5,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0002,Referenda Item #5,22,DEM,Under Votes,7,0,2,1,4,0
+Hill,0002,Referenda Item #6,22,DEM,For,40,2,6,6,14,12
+Hill,0002,Referenda Item #6,22,DEM,Against,6,0,2,0,3,1
+Hill,0002,Referenda Item #6,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0002,Referenda Item #6,22,DEM,Under Votes,6,0,2,1,3,0
+Hill,0003,Registered Voters - Total,,,,1626,0,2,1,3,0
+Hill,0003,Ballots Cast - Total,,REP,,349,19,71,80,104,75
+Hill,0003,Ballots Cast - Total,,DEM,,89,7,15,13,30,24
+Hill,0003,President,,REP,Ted Cruz,125,8,21,27,37,32
+Hill,0003,President,,REP,Jeb Bush,21,2,7,4,7,1
+Hill,0003,President,,REP,Donald J. Trump,105,5,24,26,30,20
+Hill,0003,President,,REP,Ben Carson,17,0,1,5,3,8
+Hill,0003,President,,REP,Rand Paul,0,0,0,0,0,0
+Hill,0003,President,,REP,Rick Santorum,0,0,0,0,0,0
+Hill,0003,President,,REP,Elizabeth Gray,1,0,0,0,1,0
+Hill,0003,President,,REP,Carly Fiorina,2,0,1,0,1,0
+Hill,0003,President,,REP,Lindsey Graham,2,0,1,0,1,0
+Hill,0003,President,,REP,Marco Rubio,40,4,8,12,10,6
+Hill,0003,President,,REP,John R. Kasich,3,0,1,1,1,0
+Hill,0003,President,,REP,Mike Huckabee,1,0,0,0,0,1
+Hill,0003,President,,REP,Chris Christie,2,0,0,2,0,0
+Hill,0003,President,,REP,Uncommitted,17,0,4,2,8,3
+Hill,0003,President,,REP,Over Votes,0,0,0,0,0,0
+Hill,0003,President,,REP,Under Votes,13,0,3,1,5,4
+Hill,0003,U.S. House,25,REP,Roger Williams,221,9,39,64,61,48
+Hill,0003,U.S. House,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0003,U.S. House,25,REP,Under Votes,128,10,32,16,43,27
+Hill,0003,Railroad Commissioner,25,REP,Gary Gates,95,5,20,24,27,19
+Hill,0003,Railroad Commissioner,25,REP,Lance N. Christian,24,1,3,8,6,6
+Hill,0003,Railroad Commissioner,25,REP,Weston Martinez,27,2,3,9,8,5
+Hill,0003,Railroad Commissioner,25,REP,Wayne Christian,44,3,10,8,11,12
+Hill,0003,Railroad Commissioner,25,REP,Ron Hale,34,2,7,8,9,8
+Hill,0003,Railroad Commissioner,25,REP,Doug Jeffrey,16,0,4,3,7,2
+Hill,0003,Railroad Commissioner,25,REP,John Greytok,6,0,0,3,1,2
+Hill,0003,Railroad Commissioner,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0003,Railroad Commissioner,25,REP,Under Votes,103,6,24,17,35,21
+Hill,0003,"Justice, Supreme Court, Place 3",25,REP,Michael Massengale,113,5,21,32,32,23
+Hill,0003,"Justice, Supreme Court, Place 3",25,REP,Debra Lehrmann,142,6,27,37,38,34
+Hill,0003,"Justice, Supreme Court, Place 3",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0003,"Justice, Supreme Court, Place 3",25,REP,Under Votes,94,8,23,11,34,18
+Hill,0003,"Justice, Supreme Court, Place 5",25,REP,Paul Green,129,3,22,40,36,28
+Hill,0003,"Justice, Supreme Court, Place 5",25,REP,Rick Green,108,6,22,26,30,24
+Hill,0003,"Justice, Supreme Court, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0003,"Justice, Supreme Court, Place 5",25,REP,Under Votes,112,10,27,14,38,23
+Hill,0003,"Justice, Supreme Court, Place 9",25,REP,Joe Pool,107,5,20,25,29,28
+Hill,0003,"Justice, Supreme Court, Place 9",25,REP,Eva Guzman,151,7,29,42,43,30
+Hill,0003,"Justice, Supreme Court, Place 9",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0003,"Justice, Supreme Court, Place 9",25,REP,Under Votes,91,7,22,13,32,17
+Hill,0003,"Judge, Court of Criminal Appeals, Place 2",25,REP,Chris Oldner,71,4,10,22,16,19
+Hill,0003,"Judge, Court of Criminal Appeals, Place 2",25,REP,Ray Wheless,71,2,15,12,23,19
+Hill,0003,"Judge, Court of Criminal Appeals, Place 2",25,REP,Mary Lou Keel,91,4,16,30,24,17
+Hill,0003,"Judge, Court of Criminal Appeals, Place 2",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0003,"Judge, Court of Criminal Appeals, Place 2",25,REP,Under Votes,116,9,30,16,41,20
+Hill,0003,"Judge, Court of Criminal Appeals, Place 5",25,REP,Sid Harle,40,3,6,14,10,7
+Hill,0003,"Judge, Court of Criminal Appeals, Place 5",25,REP,Brent Webster,39,1,9,7,15,7
+Hill,0003,"Judge, Court of Criminal Appeals, Place 5",25,REP,Scott Walker,90,3,16,24,22,25
+Hill,0003,"Judge, Court of Criminal Appeals, Place 5",25,REP,Steve Smith,79,4,17,16,27,15
+Hill,0003,"Judge, Court of Criminal Appeals, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0003,"Judge, Court of Criminal Appeals, Place 5",25,REP,Under Votes,101,8,23,19,30,21
+Hill,0003,"Judge, Court of Criminal Appeals, Place 6",25,REP,Richard Davis,130,3,23,37,34,33
+Hill,0003,"Judge, Court of Criminal Appeals, Place 6",25,REP,Michael E. Keasler,101,7,20,25,30,19
+Hill,0003,"Judge, Court of Criminal Appeals, Place 6",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0003,"Judge, Court of Criminal Appeals, Place 6",25,REP,Under Votes,118,9,28,18,40,23
+Hill,0003,"Member, State Board of Education, District 14",25,REP,Sue Melton-Malone,217,9,38,64,57,49
+Hill,0003,"Member, State Board of Education, District 14",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0003,"Member, State Board of Education, District 14",25,REP,Under Votes,132,10,33,16,47,26
+Hill,0003,State Senator,22,REP,Brian Birdwell,240,11,41,70,65,53
+Hill,0003,State Senator,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0003,State Senator,22,REP,Under Votes,109,8,30,10,39,22
+Hill,0003,State Representative,8,REP,Thomas McNutt,164,9,35,38,45,37
+Hill,0003,State Representative,8,REP,Byron Cook,130,5,20,40,37,28
+Hill,0003,State Representative,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0003,State Representative,8,REP,Under Votes,55,5,16,2,22,10
+Hill,0003,"Justice, 10th Court of Appeals District, Place 3",8,REP,Al Scoggins,205,7,35,61,51,51
+Hill,0003,"Justice, 10th Court of Appeals District, Place 3",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0003,"Justice, 10th Court of Appeals District, Place 3",8,REP,Under Votes,144,12,36,19,53,24
+Hill,0003,"District Attorney, 66th Judicial District",8,REP,Mark F Pratt,239,9,43,68,67,52
+Hill,0003,"District Attorney, 66th Judicial District",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0003,"District Attorney, 66th Judicial District",8,REP,Under Votes,110,10,28,12,37,23
+Hill,0003,County Attorney,8,REP,R David Holmes,209,3,31,66,55,54
+Hill,0003,County Attorney,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0003,County Attorney,8,REP,Under Votes,140,16,40,14,49,21
+Hill,0003,Sheriff,8,REP,Jimmy Johnson,73,2,14,27,16,14
+Hill,0003,Sheriff,8,REP,Dedri Hafer,22,1,4,6,5,6
+Hill,0003,Sheriff,8,REP,Rodney Watson,137,3,28,25,49,32
+Hill,0003,Sheriff,8,REP,Kyle R Cox,43,2,4,11,11,15
+Hill,0003,Sheriff,8,REP,Ronnie Myers,35,3,9,7,11,5
+Hill,0003,Sheriff,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0003,Sheriff,8,REP,Under Votes,39,8,12,4,12,3
+Hill,0003,Tax Assessor-Collector,8,REP,Ray Mabry,112,6,24,32,33,17
+Hill,0003,Tax Assessor-Collector,8,REP,Krissi Hightower,164,3,30,41,47,43
+Hill,0003,Tax Assessor-Collector,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0003,Tax Assessor-Collector,8,REP,Under Votes,73,10,17,7,24,15
+Hill,0003,County Commissioner # 3,8,REP,Scotty Hawkins,135,6,27,30,41,31
+Hill,0003,County Commissioner # 3,8,REP,Milton Stuckly,39,1,7,10,10,11
+Hill,0003,County Commissioner # 3,8,REP,"Ernest D McFarland, Jr",28,1,5,12,6,4
+Hill,0003,County Commissioner # 3,8,REP,David Bow,69,2,14,16,24,13
+Hill,0003,County Commissioner # 3,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0003,County Commissioner # 3,8,REP,Under Votes,78,9,18,12,23,16
+Hill,0003,"Constable, Precinct No. 3",8,REP,Larry Armstrong,129,4,26,35,37,27
+Hill,0003,"Constable, Precinct No. 3",8,REP,Brian Couch,53,5,8,16,10,14
+Hill,0003,"Constable, Precinct No. 3",8,REP,Stephen Nanny,104,2,22,21,35,24
+Hill,0003,"Constable, Precinct No. 3",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0003,"Constable, Precinct No. 3",8,REP,Under Votes,63,8,15,8,22,10
+Hill,0003,County Chairman,8,REP,Will Orr,234,7,37,71,60,59
+Hill,0003,County Chairman,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0003,County Chairman,8,REP,Under Votes,115,12,34,9,44,16
+Hill,0003,President,8,DEM,Bernie Sanders,21,1,3,3,5,9
+Hill,0003,President,8,DEM,Star Locke,0,0,0,0,0,0
+Hill,0003,President,8,DEM,"Roque ""Rocky"" De La Fuente",1,0,0,0,0,1
+Hill,0003,President,8,DEM,Willie L. Wilson,0,0,0,0,0,0
+Hill,0003,President,8,DEM,Calvis L. Hawes,1,0,0,1,0,0
+Hill,0003,President,8,DEM,Hillary Clinton,64,6,12,8,24,14
+Hill,0003,President,8,DEM,Keith Judd,0,0,0,0,0,0
+Hill,0003,President,8,DEM,Martin J. O'Malley,1,0,0,1,0,0
+Hill,0003,President,8,DEM,Over Votes,0,0,0,0,0,0
+Hill,0003,President,8,DEM,Under Votes,1,0,0,0,1,0
+Hill,0003,U.S. House,25,DEM,Kathi Thomas,65,7,13,8,20,17
+Hill,0003,U.S. House,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0003,U.S. House,25,DEM,Under Votes,24,0,2,5,10,7
+Hill,0003,Railroad Commissioner,25,DEM,Cody Garrett,22,1,2,5,7,7
+Hill,0003,Railroad Commissioner,25,DEM,Lon Burnam,19,2,3,2,6,6
+Hill,0003,Railroad Commissioner,25,DEM,Grady Yarbrough,36,4,8,5,10,9
+Hill,0003,Railroad Commissioner,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0003,Railroad Commissioner,25,DEM,Under Votes,12,0,2,1,7,2
+Hill,0003,"Justice, Supreme Court, Place 3",25,DEM,Mike Westergren,61,5,10,11,14,21
+Hill,0003,"Justice, Supreme Court, Place 3",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0003,"Justice, Supreme Court, Place 3",25,DEM,Under Votes,28,2,5,2,16,3
+Hill,0003,"Justice, Supreme Court, Place 5",25,DEM,Dori Contreras Garza,66,5,11,10,19,21
+Hill,0003,"Justice, Supreme Court, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0003,"Justice, Supreme Court, Place 5",25,DEM,Under Votes,23,2,4,3,11,3
+Hill,0003,"Justice, Supreme Court, Place 9",25,DEM,Savannah Robinson,68,6,11,12,19,20
+Hill,0003,"Justice, Supreme Court, Place 9",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0003,"Justice, Supreme Court, Place 9",25,DEM,Under Votes,21,1,4,1,11,4
+Hill,0003,"Judge, Court of Criminal Appeals, Place 2",25,DEM,"Lawrence ""Larry"" Meyers",65,5,11,11,18,20
+Hill,0003,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0003,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Under Votes,24,2,4,2,12,4
+Hill,0003,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Betsy Johnson,66,6,11,11,18,20
+Hill,0003,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0003,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Under Votes,23,1,4,2,12,4
+Hill,0003,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Robert Burns,62,5,10,11,16,20
+Hill,0003,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0003,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Under Votes,27,2,5,2,14,4
+Hill,0003,State Senator,22,DEM,Michael Collins,64,6,11,10,17,20
+Hill,0003,State Senator,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0003,State Senator,22,DEM,Under Votes,25,1,4,3,13,4
+Hill,0003,County Chairman,22,DEM,Thomas Hanson,63,6,11,10,18,18
+Hill,0003,County Chairman,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0003,County Chairman,22,DEM,Under Votes,26,1,4,3,12,6
+Hill,0003,Precinct Chairman 3,22,DEM,Princess Chambers-Hughes,67,6,12,11,19,19
+Hill,0003,Precinct Chairman 3,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0003,Precinct Chairman 3,22,DEM,Under Votes,22,1,3,2,11,5
+Hill,0003,Proposition 1,22,REP,Yes,208,8,41,49,54,56
+Hill,0003,Proposition 1,22,REP,No,98,7,17,29,32,13
+Hill,0003,Proposition 1,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0003,Proposition 1,22,REP,Under Votes,43,4,13,2,18,6
+Hill,0003,Proposition 2,22,REP,Yes,192,11,41,49,54,37
+Hill,0003,Proposition 2,22,REP,No,119,5,19,29,34,32
+Hill,0003,Proposition 2,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0003,Proposition 2,22,REP,Under Votes,38,3,11,2,16,6
+Hill,0003,Proposition 3,22,REP,Yes,231,12,45,61,63,50
+Hill,0003,Proposition 3,22,REP,No,75,4,13,17,22,19
+Hill,0003,Proposition 3,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0003,Proposition 3,22,REP,Under Votes,43,3,13,2,19,6
+Hill,0003,Proposition 4,22,REP,Yes,276,13,51,72,75,65
+Hill,0003,Proposition 4,22,REP,No,25,2,7,4,9,3
+Hill,0003,Proposition 4,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0003,Proposition 4,22,REP,Under Votes,48,4,13,4,20,7
+Hill,0003,Referenda Item #1,22,DEM,For,69,4,11,13,20,21
+Hill,0003,Referenda Item #1,22,DEM,Against,16,3,4,0,7,2
+Hill,0003,Referenda Item #1,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0003,Referenda Item #1,22,DEM,Under Votes,4,0,0,0,3,1
+Hill,0003,Referenda Item #2,22,DEM,For,73,4,11,13,23,22
+Hill,0003,Referenda Item #2,22,DEM,Against,10,3,3,0,3,1
+Hill,0003,Referenda Item #2,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0003,Referenda Item #2,22,DEM,Under Votes,6,0,1,0,4,1
+Hill,0003,Referenda Item #3,22,DEM,For,75,6,12,12,23,22
+Hill,0003,Referenda Item #3,22,DEM,Against,8,1,2,1,3,1
+Hill,0003,Referenda Item #3,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0003,Referenda Item #3,22,DEM,Under Votes,6,0,1,0,4,1
+Hill,0003,Referenda Item #4,22,DEM,For,69,3,10,13,22,21
+Hill,0003,Referenda Item #4,22,DEM,Against,13,3,4,0,4,2
+Hill,0003,Referenda Item #4,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0003,Referenda Item #4,22,DEM,Under Votes,7,1,1,0,4,1
+Hill,0003,Referenda Item #5,22,DEM,For,61,5,11,9,21,15
+Hill,0003,Referenda Item #5,22,DEM,Against,25,2,4,4,7,8
+Hill,0003,Referenda Item #5,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0003,Referenda Item #5,22,DEM,Under Votes,3,0,0,0,2,1
+Hill,0003,Referenda Item #6,22,DEM,For,75,5,12,13,22,23
+Hill,0003,Referenda Item #6,22,DEM,Against,5,1,1,0,3,0
+Hill,0003,Referenda Item #6,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0003,Referenda Item #6,22,DEM,Under Votes,9,1,2,0,5,1
+Hill,0004,Registered Voters - Total,,,,2358,1,2,0,5,1
+Hill,0004,Ballots Cast - Total,,REP,,1096,69,213,245,360,209
+Hill,0004,Ballots Cast - Total,,DEM,,146,16,35,18,64,13
+Hill,0004,President,,REP,Ted Cruz,442,30,81,81,153,97
+Hill,0004,President,,REP,Jeb Bush,25,3,5,4,5,8
+Hill,0004,President,,REP,Donald J. Trump,310,19,63,79,101,48
+Hill,0004,President,,REP,Ben Carson,70,3,9,19,19,20
+Hill,0004,President,,REP,Rand Paul,4,0,0,1,2,1
+Hill,0004,President,,REP,Rick Santorum,0,0,0,0,0,0
+Hill,0004,President,,REP,Elizabeth Gray,3,1,1,0,1,0
+Hill,0004,President,,REP,Carly Fiorina,0,0,0,0,0,0
+Hill,0004,President,,REP,Lindsey Graham,0,0,0,0,0,0
+Hill,0004,President,,REP,Marco Rubio,169,9,34,51,47,28
+Hill,0004,President,,REP,John R. Kasich,34,2,8,7,15,2
+Hill,0004,President,,REP,Mike Huckabee,1,0,0,0,0,1
+Hill,0004,President,,REP,Chris Christie,4,0,0,1,0,3
+Hill,0004,President,,REP,Uncommitted,22,2,8,1,11,0
+Hill,0004,President,,REP,Over Votes,0,0,0,0,0,0
+Hill,0004,President,,REP,Under Votes,12,0,4,1,6,1
+Hill,0004,U.S. House,25,REP,Roger Williams,828,60,169,170,281,148
+Hill,0004,U.S. House,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0004,U.S. House,25,REP,Under Votes,268,9,44,75,79,61
+Hill,0004,Railroad Commissioner,25,REP,Gary Gates,362,26,67,72,119,78
+Hill,0004,Railroad Commissioner,25,REP,Lance N. Christian,98,4,18,22,30,24
+Hill,0004,Railroad Commissioner,25,REP,Weston Martinez,64,5,13,13,16,17
+Hill,0004,Railroad Commissioner,25,REP,Wayne Christian,127,8,25,29,48,17
+Hill,0004,Railroad Commissioner,25,REP,Ron Hale,88,6,10,24,33,15
+Hill,0004,Railroad Commissioner,25,REP,Doug Jeffrey,46,2,10,13,14,7
+Hill,0004,Railroad Commissioner,25,REP,John Greytok,29,5,8,4,10,2
+Hill,0004,Railroad Commissioner,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0004,Railroad Commissioner,25,REP,Under Votes,282,13,62,68,90,49
+Hill,0004,"Justice, Supreme Court, Place 3",25,REP,Michael Massengale,418,32,84,97,137,68
+Hill,0004,"Justice, Supreme Court, Place 3",25,REP,Debra Lehrmann,456,28,87,87,150,104
+Hill,0004,"Justice, Supreme Court, Place 3",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0004,"Justice, Supreme Court, Place 3",25,REP,Under Votes,222,9,42,61,73,37
+Hill,0004,"Justice, Supreme Court, Place 5",25,REP,Paul Green,441,36,90,97,140,78
+Hill,0004,"Justice, Supreme Court, Place 5",25,REP,Rick Green,382,23,67,75,130,87
+Hill,0004,"Justice, Supreme Court, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0004,"Justice, Supreme Court, Place 5",25,REP,Under Votes,273,10,56,73,90,44
+Hill,0004,"Justice, Supreme Court, Place 9",25,REP,Joe Pool,428,32,88,91,149,68
+Hill,0004,"Justice, Supreme Court, Place 9",25,REP,Eva Guzman,443,27,80,97,136,103
+Hill,0004,"Justice, Supreme Court, Place 9",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0004,"Justice, Supreme Court, Place 9",25,REP,Under Votes,225,10,45,57,75,38
+Hill,0004,"Judge, Court of Criminal Appeals, Place 2",25,REP,Chris Oldner,260,16,50,73,81,40
+Hill,0004,"Judge, Court of Criminal Appeals, Place 2",25,REP,Ray Wheless,264,14,40,43,87,80
+Hill,0004,"Judge, Court of Criminal Appeals, Place 2",25,REP,Mary Lou Keel,274,26,61,56,94,37
+Hill,0004,"Judge, Court of Criminal Appeals, Place 2",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0004,"Judge, Court of Criminal Appeals, Place 2",25,REP,Under Votes,298,13,62,73,98,52
+Hill,0004,"Judge, Court of Criminal Appeals, Place 5",25,REP,Sid Harle,219,12,35,38,72,62
+Hill,0004,"Judge, Court of Criminal Appeals, Place 5",25,REP,Brent Webster,151,11,32,33,54,21
+Hill,0004,"Judge, Court of Criminal Appeals, Place 5",25,REP,Scott Walker,242,15,50,52,84,41
+Hill,0004,"Judge, Court of Criminal Appeals, Place 5",25,REP,Steve Smith,217,16,41,54,66,40
+Hill,0004,"Judge, Court of Criminal Appeals, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0004,"Judge, Court of Criminal Appeals, Place 5",25,REP,Under Votes,267,15,55,68,84,45
+Hill,0004,"Judge, Court of Criminal Appeals, Place 6",25,REP,Richard Davis,374,28,64,92,121,69
+Hill,0004,"Judge, Court of Criminal Appeals, Place 6",25,REP,Michael E. Keasler,407,27,83,75,131,91
+Hill,0004,"Judge, Court of Criminal Appeals, Place 6",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0004,"Judge, Court of Criminal Appeals, Place 6",25,REP,Under Votes,315,14,66,78,108,49
+Hill,0004,"Member, State Board of Education, District 14",25,REP,Sue Melton-Malone,765,54,155,154,253,149
+Hill,0004,"Member, State Board of Education, District 14",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0004,"Member, State Board of Education, District 14",25,REP,Under Votes,331,15,58,91,107,60
+Hill,0004,State Senator,22,REP,Brian Birdwell,848,58,171,172,283,164
+Hill,0004,State Senator,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0004,State Senator,22,REP,Under Votes,248,11,42,73,77,45
+Hill,0004,State Representative,8,REP,Thomas McNutt,460,35,73,107,141,104
+Hill,0004,State Representative,8,REP,Byron Cook,577,31,128,127,198,93
+Hill,0004,State Representative,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0004,State Representative,8,REP,Under Votes,59,3,12,11,21,12
+Hill,0004,"Justice, 10th Court of Appeals District, Place 3",8,REP,Al Scoggins,736,51,149,154,240,142
+Hill,0004,"Justice, 10th Court of Appeals District, Place 3",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0004,"Justice, 10th Court of Appeals District, Place 3",8,REP,Under Votes,360,18,64,91,120,67
+Hill,0004,"District Attorney, 66th Judicial District",8,REP,Mark F Pratt,905,57,187,188,307,166
+Hill,0004,"District Attorney, 66th Judicial District",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0004,"District Attorney, 66th Judicial District",8,REP,Under Votes,191,12,26,57,53,43
+Hill,0004,County Attorney,8,REP,R David Holmes,859,57,170,187,281,164
+Hill,0004,County Attorney,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0004,County Attorney,8,REP,Under Votes,237,12,43,58,79,45
+Hill,0004,Sheriff,8,REP,Jimmy Johnson,281,15,54,66,93,53
+Hill,0004,Sheriff,8,REP,Dedri Hafer,44,3,7,9,11,14
+Hill,0004,Sheriff,8,REP,Rodney Watson,509,28,102,105,175,99
+Hill,0004,Sheriff,8,REP,Kyle R Cox,88,6,15,23,26,18
+Hill,0004,Sheriff,8,REP,Ronnie Myers,114,13,23,32,33,13
+Hill,0004,Sheriff,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0004,Sheriff,8,REP,Under Votes,60,4,12,10,22,12
+Hill,0004,Tax Assessor-Collector,8,REP,Ray Mabry,529,39,114,110,181,85
+Hill,0004,Tax Assessor-Collector,8,REP,Krissi Hightower,442,22,78,113,135,94
+Hill,0004,Tax Assessor-Collector,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0004,Tax Assessor-Collector,8,REP,Under Votes,125,8,21,22,44,30
+Hill,0004,"Constable, Precinct No. 4",8,REP,Collin Yeaman,534,31,105,120,176,102
+Hill,0004,"Constable, Precinct No. 4",8,REP,George Willoughby,311,26,62,70,100,53
+Hill,0004,"Constable, Precinct No. 4",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0004,"Constable, Precinct No. 4",8,REP,Under Votes,251,12,46,55,84,54
+Hill,0004,County Chairman,8,REP,Will Orr,843,56,167,185,274,161
+Hill,0004,County Chairman,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0004,County Chairman,8,REP,Under Votes,253,13,46,60,86,48
+Hill,0004,President,8,DEM,Bernie Sanders,31,4,7,5,12,3
+Hill,0004,President,8,DEM,Star Locke,1,0,0,0,0,1
+Hill,0004,President,8,DEM,"Roque ""Rocky"" De La Fuente",1,0,0,0,0,1
+Hill,0004,President,8,DEM,Willie L. Wilson,0,0,0,0,0,0
+Hill,0004,President,8,DEM,Calvis L. Hawes,3,1,1,0,1,0
+Hill,0004,President,8,DEM,Hillary Clinton,109,11,27,13,50,8
+Hill,0004,President,8,DEM,Keith Judd,0,0,0,0,0,0
+Hill,0004,President,8,DEM,Martin J. O'Malley,0,0,0,0,0,0
+Hill,0004,President,8,DEM,Over Votes,0,0,0,0,0,0
+Hill,0004,President,8,DEM,Under Votes,1,0,0,0,1,0
+Hill,0004,U.S. House,25,DEM,Kathi Thomas,111,14,26,12,49,10
+Hill,0004,U.S. House,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0004,U.S. House,25,DEM,Under Votes,35,2,9,6,15,3
+Hill,0004,Railroad Commissioner,25,DEM,Cody Garrett,32,4,7,5,13,3
+Hill,0004,Railroad Commissioner,25,DEM,Lon Burnam,21,2,5,2,8,4
+Hill,0004,Railroad Commissioner,25,DEM,Grady Yarbrough,66,10,17,5,31,3
+Hill,0004,Railroad Commissioner,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0004,Railroad Commissioner,25,DEM,Under Votes,27,0,6,6,12,3
+Hill,0004,"Justice, Supreme Court, Place 3",25,DEM,Mike Westergren,110,13,25,13,49,10
+Hill,0004,"Justice, Supreme Court, Place 3",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0004,"Justice, Supreme Court, Place 3",25,DEM,Under Votes,36,3,10,5,15,3
+Hill,0004,"Justice, Supreme Court, Place 5",25,DEM,Dori Contreras Garza,111,13,25,13,50,10
+Hill,0004,"Justice, Supreme Court, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0004,"Justice, Supreme Court, Place 5",25,DEM,Under Votes,35,3,10,5,14,3
+Hill,0004,"Justice, Supreme Court, Place 9",25,DEM,Savannah Robinson,110,13,25,13,49,10
+Hill,0004,"Justice, Supreme Court, Place 9",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0004,"Justice, Supreme Court, Place 9",25,DEM,Under Votes,36,3,10,5,15,3
+Hill,0004,"Judge, Court of Criminal Appeals, Place 2",25,DEM,"Lawrence ""Larry"" Meyers",111,13,25,13,50,10
+Hill,0004,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0004,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Under Votes,35,3,10,5,14,3
+Hill,0004,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Betsy Johnson,111,13,25,13,50,10
+Hill,0004,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0004,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Under Votes,35,3,10,5,14,3
+Hill,0004,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Robert Burns,112,14,26,12,50,10
+Hill,0004,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0004,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Under Votes,34,2,9,6,14,3
+Hill,0004,State Senator,22,DEM,Michael Collins,114,14,26,12,51,11
+Hill,0004,State Senator,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0004,State Senator,22,DEM,Under Votes,32,2,9,6,13,2
+Hill,0004,County Chairman,22,DEM,Thomas Hanson,114,14,26,13,51,10
+Hill,0004,County Chairman,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0004,County Chairman,22,DEM,Under Votes,32,2,9,5,13,3
+Hill,0004,Proposition 1,22,REP,Yes,697,46,134,168,221,128
+Hill,0004,Proposition 1,22,REP,No,268,14,47,59,83,65
+Hill,0004,Proposition 1,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0004,Proposition 1,22,REP,Under Votes,131,9,32,18,56,16
+Hill,0004,Proposition 2,22,REP,Yes,550,25,97,144,164,120
+Hill,0004,Proposition 2,22,REP,No,461,40,97,85,164,75
+Hill,0004,Proposition 2,22,REP,Over Votes,3,1,1,0,1,0
+Hill,0004,Proposition 2,22,REP,Under Votes,82,3,18,16,31,14
+Hill,0004,Proposition 3,22,REP,Yes,743,50,157,184,243,109
+Hill,0004,Proposition 3,22,REP,No,261,16,35,41,83,86
+Hill,0004,Proposition 3,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0004,Proposition 3,22,REP,Under Votes,92,3,21,20,34,14
+Hill,0004,Proposition 4,22,REP,Yes,936,62,178,219,302,175
+Hill,0004,Proposition 4,22,REP,No,54,1,12,7,18,16
+Hill,0004,Proposition 4,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0004,Proposition 4,22,REP,Under Votes,106,6,23,19,40,18
+Hill,0004,Referenda Item #1,22,DEM,For,104,13,23,12,46,10
+Hill,0004,Referenda Item #1,22,DEM,Against,27,1,7,5,11,3
+Hill,0004,Referenda Item #1,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0004,Referenda Item #1,22,DEM,Under Votes,15,2,5,1,7,0
+Hill,0004,Referenda Item #2,22,DEM,For,109,11,25,14,48,11
+Hill,0004,Referenda Item #2,22,DEM,Against,14,1,3,2,6,2
+Hill,0004,Referenda Item #2,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0004,Referenda Item #2,22,DEM,Under Votes,23,4,7,2,10,0
+Hill,0004,Referenda Item #3,22,DEM,For,99,9,23,13,45,9
+Hill,0004,Referenda Item #3,22,DEM,Against,26,3,5,4,10,4
+Hill,0004,Referenda Item #3,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0004,Referenda Item #3,22,DEM,Under Votes,21,4,7,1,9,0
+Hill,0004,Referenda Item #4,22,DEM,For,110,11,24,14,49,12
+Hill,0004,Referenda Item #4,22,DEM,Against,10,1,2,2,4,1
+Hill,0004,Referenda Item #4,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0004,Referenda Item #4,22,DEM,Under Votes,26,4,9,2,11,0
+Hill,0004,Referenda Item #5,22,DEM,For,90,6,18,15,42,9
+Hill,0004,Referenda Item #5,22,DEM,Against,36,6,10,3,13,4
+Hill,0004,Referenda Item #5,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0004,Referenda Item #5,22,DEM,Under Votes,20,4,7,0,9,0
+Hill,0004,Referenda Item #6,22,DEM,For,108,9,23,17,48,11
+Hill,0004,Referenda Item #6,22,DEM,Against,18,3,5,1,7,2
+Hill,0004,Referenda Item #6,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0004,Referenda Item #6,22,DEM,Under Votes,20,4,7,0,9,0
+Hill,0005,Registered Voters - Total,,,,544,4,7,0,9,0
+Hill,0005,Ballots Cast - Total,,REP,,288,10,39,49,118,72
+Hill,0005,Ballots Cast - Total,,DEM,,23,1,3,5,11,3
+Hill,0005,President,,REP,Ted Cruz,142,8,21,17,60,36
+Hill,0005,President,,REP,Jeb Bush,3,0,0,2,1,0
+Hill,0005,President,,REP,Donald J. Trump,101,2,10,22,42,25
+Hill,0005,President,,REP,Ben Carson,11,0,2,1,5,3
+Hill,0005,President,,REP,Rand Paul,1,0,0,1,0,0
+Hill,0005,President,,REP,Rick Santorum,0,0,0,0,0,0
+Hill,0005,President,,REP,Elizabeth Gray,0,0,0,0,0,0
+Hill,0005,President,,REP,Carly Fiorina,0,0,0,0,0,0
+Hill,0005,President,,REP,Lindsey Graham,0,0,0,0,0,0
+Hill,0005,President,,REP,Marco Rubio,26,0,5,6,8,7
+Hill,0005,President,,REP,John R. Kasich,1,0,0,0,1,0
+Hill,0005,President,,REP,Mike Huckabee,0,0,0,0,0,0
+Hill,0005,President,,REP,Chris Christie,1,0,0,0,0,1
+Hill,0005,President,,REP,Uncommitted,2,0,1,0,1,0
+Hill,0005,President,,REP,Over Votes,0,0,0,0,0,0
+Hill,0005,President,,REP,Under Votes,0,0,0,0,0,0
+Hill,0005,U.S. House,25,REP,Roger Williams,218,10,34,33,91,50
+Hill,0005,U.S. House,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0005,U.S. House,25,REP,Under Votes,70,0,5,16,27,22
+Hill,0005,Railroad Commissioner,25,REP,Gary Gates,89,4,13,7,43,22
+Hill,0005,Railroad Commissioner,25,REP,Lance N. Christian,27,0,6,5,12,4
+Hill,0005,Railroad Commissioner,25,REP,Weston Martinez,11,0,0,3,4,4
+Hill,0005,Railroad Commissioner,25,REP,Wayne Christian,39,1,6,11,10,11
+Hill,0005,Railroad Commissioner,25,REP,Ron Hale,35,2,4,7,11,11
+Hill,0005,Railroad Commissioner,25,REP,Doug Jeffrey,17,0,2,3,9,3
+Hill,0005,Railroad Commissioner,25,REP,John Greytok,6,0,1,1,3,1
+Hill,0005,Railroad Commissioner,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0005,Railroad Commissioner,25,REP,Under Votes,64,3,7,12,26,16
+Hill,0005,"Justice, Supreme Court, Place 3",25,REP,Michael Massengale,143,7,23,25,59,29
+Hill,0005,"Justice, Supreme Court, Place 3",25,REP,Debra Lehrmann,84,2,13,11,37,21
+Hill,0005,"Justice, Supreme Court, Place 3",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0005,"Justice, Supreme Court, Place 3",25,REP,Under Votes,61,1,3,13,22,22
+Hill,0005,"Justice, Supreme Court, Place 5",25,REP,Paul Green,122,4,19,15,53,31
+Hill,0005,"Justice, Supreme Court, Place 5",25,REP,Rick Green,96,6,16,18,37,19
+Hill,0005,"Justice, Supreme Court, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0005,"Justice, Supreme Court, Place 5",25,REP,Under Votes,70,0,4,16,28,22
+Hill,0005,"Justice, Supreme Court, Place 9",25,REP,Joe Pool,100,0,12,17,42,29
+Hill,0005,"Justice, Supreme Court, Place 9",25,REP,Eva Guzman,133,10,25,19,56,23
+Hill,0005,"Justice, Supreme Court, Place 9",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0005,"Justice, Supreme Court, Place 9",25,REP,Under Votes,55,0,2,13,20,20
+Hill,0005,"Judge, Court of Criminal Appeals, Place 2",25,REP,Chris Oldner,65,0,7,7,34,17
+Hill,0005,"Judge, Court of Criminal Appeals, Place 2",25,REP,Ray Wheless,77,7,15,11,29,15
+Hill,0005,"Judge, Court of Criminal Appeals, Place 2",25,REP,Mary Lou Keel,74,3,13,17,26,15
+Hill,0005,"Judge, Court of Criminal Appeals, Place 2",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0005,"Judge, Court of Criminal Appeals, Place 2",25,REP,Under Votes,72,0,4,14,29,25
+Hill,0005,"Judge, Court of Criminal Appeals, Place 5",25,REP,Sid Harle,41,2,8,6,19,6
+Hill,0005,"Judge, Court of Criminal Appeals, Place 5",25,REP,Brent Webster,57,7,11,7,25,7
+Hill,0005,"Judge, Court of Criminal Appeals, Place 5",25,REP,Scott Walker,74,0,8,16,29,21
+Hill,0005,"Judge, Court of Criminal Appeals, Place 5",25,REP,Steve Smith,48,0,8,8,18,14
+Hill,0005,"Judge, Court of Criminal Appeals, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0005,"Judge, Court of Criminal Appeals, Place 5",25,REP,Under Votes,68,1,4,12,27,24
+Hill,0005,"Judge, Court of Criminal Appeals, Place 6",25,REP,Richard Davis,110,1,15,16,51,27
+Hill,0005,"Judge, Court of Criminal Appeals, Place 6",25,REP,Michael E. Keasler,105,7,20,18,38,22
+Hill,0005,"Judge, Court of Criminal Appeals, Place 6",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0005,"Judge, Court of Criminal Appeals, Place 6",25,REP,Under Votes,73,2,4,15,29,23
+Hill,0005,"Member, State Board of Education, District 14",25,REP,Sue Melton-Malone,203,10,32,28,87,46
+Hill,0005,"Member, State Board of Education, District 14",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0005,"Member, State Board of Education, District 14",25,REP,Under Votes,85,0,7,21,31,26
+Hill,0005,State Senator,22,REP,Brian Birdwell,217,10,33,31,89,54
+Hill,0005,State Senator,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0005,State Senator,22,REP,Under Votes,71,0,6,18,29,18
+Hill,0005,State Representative,8,REP,Thomas McNutt,135,10,23,22,50,30
+Hill,0005,State Representative,8,REP,Byron Cook,120,0,13,24,52,31
+Hill,0005,State Representative,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0005,State Representative,8,REP,Under Votes,33,0,3,3,16,11
+Hill,0005,"Justice, 10th Court of Appeals District, Place 3",8,REP,Al Scoggins,197,10,29,30,81,47
+Hill,0005,"Justice, 10th Court of Appeals District, Place 3",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0005,"Justice, 10th Court of Appeals District, Place 3",8,REP,Under Votes,91,0,10,19,37,25
+Hill,0005,"District Attorney, 66th Judicial District",8,REP,Mark F Pratt,219,10,33,34,91,51
+Hill,0005,"District Attorney, 66th Judicial District",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0005,"District Attorney, 66th Judicial District",8,REP,Under Votes,69,0,6,15,27,21
+Hill,0005,County Attorney,8,REP,R David Holmes,207,10,31,32,81,53
+Hill,0005,County Attorney,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0005,County Attorney,8,REP,Under Votes,81,0,8,17,37,19
+Hill,0005,Sheriff,8,REP,Jimmy Johnson,93,5,13,16,34,25
+Hill,0005,Sheriff,8,REP,Dedri Hafer,18,0,2,2,8,6
+Hill,0005,Sheriff,8,REP,Rodney Watson,104,2,12,19,46,25
+Hill,0005,Sheriff,8,REP,Kyle R Cox,18,2,2,1,8,5
+Hill,0005,Sheriff,8,REP,Ronnie Myers,36,1,7,6,16,6
+Hill,0005,Sheriff,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0005,Sheriff,8,REP,Under Votes,19,0,3,5,6,5
+Hill,0005,Tax Assessor-Collector,8,REP,Ray Mabry,105,2,13,19,45,26
+Hill,0005,Tax Assessor-Collector,8,REP,Krissi Hightower,149,8,22,26,55,38
+Hill,0005,Tax Assessor-Collector,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0005,Tax Assessor-Collector,8,REP,Under Votes,34,0,4,4,18,8
+Hill,0005,County Commissioner # 1,8,REP,Andrew Montgomery,162,4,26,27,75,30
+Hill,0005,County Commissioner # 1,8,REP,"Ted O' Neil, Jr",93,6,9,14,29,35
+Hill,0005,County Commissioner # 1,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0005,County Commissioner # 1,8,REP,Under Votes,33,0,4,8,14,7
+Hill,0005,"Constable, Precinct No. 1",8,REP,Bill Wilkins,173,9,26,25,66,47
+Hill,0005,"Constable, Precinct No. 1",8,REP,Daniel Roberson,69,1,9,14,31,14
+Hill,0005,"Constable, Precinct No. 1",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0005,"Constable, Precinct No. 1",8,REP,Under Votes,46,0,4,10,21,11
+Hill,0005,County Chairman,8,REP,Will Orr,212,10,32,33,85,52
+Hill,0005,County Chairman,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0005,County Chairman,8,REP,Under Votes,76,0,7,16,33,20
+Hill,0005,President,8,DEM,Bernie Sanders,3,0,0,3,0,0
+Hill,0005,President,8,DEM,Star Locke,0,0,0,0,0,0
+Hill,0005,President,8,DEM,"Roque ""Rocky"" De La Fuente",0,0,0,0,0,0
+Hill,0005,President,8,DEM,Willie L. Wilson,0,0,0,0,0,0
+Hill,0005,President,8,DEM,Calvis L. Hawes,0,0,0,0,0,0
+Hill,0005,President,8,DEM,Hillary Clinton,18,1,3,0,11,3
+Hill,0005,President,8,DEM,Keith Judd,1,0,0,1,0,0
+Hill,0005,President,8,DEM,Martin J. O'Malley,1,0,0,1,0,0
+Hill,0005,President,8,DEM,Over Votes,0,0,0,0,0,0
+Hill,0005,President,8,DEM,Under Votes,0,0,0,0,0,0
+Hill,0005,U.S. House,25,DEM,Kathi Thomas,21,1,3,4,10,3
+Hill,0005,U.S. House,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0005,U.S. House,25,DEM,Under Votes,2,0,0,1,1,0
+Hill,0005,Railroad Commissioner,25,DEM,Cody Garrett,3,0,0,1,2,0
+Hill,0005,Railroad Commissioner,25,DEM,Lon Burnam,4,1,1,0,1,1
+Hill,0005,Railroad Commissioner,25,DEM,Grady Yarbrough,12,0,2,2,6,2
+Hill,0005,Railroad Commissioner,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0005,Railroad Commissioner,25,DEM,Under Votes,4,0,0,2,2,0
+Hill,0005,"Justice, Supreme Court, Place 3",25,DEM,Mike Westergren,18,1,3,3,8,3
+Hill,0005,"Justice, Supreme Court, Place 3",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0005,"Justice, Supreme Court, Place 3",25,DEM,Under Votes,5,0,0,2,3,0
+Hill,0005,"Justice, Supreme Court, Place 5",25,DEM,Dori Contreras Garza,19,1,3,3,9,3
+Hill,0005,"Justice, Supreme Court, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0005,"Justice, Supreme Court, Place 5",25,DEM,Under Votes,4,0,0,2,2,0
+Hill,0005,"Justice, Supreme Court, Place 9",25,DEM,Savannah Robinson,19,1,3,3,9,3
+Hill,0005,"Justice, Supreme Court, Place 9",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0005,"Justice, Supreme Court, Place 9",25,DEM,Under Votes,4,0,0,2,2,0
+Hill,0005,"Judge, Court of Criminal Appeals, Place 2",25,DEM,"Lawrence ""Larry"" Meyers",19,1,3,3,9,3
+Hill,0005,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0005,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Under Votes,4,0,0,2,2,0
+Hill,0005,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Betsy Johnson,19,1,3,3,9,3
+Hill,0005,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0005,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Under Votes,4,0,0,2,2,0
+Hill,0005,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Robert Burns,19,1,3,3,9,3
+Hill,0005,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0005,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Under Votes,4,0,0,2,2,0
+Hill,0005,State Senator,22,DEM,Michael Collins,19,1,3,3,9,3
+Hill,0005,State Senator,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0005,State Senator,22,DEM,Under Votes,4,0,0,2,2,0
+Hill,0005,County Chairman,22,DEM,Thomas Hanson,19,1,3,3,9,3
+Hill,0005,County Chairman,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0005,County Chairman,22,DEM,Under Votes,4,0,0,2,2,0
+Hill,0005,Proposition 1,22,REP,Yes,196,9,28,33,78,48
+Hill,0005,Proposition 1,22,REP,No,63,0,7,13,27,16
+Hill,0005,Proposition 1,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0005,Proposition 1,22,REP,Under Votes,29,1,4,3,13,8
+Hill,0005,Proposition 2,22,REP,Yes,148,5,15,32,57,39
+Hill,0005,Proposition 2,22,REP,No,114,4,20,14,49,27
+Hill,0005,Proposition 2,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0005,Proposition 2,22,REP,Under Votes,26,1,4,3,12,6
+Hill,0005,Proposition 3,22,REP,Yes,208,8,29,40,86,45
+Hill,0005,Proposition 3,22,REP,No,52,2,7,6,20,17
+Hill,0005,Proposition 3,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0005,Proposition 3,22,REP,Under Votes,28,0,3,3,12,10
+Hill,0005,Proposition 4,22,REP,Yes,247,10,34,46,97,60
+Hill,0005,Proposition 4,22,REP,No,14,0,2,1,9,2
+Hill,0005,Proposition 4,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0005,Proposition 4,22,REP,Under Votes,27,0,3,2,12,10
+Hill,0005,Referenda Item #1,22,DEM,For,19,1,3,4,9,2
+Hill,0005,Referenda Item #1,22,DEM,Against,2,0,0,1,0,1
+Hill,0005,Referenda Item #1,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0005,Referenda Item #1,22,DEM,Under Votes,2,0,0,0,2,0
+Hill,0005,Referenda Item #2,22,DEM,For,13,0,0,4,7,2
+Hill,0005,Referenda Item #2,22,DEM,Against,5,0,2,1,2,0
+Hill,0005,Referenda Item #2,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0005,Referenda Item #2,22,DEM,Under Votes,5,1,1,0,2,1
+Hill,0005,Referenda Item #3,22,DEM,For,15,1,1,4,7,2
+Hill,0005,Referenda Item #3,22,DEM,Against,5,0,2,1,2,0
+Hill,0005,Referenda Item #3,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0005,Referenda Item #3,22,DEM,Under Votes,3,0,0,0,2,1
+Hill,0005,Referenda Item #4,22,DEM,For,15,1,3,2,8,1
+Hill,0005,Referenda Item #4,22,DEM,Against,3,0,0,3,0,0
+Hill,0005,Referenda Item #4,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0005,Referenda Item #4,22,DEM,Under Votes,5,0,0,0,3,2
+Hill,0005,Referenda Item #5,22,DEM,For,14,1,1,3,7,2
+Hill,0005,Referenda Item #5,22,DEM,Against,6,0,2,2,2,0
+Hill,0005,Referenda Item #5,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0005,Referenda Item #5,22,DEM,Under Votes,3,0,0,0,2,1
+Hill,0005,Referenda Item #6,22,DEM,For,17,1,2,3,9,2
+Hill,0005,Referenda Item #6,22,DEM,Against,4,0,1,2,1,0
+Hill,0005,Referenda Item #6,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0005,Referenda Item #6,22,DEM,Under Votes,2,0,0,0,1,1
+Hill,0006,Registered Voters - Total,,,,405,0,0,0,1,1
+Hill,0006,Ballots Cast - Total,,REP,,198,14,25,36,86,37
+Hill,0006,Ballots Cast - Total,,DEM,,21,3,4,2,10,2
+Hill,0006,President,,REP,Ted Cruz,96,9,13,23,34,17
+Hill,0006,President,,REP,Jeb Bush,1,0,0,0,0,1
+Hill,0006,President,,REP,Donald J. Trump,65,1,4,9,34,17
+Hill,0006,President,,REP,Ben Carson,14,1,3,1,8,1
+Hill,0006,President,,REP,Rand Paul,0,0,0,0,0,0
+Hill,0006,President,,REP,Rick Santorum,0,0,0,0,0,0
+Hill,0006,President,,REP,Elizabeth Gray,0,0,0,0,0,0
+Hill,0006,President,,REP,Carly Fiorina,3,1,1,0,1,0
+Hill,0006,President,,REP,Lindsey Graham,0,0,0,0,0,0
+Hill,0006,President,,REP,Marco Rubio,12,1,3,2,6,0
+Hill,0006,President,,REP,John R. Kasich,1,0,0,0,1,0
+Hill,0006,President,,REP,Mike Huckabee,0,0,0,0,0,0
+Hill,0006,President,,REP,Chris Christie,0,0,0,0,0,0
+Hill,0006,President,,REP,Uncommitted,3,1,1,0,1,0
+Hill,0006,President,,REP,Over Votes,0,0,0,0,0,0
+Hill,0006,President,,REP,Under Votes,3,0,0,1,1,1
+Hill,0006,U.S. House,25,REP,Roger Williams,135,10,18,27,59,21
+Hill,0006,U.S. House,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0006,U.S. House,25,REP,Under Votes,63,4,7,9,27,16
+Hill,0006,Railroad Commissioner,25,REP,Gary Gates,57,5,9,12,23,8
+Hill,0006,Railroad Commissioner,25,REP,Lance N. Christian,15,0,1,2,10,2
+Hill,0006,Railroad Commissioner,25,REP,Weston Martinez,10,2,2,0,3,3
+Hill,0006,Railroad Commissioner,25,REP,Wayne Christian,27,3,5,6,10,3
+Hill,0006,Railroad Commissioner,25,REP,Ron Hale,22,3,3,2,11,3
+Hill,0006,Railroad Commissioner,25,REP,Doug Jeffrey,13,0,1,3,7,2
+Hill,0006,Railroad Commissioner,25,REP,John Greytok,8,0,0,3,3,2
+Hill,0006,Railroad Commissioner,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0006,Railroad Commissioner,25,REP,Under Votes,46,1,4,8,19,14
+Hill,0006,"Justice, Supreme Court, Place 3",25,REP,Michael Massengale,107,9,13,23,45,17
+Hill,0006,"Justice, Supreme Court, Place 3",25,REP,Debra Lehrmann,43,3,7,6,22,5
+Hill,0006,"Justice, Supreme Court, Place 3",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0006,"Justice, Supreme Court, Place 3",25,REP,Under Votes,48,2,5,7,19,15
+Hill,0006,"Justice, Supreme Court, Place 5",25,REP,Paul Green,81,9,12,15,35,10
+Hill,0006,"Justice, Supreme Court, Place 5",25,REP,Rick Green,64,3,7,14,28,12
+Hill,0006,"Justice, Supreme Court, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0006,"Justice, Supreme Court, Place 5",25,REP,Under Votes,53,2,6,7,23,15
+Hill,0006,"Justice, Supreme Court, Place 9",25,REP,Joe Pool,84,8,13,14,36,13
+Hill,0006,"Justice, Supreme Court, Place 9",25,REP,Eva Guzman,61,4,7,16,24,10
+Hill,0006,"Justice, Supreme Court, Place 9",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0006,"Justice, Supreme Court, Place 9",25,REP,Under Votes,53,2,5,6,26,14
+Hill,0006,"Judge, Court of Criminal Appeals, Place 2",25,REP,Chris Oldner,54,5,6,13,22,8
+Hill,0006,"Judge, Court of Criminal Appeals, Place 2",25,REP,Ray Wheless,54,4,6,11,26,7
+Hill,0006,"Judge, Court of Criminal Appeals, Place 2",25,REP,Mary Lou Keel,36,3,8,4,16,5
+Hill,0006,"Judge, Court of Criminal Appeals, Place 2",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0006,"Judge, Court of Criminal Appeals, Place 2",25,REP,Under Votes,54,2,5,8,22,17
+Hill,0006,"Judge, Court of Criminal Appeals, Place 5",25,REP,Sid Harle,33,5,7,6,14,1
+Hill,0006,"Judge, Court of Criminal Appeals, Place 5",25,REP,Brent Webster,28,1,1,9,11,6
+Hill,0006,"Judge, Court of Criminal Appeals, Place 5",25,REP,Scott Walker,44,1,4,8,24,7
+Hill,0006,"Judge, Court of Criminal Appeals, Place 5",25,REP,Steve Smith,43,5,8,8,16,6
+Hill,0006,"Judge, Court of Criminal Appeals, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0006,"Judge, Court of Criminal Appeals, Place 5",25,REP,Under Votes,50,2,5,5,21,17
+Hill,0006,"Judge, Court of Criminal Appeals, Place 6",25,REP,Richard Davis,79,7,13,16,32,11
+Hill,0006,"Judge, Court of Criminal Appeals, Place 6",25,REP,Michael E. Keasler,62,5,7,10,30,10
+Hill,0006,"Judge, Court of Criminal Appeals, Place 6",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0006,"Judge, Court of Criminal Appeals, Place 6",25,REP,Under Votes,57,2,5,10,24,16
+Hill,0006,"Member, State Board of Education, District 14",25,REP,Sue Melton-Malone,122,10,17,24,52,19
+Hill,0006,"Member, State Board of Education, District 14",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0006,"Member, State Board of Education, District 14",25,REP,Under Votes,76,4,8,12,34,18
+Hill,0006,State Senator,22,REP,Brian Birdwell,136,11,18,29,57,21
+Hill,0006,State Senator,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0006,State Senator,22,REP,Under Votes,62,3,7,7,29,16
+Hill,0006,State Representative,8,REP,Thomas McNutt,100,9,15,18,42,16
+Hill,0006,State Representative,8,REP,Byron Cook,78,5,10,16,33,14
+Hill,0006,State Representative,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0006,State Representative,8,REP,Under Votes,20,0,0,2,11,7
+Hill,0006,"Justice, 10th Court of Appeals District, Place 3",8,REP,Al Scoggins,120,10,16,25,49,20
+Hill,0006,"Justice, 10th Court of Appeals District, Place 3",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0006,"Justice, 10th Court of Appeals District, Place 3",8,REP,Under Votes,78,4,9,11,37,17
+Hill,0006,"District Attorney, 66th Judicial District",8,REP,Mark F Pratt,153,12,18,33,63,27
+Hill,0006,"District Attorney, 66th Judicial District",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0006,"District Attorney, 66th Judicial District",8,REP,Under Votes,45,2,7,3,23,10
+Hill,0006,County Attorney,8,REP,R David Holmes,144,13,19,29,58,25
+Hill,0006,County Attorney,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0006,County Attorney,8,REP,Under Votes,54,1,6,7,28,12
+Hill,0006,Sheriff,8,REP,Jimmy Johnson,26,2,3,8,7,6
+Hill,0006,Sheriff,8,REP,Dedri Hafer,23,2,3,2,11,5
+Hill,0006,Sheriff,8,REP,Rodney Watson,110,8,14,20,49,19
+Hill,0006,Sheriff,8,REP,Kyle R Cox,4,0,0,1,3,0
+Hill,0006,Sheriff,8,REP,Ronnie Myers,32,2,5,4,14,7
+Hill,0006,Sheriff,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0006,Sheriff,8,REP,Under Votes,3,0,0,1,2,0
+Hill,0006,Tax Assessor-Collector,8,REP,Ray Mabry,80,3,9,16,42,10
+Hill,0006,Tax Assessor-Collector,8,REP,Krissi Hightower,90,8,10,19,30,23
+Hill,0006,Tax Assessor-Collector,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0006,Tax Assessor-Collector,8,REP,Under Votes,28,3,6,1,14,4
+Hill,0006,"Constable, Precinct No. 2",8,REP,Justin Girsh,99,8,14,16,46,15
+Hill,0006,"Constable, Precinct No. 2",8,REP,Curtis R Jones,58,4,7,13,21,13
+Hill,0006,"Constable, Precinct No. 2",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0006,"Constable, Precinct No. 2",8,REP,Under Votes,41,2,4,7,19,9
+Hill,0006,County Chairman,8,REP,Will Orr,140,12,19,27,59,23
+Hill,0006,County Chairman,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0006,County Chairman,8,REP,Under Votes,58,2,6,9,27,14
+Hill,0006,President,8,DEM,Bernie Sanders,10,3,3,0,3,1
+Hill,0006,President,8,DEM,Star Locke,0,0,0,0,0,0
+Hill,0006,President,8,DEM,"Roque ""Rocky"" De La Fuente",0,0,0,0,0,0
+Hill,0006,President,8,DEM,Willie L. Wilson,0,0,0,0,0,0
+Hill,0006,President,8,DEM,Calvis L. Hawes,0,0,0,0,0,0
+Hill,0006,President,8,DEM,Hillary Clinton,11,0,1,2,7,1
+Hill,0006,President,8,DEM,Keith Judd,0,0,0,0,0,0
+Hill,0006,President,8,DEM,Martin J. O'Malley,0,0,0,0,0,0
+Hill,0006,President,8,DEM,Over Votes,0,0,0,0,0,0
+Hill,0006,President,8,DEM,Under Votes,0,0,0,0,0,0
+Hill,0006,U.S. House,25,DEM,Kathi Thomas,12,2,2,0,7,1
+Hill,0006,U.S. House,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0006,U.S. House,25,DEM,Under Votes,9,1,2,2,3,1
+Hill,0006,Railroad Commissioner,25,DEM,Cody Garrett,6,1,1,0,4,0
+Hill,0006,Railroad Commissioner,25,DEM,Lon Burnam,3,0,0,0,3,0
+Hill,0006,Railroad Commissioner,25,DEM,Grady Yarbrough,9,2,2,1,2,2
+Hill,0006,Railroad Commissioner,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0006,Railroad Commissioner,25,DEM,Under Votes,3,0,1,1,1,0
+Hill,0006,"Justice, Supreme Court, Place 3",25,DEM,Mike Westergren,14,2,2,0,8,2
+Hill,0006,"Justice, Supreme Court, Place 3",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0006,"Justice, Supreme Court, Place 3",25,DEM,Under Votes,7,1,2,2,2,0
+Hill,0006,"Justice, Supreme Court, Place 5",25,DEM,Dori Contreras Garza,14,2,2,0,8,2
+Hill,0006,"Justice, Supreme Court, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0006,"Justice, Supreme Court, Place 5",25,DEM,Under Votes,7,1,2,2,2,0
+Hill,0006,"Justice, Supreme Court, Place 9",25,DEM,Savannah Robinson,14,2,2,0,8,2
+Hill,0006,"Justice, Supreme Court, Place 9",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0006,"Justice, Supreme Court, Place 9",25,DEM,Under Votes,7,1,2,2,2,0
+Hill,0006,"Judge, Court of Criminal Appeals, Place 2",25,DEM,"Lawrence ""Larry"" Meyers",14,2,2,0,8,2
+Hill,0006,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0006,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Under Votes,7,1,2,2,2,0
+Hill,0006,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Betsy Johnson,14,2,2,0,8,2
+Hill,0006,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0006,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Under Votes,7,1,2,2,2,0
+Hill,0006,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Robert Burns,14,2,2,0,8,2
+Hill,0006,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0006,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Under Votes,7,1,2,2,2,0
+Hill,0006,State Senator,22,DEM,Michael Collins,14,2,2,0,8,2
+Hill,0006,State Senator,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0006,State Senator,22,DEM,Under Votes,7,1,2,2,2,0
+Hill,0006,County Chairman,22,DEM,Thomas Hanson,14,2,2,0,8,2
+Hill,0006,County Chairman,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0006,County Chairman,22,DEM,Under Votes,7,1,2,2,2,0
+Hill,0006,Proposition 1,22,REP,Yes,140,10,17,23,63,27
+Hill,0006,Proposition 1,22,REP,No,38,4,7,10,13,4
+Hill,0006,Proposition 1,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0006,Proposition 1,22,REP,Under Votes,20,0,1,3,10,6
+Hill,0006,Proposition 2,22,REP,Yes,118,8,12,25,52,21
+Hill,0006,Proposition 2,22,REP,No,65,6,12,9,27,11
+Hill,0006,Proposition 2,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0006,Proposition 2,22,REP,Under Votes,15,0,1,2,7,5
+Hill,0006,Proposition 3,22,REP,Yes,156,13,21,25,67,30
+Hill,0006,Proposition 3,22,REP,No,24,1,3,6,10,4
+Hill,0006,Proposition 3,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0006,Proposition 3,22,REP,Under Votes,18,0,1,5,9,3
+Hill,0006,Proposition 4,22,REP,Yes,170,12,22,31,73,32
+Hill,0006,Proposition 4,22,REP,No,8,1,1,2,2,2
+Hill,0006,Proposition 4,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0006,Proposition 4,22,REP,Under Votes,20,1,2,3,11,3
+Hill,0006,Referenda Item #1,22,DEM,For,18,3,3,1,9,2
+Hill,0006,Referenda Item #1,22,DEM,Against,0,0,0,0,0,0
+Hill,0006,Referenda Item #1,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0006,Referenda Item #1,22,DEM,Under Votes,3,0,1,1,1,0
+Hill,0006,Referenda Item #2,22,DEM,For,17,3,3,2,7,2
+Hill,0006,Referenda Item #2,22,DEM,Against,1,0,0,0,1,0
+Hill,0006,Referenda Item #2,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0006,Referenda Item #2,22,DEM,Under Votes,3,0,1,0,2,0
+Hill,0006,Referenda Item #3,22,DEM,For,16,3,3,2,7,1
+Hill,0006,Referenda Item #3,22,DEM,Against,2,0,0,0,1,1
+Hill,0006,Referenda Item #3,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0006,Referenda Item #3,22,DEM,Under Votes,3,0,1,0,2,0
+Hill,0006,Referenda Item #4,22,DEM,For,16,3,3,1,8,1
+Hill,0006,Referenda Item #4,22,DEM,Against,1,0,0,0,0,1
+Hill,0006,Referenda Item #4,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0006,Referenda Item #4,22,DEM,Under Votes,4,0,1,1,2,0
+Hill,0006,Referenda Item #5,22,DEM,For,15,3,3,1,7,1
+Hill,0006,Referenda Item #5,22,DEM,Against,3,0,0,1,1,1
+Hill,0006,Referenda Item #5,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0006,Referenda Item #5,22,DEM,Under Votes,3,0,1,0,2,0
+Hill,0006,Referenda Item #6,22,DEM,For,11,1,1,2,5,2
+Hill,0006,Referenda Item #6,22,DEM,Against,7,2,2,0,3,0
+Hill,0006,Referenda Item #6,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0006,Referenda Item #6,22,DEM,Under Votes,3,0,1,0,2,0
+Hill,0007,Registered Voters - Total,,,,523,0,1,0,2,0
+Hill,0007,Ballots Cast - Total,,REP,,256,5,21,20,120,90
+Hill,0007,Ballots Cast - Total,,DEM,,16,0,2,0,8,6
+Hill,0007,President,,REP,Ted Cruz,126,1,8,9,55,53
+Hill,0007,President,,REP,Jeb Bush,3,0,0,0,2,1
+Hill,0007,President,,REP,Donald J. Trump,86,4,11,5,42,24
+Hill,0007,President,,REP,Ben Carson,9,0,0,2,5,2
+Hill,0007,President,,REP,Rand Paul,0,0,0,0,0,0
+Hill,0007,President,,REP,Rick Santorum,0,0,0,0,0,0
+Hill,0007,President,,REP,Elizabeth Gray,0,0,0,0,0,0
+Hill,0007,President,,REP,Carly Fiorina,0,0,0,0,0,0
+Hill,0007,President,,REP,Lindsey Graham,0,0,0,0,0,0
+Hill,0007,President,,REP,Marco Rubio,21,0,2,2,8,9
+Hill,0007,President,,REP,John R. Kasich,2,0,0,0,2,0
+Hill,0007,President,,REP,Mike Huckabee,1,0,0,0,1,0
+Hill,0007,President,,REP,Chris Christie,0,0,0,0,0,0
+Hill,0007,President,,REP,Uncommitted,4,0,0,1,3,0
+Hill,0007,President,,REP,Over Votes,0,0,0,0,0,0
+Hill,0007,President,,REP,Under Votes,4,0,0,1,2,1
+Hill,0007,U.S. House,25,REP,Roger Williams,192,5,18,17,85,67
+Hill,0007,U.S. House,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0007,U.S. House,25,REP,Under Votes,64,0,3,3,35,23
+Hill,0007,Railroad Commissioner,25,REP,Gary Gates,69,3,8,7,29,22
+Hill,0007,Railroad Commissioner,25,REP,Lance N. Christian,27,0,1,4,14,8
+Hill,0007,Railroad Commissioner,25,REP,Weston Martinez,7,0,2,0,2,3
+Hill,0007,Railroad Commissioner,25,REP,Wayne Christian,29,1,3,4,15,6
+Hill,0007,Railroad Commissioner,25,REP,Ron Hale,22,0,1,0,12,9
+Hill,0007,Railroad Commissioner,25,REP,Doug Jeffrey,13,0,2,1,6,4
+Hill,0007,Railroad Commissioner,25,REP,John Greytok,13,1,1,0,8,3
+Hill,0007,Railroad Commissioner,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0007,Railroad Commissioner,25,REP,Under Votes,76,0,3,4,34,35
+Hill,0007,"Justice, Supreme Court, Place 3",25,REP,Michael Massengale,97,2,9,9,43,34
+Hill,0007,"Justice, Supreme Court, Place 3",25,REP,Debra Lehrmann,97,3,9,8,47,30
+Hill,0007,"Justice, Supreme Court, Place 3",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0007,"Justice, Supreme Court, Place 3",25,REP,Under Votes,62,0,3,3,30,26
+Hill,0007,"Justice, Supreme Court, Place 5",25,REP,Paul Green,110,2,10,11,55,32
+Hill,0007,"Justice, Supreme Court, Place 5",25,REP,Rick Green,69,3,8,5,27,26
+Hill,0007,"Justice, Supreme Court, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0007,"Justice, Supreme Court, Place 5",25,REP,Under Votes,77,0,3,4,38,32
+Hill,0007,"Justice, Supreme Court, Place 9",25,REP,Joe Pool,108,3,10,9,52,34
+Hill,0007,"Justice, Supreme Court, Place 9",25,REP,Eva Guzman,79,2,7,7,34,29
+Hill,0007,"Justice, Supreme Court, Place 9",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0007,"Justice, Supreme Court, Place 9",25,REP,Under Votes,69,0,4,4,34,27
+Hill,0007,"Judge, Court of Criminal Appeals, Place 2",25,REP,Chris Oldner,61,0,6,10,27,18
+Hill,0007,"Judge, Court of Criminal Appeals, Place 2",25,REP,Ray Wheless,54,2,6,1,25,20
+Hill,0007,"Judge, Court of Criminal Appeals, Place 2",25,REP,Mary Lou Keel,57,3,5,5,25,19
+Hill,0007,"Judge, Court of Criminal Appeals, Place 2",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0007,"Judge, Court of Criminal Appeals, Place 2",25,REP,Under Votes,84,0,4,4,43,33
+Hill,0007,"Judge, Court of Criminal Appeals, Place 5",25,REP,Sid Harle,37,1,2,3,21,10
+Hill,0007,"Judge, Court of Criminal Appeals, Place 5",25,REP,Brent Webster,24,1,4,3,8,8
+Hill,0007,"Judge, Court of Criminal Appeals, Place 5",25,REP,Scott Walker,70,1,6,5,31,27
+Hill,0007,"Judge, Court of Criminal Appeals, Place 5",25,REP,Steve Smith,47,2,6,5,22,12
+Hill,0007,"Judge, Court of Criminal Appeals, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0007,"Judge, Court of Criminal Appeals, Place 5",25,REP,Under Votes,78,0,3,4,38,33
+Hill,0007,"Judge, Court of Criminal Appeals, Place 6",25,REP,Richard Davis,113,3,12,11,45,42
+Hill,0007,"Judge, Court of Criminal Appeals, Place 6",25,REP,Michael E. Keasler,59,2,5,5,33,14
+Hill,0007,"Judge, Court of Criminal Appeals, Place 6",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0007,"Judge, Court of Criminal Appeals, Place 6",25,REP,Under Votes,84,0,4,4,42,34
+Hill,0007,"Member, State Board of Education, District 14",25,REP,Sue Melton-Malone,184,5,18,15,84,62
+Hill,0007,"Member, State Board of Education, District 14",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0007,"Member, State Board of Education, District 14",25,REP,Under Votes,72,0,3,5,36,28
+Hill,0007,State Senator,22,REP,Brian Birdwell,199,5,18,16,91,69
+Hill,0007,State Senator,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0007,State Senator,22,REP,Under Votes,57,0,3,4,29,21
+Hill,0007,State Representative,8,REP,Thomas McNutt,105,3,9,6,55,32
+Hill,0007,State Representative,8,REP,Byron Cook,124,2,10,12,54,46
+Hill,0007,State Representative,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0007,State Representative,8,REP,Under Votes,27,0,2,2,11,12
+Hill,0007,"Justice, 10th Court of Appeals District, Place 3",8,REP,Al Scoggins,183,5,18,16,82,62
+Hill,0007,"Justice, 10th Court of Appeals District, Place 3",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0007,"Justice, 10th Court of Appeals District, Place 3",8,REP,Under Votes,73,0,3,4,38,28
+Hill,0007,"District Attorney, 66th Judicial District",8,REP,Mark F Pratt,209,5,19,18,95,72
+Hill,0007,"District Attorney, 66th Judicial District",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0007,"District Attorney, 66th Judicial District",8,REP,Under Votes,47,0,2,2,25,18
+Hill,0007,County Attorney,8,REP,R David Holmes,196,5,18,17,83,73
+Hill,0007,County Attorney,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0007,County Attorney,8,REP,Under Votes,60,0,3,3,37,17
+Hill,0007,Sheriff,8,REP,Jimmy Johnson,43,2,5,5,22,9
+Hill,0007,Sheriff,8,REP,Dedri Hafer,7,1,1,2,1,2
+Hill,0007,Sheriff,8,REP,Rodney Watson,104,0,5,9,50,40
+Hill,0007,Sheriff,8,REP,Kyle R Cox,29,1,5,0,15,8
+Hill,0007,Sheriff,8,REP,Ronnie Myers,61,1,4,3,27,26
+Hill,0007,Sheriff,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0007,Sheriff,8,REP,Under Votes,12,0,1,1,5,5
+Hill,0007,Tax Assessor-Collector,8,REP,Ray Mabry,116,2,11,9,57,37
+Hill,0007,Tax Assessor-Collector,8,REP,Krissi Hightower,83,3,7,8,35,30
+Hill,0007,Tax Assessor-Collector,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0007,Tax Assessor-Collector,8,REP,Under Votes,57,0,3,3,28,23
+Hill,0007,County Commissioner # 3,8,REP,Scotty Hawkins,123,4,8,12,54,45
+Hill,0007,County Commissioner # 3,8,REP,Milton Stuckly,47,0,2,1,22,22
+Hill,0007,County Commissioner # 3,8,REP,"Ernest D McFarland, Jr",10,1,3,0,4,2
+Hill,0007,County Commissioner # 3,8,REP,David Bow,40,0,5,6,21,8
+Hill,0007,County Commissioner # 3,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0007,County Commissioner # 3,8,REP,Under Votes,36,0,3,1,19,13
+Hill,0007,"Constable, Precinct No. 3",8,REP,Larry Armstrong,91,2,10,6,46,27
+Hill,0007,"Constable, Precinct No. 3",8,REP,Brian Couch,16,0,3,2,7,4
+Hill,0007,"Constable, Precinct No. 3",8,REP,Stephen Nanny,114,3,6,10,49,46
+Hill,0007,"Constable, Precinct No. 3",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0007,"Constable, Precinct No. 3",8,REP,Under Votes,35,0,2,2,18,13
+Hill,0007,County Chairman,8,REP,Will Orr,196,5,17,16,86,72
+Hill,0007,County Chairman,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0007,County Chairman,8,REP,Under Votes,60,0,4,4,34,18
+Hill,0007,President,8,DEM,Bernie Sanders,5,0,0,0,1,4
+Hill,0007,President,8,DEM,Star Locke,0,0,0,0,0,0
+Hill,0007,President,8,DEM,"Roque ""Rocky"" De La Fuente",0,0,0,0,0,0
+Hill,0007,President,8,DEM,Willie L. Wilson,0,0,0,0,0,0
+Hill,0007,President,8,DEM,Calvis L. Hawes,0,0,0,0,0,0
+Hill,0007,President,8,DEM,Hillary Clinton,11,0,2,0,7,2
+Hill,0007,President,8,DEM,Keith Judd,0,0,0,0,0,0
+Hill,0007,President,8,DEM,Martin J. O'Malley,0,0,0,0,0,0
+Hill,0007,President,8,DEM,Over Votes,0,0,0,0,0,0
+Hill,0007,President,8,DEM,Under Votes,0,0,0,0,0,0
+Hill,0007,U.S. House,25,DEM,Kathi Thomas,14,0,2,0,7,5
+Hill,0007,U.S. House,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0007,U.S. House,25,DEM,Under Votes,2,0,0,0,1,1
+Hill,0007,Railroad Commissioner,25,DEM,Cody Garrett,7,0,1,0,4,2
+Hill,0007,Railroad Commissioner,25,DEM,Lon Burnam,3,0,0,0,1,2
+Hill,0007,Railroad Commissioner,25,DEM,Grady Yarbrough,4,0,1,0,2,1
+Hill,0007,Railroad Commissioner,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0007,Railroad Commissioner,25,DEM,Under Votes,2,0,0,0,1,1
+Hill,0007,"Justice, Supreme Court, Place 3",25,DEM,Mike Westergren,14,0,2,0,7,5
+Hill,0007,"Justice, Supreme Court, Place 3",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0007,"Justice, Supreme Court, Place 3",25,DEM,Under Votes,2,0,0,0,1,1
+Hill,0007,"Justice, Supreme Court, Place 5",25,DEM,Dori Contreras Garza,14,0,2,0,7,5
+Hill,0007,"Justice, Supreme Court, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0007,"Justice, Supreme Court, Place 5",25,DEM,Under Votes,2,0,0,0,1,1
+Hill,0007,"Justice, Supreme Court, Place 9",25,DEM,Savannah Robinson,13,0,2,0,6,5
+Hill,0007,"Justice, Supreme Court, Place 9",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0007,"Justice, Supreme Court, Place 9",25,DEM,Under Votes,3,0,0,0,2,1
+Hill,0007,"Judge, Court of Criminal Appeals, Place 2",25,DEM,"Lawrence ""Larry"" Meyers",14,0,2,0,7,5
+Hill,0007,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0007,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Under Votes,2,0,0,0,1,1
+Hill,0007,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Betsy Johnson,13,0,2,0,6,5
+Hill,0007,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0007,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Under Votes,3,0,0,0,2,1
+Hill,0007,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Robert Burns,12,0,2,0,6,4
+Hill,0007,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0007,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Under Votes,4,0,0,0,2,2
+Hill,0007,State Senator,22,DEM,Michael Collins,13,0,2,0,6,5
+Hill,0007,State Senator,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0007,State Senator,22,DEM,Under Votes,3,0,0,0,2,1
+Hill,0007,County Chairman,22,DEM,Thomas Hanson,12,0,2,0,6,4
+Hill,0007,County Chairman,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0007,County Chairman,22,DEM,Under Votes,4,0,0,0,2,2
+Hill,0007,Proposition 1,22,REP,Yes,153,4,16,10,72,51
+Hill,0007,Proposition 1,22,REP,No,71,1,3,9,29,29
+Hill,0007,Proposition 1,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0007,Proposition 1,22,REP,Under Votes,32,0,2,1,19,10
+Hill,0007,Proposition 2,22,REP,Yes,141,3,11,7,68,52
+Hill,0007,Proposition 2,22,REP,No,94,2,8,13,38,33
+Hill,0007,Proposition 2,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0007,Proposition 2,22,REP,Under Votes,21,0,2,0,14,5
+Hill,0007,Proposition 3,22,REP,Yes,187,5,20,14,88,60
+Hill,0007,Proposition 3,22,REP,No,39,0,0,4,15,20
+Hill,0007,Proposition 3,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0007,Proposition 3,22,REP,Under Votes,30,0,1,2,17,10
+Hill,0007,Proposition 4,22,REP,Yes,214,5,18,18,95,78
+Hill,0007,Proposition 4,22,REP,No,8,0,0,0,5,3
+Hill,0007,Proposition 4,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0007,Proposition 4,22,REP,Under Votes,34,0,3,2,20,9
+Hill,0007,Referenda Item #1,22,DEM,For,14,0,1,0,7,6
+Hill,0007,Referenda Item #1,22,DEM,Against,2,0,1,0,1,0
+Hill,0007,Referenda Item #1,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0007,Referenda Item #1,22,DEM,Under Votes,0,0,0,0,0,0
+Hill,0007,Referenda Item #2,22,DEM,For,15,0,2,0,7,6
+Hill,0007,Referenda Item #2,22,DEM,Against,0,0,0,0,0,0
+Hill,0007,Referenda Item #2,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0007,Referenda Item #2,22,DEM,Under Votes,1,0,0,0,1,0
+Hill,0007,Referenda Item #3,22,DEM,For,14,0,2,0,6,6
+Hill,0007,Referenda Item #3,22,DEM,Against,1,0,0,0,1,0
+Hill,0007,Referenda Item #3,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0007,Referenda Item #3,22,DEM,Under Votes,1,0,0,0,1,0
+Hill,0007,Referenda Item #4,22,DEM,For,14,0,2,0,7,5
+Hill,0007,Referenda Item #4,22,DEM,Against,1,0,0,0,0,1
+Hill,0007,Referenda Item #4,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0007,Referenda Item #4,22,DEM,Under Votes,1,0,0,0,1,0
+Hill,0007,Referenda Item #5,22,DEM,For,10,0,2,0,4,4
+Hill,0007,Referenda Item #5,22,DEM,Against,5,0,0,0,3,2
+Hill,0007,Referenda Item #5,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0007,Referenda Item #5,22,DEM,Under Votes,1,0,0,0,1,0
+Hill,0007,Referenda Item #6,22,DEM,For,15,0,2,0,7,6
+Hill,0007,Referenda Item #6,22,DEM,Against,0,0,0,0,0,0
+Hill,0007,Referenda Item #6,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0007,Referenda Item #6,22,DEM,Under Votes,1,0,0,0,1,0
+Hill,0008,Registered Voters - Total,,,,349,0,0,0,1,0
+Hill,0008,Ballots Cast - Total,,REP,,174,8,26,21,71,48
+Hill,0008,Ballots Cast - Total,,DEM,,38,3,3,4,22,6
+Hill,0008,President,,REP,Ted Cruz,79,3,10,7,30,29
+Hill,0008,President,,REP,Jeb Bush,4,1,1,1,1,0
+Hill,0008,President,,REP,Donald J. Trump,62,3,12,7,30,10
+Hill,0008,President,,REP,Ben Carson,7,0,0,2,2,3
+Hill,0008,President,,REP,Rand Paul,0,0,0,0,0,0
+Hill,0008,President,,REP,Rick Santorum,0,0,0,0,0,0
+Hill,0008,President,,REP,Elizabeth Gray,0,0,0,0,0,0
+Hill,0008,President,,REP,Carly Fiorina,0,0,0,0,0,0
+Hill,0008,President,,REP,Lindsey Graham,0,0,0,0,0,0
+Hill,0008,President,,REP,Marco Rubio,12,1,1,4,1,5
+Hill,0008,President,,REP,John R. Kasich,6,0,2,0,3,1
+Hill,0008,President,,REP,Mike Huckabee,0,0,0,0,0,0
+Hill,0008,President,,REP,Chris Christie,0,0,0,0,0,0
+Hill,0008,President,,REP,Uncommitted,0,0,0,0,0,0
+Hill,0008,President,,REP,Over Votes,0,0,0,0,0,0
+Hill,0008,President,,REP,Under Votes,4,0,0,0,4,0
+Hill,0008,U.S. House,25,REP,Roger Williams,112,5,19,16,46,26
+Hill,0008,U.S. House,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0008,U.S. House,25,REP,Under Votes,62,3,7,5,25,22
+Hill,0008,Railroad Commissioner,25,REP,Gary Gates,38,3,6,3,13,13
+Hill,0008,Railroad Commissioner,25,REP,Lance N. Christian,17,1,2,4,6,4
+Hill,0008,Railroad Commissioner,25,REP,Weston Martinez,4,0,0,1,0,3
+Hill,0008,Railroad Commissioner,25,REP,Wayne Christian,22,0,4,4,10,4
+Hill,0008,Railroad Commissioner,25,REP,Ron Hale,15,2,4,2,7,0
+Hill,0008,Railroad Commissioner,25,REP,Doug Jeffrey,12,0,2,2,4,4
+Hill,0008,Railroad Commissioner,25,REP,John Greytok,2,0,0,1,1,0
+Hill,0008,Railroad Commissioner,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0008,Railroad Commissioner,25,REP,Under Votes,64,2,8,4,30,20
+Hill,0008,"Justice, Supreme Court, Place 3",25,REP,Michael Massengale,54,1,6,10,19,18
+Hill,0008,"Justice, Supreme Court, Place 3",25,REP,Debra Lehrmann,67,5,12,8,28,14
+Hill,0008,"Justice, Supreme Court, Place 3",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0008,"Justice, Supreme Court, Place 3",25,REP,Under Votes,53,2,8,3,24,16
+Hill,0008,"Justice, Supreme Court, Place 5",25,REP,Paul Green,62,1,8,14,23,16
+Hill,0008,"Justice, Supreme Court, Place 5",25,REP,Rick Green,45,4,7,4,19,11
+Hill,0008,"Justice, Supreme Court, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0008,"Justice, Supreme Court, Place 5",25,REP,Under Votes,67,3,11,3,29,21
+Hill,0008,"Justice, Supreme Court, Place 9",25,REP,Joe Pool,70,3,11,10,26,20
+Hill,0008,"Justice, Supreme Court, Place 9",25,REP,Eva Guzman,47,2,7,8,20,10
+Hill,0008,"Justice, Supreme Court, Place 9",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0008,"Justice, Supreme Court, Place 9",25,REP,Under Votes,57,3,8,3,25,18
+Hill,0008,"Judge, Court of Criminal Appeals, Place 2",25,REP,Chris Oldner,32,0,3,8,8,13
+Hill,0008,"Judge, Court of Criminal Appeals, Place 2",25,REP,Ray Wheless,33,2,7,3,15,6
+Hill,0008,"Judge, Court of Criminal Appeals, Place 2",25,REP,Mary Lou Keel,45,3,9,6,19,8
+Hill,0008,"Judge, Court of Criminal Appeals, Place 2",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0008,"Judge, Court of Criminal Appeals, Place 2",25,REP,Under Votes,64,3,7,4,29,21
+Hill,0008,"Judge, Court of Criminal Appeals, Place 5",25,REP,Sid Harle,14,1,1,5,3,4
+Hill,0008,"Judge, Court of Criminal Appeals, Place 5",25,REP,Brent Webster,16,1,3,2,5,5
+Hill,0008,"Judge, Court of Criminal Appeals, Place 5",25,REP,Scott Walker,52,1,8,7,21,15
+Hill,0008,"Judge, Court of Criminal Appeals, Place 5",25,REP,Steve Smith,32,3,7,4,15,3
+Hill,0008,"Judge, Court of Criminal Appeals, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0008,"Judge, Court of Criminal Appeals, Place 5",25,REP,Under Votes,60,2,7,3,27,21
+Hill,0008,"Judge, Court of Criminal Appeals, Place 6",25,REP,Richard Davis,80,3,13,12,32,20
+Hill,0008,"Judge, Court of Criminal Appeals, Place 6",25,REP,Michael E. Keasler,26,2,4,5,9,6
+Hill,0008,"Judge, Court of Criminal Appeals, Place 6",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0008,"Judge, Court of Criminal Appeals, Place 6",25,REP,Under Votes,68,3,9,4,30,22
+Hill,0008,"Member, State Board of Education, District 14",25,REP,Sue Melton-Malone,109,6,18,17,44,24
+Hill,0008,"Member, State Board of Education, District 14",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0008,"Member, State Board of Education, District 14",25,REP,Under Votes,65,2,8,4,27,24
+Hill,0008,State Senator,22,REP,Brian Birdwell,126,7,21,20,50,28
+Hill,0008,State Senator,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0008,State Senator,22,REP,Under Votes,48,1,5,1,21,20
+Hill,0008,State Representative,8,REP,Thomas McNutt,75,4,11,9,31,20
+Hill,0008,State Representative,8,REP,Byron Cook,77,3,13,12,29,20
+Hill,0008,State Representative,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0008,State Representative,8,REP,Under Votes,22,1,2,0,11,8
+Hill,0008,"Justice, 10th Court of Appeals District, Place 3",8,REP,Al Scoggins,97,5,17,16,40,19
+Hill,0008,"Justice, 10th Court of Appeals District, Place 3",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0008,"Justice, 10th Court of Appeals District, Place 3",8,REP,Under Votes,77,3,9,5,31,29
+Hill,0008,"District Attorney, 66th Judicial District",8,REP,Mark F Pratt,119,6,21,17,49,26
+Hill,0008,"District Attorney, 66th Judicial District",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0008,"District Attorney, 66th Judicial District",8,REP,Under Votes,55,2,5,4,22,22
+Hill,0008,County Attorney,8,REP,R David Holmes,116,6,21,18,46,25
+Hill,0008,County Attorney,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0008,County Attorney,8,REP,Under Votes,58,2,5,3,25,23
+Hill,0008,Sheriff,8,REP,Jimmy Johnson,50,0,8,6,20,16
+Hill,0008,Sheriff,8,REP,Dedri Hafer,4,0,0,2,1,1
+Hill,0008,Sheriff,8,REP,Rodney Watson,70,4,10,5,30,21
+Hill,0008,Sheriff,8,REP,Kyle R Cox,17,0,3,5,6,3
+Hill,0008,Sheriff,8,REP,Ronnie Myers,26,4,5,3,10,4
+Hill,0008,Sheriff,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0008,Sheriff,8,REP,Under Votes,7,0,0,0,4,3
+Hill,0008,Tax Assessor-Collector,8,REP,Ray Mabry,78,5,13,8,31,21
+Hill,0008,Tax Assessor-Collector,8,REP,Krissi Hightower,66,2,9,13,26,16
+Hill,0008,Tax Assessor-Collector,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0008,Tax Assessor-Collector,8,REP,Under Votes,30,1,4,0,14,11
+Hill,0008,County Commissioner # 3,8,REP,Scotty Hawkins,96,5,18,8,42,23
+Hill,0008,County Commissioner # 3,8,REP,Milton Stuckly,4,1,1,1,1,0
+Hill,0008,County Commissioner # 3,8,REP,"Ernest D McFarland, Jr",3,0,0,1,0,2
+Hill,0008,County Commissioner # 3,8,REP,David Bow,55,2,5,10,21,17
+Hill,0008,County Commissioner # 3,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0008,County Commissioner # 3,8,REP,Under Votes,16,0,2,1,7,6
+Hill,0008,"Constable, Precinct No. 3",8,REP,Larry Armstrong,90,5,20,12,36,17
+Hill,0008,"Constable, Precinct No. 3",8,REP,Brian Couch,20,1,2,3,7,7
+Hill,0008,"Constable, Precinct No. 3",8,REP,Stephen Nanny,42,2,3,4,20,13
+Hill,0008,"Constable, Precinct No. 3",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0008,"Constable, Precinct No. 3",8,REP,Under Votes,22,0,1,2,8,11
+Hill,0008,County Chairman,8,REP,Will Orr,118,7,21,19,45,26
+Hill,0008,County Chairman,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0008,County Chairman,8,REP,Under Votes,56,1,5,2,26,22
+Hill,0008,President,8,DEM,Bernie Sanders,10,1,1,1,5,2
+Hill,0008,President,8,DEM,Star Locke,0,0,0,0,0,0
+Hill,0008,President,8,DEM,"Roque ""Rocky"" De La Fuente",0,0,0,0,0,0
+Hill,0008,President,8,DEM,Willie L. Wilson,0,0,0,0,0,0
+Hill,0008,President,8,DEM,Calvis L. Hawes,0,0,0,0,0,0
+Hill,0008,President,8,DEM,Hillary Clinton,15,2,2,3,4,4
+Hill,0008,President,8,DEM,Keith Judd,0,0,0,0,0,0
+Hill,0008,President,8,DEM,Martin J. O'Malley,0,0,0,0,0,0
+Hill,0008,President,8,DEM,Over Votes,0,0,0,0,0,0
+Hill,0008,President,8,DEM,Under Votes,13,0,0,0,13,0
+Hill,0008,U.S. House,25,DEM,Kathi Thomas,22,3,3,4,7,5
+Hill,0008,U.S. House,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0008,U.S. House,25,DEM,Under Votes,16,0,0,0,15,1
+Hill,0008,Railroad Commissioner,25,DEM,Cody Garrett,6,0,0,3,1,2
+Hill,0008,Railroad Commissioner,25,DEM,Lon Burnam,3,0,0,1,0,2
+Hill,0008,Railroad Commissioner,25,DEM,Grady Yarbrough,4,0,0,0,3,1
+Hill,0008,Railroad Commissioner,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0008,Railroad Commissioner,25,DEM,Under Votes,25,3,3,0,18,1
+Hill,0008,"Justice, Supreme Court, Place 3",25,DEM,Mike Westergren,23,3,3,4,8,5
+Hill,0008,"Justice, Supreme Court, Place 3",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0008,"Justice, Supreme Court, Place 3",25,DEM,Under Votes,15,0,0,0,14,1
+Hill,0008,"Justice, Supreme Court, Place 5",25,DEM,Dori Contreras Garza,23,3,3,4,8,5
+Hill,0008,"Justice, Supreme Court, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0008,"Justice, Supreme Court, Place 5",25,DEM,Under Votes,15,0,0,0,14,1
+Hill,0008,"Justice, Supreme Court, Place 9",25,DEM,Savannah Robinson,22,3,3,4,7,5
+Hill,0008,"Justice, Supreme Court, Place 9",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0008,"Justice, Supreme Court, Place 9",25,DEM,Under Votes,16,0,0,0,15,1
+Hill,0008,"Judge, Court of Criminal Appeals, Place 2",25,DEM,"Lawrence ""Larry"" Meyers",22,3,3,4,7,5
+Hill,0008,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0008,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Under Votes,16,0,0,0,15,1
+Hill,0008,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Betsy Johnson,21,3,3,4,6,5
+Hill,0008,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0008,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Under Votes,17,0,0,0,16,1
+Hill,0008,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Robert Burns,22,3,3,4,6,6
+Hill,0008,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0008,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Under Votes,16,0,0,0,16,0
+Hill,0008,State Senator,22,DEM,Michael Collins,22,3,3,4,6,6
+Hill,0008,State Senator,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0008,State Senator,22,DEM,Under Votes,16,0,0,0,16,0
+Hill,0008,County Chairman,22,DEM,Thomas Hanson,22,3,3,4,6,6
+Hill,0008,County Chairman,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0008,County Chairman,22,DEM,Under Votes,16,0,0,0,16,0
+Hill,0008,Precinct Chairman 8,22,DEM,Rosie Salinas,20,3,3,4,5,5
+Hill,0008,Precinct Chairman 8,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0008,Precinct Chairman 8,22,DEM,Under Votes,18,0,0,0,17,1
+Hill,0008,Proposition 1,22,REP,Yes,116,4,21,11,51,29
+Hill,0008,Proposition 1,22,REP,No,31,3,3,9,7,9
+Hill,0008,Proposition 1,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0008,Proposition 1,22,REP,Under Votes,27,1,2,1,13,10
+Hill,0008,Proposition 2,22,REP,Yes,87,5,16,9,36,21
+Hill,0008,Proposition 2,22,REP,No,67,2,9,11,24,21
+Hill,0008,Proposition 2,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0008,Proposition 2,22,REP,Under Votes,20,1,1,1,11,6
+Hill,0008,Proposition 3,22,REP,Yes,122,7,19,15,49,32
+Hill,0008,Proposition 3,22,REP,No,26,0,5,5,9,7
+Hill,0008,Proposition 3,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0008,Proposition 3,22,REP,Under Votes,26,1,2,1,13,9
+Hill,0008,Proposition 4,22,REP,Yes,142,7,22,20,53,40
+Hill,0008,Proposition 4,22,REP,No,6,0,2,0,3,1
+Hill,0008,Proposition 4,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0008,Proposition 4,22,REP,Under Votes,26,1,2,1,15,7
+Hill,0008,Referenda Item #1,22,DEM,For,18,1,1,4,6,6
+Hill,0008,Referenda Item #1,22,DEM,Against,3,1,1,0,1,0
+Hill,0008,Referenda Item #1,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0008,Referenda Item #1,22,DEM,Under Votes,17,1,1,0,15,0
+Hill,0008,Referenda Item #2,22,DEM,For,20,2,2,4,7,5
+Hill,0008,Referenda Item #2,22,DEM,Against,4,1,1,0,1,1
+Hill,0008,Referenda Item #2,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0008,Referenda Item #2,22,DEM,Under Votes,14,0,0,0,14,0
+Hill,0008,Referenda Item #3,22,DEM,For,24,3,3,4,8,6
+Hill,0008,Referenda Item #3,22,DEM,Against,0,0,0,0,0,0
+Hill,0008,Referenda Item #3,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0008,Referenda Item #3,22,DEM,Under Votes,14,0,0,0,14,0
+Hill,0008,Referenda Item #4,22,DEM,For,24,3,3,4,8,6
+Hill,0008,Referenda Item #4,22,DEM,Against,0,0,0,0,0,0
+Hill,0008,Referenda Item #4,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0008,Referenda Item #4,22,DEM,Under Votes,14,0,0,0,14,0
+Hill,0008,Referenda Item #5,22,DEM,For,20,2,2,4,7,5
+Hill,0008,Referenda Item #5,22,DEM,Against,4,1,1,0,1,1
+Hill,0008,Referenda Item #5,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0008,Referenda Item #5,22,DEM,Under Votes,14,0,0,0,14,0
+Hill,0008,Referenda Item #6,22,DEM,For,17,1,1,4,6,5
+Hill,0008,Referenda Item #6,22,DEM,Against,1,0,0,0,0,1
+Hill,0008,Referenda Item #6,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0008,Referenda Item #6,22,DEM,Under Votes,20,2,2,0,16,0
+Hill,0009,Registered Voters - Total,,,,547,2,2,0,16,0
+Hill,0009,Ballots Cast - Total,,REP,,217,13,39,45,87,33
+Hill,0009,Ballots Cast - Total,,DEM,,23,2,3,1,8,9
+Hill,0009,President,,REP,Ted Cruz,103,7,21,20,46,9
+Hill,0009,President,,REP,Jeb Bush,4,1,1,0,1,1
+Hill,0009,President,,REP,Donald J. Trump,71,2,11,15,30,13
+Hill,0009,President,,REP,Ben Carson,12,1,1,2,3,5
+Hill,0009,President,,REP,Rand Paul,1,0,0,1,0,0
+Hill,0009,President,,REP,Rick Santorum,0,0,0,0,0,0
+Hill,0009,President,,REP,Elizabeth Gray,0,0,0,0,0,0
+Hill,0009,President,,REP,Carly Fiorina,0,0,0,0,0,0
+Hill,0009,President,,REP,Lindsey Graham,0,0,0,0,0,0
+Hill,0009,President,,REP,Marco Rubio,18,2,3,4,5,4
+Hill,0009,President,,REP,John R. Kasich,1,0,0,1,0,0
+Hill,0009,President,,REP,Mike Huckabee,0,0,0,0,0,0
+Hill,0009,President,,REP,Chris Christie,2,0,0,1,0,1
+Hill,0009,President,,REP,Uncommitted,3,0,1,1,1,0
+Hill,0009,President,,REP,Over Votes,0,0,0,0,0,0
+Hill,0009,President,,REP,Under Votes,2,0,1,0,1,0
+Hill,0009,U.S. House,25,REP,Roger Williams,156,12,30,28,67,19
+Hill,0009,U.S. House,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0009,U.S. House,25,REP,Under Votes,61,1,9,17,20,14
+Hill,0009,Railroad Commissioner,25,REP,Gary Gates,61,3,8,18,23,9
+Hill,0009,Railroad Commissioner,25,REP,Lance N. Christian,29,4,6,4,11,4
+Hill,0009,Railroad Commissioner,25,REP,Weston Martinez,14,2,3,1,7,1
+Hill,0009,Railroad Commissioner,25,REP,Wayne Christian,24,0,3,9,8,4
+Hill,0009,Railroad Commissioner,25,REP,Ron Hale,24,1,4,5,11,3
+Hill,0009,Railroad Commissioner,25,REP,Doug Jeffrey,5,0,1,1,2,1
+Hill,0009,Railroad Commissioner,25,REP,John Greytok,6,1,2,0,3,0
+Hill,0009,Railroad Commissioner,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0009,Railroad Commissioner,25,REP,Under Votes,54,2,12,7,22,11
+Hill,0009,"Justice, Supreme Court, Place 3",25,REP,Michael Massengale,89,5,15,21,34,14
+Hill,0009,"Justice, Supreme Court, Place 3",25,REP,Debra Lehrmann,86,7,15,17,35,12
+Hill,0009,"Justice, Supreme Court, Place 3",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0009,"Justice, Supreme Court, Place 3",25,REP,Under Votes,42,1,9,7,18,7
+Hill,0009,"Justice, Supreme Court, Place 5",25,REP,Paul Green,86,4,16,22,30,14
+Hill,0009,"Justice, Supreme Court, Place 5",25,REP,Rick Green,71,6,11,13,31,10
+Hill,0009,"Justice, Supreme Court, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0009,"Justice, Supreme Court, Place 5",25,REP,Under Votes,60,3,12,10,26,9
+Hill,0009,"Justice, Supreme Court, Place 9",25,REP,Joe Pool,89,6,16,8,40,19
+Hill,0009,"Justice, Supreme Court, Place 9",25,REP,Eva Guzman,88,6,13,32,30,7
+Hill,0009,"Justice, Supreme Court, Place 9",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0009,"Justice, Supreme Court, Place 9",25,REP,Under Votes,40,1,10,5,17,7
+Hill,0009,"Judge, Court of Criminal Appeals, Place 2",25,REP,Chris Oldner,39,3,6,6,18,6
+Hill,0009,"Judge, Court of Criminal Appeals, Place 2",25,REP,Ray Wheless,49,3,7,13,17,9
+Hill,0009,"Judge, Court of Criminal Appeals, Place 2",25,REP,Mary Lou Keel,62,4,12,16,20,10
+Hill,0009,"Judge, Court of Criminal Appeals, Place 2",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0009,"Judge, Court of Criminal Appeals, Place 2",25,REP,Under Votes,67,3,14,10,32,8
+Hill,0009,"Judge, Court of Criminal Appeals, Place 5",25,REP,Sid Harle,14,0,0,7,5,2
+Hill,0009,"Judge, Court of Criminal Appeals, Place 5",25,REP,Brent Webster,49,3,9,10,18,9
+Hill,0009,"Judge, Court of Criminal Appeals, Place 5",25,REP,Scott Walker,58,5,9,11,23,10
+Hill,0009,"Judge, Court of Criminal Appeals, Place 5",25,REP,Steve Smith,37,2,8,9,15,3
+Hill,0009,"Judge, Court of Criminal Appeals, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0009,"Judge, Court of Criminal Appeals, Place 5",25,REP,Under Votes,59,3,13,8,26,9
+Hill,0009,"Judge, Court of Criminal Appeals, Place 6",25,REP,Richard Davis,73,5,12,13,28,15
+Hill,0009,"Judge, Court of Criminal Appeals, Place 6",25,REP,Michael E. Keasler,68,5,12,21,22,8
+Hill,0009,"Judge, Court of Criminal Appeals, Place 6",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0009,"Judge, Court of Criminal Appeals, Place 6",25,REP,Under Votes,76,3,15,11,37,10
+Hill,0009,"Member, State Board of Education, District 14",25,REP,Sue Melton-Malone,145,10,26,31,55,23
+Hill,0009,"Member, State Board of Education, District 14",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0009,"Member, State Board of Education, District 14",25,REP,Under Votes,72,3,13,14,32,10
+Hill,0009,State Senator,22,REP,Brian Birdwell,157,11,29,32,60,25
+Hill,0009,State Senator,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0009,State Senator,22,REP,Under Votes,60,2,10,13,27,8
+Hill,0009,State Representative,8,REP,Thomas McNutt,86,4,12,25,31,14
+Hill,0009,State Representative,8,REP,Byron Cook,119,9,24,19,48,19
+Hill,0009,State Representative,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0009,State Representative,8,REP,Under Votes,12,0,3,1,8,0
+Hill,0009,"Justice, 10th Court of Appeals District, Place 3",8,REP,Al Scoggins,138,8,24,29,55,22
+Hill,0009,"Justice, 10th Court of Appeals District, Place 3",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0009,"Justice, 10th Court of Appeals District, Place 3",8,REP,Under Votes,79,5,15,16,32,11
+Hill,0009,"District Attorney, 66th Judicial District",8,REP,Mark F Pratt,163,9,28,34,65,27
+Hill,0009,"District Attorney, 66th Judicial District",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0009,"District Attorney, 66th Judicial District",8,REP,Under Votes,54,4,11,11,22,6
+Hill,0009,County Attorney,8,REP,R David Holmes,155,8,28,34,59,26
+Hill,0009,County Attorney,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0009,County Attorney,8,REP,Under Votes,62,5,11,11,28,7
+Hill,0009,Sheriff,8,REP,Jimmy Johnson,66,5,12,10,26,13
+Hill,0009,Sheriff,8,REP,Dedri Hafer,10,1,2,1,5,1
+Hill,0009,Sheriff,8,REP,Rodney Watson,77,5,14,22,28,8
+Hill,0009,Sheriff,8,REP,Kyle R Cox,26,2,4,5,9,6
+Hill,0009,Sheriff,8,REP,Ronnie Myers,15,0,2,5,6,2
+Hill,0009,Sheriff,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0009,Sheriff,8,REP,Under Votes,23,0,5,2,13,3
+Hill,0009,Tax Assessor-Collector,8,REP,Ray Mabry,90,6,13,20,37,14
+Hill,0009,Tax Assessor-Collector,8,REP,Krissi Hightower,85,6,18,16,33,12
+Hill,0009,Tax Assessor-Collector,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0009,Tax Assessor-Collector,8,REP,Under Votes,42,1,8,9,17,7
+Hill,0009,"Constable, Precinct No. 4",8,REP,Collin Yeaman,81,5,13,15,32,16
+Hill,0009,"Constable, Precinct No. 4",8,REP,George Willoughby,76,8,14,19,26,9
+Hill,0009,"Constable, Precinct No. 4",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0009,"Constable, Precinct No. 4",8,REP,Under Votes,60,0,12,11,29,8
+Hill,0009,County Chairman,8,REP,Will Orr,151,10,28,33,55,25
+Hill,0009,County Chairman,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0009,County Chairman,8,REP,Under Votes,66,3,11,12,32,8
+Hill,0009,President,8,DEM,Bernie Sanders,8,0,0,1,1,6
+Hill,0009,President,8,DEM,Star Locke,0,0,0,0,0,0
+Hill,0009,President,8,DEM,"Roque ""Rocky"" De La Fuente",0,0,0,0,0,0
+Hill,0009,President,8,DEM,Willie L. Wilson,0,0,0,0,0,0
+Hill,0009,President,8,DEM,Calvis L. Hawes,0,0,0,0,0,0
+Hill,0009,President,8,DEM,Hillary Clinton,15,2,3,0,7,3
+Hill,0009,President,8,DEM,Keith Judd,0,0,0,0,0,0
+Hill,0009,President,8,DEM,Martin J. O'Malley,0,0,0,0,0,0
+Hill,0009,President,8,DEM,Over Votes,0,0,0,0,0,0
+Hill,0009,President,8,DEM,Under Votes,0,0,0,0,0,0
+Hill,0009,U.S. House,25,DEM,Kathi Thomas,13,0,1,1,5,6
+Hill,0009,U.S. House,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0009,U.S. House,25,DEM,Under Votes,10,2,2,0,3,3
+Hill,0009,Railroad Commissioner,25,DEM,Cody Garrett,11,1,1,1,4,4
+Hill,0009,Railroad Commissioner,25,DEM,Lon Burnam,3,0,0,0,0,3
+Hill,0009,Railroad Commissioner,25,DEM,Grady Yarbrough,5,0,1,0,3,1
+Hill,0009,Railroad Commissioner,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0009,Railroad Commissioner,25,DEM,Under Votes,4,1,1,0,1,1
+Hill,0009,"Justice, Supreme Court, Place 3",25,DEM,Mike Westergren,13,0,1,1,4,7
+Hill,0009,"Justice, Supreme Court, Place 3",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0009,"Justice, Supreme Court, Place 3",25,DEM,Under Votes,10,2,2,0,4,2
+Hill,0009,"Justice, Supreme Court, Place 5",25,DEM,Dori Contreras Garza,17,1,2,1,5,8
+Hill,0009,"Justice, Supreme Court, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0009,"Justice, Supreme Court, Place 5",25,DEM,Under Votes,6,1,1,0,3,1
+Hill,0009,"Justice, Supreme Court, Place 9",25,DEM,Savannah Robinson,16,1,2,1,5,7
+Hill,0009,"Justice, Supreme Court, Place 9",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0009,"Justice, Supreme Court, Place 9",25,DEM,Under Votes,7,1,1,0,3,2
+Hill,0009,"Judge, Court of Criminal Appeals, Place 2",25,DEM,"Lawrence ""Larry"" Meyers",13,0,1,1,4,7
+Hill,0009,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0009,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Under Votes,10,2,2,0,4,2
+Hill,0009,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Betsy Johnson,16,1,2,1,5,7
+Hill,0009,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0009,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Under Votes,7,1,1,0,3,2
+Hill,0009,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Robert Burns,13,0,1,1,4,7
+Hill,0009,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0009,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Under Votes,10,2,2,0,4,2
+Hill,0009,State Senator,22,DEM,Michael Collins,16,1,2,1,5,7
+Hill,0009,State Senator,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0009,State Senator,22,DEM,Under Votes,7,1,1,0,3,2
+Hill,0009,County Chairman,22,DEM,Thomas Hanson,16,1,2,1,5,7
+Hill,0009,County Chairman,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0009,County Chairman,22,DEM,Under Votes,7,1,1,0,3,2
+Hill,0009,Proposition 1,22,REP,Yes,150,11,26,29,57,27
+Hill,0009,Proposition 1,22,REP,No,47,2,9,15,17,4
+Hill,0009,Proposition 1,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0009,Proposition 1,22,REP,Under Votes,20,0,4,1,13,2
+Hill,0009,Proposition 2,22,REP,Yes,121,5,22,25,48,21
+Hill,0009,Proposition 2,22,REP,No,79,7,13,17,31,11
+Hill,0009,Proposition 2,22,REP,Over Votes,3,1,1,0,1,0
+Hill,0009,Proposition 2,22,REP,Under Votes,14,0,3,3,7,1
+Hill,0009,Proposition 3,22,REP,Yes,158,11,30,30,64,23
+Hill,0009,Proposition 3,22,REP,No,38,2,5,10,14,7
+Hill,0009,Proposition 3,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0009,Proposition 3,22,REP,Under Votes,21,0,4,5,9,3
+Hill,0009,Proposition 4,22,REP,Yes,191,13,35,38,78,27
+Hill,0009,Proposition 4,22,REP,No,9,0,1,3,2,3
+Hill,0009,Proposition 4,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0009,Proposition 4,22,REP,Under Votes,17,0,3,4,7,3
+Hill,0009,Referenda Item #1,22,DEM,For,18,1,2,1,7,7
+Hill,0009,Referenda Item #1,22,DEM,Against,2,0,0,0,0,2
+Hill,0009,Referenda Item #1,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0009,Referenda Item #1,22,DEM,Under Votes,3,1,1,0,1,0
+Hill,0009,Referenda Item #2,22,DEM,For,18,1,2,1,6,8
+Hill,0009,Referenda Item #2,22,DEM,Against,1,0,0,0,0,1
+Hill,0009,Referenda Item #2,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0009,Referenda Item #2,22,DEM,Under Votes,4,1,1,0,2,0
+Hill,0009,Referenda Item #3,22,DEM,For,20,1,2,1,7,9
+Hill,0009,Referenda Item #3,22,DEM,Against,0,0,0,0,0,0
+Hill,0009,Referenda Item #3,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0009,Referenda Item #3,22,DEM,Under Votes,3,1,1,0,1,0
+Hill,0009,Referenda Item #4,22,DEM,For,20,1,2,1,7,9
+Hill,0009,Referenda Item #4,22,DEM,Against,0,0,0,0,0,0
+Hill,0009,Referenda Item #4,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0009,Referenda Item #4,22,DEM,Under Votes,3,1,1,0,1,0
+Hill,0009,Referenda Item #5,22,DEM,For,13,1,1,1,4,6
+Hill,0009,Referenda Item #5,22,DEM,Against,7,0,1,0,3,3
+Hill,0009,Referenda Item #5,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0009,Referenda Item #5,22,DEM,Under Votes,3,1,1,0,1,0
+Hill,0009,Referenda Item #6,22,DEM,For,16,1,1,1,4,9
+Hill,0009,Referenda Item #6,22,DEM,Against,4,0,1,0,3,0
+Hill,0009,Referenda Item #6,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0009,Referenda Item #6,22,DEM,Under Votes,3,1,1,0,1,0
+Hill,0010,Registered Voters - Total,,,,1894,1,1,0,1,0
+Hill,0010,Ballots Cast - Total,,REP,,589,32,69,123,155,210
+Hill,0010,Ballots Cast - Total,,DEM,,95,2,9,5,46,33
+Hill,0010,President,,REP,Ted Cruz,259,14,24,49,71,101
+Hill,0010,President,,REP,Jeb Bush,11,1,2,5,2,1
+Hill,0010,President,,REP,Donald J. Trump,221,12,31,48,60,70
+Hill,0010,President,,REP,Ben Carson,20,0,0,6,6,8
+Hill,0010,President,,REP,Rand Paul,1,0,0,0,0,1
+Hill,0010,President,,REP,Rick Santorum,0,0,0,0,0,0
+Hill,0010,President,,REP,Elizabeth Gray,0,0,0,0,0,0
+Hill,0010,President,,REP,Carly Fiorina,0,0,0,0,0,0
+Hill,0010,President,,REP,Lindsey Graham,0,0,0,0,0,0
+Hill,0010,President,,REP,Marco Rubio,56,4,8,13,12,19
+Hill,0010,President,,REP,John R. Kasich,2,0,0,0,0,2
+Hill,0010,President,,REP,Mike Huckabee,1,0,0,0,0,1
+Hill,0010,President,,REP,Chris Christie,5,0,0,1,0,4
+Hill,0010,President,,REP,Uncommitted,8,1,2,0,2,3
+Hill,0010,President,,REP,Over Votes,0,0,0,0,0,0
+Hill,0010,President,,REP,Under Votes,5,0,2,1,2,0
+Hill,0010,U.S. House,25,REP,Roger Williams,439,30,57,92,118,142
+Hill,0010,U.S. House,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0010,U.S. House,25,REP,Under Votes,150,2,12,31,37,68
+Hill,0010,Railroad Commissioner,25,REP,Gary Gates,185,11,26,35,53,60
+Hill,0010,Railroad Commissioner,25,REP,Lance N. Christian,47,3,3,11,9,21
+Hill,0010,Railroad Commissioner,25,REP,Weston Martinez,38,1,4,17,8,8
+Hill,0010,Railroad Commissioner,25,REP,Wayne Christian,61,3,6,13,17,22
+Hill,0010,Railroad Commissioner,25,REP,Ron Hale,67,5,10,8,18,26
+Hill,0010,Railroad Commissioner,25,REP,Doug Jeffrey,30,1,5,9,5,10
+Hill,0010,Railroad Commissioner,25,REP,John Greytok,16,2,2,3,3,6
+Hill,0010,Railroad Commissioner,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0010,Railroad Commissioner,25,REP,Under Votes,145,6,13,27,42,57
+Hill,0010,"Justice, Supreme Court, Place 3",25,REP,Michael Massengale,248,10,24,59,71,84
+Hill,0010,"Justice, Supreme Court, Place 3",25,REP,Debra Lehrmann,221,15,33,42,50,81
+Hill,0010,"Justice, Supreme Court, Place 3",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0010,"Justice, Supreme Court, Place 3",25,REP,Under Votes,120,7,12,22,34,45
+Hill,0010,"Justice, Supreme Court, Place 5",25,REP,Paul Green,215,12,24,43,58,78
+Hill,0010,"Justice, Supreme Court, Place 5",25,REP,Rick Green,240,14,31,54,61,80
+Hill,0010,"Justice, Supreme Court, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0010,"Justice, Supreme Court, Place 5",25,REP,Under Votes,134,6,14,26,36,52
+Hill,0010,"Justice, Supreme Court, Place 9",25,REP,Joe Pool,238,15,33,50,64,76
+Hill,0010,"Justice, Supreme Court, Place 9",25,REP,Eva Guzman,224,11,24,46,57,86
+Hill,0010,"Justice, Supreme Court, Place 9",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0010,"Justice, Supreme Court, Place 9",25,REP,Under Votes,127,6,12,27,34,48
+Hill,0010,"Judge, Court of Criminal Appeals, Place 2",25,REP,Chris Oldner,132,4,11,27,41,49
+Hill,0010,"Judge, Court of Criminal Appeals, Place 2",25,REP,Ray Wheless,145,7,17,36,35,50
+Hill,0010,"Judge, Court of Criminal Appeals, Place 2",25,REP,Mary Lou Keel,149,14,25,29,35,46
+Hill,0010,"Judge, Court of Criminal Appeals, Place 2",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0010,"Judge, Court of Criminal Appeals, Place 2",25,REP,Under Votes,163,7,16,31,44,65
+Hill,0010,"Judge, Court of Criminal Appeals, Place 5",25,REP,Sid Harle,91,8,17,15,24,27
+Hill,0010,"Judge, Court of Criminal Appeals, Place 5",25,REP,Brent Webster,90,5,10,20,30,25
+Hill,0010,"Judge, Court of Criminal Appeals, Place 5",25,REP,Scott Walker,166,8,18,40,39,61
+Hill,0010,"Judge, Court of Criminal Appeals, Place 5",25,REP,Steve Smith,84,4,10,17,21,32
+Hill,0010,"Judge, Court of Criminal Appeals, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0010,"Judge, Court of Criminal Appeals, Place 5",25,REP,Under Votes,158,7,14,31,41,65
+Hill,0010,"Judge, Court of Criminal Appeals, Place 6",25,REP,Richard Davis,251,11,26,59,63,92
+Hill,0010,"Judge, Court of Criminal Appeals, Place 6",25,REP,Michael E. Keasler,167,13,26,30,47,51
+Hill,0010,"Judge, Court of Criminal Appeals, Place 6",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0010,"Judge, Court of Criminal Appeals, Place 6",25,REP,Under Votes,171,8,17,34,45,67
+Hill,0010,"Member, State Board of Education, District 14",25,REP,Sue Melton-Malone,407,27,53,89,101,137
+Hill,0010,"Member, State Board of Education, District 14",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0010,"Member, State Board of Education, District 14",25,REP,Under Votes,182,5,16,34,54,73
+Hill,0010,State Senator,22,REP,Brian Birdwell,431,27,55,94,111,144
+Hill,0010,State Senator,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0010,State Senator,22,REP,Under Votes,158,5,14,29,44,66
+Hill,0010,State Representative,8,REP,Thomas McNutt,249,10,27,49,71,92
+Hill,0010,State Representative,8,REP,Byron Cook,280,20,36,64,66,94
+Hill,0010,State Representative,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0010,State Representative,8,REP,Under Votes,60,2,6,10,18,24
+Hill,0010,"Justice, 10th Court of Appeals District, Place 3",8,REP,Al Scoggins,382,23,44,87,95,133
+Hill,0010,"Justice, 10th Court of Appeals District, Place 3",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0010,"Justice, 10th Court of Appeals District, Place 3",8,REP,Under Votes,207,9,25,36,60,77
+Hill,0010,"District Attorney, 66th Judicial District",8,REP,Mark F Pratt,443,26,58,96,118,145
+Hill,0010,"District Attorney, 66th Judicial District",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0010,"District Attorney, 66th Judicial District",8,REP,Under Votes,146,6,11,27,37,65
+Hill,0010,County Attorney,8,REP,R David Holmes,418,24,51,96,102,145
+Hill,0010,County Attorney,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0010,County Attorney,8,REP,Under Votes,171,8,18,27,53,65
+Hill,0010,Sheriff,8,REP,Jimmy Johnson,216,14,31,51,64,56
+Hill,0010,Sheriff,8,REP,Dedri Hafer,35,1,7,1,10,16
+Hill,0010,Sheriff,8,REP,Rodney Watson,155,5,11,38,29,72
+Hill,0010,Sheriff,8,REP,Kyle R Cox,55,3,6,7,14,25
+Hill,0010,Sheriff,8,REP,Ronnie Myers,64,4,8,17,19,16
+Hill,0010,Sheriff,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0010,Sheriff,8,REP,Under Votes,64,5,6,9,19,25
+Hill,0010,Tax Assessor-Collector,8,REP,Ray Mabry,203,12,23,44,56,68
+Hill,0010,Tax Assessor-Collector,8,REP,Krissi Hightower,255,11,33,53,62,96
+Hill,0010,Tax Assessor-Collector,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0010,Tax Assessor-Collector,8,REP,Under Votes,131,9,13,26,37,46
+Hill,0010,"Constable, Precinct No. 4",8,REP,Collin Yeaman,199,11,26,43,58,61
+Hill,0010,"Constable, Precinct No. 4",8,REP,George Willoughby,247,11,28,60,56,92
+Hill,0010,"Constable, Precinct No. 4",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0010,"Constable, Precinct No. 4",8,REP,Under Votes,143,10,15,20,41,57
+Hill,0010,County Chairman,8,REP,Will Orr,427,23,52,94,108,150
+Hill,0010,County Chairman,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0010,County Chairman,8,REP,Under Votes,162,9,17,29,47,60
+Hill,0010,President,8,DEM,Bernie Sanders,16,0,1,1,10,4
+Hill,0010,President,8,DEM,Star Locke,0,0,0,0,0,0
+Hill,0010,President,8,DEM,"Roque ""Rocky"" De La Fuente",0,0,0,0,0,0
+Hill,0010,President,8,DEM,Willie L. Wilson,0,0,0,0,0,0
+Hill,0010,President,8,DEM,Calvis L. Hawes,0,0,0,0,0,0
+Hill,0010,President,8,DEM,Hillary Clinton,78,2,8,4,35,29
+Hill,0010,President,8,DEM,Keith Judd,0,0,0,0,0,0
+Hill,0010,President,8,DEM,Martin J. O'Malley,0,0,0,0,0,0
+Hill,0010,President,8,DEM,Over Votes,0,0,0,0,0,0
+Hill,0010,President,8,DEM,Under Votes,1,0,0,0,1,0
+Hill,0010,U.S. House,25,DEM,Kathi Thomas,69,1,7,4,35,22
+Hill,0010,U.S. House,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0010,U.S. House,25,DEM,Under Votes,26,1,2,1,11,11
+Hill,0010,Railroad Commissioner,25,DEM,Cody Garrett,33,0,4,1,17,11
+Hill,0010,Railroad Commissioner,25,DEM,Lon Burnam,19,1,2,3,5,8
+Hill,0010,Railroad Commissioner,25,DEM,Grady Yarbrough,33,1,3,1,20,8
+Hill,0010,Railroad Commissioner,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0010,Railroad Commissioner,25,DEM,Under Votes,10,0,0,0,4,6
+Hill,0010,"Justice, Supreme Court, Place 3",25,DEM,Mike Westergren,78,1,8,5,39,25
+Hill,0010,"Justice, Supreme Court, Place 3",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0010,"Justice, Supreme Court, Place 3",25,DEM,Under Votes,17,1,1,0,7,8
+Hill,0010,"Justice, Supreme Court, Place 5",25,DEM,Dori Contreras Garza,74,1,8,5,39,21
+Hill,0010,"Justice, Supreme Court, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0010,"Justice, Supreme Court, Place 5",25,DEM,Under Votes,21,1,1,0,7,12
+Hill,0010,"Justice, Supreme Court, Place 9",25,DEM,Savannah Robinson,80,2,9,5,41,23
+Hill,0010,"Justice, Supreme Court, Place 9",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0010,"Justice, Supreme Court, Place 9",25,DEM,Under Votes,15,0,0,0,5,10
+Hill,0010,"Judge, Court of Criminal Appeals, Place 2",25,DEM,"Lawrence ""Larry"" Meyers",75,1,8,5,39,22
+Hill,0010,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0010,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Under Votes,20,1,1,0,7,11
+Hill,0010,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Betsy Johnson,80,2,9,5,40,24
+Hill,0010,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0010,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Under Votes,15,0,0,0,6,9
+Hill,0010,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Robert Burns,73,1,8,5,37,22
+Hill,0010,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0010,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Under Votes,22,1,1,0,9,11
+Hill,0010,State Senator,22,DEM,Michael Collins,76,1,8,5,40,22
+Hill,0010,State Senator,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0010,State Senator,22,DEM,Under Votes,19,1,1,0,6,11
+Hill,0010,County Chairman,22,DEM,Thomas Hanson,77,1,8,5,40,23
+Hill,0010,County Chairman,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0010,County Chairman,22,DEM,Under Votes,18,1,1,0,6,10
+Hill,0010,Proposition 1,22,REP,Yes,388,19,46,82,98,143
+Hill,0010,Proposition 1,22,REP,No,123,8,8,36,24,47
+Hill,0010,Proposition 1,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0010,Proposition 1,22,REP,Under Votes,78,5,15,5,33,20
+Hill,0010,Proposition 2,22,REP,Yes,323,10,28,81,74,130
+Hill,0010,Proposition 2,22,REP,No,221,19,34,40,63,65
+Hill,0010,Proposition 2,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0010,Proposition 2,22,REP,Under Votes,45,3,7,2,18,15
+Hill,0010,Proposition 3,22,REP,Yes,445,25,53,90,113,164
+Hill,0010,Proposition 3,22,REP,No,95,4,9,28,25,29
+Hill,0010,Proposition 3,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0010,Proposition 3,22,REP,Under Votes,49,3,7,5,17,17
+Hill,0010,Proposition 4,22,REP,Yes,522,28,61,118,132,183
+Hill,0010,Proposition 4,22,REP,No,16,1,1,4,4,6
+Hill,0010,Proposition 4,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0010,Proposition 4,22,REP,Under Votes,51,3,7,1,19,21
+Hill,0010,Referenda Item #1,22,DEM,For,74,0,7,5,34,28
+Hill,0010,Referenda Item #1,22,DEM,Against,9,1,1,0,7,0
+Hill,0010,Referenda Item #1,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0010,Referenda Item #1,22,DEM,Under Votes,12,1,1,0,5,5
+Hill,0010,Referenda Item #2,22,DEM,For,76,1,8,5,35,27
+Hill,0010,Referenda Item #2,22,DEM,Against,7,0,0,0,6,1
+Hill,0010,Referenda Item #2,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0010,Referenda Item #2,22,DEM,Under Votes,12,1,1,0,5,5
+Hill,0010,Referenda Item #3,22,DEM,For,70,1,8,5,30,26
+Hill,0010,Referenda Item #3,22,DEM,Against,11,0,0,0,9,2
+Hill,0010,Referenda Item #3,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0010,Referenda Item #3,22,DEM,Under Votes,14,1,1,0,7,5
+Hill,0010,Referenda Item #4,22,DEM,For,77,1,7,2,38,29
+Hill,0010,Referenda Item #4,22,DEM,Against,8,0,1,3,3,1
+Hill,0010,Referenda Item #4,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0010,Referenda Item #4,22,DEM,Under Votes,10,1,1,0,5,3
+Hill,0010,Referenda Item #5,22,DEM,For,72,1,8,5,33,25
+Hill,0010,Referenda Item #5,22,DEM,Against,13,0,0,0,8,5
+Hill,0010,Referenda Item #5,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0010,Referenda Item #5,22,DEM,Under Votes,10,1,1,0,5,3
+Hill,0010,Referenda Item #6,22,DEM,For,72,1,8,4,35,24
+Hill,0010,Referenda Item #6,22,DEM,Against,12,0,0,1,6,5
+Hill,0010,Referenda Item #6,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0010,Referenda Item #6,22,DEM,Under Votes,11,1,1,0,5,4
+Hill,0012,Registered Voters - Total,,,,811,1,1,0,5,4
+Hill,0012,Ballots Cast - Total,,REP,,353,18,44,56,109,126
+Hill,0012,Ballots Cast - Total,,DEM,,26,0,4,3,12,7
+Hill,0012,President,,REP,Ted Cruz,166,6,17,25,51,67
+Hill,0012,President,,REP,Jeb Bush,3,0,0,2,0,1
+Hill,0012,President,,REP,Donald J. Trump,91,5,11,19,27,29
+Hill,0012,President,,REP,Ben Carson,16,2,4,1,5,4
+Hill,0012,President,,REP,Rand Paul,0,0,0,0,0,0
+Hill,0012,President,,REP,Rick Santorum,0,0,0,0,0,0
+Hill,0012,President,,REP,Elizabeth Gray,0,0,0,0,0,0
+Hill,0012,President,,REP,Carly Fiorina,0,0,0,0,0,0
+Hill,0012,President,,REP,Lindsey Graham,0,0,0,0,0,0
+Hill,0012,President,,REP,Marco Rubio,45,1,6,4,16,18
+Hill,0012,President,,REP,John R. Kasich,17,4,5,1,6,1
+Hill,0012,President,,REP,Mike Huckabee,2,0,0,0,1,1
+Hill,0012,President,,REP,Chris Christie,3,0,0,3,0,0
+Hill,0012,President,,REP,Uncommitted,7,0,1,0,3,3
+Hill,0012,President,,REP,Over Votes,0,0,0,0,0,0
+Hill,0012,President,,REP,Under Votes,3,0,0,1,0,2
+Hill,0012,U.S. House,25,REP,Roger Williams,246,14,31,31,84,86
+Hill,0012,U.S. House,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0012,U.S. House,25,REP,Under Votes,107,4,13,25,25,40
+Hill,0012,Railroad Commissioner,25,REP,Gary Gates,89,4,11,14,29,31
+Hill,0012,Railroad Commissioner,25,REP,Lance N. Christian,35,1,3,7,9,15
+Hill,0012,Railroad Commissioner,25,REP,Weston Martinez,22,1,2,2,5,12
+Hill,0012,Railroad Commissioner,25,REP,Wayne Christian,56,3,10,7,22,14
+Hill,0012,Railroad Commissioner,25,REP,Ron Hale,24,2,2,2,7,11
+Hill,0012,Railroad Commissioner,25,REP,Doug Jeffrey,24,0,2,7,8,7
+Hill,0012,Railroad Commissioner,25,REP,John Greytok,4,1,1,0,2,0
+Hill,0012,Railroad Commissioner,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0012,Railroad Commissioner,25,REP,Under Votes,99,6,13,17,27,36
+Hill,0012,"Justice, Supreme Court, Place 3",25,REP,Michael Massengale,172,10,25,25,55,57
+Hill,0012,"Justice, Supreme Court, Place 3",25,REP,Debra Lehrmann,104,6,12,14,36,36
+Hill,0012,"Justice, Supreme Court, Place 3",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0012,"Justice, Supreme Court, Place 3",25,REP,Under Votes,77,2,7,17,18,33
+Hill,0012,"Justice, Supreme Court, Place 5",25,REP,Paul Green,149,6,21,23,48,51
+Hill,0012,"Justice, Supreme Court, Place 5",25,REP,Rick Green,112,6,12,15,38,41
+Hill,0012,"Justice, Supreme Court, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0012,"Justice, Supreme Court, Place 5",25,REP,Under Votes,92,6,11,18,23,34
+Hill,0012,"Justice, Supreme Court, Place 9",25,REP,Joe Pool,142,6,17,20,51,48
+Hill,0012,"Justice, Supreme Court, Place 9",25,REP,Eva Guzman,134,9,20,20,39,46
+Hill,0012,"Justice, Supreme Court, Place 9",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0012,"Justice, Supreme Court, Place 9",25,REP,Under Votes,77,3,7,16,19,32
+Hill,0012,"Judge, Court of Criminal Appeals, Place 2",25,REP,Chris Oldner,92,1,11,15,28,37
+Hill,0012,"Judge, Court of Criminal Appeals, Place 2",25,REP,Ray Wheless,95,6,15,10,34,30
+Hill,0012,"Judge, Court of Criminal Appeals, Place 2",25,REP,Mary Lou Keel,69,5,7,14,20,23
+Hill,0012,"Judge, Court of Criminal Appeals, Place 2",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0012,"Judge, Court of Criminal Appeals, Place 2",25,REP,Under Votes,97,6,11,17,27,36
+Hill,0012,"Judge, Court of Criminal Appeals, Place 5",25,REP,Sid Harle,67,5,12,8,23,19
+Hill,0012,"Judge, Court of Criminal Appeals, Place 5",25,REP,Brent Webster,66,3,9,11,17,26
+Hill,0012,"Judge, Court of Criminal Appeals, Place 5",25,REP,Scott Walker,90,5,10,12,35,28
+Hill,0012,"Judge, Court of Criminal Appeals, Place 5",25,REP,Steve Smith,40,0,4,6,12,18
+Hill,0012,"Judge, Court of Criminal Appeals, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0012,"Judge, Court of Criminal Appeals, Place 5",25,REP,Under Votes,90,5,9,19,22,35
+Hill,0012,"Judge, Court of Criminal Appeals, Place 6",25,REP,Richard Davis,124,2,14,18,44,46
+Hill,0012,"Judge, Court of Criminal Appeals, Place 6",25,REP,Michael E. Keasler,130,11,20,18,41,40
+Hill,0012,"Judge, Court of Criminal Appeals, Place 6",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0012,"Judge, Court of Criminal Appeals, Place 6",25,REP,Under Votes,99,5,10,20,24,40
+Hill,0012,"Member, State Board of Education, District 14",25,REP,Sue Melton-Malone,232,13,26,33,77,83
+Hill,0012,"Member, State Board of Education, District 14",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0012,"Member, State Board of Education, District 14",25,REP,Under Votes,121,5,18,23,32,43
+Hill,0012,State Senator,22,REP,Brian Birdwell,264,16,31,40,82,95
+Hill,0012,State Senator,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0012,State Senator,22,REP,Under Votes,89,2,13,16,27,31
+Hill,0012,State Representative,8,REP,Thomas McNutt,139,6,15,21,37,60
+Hill,0012,State Representative,8,REP,Byron Cook,183,10,24,31,65,53
+Hill,0012,State Representative,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0012,State Representative,8,REP,Under Votes,31,2,5,4,7,13
+Hill,0012,"Justice, 10th Court of Appeals District, Place 3",8,REP,Al Scoggins,226,14,26,30,75,81
+Hill,0012,"Justice, 10th Court of Appeals District, Place 3",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0012,"Justice, 10th Court of Appeals District, Place 3",8,REP,Under Votes,127,4,18,26,34,45
+Hill,0012,"District Attorney, 66th Judicial District",8,REP,Mark F Pratt,250,14,28,32,83,93
+Hill,0012,"District Attorney, 66th Judicial District",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0012,"District Attorney, 66th Judicial District",8,REP,Under Votes,103,4,16,24,26,33
+Hill,0012,County Attorney,8,REP,R David Holmes,252,13,29,36,81,93
+Hill,0012,County Attorney,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0012,County Attorney,8,REP,Under Votes,101,5,15,20,28,33
+Hill,0012,Sheriff,8,REP,Jimmy Johnson,76,5,15,8,26,22
+Hill,0012,Sheriff,8,REP,Dedri Hafer,37,2,2,3,12,18
+Hill,0012,Sheriff,8,REP,Rodney Watson,137,4,16,29,35,53
+Hill,0012,Sheriff,8,REP,Kyle R Cox,17,0,0,4,4,9
+Hill,0012,Sheriff,8,REP,Ronnie Myers,62,6,7,9,22,18
+Hill,0012,Sheriff,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0012,Sheriff,8,REP,Under Votes,24,1,4,3,10,6
+Hill,0012,Tax Assessor-Collector,8,REP,Ray Mabry,153,10,21,23,50,49
+Hill,0012,Tax Assessor-Collector,8,REP,Krissi Hightower,170,8,20,27,47,68
+Hill,0012,Tax Assessor-Collector,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0012,Tax Assessor-Collector,8,REP,Under Votes,30,0,3,6,12,9
+Hill,0012,County Commissioner # 1,8,REP,Andrew Montgomery,161,10,21,26,48,56
+Hill,0012,County Commissioner # 1,8,REP,"Ted O' Neil, Jr",165,8,22,22,53,60
+Hill,0012,County Commissioner # 1,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0012,County Commissioner # 1,8,REP,Under Votes,27,0,1,8,8,10
+Hill,0012,"Constable, Precinct No. 1",8,REP,Bill Wilkins,247,17,30,38,78,84
+Hill,0012,"Constable, Precinct No. 1",8,REP,Daniel Roberson,68,1,10,12,18,27
+Hill,0012,"Constable, Precinct No. 1",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0012,"Constable, Precinct No. 1",8,REP,Under Votes,38,0,4,6,13,15
+Hill,0012,County Chairman,8,REP,Will Orr,259,15,34,36,83,91
+Hill,0012,County Chairman,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0012,County Chairman,8,REP,Under Votes,94,3,10,20,26,35
+Hill,0012,President,8,DEM,Bernie Sanders,16,0,4,0,9,3
+Hill,0012,President,8,DEM,Star Locke,0,0,0,0,0,0
+Hill,0012,President,8,DEM,"Roque ""Rocky"" De La Fuente",0,0,0,0,0,0
+Hill,0012,President,8,DEM,Willie L. Wilson,0,0,0,0,0,0
+Hill,0012,President,8,DEM,Calvis L. Hawes,0,0,0,0,0,0
+Hill,0012,President,8,DEM,Hillary Clinton,9,0,0,2,3,4
+Hill,0012,President,8,DEM,Keith Judd,0,0,0,0,0,0
+Hill,0012,President,8,DEM,Martin J. O'Malley,1,0,0,1,0,0
+Hill,0012,President,8,DEM,Over Votes,0,0,0,0,0,0
+Hill,0012,President,8,DEM,Under Votes,0,0,0,0,0,0
+Hill,0012,U.S. House,25,DEM,Kathi Thomas,22,0,4,2,11,5
+Hill,0012,U.S. House,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0012,U.S. House,25,DEM,Under Votes,4,0,0,1,1,2
+Hill,0012,Railroad Commissioner,25,DEM,Cody Garrett,6,0,0,1,3,2
+Hill,0012,Railroad Commissioner,25,DEM,Lon Burnam,6,0,2,1,2,1
+Hill,0012,Railroad Commissioner,25,DEM,Grady Yarbrough,11,0,1,1,5,4
+Hill,0012,Railroad Commissioner,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0012,Railroad Commissioner,25,DEM,Under Votes,3,0,1,0,2,0
+Hill,0012,"Justice, Supreme Court, Place 3",25,DEM,Mike Westergren,21,0,3,2,10,6
+Hill,0012,"Justice, Supreme Court, Place 3",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0012,"Justice, Supreme Court, Place 3",25,DEM,Under Votes,5,0,1,1,2,1
+Hill,0012,"Justice, Supreme Court, Place 5",25,DEM,Dori Contreras Garza,22,0,4,2,11,5
+Hill,0012,"Justice, Supreme Court, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0012,"Justice, Supreme Court, Place 5",25,DEM,Under Votes,4,0,0,1,1,2
+Hill,0012,"Justice, Supreme Court, Place 9",25,DEM,Savannah Robinson,23,0,4,2,11,6
+Hill,0012,"Justice, Supreme Court, Place 9",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0012,"Justice, Supreme Court, Place 9",25,DEM,Under Votes,3,0,0,1,1,1
+Hill,0012,"Judge, Court of Criminal Appeals, Place 2",25,DEM,"Lawrence ""Larry"" Meyers",19,0,3,2,10,4
+Hill,0012,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0012,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Under Votes,7,0,1,1,2,3
+Hill,0012,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Betsy Johnson,21,0,3,2,10,6
+Hill,0012,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0012,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Under Votes,5,0,1,1,2,1
+Hill,0012,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Robert Burns,19,0,3,2,9,5
+Hill,0012,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0012,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Under Votes,7,0,1,1,3,2
+Hill,0012,State Senator,22,DEM,Michael Collins,22,0,4,2,11,5
+Hill,0012,State Senator,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0012,State Senator,22,DEM,Under Votes,4,0,0,1,1,2
+Hill,0012,County Chairman,22,DEM,Thomas Hanson,21,0,4,2,11,4
+Hill,0012,County Chairman,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0012,County Chairman,22,DEM,Under Votes,5,0,0,1,1,3
+Hill,0012,Proposition 1,22,REP,Yes,254,13,34,37,77,93
+Hill,0012,Proposition 1,22,REP,No,80,5,10,17,27,21
+Hill,0012,Proposition 1,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0012,Proposition 1,22,REP,Under Votes,19,0,0,2,5,12
+Hill,0012,Proposition 2,22,REP,Yes,197,8,25,35,59,70
+Hill,0012,Proposition 2,22,REP,No,137,10,19,21,41,46
+Hill,0012,Proposition 2,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0012,Proposition 2,22,REP,Under Votes,19,0,0,0,9,10
+Hill,0012,Proposition 3,22,REP,Yes,284,15,39,42,93,95
+Hill,0012,Proposition 3,22,REP,No,51,3,5,13,9,21
+Hill,0012,Proposition 3,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0012,Proposition 3,22,REP,Under Votes,18,0,0,1,7,10
+Hill,0012,Proposition 4,22,REP,Yes,313,17,41,51,95,109
+Hill,0012,Proposition 4,22,REP,No,10,1,1,1,2,5
+Hill,0012,Proposition 4,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0012,Proposition 4,22,REP,Under Votes,30,0,2,4,12,12
+Hill,0012,Referenda Item #1,22,DEM,For,25,0,4,3,11,7
+Hill,0012,Referenda Item #1,22,DEM,Against,1,0,0,0,1,0
+Hill,0012,Referenda Item #1,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0012,Referenda Item #1,22,DEM,Under Votes,0,0,0,0,0,0
+Hill,0012,Referenda Item #2,22,DEM,For,22,0,4,3,9,6
+Hill,0012,Referenda Item #2,22,DEM,Against,3,0,0,0,3,0
+Hill,0012,Referenda Item #2,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0012,Referenda Item #2,22,DEM,Under Votes,1,0,0,0,0,1
+Hill,0012,Referenda Item #3,22,DEM,For,24,0,4,3,11,6
+Hill,0012,Referenda Item #3,22,DEM,Against,2,0,0,0,1,1
+Hill,0012,Referenda Item #3,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0012,Referenda Item #3,22,DEM,Under Votes,0,0,0,0,0,0
+Hill,0012,Referenda Item #4,22,DEM,For,23,0,4,3,10,6
+Hill,0012,Referenda Item #4,22,DEM,Against,2,0,0,0,2,0
+Hill,0012,Referenda Item #4,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0012,Referenda Item #4,22,DEM,Under Votes,1,0,0,0,0,1
+Hill,0012,Referenda Item #5,22,DEM,For,20,0,4,1,9,6
+Hill,0012,Referenda Item #5,22,DEM,Against,6,0,0,2,3,1
+Hill,0012,Referenda Item #5,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0012,Referenda Item #5,22,DEM,Under Votes,0,0,0,0,0,0
+Hill,0012,Referenda Item #6,22,DEM,For,21,0,4,2,9,6
+Hill,0012,Referenda Item #6,22,DEM,Against,4,0,0,1,2,1
+Hill,0012,Referenda Item #6,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0012,Referenda Item #6,22,DEM,Under Votes,1,0,0,0,1,0
+Hill,0013,Registered Voters - Total,,,,2855,0,0,0,1,0
+Hill,0013,Ballots Cast - Total,,REP,,1102,71,127,167,243,494
+Hill,0013,Ballots Cast - Total,,DEM,,142,15,25,9,73,20
+Hill,0013,President,,REP,Ted Cruz,485,24,49,77,112,223
+Hill,0013,President,,REP,Jeb Bush,30,8,9,2,11,0
+Hill,0013,President,,REP,Donald J. Trump,342,14,35,64,71,158
+Hill,0013,President,,REP,Ben Carson,39,1,1,8,3,26
+Hill,0013,President,,REP,Rand Paul,4,1,1,0,1,1
+Hill,0013,President,,REP,Rick Santorum,0,0,0,0,0,0
+Hill,0013,President,,REP,Elizabeth Gray,3,1,1,0,1,0
+Hill,0013,President,,REP,Carly Fiorina,0,0,0,0,0,0
+Hill,0013,President,,REP,Lindsey Graham,0,0,0,0,0,0
+Hill,0013,President,,REP,Marco Rubio,111,9,14,8,21,59
+Hill,0013,President,,REP,John R. Kasich,20,1,4,2,5,8
+Hill,0013,President,,REP,Mike Huckabee,3,0,0,1,1,1
+Hill,0013,President,,REP,Chris Christie,13,3,3,1,3,3
+Hill,0013,President,,REP,Uncommitted,34,7,7,2,10,8
+Hill,0013,President,,REP,Over Votes,0,0,0,0,0,0
+Hill,0013,President,,REP,Under Votes,18,2,3,2,4,7
+Hill,0013,U.S. House,25,REP,Roger Williams,788,60,106,122,189,311
+Hill,0013,U.S. House,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0013,U.S. House,25,REP,Under Votes,314,11,21,45,54,183
+Hill,0013,Railroad Commissioner,25,REP,Gary Gates,340,31,48,46,84,131
+Hill,0013,Railroad Commissioner,25,REP,Lance N. Christian,97,3,11,22,22,39
+Hill,0013,Railroad Commissioner,25,REP,Weston Martinez,57,2,6,9,13,27
+Hill,0013,Railroad Commissioner,25,REP,Wayne Christian,146,11,14,27,29,65
+Hill,0013,Railroad Commissioner,25,REP,Ron Hale,114,10,15,15,29,45
+Hill,0013,Railroad Commissioner,25,REP,Doug Jeffrey,52,0,5,7,14,26
+Hill,0013,Railroad Commissioner,25,REP,John Greytok,41,3,5,5,9,19
+Hill,0013,Railroad Commissioner,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0013,Railroad Commissioner,25,REP,Under Votes,255,11,23,36,43,142
+Hill,0013,"Justice, Supreme Court, Place 3",25,REP,Michael Massengale,474,27,48,80,106,213
+Hill,0013,"Justice, Supreme Court, Place 3",25,REP,Debra Lehrmann,405,33,58,62,102,150
+Hill,0013,"Justice, Supreme Court, Place 3",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0013,"Justice, Supreme Court, Place 3",25,REP,Under Votes,223,11,21,25,35,131
+Hill,0013,"Justice, Supreme Court, Place 5",25,REP,Paul Green,442,29,57,80,104,172
+Hill,0013,"Justice, Supreme Court, Place 5",25,REP,Rick Green,382,28,41,51,88,174
+Hill,0013,"Justice, Supreme Court, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0013,"Justice, Supreme Court, Place 5",25,REP,Under Votes,278,14,29,36,51,148
+Hill,0013,"Justice, Supreme Court, Place 9",25,REP,Joe Pool,474,32,66,79,118,179
+Hill,0013,"Justice, Supreme Court, Place 9",25,REP,Eva Guzman,384,30,39,58,86,171
+Hill,0013,"Justice, Supreme Court, Place 9",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0013,"Justice, Supreme Court, Place 9",25,REP,Under Votes,244,9,22,30,39,144
+Hill,0013,"Judge, Court of Criminal Appeals, Place 2",25,REP,Chris Oldner,269,13,30,53,61,112
+Hill,0013,"Judge, Court of Criminal Appeals, Place 2",25,REP,Ray Wheless,264,20,29,44,64,107
+Hill,0013,"Judge, Court of Criminal Appeals, Place 2",25,REP,Mary Lou Keel,268,25,40,36,64,103
+Hill,0013,"Judge, Court of Criminal Appeals, Place 2",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0013,"Judge, Court of Criminal Appeals, Place 2",25,REP,Under Votes,301,13,28,34,54,172
+Hill,0013,"Judge, Court of Criminal Appeals, Place 5",25,REP,Sid Harle,180,20,26,18,41,75
+Hill,0013,"Judge, Court of Criminal Appeals, Place 5",25,REP,Brent Webster,140,12,18,25,32,53
+Hill,0013,"Judge, Court of Criminal Appeals, Place 5",25,REP,Scott Walker,322,19,40,57,80,126
+Hill,0013,"Judge, Court of Criminal Appeals, Place 5",25,REP,Steve Smith,179,8,18,31,43,79
+Hill,0013,"Judge, Court of Criminal Appeals, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0013,"Judge, Court of Criminal Appeals, Place 5",25,REP,Under Votes,281,12,25,36,47,161
+Hill,0013,"Judge, Court of Criminal Appeals, Place 6",25,REP,Richard Davis,418,25,42,69,95,187
+Hill,0013,"Judge, Court of Criminal Appeals, Place 6",25,REP,Michael E. Keasler,378,33,55,60,91,139
+Hill,0013,"Judge, Court of Criminal Appeals, Place 6",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0013,"Judge, Court of Criminal Appeals, Place 6",25,REP,Under Votes,306,13,30,38,57,168
+Hill,0013,"Member, State Board of Education, District 14",25,REP,Sue Melton-Malone,744,56,95,118,171,304
+Hill,0013,"Member, State Board of Education, District 14",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0013,"Member, State Board of Education, District 14",25,REP,Under Votes,358,15,32,49,72,190
+Hill,0013,State Senator,22,REP,Brian Birdwell,829,63,107,129,192,338
+Hill,0013,State Senator,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0013,State Senator,22,REP,Under Votes,273,8,20,38,51,156
+Hill,0013,State Representative,8,REP,Thomas McNutt,537,42,72,79,129,215
+Hill,0013,State Representative,8,REP,Byron Cook,469,26,49,78,100,216
+Hill,0013,State Representative,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0013,State Representative,8,REP,Under Votes,96,3,6,10,14,63
+Hill,0013,"Justice, 10th Court of Appeals District, Place 3",8,REP,Al Scoggins,722,55,94,123,170,280
+Hill,0013,"Justice, 10th Court of Appeals District, Place 3",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0013,"Justice, 10th Court of Appeals District, Place 3",8,REP,Under Votes,380,16,33,44,73,214
+Hill,0013,"District Attorney, 66th Judicial District",8,REP,Mark F Pratt,835,61,105,130,190,349
+Hill,0013,"District Attorney, 66th Judicial District",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0013,"District Attorney, 66th Judicial District",8,REP,Under Votes,267,10,22,37,53,145
+Hill,0013,County Attorney,8,REP,R David Holmes,800,58,101,127,178,336
+Hill,0013,County Attorney,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0013,County Attorney,8,REP,Under Votes,302,13,26,40,65,158
+Hill,0013,Sheriff,8,REP,Jimmy Johnson,250,15,26,54,42,113
+Hill,0013,Sheriff,8,REP,Dedri Hafer,123,8,13,21,25,56
+Hill,0013,Sheriff,8,REP,Rodney Watson,378,17,41,51,90,179
+Hill,0013,Sheriff,8,REP,Kyle R Cox,79,8,11,11,22,27
+Hill,0013,Sheriff,8,REP,Ronnie Myers,211,16,27,25,52,91
+Hill,0013,Sheriff,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0013,Sheriff,8,REP,Under Votes,61,7,9,5,12,28
+Hill,0013,Tax Assessor-Collector,8,REP,Ray Mabry,522,45,69,75,113,220
+Hill,0013,Tax Assessor-Collector,8,REP,Krissi Hightower,506,22,50,83,113,238
+Hill,0013,Tax Assessor-Collector,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0013,Tax Assessor-Collector,8,REP,Under Votes,74,4,8,9,17,36
+Hill,0013,"Constable, Precinct No. 2",8,REP,Justin Girsh,530,26,52,81,106,265
+Hill,0013,"Constable, Precinct No. 2",8,REP,Curtis R Jones,331,24,40,58,87,122
+Hill,0013,"Constable, Precinct No. 2",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0013,"Constable, Precinct No. 2",8,REP,Under Votes,241,21,35,28,50,107
+Hill,0013,County Chairman,8,REP,Will Orr,788,58,95,133,174,328
+Hill,0013,County Chairman,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0013,County Chairman,8,REP,Under Votes,314,13,32,34,69,166
+Hill,0013,President,8,DEM,Bernie Sanders,42,2,6,2,25,7
+Hill,0013,President,8,DEM,Star Locke,1,0,0,1,0,0
+Hill,0013,President,8,DEM,"Roque ""Rocky"" De La Fuente",0,0,0,0,0,0
+Hill,0013,President,8,DEM,Willie L. Wilson,3,1,1,0,1,0
+Hill,0013,President,8,DEM,Calvis L. Hawes,1,0,0,0,1,0
+Hill,0013,President,8,DEM,Hillary Clinton,94,12,18,6,45,13
+Hill,0013,President,8,DEM,Keith Judd,1,0,0,0,1,0
+Hill,0013,President,8,DEM,Martin J. O'Malley,0,0,0,0,0,0
+Hill,0013,President,8,DEM,Over Votes,0,0,0,0,0,0
+Hill,0013,President,8,DEM,Under Votes,0,0,0,0,0,0
+Hill,0013,U.S. House,25,DEM,Kathi Thomas,108,14,22,5,53,14
+Hill,0013,U.S. House,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0013,U.S. House,25,DEM,Under Votes,34,1,3,4,20,6
+Hill,0013,Railroad Commissioner,25,DEM,Cody Garrett,46,7,10,3,17,9
+Hill,0013,Railroad Commissioner,25,DEM,Lon Burnam,25,3,7,1,13,1
+Hill,0013,Railroad Commissioner,25,DEM,Grady Yarbrough,39,3,3,4,23,6
+Hill,0013,Railroad Commissioner,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0013,Railroad Commissioner,25,DEM,Under Votes,32,2,5,1,20,4
+Hill,0013,"Justice, Supreme Court, Place 3",25,DEM,Mike Westergren,103,14,21,7,49,12
+Hill,0013,"Justice, Supreme Court, Place 3",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0013,"Justice, Supreme Court, Place 3",25,DEM,Under Votes,39,1,4,2,24,8
+Hill,0013,"Justice, Supreme Court, Place 5",25,DEM,Dori Contreras Garza,100,13,19,7,49,12
+Hill,0013,"Justice, Supreme Court, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0013,"Justice, Supreme Court, Place 5",25,DEM,Under Votes,42,2,6,2,24,8
+Hill,0013,"Justice, Supreme Court, Place 9",25,DEM,Savannah Robinson,106,13,21,7,53,12
+Hill,0013,"Justice, Supreme Court, Place 9",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0013,"Justice, Supreme Court, Place 9",25,DEM,Under Votes,36,2,4,2,20,8
+Hill,0013,"Judge, Court of Criminal Appeals, Place 2",25,DEM,"Lawrence ""Larry"" Meyers",104,14,21,7,49,13
+Hill,0013,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0013,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Under Votes,38,1,4,2,24,7
+Hill,0013,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Betsy Johnson,107,14,21,7,53,12
+Hill,0013,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0013,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Under Votes,35,1,4,2,20,8
+Hill,0013,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Robert Burns,105,14,21,7,50,13
+Hill,0013,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0013,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Under Votes,37,1,4,2,23,7
+Hill,0013,State Senator,22,DEM,Michael Collins,110,14,21,7,54,14
+Hill,0013,State Senator,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0013,State Senator,22,DEM,Under Votes,32,1,4,2,19,6
+Hill,0013,County Chairman,22,DEM,Thomas Hanson,112,14,22,7,54,15
+Hill,0013,County Chairman,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0013,County Chairman,22,DEM,Under Votes,30,1,3,2,19,5
+Hill,0013,Proposition 1,22,REP,Yes,728,41,81,110,164,332
+Hill,0013,Proposition 1,22,REP,No,277,22,35,42,57,121
+Hill,0013,Proposition 1,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0013,Proposition 1,22,REP,Under Votes,97,8,11,15,22,41
+Hill,0013,Proposition 2,22,REP,Yes,576,30,55,91,113,287
+Hill,0013,Proposition 2,22,REP,No,446,36,64,63,117,166
+Hill,0013,Proposition 2,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0013,Proposition 2,22,REP,Under Votes,80,5,8,13,13,41
+Hill,0013,Proposition 3,22,REP,Yes,820,53,102,120,185,360
+Hill,0013,Proposition 3,22,REP,No,186,14,17,33,40,82
+Hill,0013,Proposition 3,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0013,Proposition 3,22,REP,Under Votes,96,4,8,14,18,52
+Hill,0013,Proposition 4,22,REP,Yes,963,64,113,148,216,422
+Hill,0013,Proposition 4,22,REP,No,39,2,5,2,9,21
+Hill,0013,Proposition 4,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0013,Proposition 4,22,REP,Under Votes,100,5,9,17,18,51
+Hill,0013,Referenda Item #1,22,DEM,For,120,14,23,6,59,18
+Hill,0013,Referenda Item #1,22,DEM,Against,10,1,1,3,4,1
+Hill,0013,Referenda Item #1,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0013,Referenda Item #1,22,DEM,Under Votes,12,0,1,0,10,1
+Hill,0013,Referenda Item #2,22,DEM,For,123,15,24,8,58,18
+Hill,0013,Referenda Item #2,22,DEM,Against,6,0,0,1,3,2
+Hill,0013,Referenda Item #2,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0013,Referenda Item #2,22,DEM,Under Votes,13,0,1,0,12,0
+Hill,0013,Referenda Item #3,22,DEM,For,113,14,21,7,54,17
+Hill,0013,Referenda Item #3,22,DEM,Against,16,1,3,2,7,3
+Hill,0013,Referenda Item #3,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0013,Referenda Item #3,22,DEM,Under Votes,13,0,1,0,12,0
+Hill,0013,Referenda Item #4,22,DEM,For,111,13,20,8,53,17
+Hill,0013,Referenda Item #4,22,DEM,Against,18,2,4,1,8,3
+Hill,0013,Referenda Item #4,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0013,Referenda Item #4,22,DEM,Under Votes,13,0,1,0,12,0
+Hill,0013,Referenda Item #5,22,DEM,For,106,13,19,8,51,15
+Hill,0013,Referenda Item #5,22,DEM,Against,27,2,5,1,14,5
+Hill,0013,Referenda Item #5,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0013,Referenda Item #5,22,DEM,Under Votes,9,0,1,0,8,0
+Hill,0013,Referenda Item #6,22,DEM,For,115,15,24,7,54,15
+Hill,0013,Referenda Item #6,22,DEM,Against,13,0,0,2,6,5
+Hill,0013,Referenda Item #6,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0013,Referenda Item #6,22,DEM,Under Votes,14,0,1,0,13,0
+Hill,0014,Registered Voters - Total,,,,977,0,1,0,13,0
+Hill,0014,Ballots Cast - Total,,REP,,453,12,39,44,163,195
+Hill,0014,Ballots Cast - Total,,DEM,,32,2,4,8,15,3
+Hill,0014,President,,REP,Ted Cruz,245,3,19,19,95,109
+Hill,0014,President,,REP,Jeb Bush,10,1,2,2,4,1
+Hill,0014,President,,REP,Donald J. Trump,121,4,9,12,44,52
+Hill,0014,President,,REP,Ben Carson,15,1,2,1,4,7
+Hill,0014,President,,REP,Rand Paul,3,1,1,0,1,0
+Hill,0014,President,,REP,Rick Santorum,3,1,1,0,1,0
+Hill,0014,President,,REP,Elizabeth Gray,0,0,0,0,0,0
+Hill,0014,President,,REP,Carly Fiorina,0,0,0,0,0,0
+Hill,0014,President,,REP,Lindsey Graham,0,0,0,0,0,0
+Hill,0014,President,,REP,Marco Rubio,39,1,3,7,8,20
+Hill,0014,President,,REP,John R. Kasich,6,0,1,3,2,0
+Hill,0014,President,,REP,Mike Huckabee,0,0,0,0,0,0
+Hill,0014,President,,REP,Chris Christie,3,0,0,0,0,3
+Hill,0014,President,,REP,Uncommitted,6,0,1,0,2,3
+Hill,0014,President,,REP,Over Votes,0,0,0,0,0,0
+Hill,0014,President,,REP,Under Votes,2,0,0,0,2,0
+Hill,0014,U.S. House,25,REP,Roger Williams,317,10,28,31,114,134
+Hill,0014,U.S. House,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0014,U.S. House,25,REP,Under Votes,136,2,11,13,49,61
+Hill,0014,Railroad Commissioner,25,REP,Gary Gates,137,4,12,10,51,60
+Hill,0014,Railroad Commissioner,25,REP,Lance N. Christian,35,2,3,6,8,16
+Hill,0014,Railroad Commissioner,25,REP,Weston Martinez,19,0,2,5,4,8
+Hill,0014,Railroad Commissioner,25,REP,Wayne Christian,55,1,2,5,19,28
+Hill,0014,Railroad Commissioner,25,REP,Ron Hale,37,1,4,4,15,13
+Hill,0014,Railroad Commissioner,25,REP,Doug Jeffrey,22,0,3,3,7,9
+Hill,0014,Railroad Commissioner,25,REP,John Greytok,33,3,3,3,9,15
+Hill,0014,Railroad Commissioner,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0014,Railroad Commissioner,25,REP,Under Votes,115,1,10,8,50,46
+Hill,0014,"Justice, Supreme Court, Place 3",25,REP,Michael Massengale,182,4,15,24,63,76
+Hill,0014,"Justice, Supreme Court, Place 3",25,REP,Debra Lehrmann,173,7,16,14,67,69
+Hill,0014,"Justice, Supreme Court, Place 3",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0014,"Justice, Supreme Court, Place 3",25,REP,Under Votes,98,1,8,6,33,50
+Hill,0014,"Justice, Supreme Court, Place 5",25,REP,Paul Green,194,7,18,24,67,78
+Hill,0014,"Justice, Supreme Court, Place 5",25,REP,Rick Green,138,3,9,11,50,65
+Hill,0014,"Justice, Supreme Court, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0014,"Justice, Supreme Court, Place 5",25,REP,Under Votes,121,2,12,9,46,52
+Hill,0014,"Justice, Supreme Court, Place 9",25,REP,Joe Pool,177,8,17,22,61,69
+Hill,0014,"Justice, Supreme Court, Place 9",25,REP,Eva Guzman,173,4,15,15,63,76
+Hill,0014,"Justice, Supreme Court, Place 9",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0014,"Justice, Supreme Court, Place 9",25,REP,Under Votes,103,0,7,7,39,50
+Hill,0014,"Judge, Court of Criminal Appeals, Place 2",25,REP,Chris Oldner,104,3,7,13,33,48
+Hill,0014,"Judge, Court of Criminal Appeals, Place 2",25,REP,Ray Wheless,128,4,12,12,50,50
+Hill,0014,"Judge, Court of Criminal Appeals, Place 2",25,REP,Mary Lou Keel,95,5,12,9,31,38
+Hill,0014,"Judge, Court of Criminal Appeals, Place 2",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0014,"Judge, Court of Criminal Appeals, Place 2",25,REP,Under Votes,126,0,8,10,49,59
+Hill,0014,"Judge, Court of Criminal Appeals, Place 5",25,REP,Sid Harle,81,5,11,8,26,31
+Hill,0014,"Judge, Court of Criminal Appeals, Place 5",25,REP,Brent Webster,60,1,8,5,31,15
+Hill,0014,"Judge, Court of Criminal Appeals, Place 5",25,REP,Scott Walker,128,5,8,13,36,66
+Hill,0014,"Judge, Court of Criminal Appeals, Place 5",25,REP,Steve Smith,61,1,4,9,22,25
+Hill,0014,"Judge, Court of Criminal Appeals, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0014,"Judge, Court of Criminal Appeals, Place 5",25,REP,Under Votes,123,0,8,9,48,58
+Hill,0014,"Judge, Court of Criminal Appeals, Place 6",25,REP,Richard Davis,184,6,17,20,58,83
+Hill,0014,"Judge, Court of Criminal Appeals, Place 6",25,REP,Michael E. Keasler,139,6,13,13,56,51
+Hill,0014,"Judge, Court of Criminal Appeals, Place 6",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0014,"Judge, Court of Criminal Appeals, Place 6",25,REP,Under Votes,130,0,9,11,49,61
+Hill,0014,"Member, State Board of Education, District 14",25,REP,Sue Melton-Malone,296,9,23,32,100,132
+Hill,0014,"Member, State Board of Education, District 14",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0014,"Member, State Board of Education, District 14",25,REP,Under Votes,157,3,16,12,63,63
+Hill,0014,State Senator,22,REP,Brian Birdwell,325,9,29,32,110,145
+Hill,0014,State Senator,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0014,State Senator,22,REP,Under Votes,128,3,10,12,53,50
+Hill,0014,State Representative,8,REP,Thomas McNutt,165,3,13,20,55,74
+Hill,0014,State Representative,8,REP,Byron Cook,241,9,23,22,90,97
+Hill,0014,State Representative,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0014,State Representative,8,REP,Under Votes,47,0,3,2,18,24
+Hill,0014,"Justice, 10th Court of Appeals District, Place 3",8,REP,Al Scoggins,286,8,22,30,95,131
+Hill,0014,"Justice, 10th Court of Appeals District, Place 3",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0014,"Justice, 10th Court of Appeals District, Place 3",8,REP,Under Votes,167,4,17,14,68,64
+Hill,0014,"District Attorney, 66th Judicial District",8,REP,Mark F Pratt,326,10,28,38,110,140
+Hill,0014,"District Attorney, 66th Judicial District",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0014,"District Attorney, 66th Judicial District",8,REP,Under Votes,127,2,11,6,53,55
+Hill,0014,County Attorney,8,REP,R David Holmes,321,9,28,35,110,139
+Hill,0014,County Attorney,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0014,County Attorney,8,REP,Under Votes,132,3,11,9,53,56
+Hill,0014,Sheriff,8,REP,Jimmy Johnson,49,5,6,2,14,22
+Hill,0014,Sheriff,8,REP,Dedri Hafer,32,0,1,2,7,22
+Hill,0014,Sheriff,8,REP,Rodney Watson,68,1,8,17,22,20
+Hill,0014,Sheriff,8,REP,Kyle R Cox,16,0,0,0,6,10
+Hill,0014,Sheriff,8,REP,Ronnie Myers,265,5,20,22,102,116
+Hill,0014,Sheriff,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0014,Sheriff,8,REP,Under Votes,23,1,4,1,12,5
+Hill,0014,Tax Assessor-Collector,8,REP,Ray Mabry,185,6,18,16,75,70
+Hill,0014,Tax Assessor-Collector,8,REP,Krissi Hightower,203,4,14,22,63,100
+Hill,0014,Tax Assessor-Collector,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0014,Tax Assessor-Collector,8,REP,Under Votes,65,2,7,6,25,25
+Hill,0014,"Constable, Precinct No. 2",8,REP,Justin Girsh,167,1,10,19,58,79
+Hill,0014,"Constable, Precinct No. 2",8,REP,Curtis R Jones,158,9,19,13,60,57
+Hill,0014,"Constable, Precinct No. 2",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0014,"Constable, Precinct No. 2",8,REP,Under Votes,128,2,10,12,45,59
+Hill,0014,County Chairman,8,REP,Will Orr,310,7,26,33,106,138
+Hill,0014,County Chairman,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0014,County Chairman,8,REP,Under Votes,143,5,13,11,57,57
+Hill,0014,President,8,DEM,Bernie Sanders,17,1,2,3,9,2
+Hill,0014,President,8,DEM,Star Locke,0,0,0,0,0,0
+Hill,0014,President,8,DEM,"Roque ""Rocky"" De La Fuente",0,0,0,0,0,0
+Hill,0014,President,8,DEM,Willie L. Wilson,0,0,0,0,0,0
+Hill,0014,President,8,DEM,Calvis L. Hawes,0,0,0,0,0,0
+Hill,0014,President,8,DEM,Hillary Clinton,15,1,2,5,6,1
+Hill,0014,President,8,DEM,Keith Judd,0,0,0,0,0,0
+Hill,0014,President,8,DEM,Martin J. O'Malley,0,0,0,0,0,0
+Hill,0014,President,8,DEM,Over Votes,0,0,0,0,0,0
+Hill,0014,President,8,DEM,Under Votes,0,0,0,0,0,0
+Hill,0014,U.S. House,25,DEM,Kathi Thomas,26,2,4,7,11,2
+Hill,0014,U.S. House,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0014,U.S. House,25,DEM,Under Votes,6,0,0,1,4,1
+Hill,0014,Railroad Commissioner,25,DEM,Cody Garrett,5,1,1,1,2,0
+Hill,0014,Railroad Commissioner,25,DEM,Lon Burnam,5,0,0,3,2,0
+Hill,0014,Railroad Commissioner,25,DEM,Grady Yarbrough,19,1,3,3,10,2
+Hill,0014,Railroad Commissioner,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0014,Railroad Commissioner,25,DEM,Under Votes,3,0,0,1,1,1
+Hill,0014,"Justice, Supreme Court, Place 3",25,DEM,Mike Westergren,27,2,4,7,12,2
+Hill,0014,"Justice, Supreme Court, Place 3",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0014,"Justice, Supreme Court, Place 3",25,DEM,Under Votes,5,0,0,1,3,1
+Hill,0014,"Justice, Supreme Court, Place 5",25,DEM,Dori Contreras Garza,26,2,4,7,11,2
+Hill,0014,"Justice, Supreme Court, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0014,"Justice, Supreme Court, Place 5",25,DEM,Under Votes,6,0,0,1,4,1
+Hill,0014,"Justice, Supreme Court, Place 9",25,DEM,Savannah Robinson,26,2,4,7,11,2
+Hill,0014,"Justice, Supreme Court, Place 9",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0014,"Justice, Supreme Court, Place 9",25,DEM,Under Votes,6,0,0,1,4,1
+Hill,0014,"Judge, Court of Criminal Appeals, Place 2",25,DEM,"Lawrence ""Larry"" Meyers",27,2,4,7,12,2
+Hill,0014,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0014,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Under Votes,5,0,0,1,3,1
+Hill,0014,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Betsy Johnson,26,2,4,7,11,2
+Hill,0014,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0014,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Under Votes,6,0,0,1,4,1
+Hill,0014,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Robert Burns,26,2,4,7,11,2
+Hill,0014,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0014,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Under Votes,6,0,0,1,4,1
+Hill,0014,State Senator,22,DEM,Michael Collins,27,2,4,7,12,2
+Hill,0014,State Senator,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0014,State Senator,22,DEM,Under Votes,5,0,0,1,3,1
+Hill,0014,County Chairman,22,DEM,Thomas Hanson,26,2,4,7,11,2
+Hill,0014,County Chairman,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0014,County Chairman,22,DEM,Under Votes,6,0,0,1,4,1
+Hill,0014,Proposition 1,22,REP,Yes,306,9,29,27,99,142
+Hill,0014,Proposition 1,22,REP,No,96,2,5,14,34,41
+Hill,0014,Proposition 1,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0014,Proposition 1,22,REP,Under Votes,51,1,5,3,30,12
+Hill,0014,Proposition 2,22,REP,Yes,252,4,21,19,92,116
+Hill,0014,Proposition 2,22,REP,No,168,8,16,23,52,69
+Hill,0014,Proposition 2,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0014,Proposition 2,22,REP,Under Votes,33,0,2,2,19,10
+Hill,0014,Proposition 3,22,REP,Yes,346,8,31,32,122,153
+Hill,0014,Proposition 3,22,REP,No,62,3,6,10,20,23
+Hill,0014,Proposition 3,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0014,Proposition 3,22,REP,Under Votes,45,1,2,2,21,19
+Hill,0014,Proposition 4,22,REP,Yes,388,11,35,38,137,167
+Hill,0014,Proposition 4,22,REP,No,21,0,2,2,7,10
+Hill,0014,Proposition 4,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0014,Proposition 4,22,REP,Under Votes,44,1,2,4,19,18
+Hill,0014,Referenda Item #1,22,DEM,For,30,2,4,8,14,2
+Hill,0014,Referenda Item #1,22,DEM,Against,1,0,0,0,1,0
+Hill,0014,Referenda Item #1,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0014,Referenda Item #1,22,DEM,Under Votes,1,0,0,0,0,1
+Hill,0014,Referenda Item #2,22,DEM,For,30,2,4,8,14,2
+Hill,0014,Referenda Item #2,22,DEM,Against,1,0,0,0,1,0
+Hill,0014,Referenda Item #2,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0014,Referenda Item #2,22,DEM,Under Votes,1,0,0,0,0,1
+Hill,0014,Referenda Item #3,22,DEM,For,28,2,4,8,13,1
+Hill,0014,Referenda Item #3,22,DEM,Against,3,0,0,0,2,1
+Hill,0014,Referenda Item #3,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0014,Referenda Item #3,22,DEM,Under Votes,1,0,0,0,0,1
+Hill,0014,Referenda Item #4,22,DEM,For,28,2,4,8,12,2
+Hill,0014,Referenda Item #4,22,DEM,Against,3,0,0,0,3,0
+Hill,0014,Referenda Item #4,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0014,Referenda Item #4,22,DEM,Under Votes,1,0,0,0,0,1
+Hill,0014,Referenda Item #5,22,DEM,For,30,2,4,7,14,3
+Hill,0014,Referenda Item #5,22,DEM,Against,2,0,0,1,1,0
+Hill,0014,Referenda Item #5,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0014,Referenda Item #5,22,DEM,Under Votes,0,0,0,0,0,0
+Hill,0014,Referenda Item #6,22,DEM,For,25,2,4,7,10,2
+Hill,0014,Referenda Item #6,22,DEM,Against,6,0,0,1,5,0
+Hill,0014,Referenda Item #6,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0014,Referenda Item #6,22,DEM,Under Votes,1,0,0,0,0,1
+Hill,0015,Registered Voters - Total,,,,436,0,0,0,0,1
+Hill,0015,Ballots Cast - Total,,REP,,185,13,20,11,55,86
+Hill,0015,Ballots Cast - Total,,DEM,,12,2,2,0,5,3
+Hill,0015,President,,REP,Ted Cruz,78,0,3,4,24,47
+Hill,0015,President,,REP,Jeb Bush,4,0,1,1,2,0
+Hill,0015,President,,REP,Donald J. Trump,59,6,7,3,16,27
+Hill,0015,President,,REP,Ben Carson,7,1,1,1,1,3
+Hill,0015,President,,REP,Rand Paul,0,0,0,0,0,0
+Hill,0015,President,,REP,Rick Santorum,0,0,0,0,0,0
+Hill,0015,President,,REP,Elizabeth Gray,0,0,0,0,0,0
+Hill,0015,President,,REP,Carly Fiorina,0,0,0,0,0,0
+Hill,0015,President,,REP,Lindsey Graham,0,0,0,0,0,0
+Hill,0015,President,,REP,Marco Rubio,26,5,7,1,8,5
+Hill,0015,President,,REP,John R. Kasich,3,0,0,0,2,1
+Hill,0015,President,,REP,Mike Huckabee,0,0,0,0,0,0
+Hill,0015,President,,REP,Chris Christie,1,0,0,0,0,1
+Hill,0015,President,,REP,Uncommitted,2,0,0,0,0,2
+Hill,0015,President,,REP,Over Votes,0,0,0,0,0,0
+Hill,0015,President,,REP,Under Votes,5,1,1,1,2,0
+Hill,0015,U.S. House,25,REP,Roger Williams,141,11,17,7,43,63
+Hill,0015,U.S. House,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0015,U.S. House,25,REP,Under Votes,44,2,3,4,12,23
+Hill,0015,Railroad Commissioner,25,REP,Gary Gates,64,4,7,3,18,32
+Hill,0015,Railroad Commissioner,25,REP,Lance N. Christian,27,3,4,0,11,9
+Hill,0015,Railroad Commissioner,25,REP,Weston Martinez,12,1,2,0,3,6
+Hill,0015,Railroad Commissioner,25,REP,Wayne Christian,15,1,1,1,5,7
+Hill,0015,Railroad Commissioner,25,REP,Ron Hale,14,0,0,2,1,11
+Hill,0015,Railroad Commissioner,25,REP,Doug Jeffrey,10,0,1,1,3,5
+Hill,0015,Railroad Commissioner,25,REP,John Greytok,9,0,0,0,3,6
+Hill,0015,Railroad Commissioner,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0015,Railroad Commissioner,25,REP,Under Votes,34,4,5,4,11,10
+Hill,0015,"Justice, Supreme Court, Place 3",25,REP,Michael Massengale,78,5,10,1,26,36
+Hill,0015,"Justice, Supreme Court, Place 3",25,REP,Debra Lehrmann,83,6,7,7,22,41
+Hill,0015,"Justice, Supreme Court, Place 3",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0015,"Justice, Supreme Court, Place 3",25,REP,Under Votes,24,2,3,3,7,9
+Hill,0015,"Justice, Supreme Court, Place 5",25,REP,Paul Green,91,5,11,3,25,47
+Hill,0015,"Justice, Supreme Court, Place 5",25,REP,Rick Green,57,3,3,4,18,29
+Hill,0015,"Justice, Supreme Court, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0015,"Justice, Supreme Court, Place 5",25,REP,Under Votes,37,5,6,4,12,10
+Hill,0015,"Justice, Supreme Court, Place 9",25,REP,Joe Pool,83,7,12,4,27,33
+Hill,0015,"Justice, Supreme Court, Place 9",25,REP,Eva Guzman,73,4,5,3,20,41
+Hill,0015,"Justice, Supreme Court, Place 9",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0015,"Justice, Supreme Court, Place 9",25,REP,Under Votes,29,2,3,4,8,12
+Hill,0015,"Judge, Court of Criminal Appeals, Place 2",25,REP,Chris Oldner,42,2,3,1,14,22
+Hill,0015,"Judge, Court of Criminal Appeals, Place 2",25,REP,Ray Wheless,53,4,5,2,16,26
+Hill,0015,"Judge, Court of Criminal Appeals, Place 2",25,REP,Mary Lou Keel,51,4,7,4,14,22
+Hill,0015,"Judge, Court of Criminal Appeals, Place 2",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0015,"Judge, Court of Criminal Appeals, Place 2",25,REP,Under Votes,39,3,5,4,11,16
+Hill,0015,"Judge, Court of Criminal Appeals, Place 5",25,REP,Sid Harle,26,3,3,3,11,6
+Hill,0015,"Judge, Court of Criminal Appeals, Place 5",25,REP,Brent Webster,15,0,2,1,6,6
+Hill,0015,"Judge, Court of Criminal Appeals, Place 5",25,REP,Scott Walker,76,4,8,3,24,37
+Hill,0015,"Judge, Court of Criminal Appeals, Place 5",25,REP,Steve Smith,29,2,2,1,2,22
+Hill,0015,"Judge, Court of Criminal Appeals, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0015,"Judge, Court of Criminal Appeals, Place 5",25,REP,Under Votes,39,4,5,3,12,15
+Hill,0015,"Judge, Court of Criminal Appeals, Place 6",25,REP,Richard Davis,88,6,9,3,28,42
+Hill,0015,"Judge, Court of Criminal Appeals, Place 6",25,REP,Michael E. Keasler,51,2,5,4,13,27
+Hill,0015,"Judge, Court of Criminal Appeals, Place 6",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0015,"Judge, Court of Criminal Appeals, Place 6",25,REP,Under Votes,46,5,6,4,14,17
+Hill,0015,"Member, State Board of Education, District 14",25,REP,Sue Melton-Malone,143,11,17,7,41,67
+Hill,0015,"Member, State Board of Education, District 14",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0015,"Member, State Board of Education, District 14",25,REP,Under Votes,42,2,3,4,14,19
+Hill,0015,State Senator,22,REP,Brian Birdwell,148,12,18,7,43,68
+Hill,0015,State Senator,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0015,State Senator,22,REP,Under Votes,37,1,2,4,12,18
+Hill,0015,State Representative,8,REP,Thomas McNutt,71,3,5,3,21,39
+Hill,0015,State Representative,8,REP,Byron Cook,101,10,14,6,30,41
+Hill,0015,State Representative,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0015,State Representative,8,REP,Under Votes,13,0,1,2,4,6
+Hill,0015,"Justice, 10th Court of Appeals District, Place 3",8,REP,Al Scoggins,132,8,14,6,39,65
+Hill,0015,"Justice, 10th Court of Appeals District, Place 3",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0015,"Justice, 10th Court of Appeals District, Place 3",8,REP,Under Votes,53,5,6,5,16,21
+Hill,0015,"District Attorney, 66th Judicial District",8,REP,Mark F Pratt,141,9,15,7,42,68
+Hill,0015,"District Attorney, 66th Judicial District",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0015,"District Attorney, 66th Judicial District",8,REP,Under Votes,44,4,5,4,13,18
+Hill,0015,County Attorney,8,REP,R David Holmes,143,11,17,7,41,67
+Hill,0015,County Attorney,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0015,County Attorney,8,REP,Under Votes,42,2,3,4,14,19
+Hill,0015,Sheriff,8,REP,Jimmy Johnson,50,2,4,7,16,21
+Hill,0015,Sheriff,8,REP,Dedri Hafer,9,0,0,0,3,6
+Hill,0015,Sheriff,8,REP,Rodney Watson,53,6,6,0,15,26
+Hill,0015,Sheriff,8,REP,Kyle R Cox,30,0,1,1,7,21
+Hill,0015,Sheriff,8,REP,Ronnie Myers,33,4,8,2,10,9
+Hill,0015,Sheriff,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0015,Sheriff,8,REP,Under Votes,10,1,1,1,4,3
+Hill,0015,Tax Assessor-Collector,8,REP,Ray Mabry,74,8,8,4,24,30
+Hill,0015,Tax Assessor-Collector,8,REP,Krissi Hightower,94,4,11,5,26,48
+Hill,0015,Tax Assessor-Collector,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0015,Tax Assessor-Collector,8,REP,Under Votes,17,1,1,2,5,8
+Hill,0015,County Commissioner # 3,8,REP,Scotty Hawkins,153,11,18,7,47,70
+Hill,0015,County Commissioner # 3,8,REP,Milton Stuckly,5,0,0,0,0,5
+Hill,0015,County Commissioner # 3,8,REP,"Ernest D McFarland, Jr",3,0,0,0,1,2
+Hill,0015,County Commissioner # 3,8,REP,David Bow,19,1,1,3,5,9
+Hill,0015,County Commissioner # 3,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0015,County Commissioner # 3,8,REP,Under Votes,5,1,1,1,2,0
+Hill,0015,"Constable, Precinct No. 3",8,REP,Larry Armstrong,102,5,9,6,34,48
+Hill,0015,"Constable, Precinct No. 3",8,REP,Brian Couch,49,7,8,1,11,22
+Hill,0015,"Constable, Precinct No. 3",8,REP,Stephen Nanny,28,1,3,2,7,15
+Hill,0015,"Constable, Precinct No. 3",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0015,"Constable, Precinct No. 3",8,REP,Under Votes,6,0,0,2,3,1
+Hill,0015,County Chairman,8,REP,Will Orr,153,11,18,8,45,71
+Hill,0015,County Chairman,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0015,County Chairman,8,REP,Under Votes,32,2,2,3,10,15
+Hill,0015,President,8,DEM,Bernie Sanders,3,0,0,0,3,0
+Hill,0015,President,8,DEM,Star Locke,0,0,0,0,0,0
+Hill,0015,President,8,DEM,"Roque ""Rocky"" De La Fuente",0,0,0,0,0,0
+Hill,0015,President,8,DEM,Willie L. Wilson,0,0,0,0,0,0
+Hill,0015,President,8,DEM,Calvis L. Hawes,0,0,0,0,0,0
+Hill,0015,President,8,DEM,Hillary Clinton,9,2,2,0,2,3
+Hill,0015,President,8,DEM,Keith Judd,0,0,0,0,0,0
+Hill,0015,President,8,DEM,Martin J. O'Malley,0,0,0,0,0,0
+Hill,0015,President,8,DEM,Over Votes,0,0,0,0,0,0
+Hill,0015,President,8,DEM,Under Votes,0,0,0,0,0,0
+Hill,0015,U.S. House,25,DEM,Kathi Thomas,10,2,2,0,4,2
+Hill,0015,U.S. House,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0015,U.S. House,25,DEM,Under Votes,2,0,0,0,1,1
+Hill,0015,Railroad Commissioner,25,DEM,Cody Garrett,5,1,1,0,2,1
+Hill,0015,Railroad Commissioner,25,DEM,Lon Burnam,1,0,0,0,0,1
+Hill,0015,Railroad Commissioner,25,DEM,Grady Yarbrough,5,1,1,0,2,1
+Hill,0015,Railroad Commissioner,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0015,Railroad Commissioner,25,DEM,Under Votes,1,0,0,0,1,0
+Hill,0015,"Justice, Supreme Court, Place 3",25,DEM,Mike Westergren,11,2,2,0,4,3
+Hill,0015,"Justice, Supreme Court, Place 3",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0015,"Justice, Supreme Court, Place 3",25,DEM,Under Votes,1,0,0,0,1,0
+Hill,0015,"Justice, Supreme Court, Place 5",25,DEM,Dori Contreras Garza,11,2,2,0,4,3
+Hill,0015,"Justice, Supreme Court, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0015,"Justice, Supreme Court, Place 5",25,DEM,Under Votes,1,0,0,0,1,0
+Hill,0015,"Justice, Supreme Court, Place 9",25,DEM,Savannah Robinson,11,2,2,0,4,3
+Hill,0015,"Justice, Supreme Court, Place 9",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0015,"Justice, Supreme Court, Place 9",25,DEM,Under Votes,1,0,0,0,1,0
+Hill,0015,"Judge, Court of Criminal Appeals, Place 2",25,DEM,"Lawrence ""Larry"" Meyers",11,2,2,0,4,3
+Hill,0015,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0015,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Under Votes,1,0,0,0,1,0
+Hill,0015,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Betsy Johnson,11,2,2,0,4,3
+Hill,0015,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0015,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Under Votes,1,0,0,0,1,0
+Hill,0015,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Robert Burns,11,2,2,0,4,3
+Hill,0015,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0015,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Under Votes,1,0,0,0,1,0
+Hill,0015,State Senator,22,DEM,Michael Collins,11,2,2,0,4,3
+Hill,0015,State Senator,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0015,State Senator,22,DEM,Under Votes,1,0,0,0,1,0
+Hill,0015,County Chairman,22,DEM,Thomas Hanson,11,2,2,0,4,3
+Hill,0015,County Chairman,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0015,County Chairman,22,DEM,Under Votes,1,0,0,0,1,0
+Hill,0015,Proposition 1,22,REP,Yes,114,7,13,7,32,55
+Hill,0015,Proposition 1,22,REP,No,56,4,5,2,16,29
+Hill,0015,Proposition 1,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0015,Proposition 1,22,REP,Under Votes,15,2,2,2,7,2
+Hill,0015,Proposition 2,22,REP,Yes,102,4,9,7,31,51
+Hill,0015,Proposition 2,22,REP,No,72,8,10,3,18,33
+Hill,0015,Proposition 2,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0015,Proposition 2,22,REP,Under Votes,11,1,1,1,6,2
+Hill,0015,Proposition 3,22,REP,Yes,141,10,15,6,40,70
+Hill,0015,Proposition 3,22,REP,No,33,2,4,4,10,13
+Hill,0015,Proposition 3,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0015,Proposition 3,22,REP,Under Votes,11,1,1,1,5,3
+Hill,0015,Proposition 4,22,REP,Yes,161,11,18,7,46,79
+Hill,0015,Proposition 4,22,REP,No,7,0,0,1,3,3
+Hill,0015,Proposition 4,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0015,Proposition 4,22,REP,Under Votes,17,2,2,3,6,4
+Hill,0015,Referenda Item #1,22,DEM,For,11,2,2,0,4,3
+Hill,0015,Referenda Item #1,22,DEM,Against,1,0,0,0,1,0
+Hill,0015,Referenda Item #1,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0015,Referenda Item #1,22,DEM,Under Votes,0,0,0,0,0,0
+Hill,0015,Referenda Item #2,22,DEM,For,11,2,2,0,4,3
+Hill,0015,Referenda Item #2,22,DEM,Against,1,0,0,0,1,0
+Hill,0015,Referenda Item #2,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0015,Referenda Item #2,22,DEM,Under Votes,0,0,0,0,0,0
+Hill,0015,Referenda Item #3,22,DEM,For,11,2,2,0,4,3
+Hill,0015,Referenda Item #3,22,DEM,Against,1,0,0,0,1,0
+Hill,0015,Referenda Item #3,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0015,Referenda Item #3,22,DEM,Under Votes,0,0,0,0,0,0
+Hill,0015,Referenda Item #4,22,DEM,For,11,2,2,0,4,3
+Hill,0015,Referenda Item #4,22,DEM,Against,1,0,0,0,1,0
+Hill,0015,Referenda Item #4,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0015,Referenda Item #4,22,DEM,Under Votes,0,0,0,0,0,0
+Hill,0015,Referenda Item #5,22,DEM,For,9,2,2,0,3,2
+Hill,0015,Referenda Item #5,22,DEM,Against,3,0,0,0,2,1
+Hill,0015,Referenda Item #5,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0015,Referenda Item #5,22,DEM,Under Votes,0,0,0,0,0,0
+Hill,0015,Referenda Item #6,22,DEM,For,9,2,2,0,3,2
+Hill,0015,Referenda Item #6,22,DEM,Against,3,0,0,0,2,1
+Hill,0015,Referenda Item #6,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0015,Referenda Item #6,22,DEM,Under Votes,0,0,0,0,0,0
+Hill,0016,Registered Voters - Total,,,,392,0,0,0,0,0
+Hill,0016,Ballots Cast - Total,,REP,,190,6,14,15,130,25
+Hill,0016,Ballots Cast - Total,,DEM,,6,0,1,0,5,0
+Hill,0016,President,,REP,Ted Cruz,83,1,5,10,57,10
+Hill,0016,President,,REP,Jeb Bush,2,0,0,1,0,1
+Hill,0016,President,,REP,Donald J. Trump,69,2,3,3,49,12
+Hill,0016,President,,REP,Ben Carson,8,0,1,1,4,2
+Hill,0016,President,,REP,Rand Paul,0,0,0,0,0,0
+Hill,0016,President,,REP,Rick Santorum,0,0,0,0,0,0
+Hill,0016,President,,REP,Elizabeth Gray,0,0,0,0,0,0
+Hill,0016,President,,REP,Carly Fiorina,0,0,0,0,0,0
+Hill,0016,President,,REP,Lindsey Graham,0,0,0,0,0,0
+Hill,0016,President,,REP,Marco Rubio,14,2,3,0,9,0
+Hill,0016,President,,REP,John R. Kasich,0,0,0,0,0,0
+Hill,0016,President,,REP,Mike Huckabee,0,0,0,0,0,0
+Hill,0016,President,,REP,Chris Christie,0,0,0,0,0,0
+Hill,0016,President,,REP,Uncommitted,7,0,1,0,6,0
+Hill,0016,President,,REP,Over Votes,0,0,0,0,0,0
+Hill,0016,President,,REP,Under Votes,7,1,1,0,5,0
+Hill,0016,U.S. House,25,REP,Roger Williams,120,4,9,12,80,15
+Hill,0016,U.S. House,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0016,U.S. House,25,REP,Under Votes,70,2,5,3,50,10
+Hill,0016,Railroad Commissioner,25,REP,Gary Gates,61,2,6,3,47,3
+Hill,0016,Railroad Commissioner,25,REP,Lance N. Christian,23,2,4,1,13,3
+Hill,0016,Railroad Commissioner,25,REP,Weston Martinez,9,0,0,1,4,4
+Hill,0016,Railroad Commissioner,25,REP,Wayne Christian,20,0,0,5,14,1
+Hill,0016,Railroad Commissioner,25,REP,Ron Hale,9,0,1,1,6,1
+Hill,0016,Railroad Commissioner,25,REP,Doug Jeffrey,13,1,2,2,6,2
+Hill,0016,Railroad Commissioner,25,REP,John Greytok,2,0,0,0,1,1
+Hill,0016,Railroad Commissioner,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0016,Railroad Commissioner,25,REP,Under Votes,53,1,1,2,39,10
+Hill,0016,"Justice, Supreme Court, Place 3",25,REP,Michael Massengale,61,2,6,2,42,9
+Hill,0016,"Justice, Supreme Court, Place 3",25,REP,Debra Lehrmann,82,3,7,12,52,8
+Hill,0016,"Justice, Supreme Court, Place 3",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0016,"Justice, Supreme Court, Place 3",25,REP,Under Votes,47,1,1,1,36,8
+Hill,0016,"Justice, Supreme Court, Place 5",25,REP,Paul Green,80,3,8,7,55,7
+Hill,0016,"Justice, Supreme Court, Place 5",25,REP,Rick Green,52,2,5,6,32,7
+Hill,0016,"Justice, Supreme Court, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0016,"Justice, Supreme Court, Place 5",25,REP,Under Votes,58,1,1,2,43,11
+Hill,0016,"Justice, Supreme Court, Place 9",25,REP,Joe Pool,68,1,5,9,47,6
+Hill,0016,"Justice, Supreme Court, Place 9",25,REP,Eva Guzman,57,3,5,4,37,8
+Hill,0016,"Justice, Supreme Court, Place 9",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0016,"Justice, Supreme Court, Place 9",25,REP,Under Votes,65,2,4,2,46,11
+Hill,0016,"Judge, Court of Criminal Appeals, Place 2",25,REP,Chris Oldner,41,1,4,5,26,5
+Hill,0016,"Judge, Court of Criminal Appeals, Place 2",25,REP,Ray Wheless,28,0,0,2,24,2
+Hill,0016,"Judge, Court of Criminal Appeals, Place 2",25,REP,Mary Lou Keel,48,2,6,6,27,7
+Hill,0016,"Judge, Court of Criminal Appeals, Place 2",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0016,"Judge, Court of Criminal Appeals, Place 2",25,REP,Under Votes,73,3,4,2,53,11
+Hill,0016,"Judge, Court of Criminal Appeals, Place 5",25,REP,Sid Harle,31,2,5,1,19,4
+Hill,0016,"Judge, Court of Criminal Appeals, Place 5",25,REP,Brent Webster,14,0,1,2,10,1
+Hill,0016,"Judge, Court of Criminal Appeals, Place 5",25,REP,Scott Walker,58,2,6,4,38,8
+Hill,0016,"Judge, Court of Criminal Appeals, Place 5",25,REP,Steve Smith,23,1,1,8,12,1
+Hill,0016,"Judge, Court of Criminal Appeals, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0016,"Judge, Court of Criminal Appeals, Place 5",25,REP,Under Votes,64,1,1,0,51,11
+Hill,0016,"Judge, Court of Criminal Appeals, Place 6",25,REP,Richard Davis,68,2,7,9,42,8
+Hill,0016,"Judge, Court of Criminal Appeals, Place 6",25,REP,Michael E. Keasler,56,3,6,4,37,6
+Hill,0016,"Judge, Court of Criminal Appeals, Place 6",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0016,"Judge, Court of Criminal Appeals, Place 6",25,REP,Under Votes,66,1,1,2,51,11
+Hill,0016,"Member, State Board of Education, District 14",25,REP,Sue Melton-Malone,114,3,9,12,76,14
+Hill,0016,"Member, State Board of Education, District 14",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0016,"Member, State Board of Education, District 14",25,REP,Under Votes,76,3,5,3,54,11
+Hill,0016,State Senator,22,REP,Brian Birdwell,123,3,8,12,84,16
+Hill,0016,State Senator,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0016,State Senator,22,REP,Under Votes,67,3,6,3,46,9
+Hill,0016,State Representative,8,REP,Thomas McNutt,76,3,8,3,53,9
+Hill,0016,State Representative,8,REP,Byron Cook,84,0,3,11,57,13
+Hill,0016,State Representative,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0016,State Representative,8,REP,Under Votes,30,3,3,1,20,3
+Hill,0016,"Justice, 10th Court of Appeals District, Place 3",8,REP,Al Scoggins,105,3,6,12,70,14
+Hill,0016,"Justice, 10th Court of Appeals District, Place 3",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0016,"Justice, 10th Court of Appeals District, Place 3",8,REP,Under Votes,85,3,8,3,60,11
+Hill,0016,"District Attorney, 66th Judicial District",8,REP,Mark F Pratt,131,5,9,13,86,18
+Hill,0016,"District Attorney, 66th Judicial District",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0016,"District Attorney, 66th Judicial District",8,REP,Under Votes,59,1,5,2,44,7
+Hill,0016,County Attorney,8,REP,R David Holmes,114,3,6,13,77,15
+Hill,0016,County Attorney,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0016,County Attorney,8,REP,Under Votes,76,3,8,2,53,10
+Hill,0016,Sheriff,8,REP,Jimmy Johnson,85,0,3,10,66,6
+Hill,0016,Sheriff,8,REP,Dedri Hafer,20,5,6,0,8,1
+Hill,0016,Sheriff,8,REP,Rodney Watson,42,1,3,4,27,7
+Hill,0016,Sheriff,8,REP,Kyle R Cox,21,0,1,1,13,6
+Hill,0016,Sheriff,8,REP,Ronnie Myers,11,0,1,0,7,3
+Hill,0016,Sheriff,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0016,Sheriff,8,REP,Under Votes,11,0,0,0,9,2
+Hill,0016,Tax Assessor-Collector,8,REP,Ray Mabry,54,1,3,6,35,9
+Hill,0016,Tax Assessor-Collector,8,REP,Krissi Hightower,96,2,7,9,68,10
+Hill,0016,Tax Assessor-Collector,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0016,Tax Assessor-Collector,8,REP,Under Votes,40,3,4,0,27,6
+Hill,0016,County Commissioner # 3,8,REP,Scotty Hawkins,114,4,8,7,83,12
+Hill,0016,County Commissioner # 3,8,REP,Milton Stuckly,13,1,1,1,9,1
+Hill,0016,County Commissioner # 3,8,REP,"Ernest D McFarland, Jr",3,0,0,0,1,2
+Hill,0016,County Commissioner # 3,8,REP,David Bow,55,1,5,7,34,8
+Hill,0016,County Commissioner # 3,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0016,County Commissioner # 3,8,REP,Under Votes,5,0,0,0,3,2
+Hill,0016,"Constable, Precinct No. 3",8,REP,Larry Armstrong,133,2,8,11,97,15
+Hill,0016,"Constable, Precinct No. 3",8,REP,Brian Couch,21,2,3,1,14,1
+Hill,0016,"Constable, Precinct No. 3",8,REP,Stephen Nanny,22,0,1,3,13,5
+Hill,0016,"Constable, Precinct No. 3",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0016,"Constable, Precinct No. 3",8,REP,Under Votes,14,2,2,0,6,4
+Hill,0016,County Chairman,8,REP,Will Orr,123,4,8,14,81,16
+Hill,0016,County Chairman,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0016,County Chairman,8,REP,Under Votes,67,2,6,1,49,9
+Hill,0016,President,8,DEM,Bernie Sanders,1,0,0,0,1,0
+Hill,0016,President,8,DEM,Star Locke,0,0,0,0,0,0
+Hill,0016,President,8,DEM,"Roque ""Rocky"" De La Fuente",0,0,0,0,0,0
+Hill,0016,President,8,DEM,Willie L. Wilson,0,0,0,0,0,0
+Hill,0016,President,8,DEM,Calvis L. Hawes,0,0,0,0,0,0
+Hill,0016,President,8,DEM,Hillary Clinton,5,0,1,0,4,0
+Hill,0016,President,8,DEM,Keith Judd,0,0,0,0,0,0
+Hill,0016,President,8,DEM,Martin J. O'Malley,0,0,0,0,0,0
+Hill,0016,President,8,DEM,Over Votes,0,0,0,0,0,0
+Hill,0016,President,8,DEM,Under Votes,0,0,0,0,0,0
+Hill,0016,U.S. House,25,DEM,Kathi Thomas,5,0,1,0,4,0
+Hill,0016,U.S. House,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0016,U.S. House,25,DEM,Under Votes,1,0,0,0,1,0
+Hill,0016,Railroad Commissioner,25,DEM,Cody Garrett,5,0,1,0,4,0
+Hill,0016,Railroad Commissioner,25,DEM,Lon Burnam,1,0,0,0,1,0
+Hill,0016,Railroad Commissioner,25,DEM,Grady Yarbrough,0,0,0,0,0,0
+Hill,0016,Railroad Commissioner,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0016,Railroad Commissioner,25,DEM,Under Votes,0,0,0,0,0,0
+Hill,0016,"Justice, Supreme Court, Place 3",25,DEM,Mike Westergren,6,0,1,0,5,0
+Hill,0016,"Justice, Supreme Court, Place 3",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0016,"Justice, Supreme Court, Place 3",25,DEM,Under Votes,0,0,0,0,0,0
+Hill,0016,"Justice, Supreme Court, Place 5",25,DEM,Dori Contreras Garza,6,0,1,0,5,0
+Hill,0016,"Justice, Supreme Court, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0016,"Justice, Supreme Court, Place 5",25,DEM,Under Votes,0,0,0,0,0,0
+Hill,0016,"Justice, Supreme Court, Place 9",25,DEM,Savannah Robinson,6,0,1,0,5,0
+Hill,0016,"Justice, Supreme Court, Place 9",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0016,"Justice, Supreme Court, Place 9",25,DEM,Under Votes,0,0,0,0,0,0
+Hill,0016,"Judge, Court of Criminal Appeals, Place 2",25,DEM,"Lawrence ""Larry"" Meyers",6,0,1,0,5,0
+Hill,0016,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0016,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Under Votes,0,0,0,0,0,0
+Hill,0016,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Betsy Johnson,6,0,1,0,5,0
+Hill,0016,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0016,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Under Votes,0,0,0,0,0,0
+Hill,0016,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Robert Burns,6,0,1,0,5,0
+Hill,0016,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0016,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Under Votes,0,0,0,0,0,0
+Hill,0016,State Senator,22,DEM,Michael Collins,6,0,1,0,5,0
+Hill,0016,State Senator,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0016,State Senator,22,DEM,Under Votes,0,0,0,0,0,0
+Hill,0016,County Chairman,22,DEM,Thomas Hanson,6,0,1,0,5,0
+Hill,0016,County Chairman,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0016,County Chairman,22,DEM,Under Votes,0,0,0,0,0,0
+Hill,0016,Proposition 1,22,REP,Yes,105,4,11,8,68,14
+Hill,0016,Proposition 1,22,REP,No,52,2,3,4,36,7
+Hill,0016,Proposition 1,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0016,Proposition 1,22,REP,Under Votes,33,0,0,3,26,4
+Hill,0016,Proposition 2,22,REP,Yes,96,4,9,9,63,11
+Hill,0016,Proposition 2,22,REP,No,66,2,5,5,43,11
+Hill,0016,Proposition 2,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0016,Proposition 2,22,REP,Under Votes,28,0,0,1,24,3
+Hill,0016,Proposition 3,22,REP,Yes,124,4,12,10,82,16
+Hill,0016,Proposition 3,22,REP,No,33,2,2,4,20,5
+Hill,0016,Proposition 3,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0016,Proposition 3,22,REP,Under Votes,33,0,0,1,28,4
+Hill,0016,Proposition 4,22,REP,Yes,145,6,14,14,90,21
+Hill,0016,Proposition 4,22,REP,No,10,0,0,0,10,0
+Hill,0016,Proposition 4,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0016,Proposition 4,22,REP,Under Votes,35,0,0,1,30,4
+Hill,0016,Referenda Item #1,22,DEM,For,6,0,1,0,5,0
+Hill,0016,Referenda Item #1,22,DEM,Against,0,0,0,0,0,0
+Hill,0016,Referenda Item #1,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0016,Referenda Item #1,22,DEM,Under Votes,0,0,0,0,0,0
+Hill,0016,Referenda Item #2,22,DEM,For,6,0,1,0,5,0
+Hill,0016,Referenda Item #2,22,DEM,Against,0,0,0,0,0,0
+Hill,0016,Referenda Item #2,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0016,Referenda Item #2,22,DEM,Under Votes,0,0,0,0,0,0
+Hill,0016,Referenda Item #3,22,DEM,For,6,0,1,0,5,0
+Hill,0016,Referenda Item #3,22,DEM,Against,0,0,0,0,0,0
+Hill,0016,Referenda Item #3,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0016,Referenda Item #3,22,DEM,Under Votes,0,0,0,0,0,0
+Hill,0016,Referenda Item #4,22,DEM,For,4,0,0,0,4,0
+Hill,0016,Referenda Item #4,22,DEM,Against,2,0,1,0,1,0
+Hill,0016,Referenda Item #4,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0016,Referenda Item #4,22,DEM,Under Votes,0,0,0,0,0,0
+Hill,0016,Referenda Item #5,22,DEM,For,5,0,1,0,4,0
+Hill,0016,Referenda Item #5,22,DEM,Against,1,0,0,0,1,0
+Hill,0016,Referenda Item #5,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0016,Referenda Item #5,22,DEM,Under Votes,0,0,0,0,0,0
+Hill,0016,Referenda Item #6,22,DEM,For,6,0,1,0,5,0
+Hill,0016,Referenda Item #6,22,DEM,Against,0,0,0,0,0,0
+Hill,0016,Referenda Item #6,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0016,Referenda Item #6,22,DEM,Under Votes,0,0,0,0,0,0
+Hill,0018,Registered Voters - Total,,,,191,0,0,0,0,0
+Hill,0018,Ballots Cast - Total,,REP,,73,1,6,13,32,21
+Hill,0018,Ballots Cast - Total,,DEM,,6,1,1,0,4,0
+Hill,0018,President,,REP,Ted Cruz,37,1,5,6,17,8
+Hill,0018,President,,REP,Jeb Bush,0,0,0,0,0,0
+Hill,0018,President,,REP,Donald J. Trump,29,0,1,5,14,9
+Hill,0018,President,,REP,Ben Carson,1,0,0,0,0,1
+Hill,0018,President,,REP,Rand Paul,0,0,0,0,0,0
+Hill,0018,President,,REP,Rick Santorum,0,0,0,0,0,0
+Hill,0018,President,,REP,Elizabeth Gray,0,0,0,0,0,0
+Hill,0018,President,,REP,Carly Fiorina,0,0,0,0,0,0
+Hill,0018,President,,REP,Lindsey Graham,0,0,0,0,0,0
+Hill,0018,President,,REP,Marco Rubio,3,0,0,0,1,2
+Hill,0018,President,,REP,John R. Kasich,1,0,0,1,0,0
+Hill,0018,President,,REP,Mike Huckabee,0,0,0,0,0,0
+Hill,0018,President,,REP,Chris Christie,1,0,0,1,0,0
+Hill,0018,President,,REP,Uncommitted,1,0,0,0,0,1
+Hill,0018,President,,REP,Over Votes,0,0,0,0,0,0
+Hill,0018,President,,REP,Under Votes,0,0,0,0,0,0
+Hill,0018,U.S. House,25,REP,Roger Williams,48,1,5,8,23,11
+Hill,0018,U.S. House,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0018,U.S. House,25,REP,Under Votes,25,0,1,5,9,10
+Hill,0018,Railroad Commissioner,25,REP,Gary Gates,23,0,3,3,11,6
+Hill,0018,Railroad Commissioner,25,REP,Lance N. Christian,6,0,0,3,3,0
+Hill,0018,Railroad Commissioner,25,REP,Weston Martinez,7,0,2,0,2,3
+Hill,0018,Railroad Commissioner,25,REP,Wayne Christian,10,1,1,1,4,3
+Hill,0018,Railroad Commissioner,25,REP,Ron Hale,2,0,0,0,1,1
+Hill,0018,Railroad Commissioner,25,REP,Doug Jeffrey,3,0,0,1,2,0
+Hill,0018,Railroad Commissioner,25,REP,John Greytok,1,0,0,0,1,0
+Hill,0018,Railroad Commissioner,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0018,Railroad Commissioner,25,REP,Under Votes,21,0,0,5,8,8
+Hill,0018,"Justice, Supreme Court, Place 3",25,REP,Michael Massengale,32,0,3,5,18,6
+Hill,0018,"Justice, Supreme Court, Place 3",25,REP,Debra Lehrmann,23,1,3,3,8,8
+Hill,0018,"Justice, Supreme Court, Place 3",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0018,"Justice, Supreme Court, Place 3",25,REP,Under Votes,18,0,0,5,6,7
+Hill,0018,"Justice, Supreme Court, Place 5",25,REP,Paul Green,26,1,4,5,8,8
+Hill,0018,"Justice, Supreme Court, Place 5",25,REP,Rick Green,24,0,2,3,14,5
+Hill,0018,"Justice, Supreme Court, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0018,"Justice, Supreme Court, Place 5",25,REP,Under Votes,23,0,0,5,10,8
+Hill,0018,"Justice, Supreme Court, Place 9",25,REP,Joe Pool,20,0,1,4,11,4
+Hill,0018,"Justice, Supreme Court, Place 9",25,REP,Eva Guzman,30,1,5,4,12,8
+Hill,0018,"Justice, Supreme Court, Place 9",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0018,"Justice, Supreme Court, Place 9",25,REP,Under Votes,23,0,0,5,9,9
+Hill,0018,"Judge, Court of Criminal Appeals, Place 2",25,REP,Chris Oldner,15,0,1,2,7,5
+Hill,0018,"Judge, Court of Criminal Appeals, Place 2",25,REP,Ray Wheless,18,0,3,2,9,4
+Hill,0018,"Judge, Court of Criminal Appeals, Place 2",25,REP,Mary Lou Keel,15,1,1,4,5,4
+Hill,0018,"Judge, Court of Criminal Appeals, Place 2",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0018,"Judge, Court of Criminal Appeals, Place 2",25,REP,Under Votes,25,0,1,5,11,8
+Hill,0018,"Judge, Court of Criminal Appeals, Place 5",25,REP,Sid Harle,13,1,3,1,6,2
+Hill,0018,"Judge, Court of Criminal Appeals, Place 5",25,REP,Brent Webster,11,0,2,2,5,2
+Hill,0018,"Judge, Court of Criminal Appeals, Place 5",25,REP,Scott Walker,13,0,0,1,4,8
+Hill,0018,"Judge, Court of Criminal Appeals, Place 5",25,REP,Steve Smith,16,0,1,5,9,1
+Hill,0018,"Judge, Court of Criminal Appeals, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0018,"Judge, Court of Criminal Appeals, Place 5",25,REP,Under Votes,20,0,0,4,8,8
+Hill,0018,"Judge, Court of Criminal Appeals, Place 6",25,REP,Richard Davis,26,0,4,6,11,5
+Hill,0018,"Judge, Court of Criminal Appeals, Place 6",25,REP,Michael E. Keasler,24,1,2,2,11,8
+Hill,0018,"Judge, Court of Criminal Appeals, Place 6",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0018,"Judge, Court of Criminal Appeals, Place 6",25,REP,Under Votes,23,0,0,5,10,8
+Hill,0018,"Member, State Board of Education, District 14",25,REP,Sue Melton-Malone,46,1,5,7,19,14
+Hill,0018,"Member, State Board of Education, District 14",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0018,"Member, State Board of Education, District 14",25,REP,Under Votes,27,0,1,6,13,7
+Hill,0018,State Senator,22,REP,Brian Birdwell,46,1,5,8,19,13
+Hill,0018,State Senator,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0018,State Senator,22,REP,Under Votes,27,0,1,5,13,8
+Hill,0018,State Representative,8,REP,Thomas McNutt,44,1,5,7,19,12
+Hill,0018,State Representative,8,REP,Byron Cook,22,0,1,4,10,7
+Hill,0018,State Representative,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0018,State Representative,8,REP,Under Votes,7,0,0,2,3,2
+Hill,0018,"Justice, 10th Court of Appeals District, Place 3",8,REP,Al Scoggins,43,1,5,6,19,12
+Hill,0018,"Justice, 10th Court of Appeals District, Place 3",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0018,"Justice, 10th Court of Appeals District, Place 3",8,REP,Under Votes,30,0,1,7,13,9
+Hill,0018,"District Attorney, 66th Judicial District",8,REP,Mark F Pratt,47,1,5,5,23,13
+Hill,0018,"District Attorney, 66th Judicial District",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0018,"District Attorney, 66th Judicial District",8,REP,Under Votes,26,0,1,8,9,8
+Hill,0018,County Attorney,8,REP,R David Holmes,48,1,6,6,23,12
+Hill,0018,County Attorney,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0018,County Attorney,8,REP,Under Votes,25,0,0,7,9,9
+Hill,0018,Sheriff,8,REP,Jimmy Johnson,20,1,1,3,6,9
+Hill,0018,Sheriff,8,REP,Dedri Hafer,2,0,0,0,0,2
+Hill,0018,Sheriff,8,REP,Rodney Watson,25,0,5,4,13,3
+Hill,0018,Sheriff,8,REP,Kyle R Cox,6,0,0,1,2,3
+Hill,0018,Sheriff,8,REP,Ronnie Myers,9,0,0,1,6,2
+Hill,0018,Sheriff,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0018,Sheriff,8,REP,Under Votes,11,0,0,4,5,2
+Hill,0018,Tax Assessor-Collector,8,REP,Ray Mabry,30,1,2,4,14,9
+Hill,0018,Tax Assessor-Collector,8,REP,Krissi Hightower,26,0,4,5,12,5
+Hill,0018,Tax Assessor-Collector,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0018,Tax Assessor-Collector,8,REP,Under Votes,17,0,0,4,6,7
+Hill,0018,"Constable, Precinct No. 4",8,REP,Collin Yeaman,28,1,4,3,15,5
+Hill,0018,"Constable, Precinct No. 4",8,REP,George Willoughby,25,0,2,5,10,8
+Hill,0018,"Constable, Precinct No. 4",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0018,"Constable, Precinct No. 4",8,REP,Under Votes,20,0,0,5,7,8
+Hill,0018,County Chairman,8,REP,Will Orr,47,1,6,6,22,12
+Hill,0018,County Chairman,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0018,County Chairman,8,REP,Under Votes,26,0,0,7,10,9
+Hill,0018,President,8,DEM,Bernie Sanders,0,0,0,0,0,0
+Hill,0018,President,8,DEM,Star Locke,0,0,0,0,0,0
+Hill,0018,President,8,DEM,"Roque ""Rocky"" De La Fuente",0,0,0,0,0,0
+Hill,0018,President,8,DEM,Willie L. Wilson,0,0,0,0,0,0
+Hill,0018,President,8,DEM,Calvis L. Hawes,0,0,0,0,0,0
+Hill,0018,President,8,DEM,Hillary Clinton,6,1,1,0,4,0
+Hill,0018,President,8,DEM,Keith Judd,0,0,0,0,0,0
+Hill,0018,President,8,DEM,Martin J. O'Malley,0,0,0,0,0,0
+Hill,0018,President,8,DEM,Over Votes,0,0,0,0,0,0
+Hill,0018,President,8,DEM,Under Votes,0,0,0,0,0,0
+Hill,0018,U.S. House,25,DEM,Kathi Thomas,2,0,0,0,2,0
+Hill,0018,U.S. House,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0018,U.S. House,25,DEM,Under Votes,4,1,1,0,2,0
+Hill,0018,Railroad Commissioner,25,DEM,Cody Garrett,1,0,0,0,1,0
+Hill,0018,Railroad Commissioner,25,DEM,Lon Burnam,1,0,0,0,1,0
+Hill,0018,Railroad Commissioner,25,DEM,Grady Yarbrough,1,0,0,0,1,0
+Hill,0018,Railroad Commissioner,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0018,Railroad Commissioner,25,DEM,Under Votes,3,1,1,0,1,0
+Hill,0018,"Justice, Supreme Court, Place 3",25,DEM,Mike Westergren,3,0,0,0,3,0
+Hill,0018,"Justice, Supreme Court, Place 3",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0018,"Justice, Supreme Court, Place 3",25,DEM,Under Votes,3,1,1,0,1,0
+Hill,0018,"Justice, Supreme Court, Place 5",25,DEM,Dori Contreras Garza,3,0,0,0,3,0
+Hill,0018,"Justice, Supreme Court, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0018,"Justice, Supreme Court, Place 5",25,DEM,Under Votes,3,1,1,0,1,0
+Hill,0018,"Justice, Supreme Court, Place 9",25,DEM,Savannah Robinson,3,0,0,0,3,0
+Hill,0018,"Justice, Supreme Court, Place 9",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0018,"Justice, Supreme Court, Place 9",25,DEM,Under Votes,3,1,1,0,1,0
+Hill,0018,"Judge, Court of Criminal Appeals, Place 2",25,DEM,"Lawrence ""Larry"" Meyers",2,0,0,0,2,0
+Hill,0018,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0018,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Under Votes,4,1,1,0,2,0
+Hill,0018,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Betsy Johnson,2,0,0,0,2,0
+Hill,0018,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0018,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Under Votes,4,1,1,0,2,0
+Hill,0018,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Robert Burns,2,0,0,0,2,0
+Hill,0018,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0018,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Under Votes,4,1,1,0,2,0
+Hill,0018,State Senator,22,DEM,Michael Collins,3,0,0,0,3,0
+Hill,0018,State Senator,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0018,State Senator,22,DEM,Under Votes,3,1,1,0,1,0
+Hill,0018,County Chairman,22,DEM,Thomas Hanson,5,1,1,0,3,0
+Hill,0018,County Chairman,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0018,County Chairman,22,DEM,Under Votes,1,0,0,0,1,0
+Hill,0018,Proposition 1,22,REP,Yes,44,1,6,9,17,11
+Hill,0018,Proposition 1,22,REP,No,17,0,0,3,7,7
+Hill,0018,Proposition 1,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0018,Proposition 1,22,REP,Under Votes,12,0,0,1,8,3
+Hill,0018,Proposition 2,22,REP,Yes,38,0,4,5,19,10
+Hill,0018,Proposition 2,22,REP,No,25,1,2,7,7,8
+Hill,0018,Proposition 2,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0018,Proposition 2,22,REP,Under Votes,10,0,0,1,6,3
+Hill,0018,Proposition 3,22,REP,Yes,55,1,6,11,22,15
+Hill,0018,Proposition 3,22,REP,No,10,0,0,1,4,5
+Hill,0018,Proposition 3,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0018,Proposition 3,22,REP,Under Votes,8,0,0,1,6,1
+Hill,0018,Proposition 4,22,REP,Yes,60,1,6,10,25,18
+Hill,0018,Proposition 4,22,REP,No,3,0,0,2,1,0
+Hill,0018,Proposition 4,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0018,Proposition 4,22,REP,Under Votes,10,0,0,1,6,3
+Hill,0018,Referenda Item #1,22,DEM,For,1,0,0,0,1,0
+Hill,0018,Referenda Item #1,22,DEM,Against,2,0,0,0,2,0
+Hill,0018,Referenda Item #1,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0018,Referenda Item #1,22,DEM,Under Votes,3,1,1,0,1,0
+Hill,0018,Referenda Item #2,22,DEM,For,2,0,0,0,2,0
+Hill,0018,Referenda Item #2,22,DEM,Against,1,0,0,0,1,0
+Hill,0018,Referenda Item #2,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0018,Referenda Item #2,22,DEM,Under Votes,3,1,1,0,1,0
+Hill,0018,Referenda Item #3,22,DEM,For,2,0,0,0,2,0
+Hill,0018,Referenda Item #3,22,DEM,Against,1,0,0,0,1,0
+Hill,0018,Referenda Item #3,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0018,Referenda Item #3,22,DEM,Under Votes,3,1,1,0,1,0
+Hill,0018,Referenda Item #4,22,DEM,For,2,0,0,0,2,0
+Hill,0018,Referenda Item #4,22,DEM,Against,0,0,0,0,0,0
+Hill,0018,Referenda Item #4,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0018,Referenda Item #4,22,DEM,Under Votes,4,1,1,0,2,0
+Hill,0018,Referenda Item #5,22,DEM,For,3,0,0,0,3,0
+Hill,0018,Referenda Item #5,22,DEM,Against,0,0,0,0,0,0
+Hill,0018,Referenda Item #5,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0018,Referenda Item #5,22,DEM,Under Votes,3,1,1,0,1,0
+Hill,0018,Referenda Item #6,22,DEM,For,2,0,0,0,2,0
+Hill,0018,Referenda Item #6,22,DEM,Against,1,0,0,0,1,0
+Hill,0018,Referenda Item #6,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0018,Referenda Item #6,22,DEM,Under Votes,3,1,1,0,1,0
+Hill,0019,Registered Voters - Total,,,,389,1,1,0,1,0
+Hill,0019,Ballots Cast - Total,,REP,,134,1,9,14,50,60
+Hill,0019,Ballots Cast - Total,,DEM,,14,0,0,3,11,0
+Hill,0019,President,,REP,Ted Cruz,66,0,6,8,25,27
+Hill,0019,President,,REP,Jeb Bush,1,0,0,0,0,1
+Hill,0019,President,,REP,Donald J. Trump,42,0,0,3,17,22
+Hill,0019,President,,REP,Ben Carson,9,0,0,0,3,6
+Hill,0019,President,,REP,Rand Paul,1,0,0,1,0,0
+Hill,0019,President,,REP,Rick Santorum,0,0,0,0,0,0
+Hill,0019,President,,REP,Elizabeth Gray,0,0,0,0,0,0
+Hill,0019,President,,REP,Carly Fiorina,0,0,0,0,0,0
+Hill,0019,President,,REP,Lindsey Graham,0,0,0,0,0,0
+Hill,0019,President,,REP,Marco Rubio,12,1,3,2,4,2
+Hill,0019,President,,REP,John R. Kasich,1,0,0,0,0,1
+Hill,0019,President,,REP,Mike Huckabee,0,0,0,0,0,0
+Hill,0019,President,,REP,Chris Christie,0,0,0,0,0,0
+Hill,0019,President,,REP,Uncommitted,1,0,0,0,1,0
+Hill,0019,President,,REP,Over Votes,0,0,0,0,0,0
+Hill,0019,President,,REP,Under Votes,1,0,0,0,0,1
+Hill,0019,U.S. House,25,REP,Roger Williams,89,1,8,8,37,35
+Hill,0019,U.S. House,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0019,U.S. House,25,REP,Under Votes,45,0,1,6,13,25
+Hill,0019,Railroad Commissioner,25,REP,Gary Gates,44,0,2,4,13,25
+Hill,0019,Railroad Commissioner,25,REP,Lance N. Christian,10,0,0,0,4,6
+Hill,0019,Railroad Commissioner,25,REP,Weston Martinez,12,0,3,1,5,3
+Hill,0019,Railroad Commissioner,25,REP,Wayne Christian,13,0,2,2,6,3
+Hill,0019,Railroad Commissioner,25,REP,Ron Hale,14,1,1,1,10,1
+Hill,0019,Railroad Commissioner,25,REP,Doug Jeffrey,6,0,1,2,2,1
+Hill,0019,Railroad Commissioner,25,REP,John Greytok,4,0,0,0,2,2
+Hill,0019,Railroad Commissioner,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0019,Railroad Commissioner,25,REP,Under Votes,31,0,0,4,8,19
+Hill,0019,"Justice, Supreme Court, Place 3",25,REP,Michael Massengale,57,0,4,9,20,24
+Hill,0019,"Justice, Supreme Court, Place 3",25,REP,Debra Lehrmann,50,1,5,4,23,17
+Hill,0019,"Justice, Supreme Court, Place 3",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0019,"Justice, Supreme Court, Place 3",25,REP,Under Votes,27,0,0,1,7,19
+Hill,0019,"Justice, Supreme Court, Place 5",25,REP,Paul Green,64,1,4,7,21,31
+Hill,0019,"Justice, Supreme Court, Place 5",25,REP,Rick Green,32,0,4,3,16,9
+Hill,0019,"Justice, Supreme Court, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0019,"Justice, Supreme Court, Place 5",25,REP,Under Votes,38,0,1,4,13,20
+Hill,0019,"Justice, Supreme Court, Place 9",25,REP,Joe Pool,58,1,3,6,26,22
+Hill,0019,"Justice, Supreme Court, Place 9",25,REP,Eva Guzman,41,0,5,5,16,15
+Hill,0019,"Justice, Supreme Court, Place 9",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0019,"Justice, Supreme Court, Place 9",25,REP,Under Votes,35,0,1,3,8,23
+Hill,0019,"Judge, Court of Criminal Appeals, Place 2",25,REP,Chris Oldner,38,1,4,3,15,15
+Hill,0019,"Judge, Court of Criminal Appeals, Place 2",25,REP,Ray Wheless,29,0,2,4,12,11
+Hill,0019,"Judge, Court of Criminal Appeals, Place 2",25,REP,Mary Lou Keel,27,0,2,2,13,10
+Hill,0019,"Judge, Court of Criminal Appeals, Place 2",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0019,"Judge, Court of Criminal Appeals, Place 2",25,REP,Under Votes,40,0,1,5,10,24
+Hill,0019,"Judge, Court of Criminal Appeals, Place 5",25,REP,Sid Harle,14,0,1,1,3,9
+Hill,0019,"Judge, Court of Criminal Appeals, Place 5",25,REP,Brent Webster,26,1,2,5,10,8
+Hill,0019,"Judge, Court of Criminal Appeals, Place 5",25,REP,Scott Walker,37,0,3,3,22,9
+Hill,0019,"Judge, Court of Criminal Appeals, Place 5",25,REP,Steve Smith,19,0,2,0,5,12
+Hill,0019,"Judge, Court of Criminal Appeals, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0019,"Judge, Court of Criminal Appeals, Place 5",25,REP,Under Votes,38,0,1,5,10,22
+Hill,0019,"Judge, Court of Criminal Appeals, Place 6",25,REP,Richard Davis,57,1,6,4,27,19
+Hill,0019,"Judge, Court of Criminal Appeals, Place 6",25,REP,Michael E. Keasler,34,0,2,3,13,16
+Hill,0019,"Judge, Court of Criminal Appeals, Place 6",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0019,"Judge, Court of Criminal Appeals, Place 6",25,REP,Under Votes,43,0,1,7,10,25
+Hill,0019,"Member, State Board of Education, District 14",25,REP,Sue Melton-Malone,76,1,7,5,33,30
+Hill,0019,"Member, State Board of Education, District 14",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0019,"Member, State Board of Education, District 14",25,REP,Under Votes,58,0,2,9,17,30
+Hill,0019,State Senator,22,REP,Brian Birdwell,85,1,9,6,37,32
+Hill,0019,State Senator,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0019,State Senator,22,REP,Under Votes,49,0,0,8,13,28
+Hill,0019,State Representative,8,REP,Thomas McNutt,59,1,5,5,22,26
+Hill,0019,State Representative,8,REP,Byron Cook,53,0,4,8,22,19
+Hill,0019,State Representative,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0019,State Representative,8,REP,Under Votes,22,0,0,1,6,15
+Hill,0019,"Justice, 10th Court of Appeals District, Place 3",8,REP,Al Scoggins,81,1,7,5,35,33
+Hill,0019,"Justice, 10th Court of Appeals District, Place 3",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0019,"Justice, 10th Court of Appeals District, Place 3",8,REP,Under Votes,53,0,2,9,15,27
+Hill,0019,"District Attorney, 66th Judicial District",8,REP,Mark F Pratt,82,1,8,6,36,31
+Hill,0019,"District Attorney, 66th Judicial District",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0019,"District Attorney, 66th Judicial District",8,REP,Under Votes,52,0,1,8,14,29
+Hill,0019,County Attorney,8,REP,R David Holmes,79,0,6,7,33,33
+Hill,0019,County Attorney,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0019,County Attorney,8,REP,Under Votes,55,1,3,7,17,27
+Hill,0019,Sheriff,8,REP,Jimmy Johnson,62,1,2,6,23,30
+Hill,0019,Sheriff,8,REP,Dedri Hafer,11,0,0,0,7,4
+Hill,0019,Sheriff,8,REP,Rodney Watson,22,0,5,3,8,6
+Hill,0019,Sheriff,8,REP,Kyle R Cox,5,0,0,2,0,3
+Hill,0019,Sheriff,8,REP,Ronnie Myers,18,0,2,0,10,6
+Hill,0019,Sheriff,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0019,Sheriff,8,REP,Under Votes,16,0,0,3,2,11
+Hill,0019,Tax Assessor-Collector,8,REP,Ray Mabry,37,0,0,5,13,19
+Hill,0019,Tax Assessor-Collector,8,REP,Krissi Hightower,63,1,9,4,30,19
+Hill,0019,Tax Assessor-Collector,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0019,Tax Assessor-Collector,8,REP,Under Votes,34,0,0,5,7,22
+Hill,0019,"Constable, Precinct No. 4",8,REP,Collin Yeaman,50,0,5,6,19,20
+Hill,0019,"Constable, Precinct No. 4",8,REP,George Willoughby,46,1,4,3,20,18
+Hill,0019,"Constable, Precinct No. 4",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0019,"Constable, Precinct No. 4",8,REP,Under Votes,38,0,0,5,11,22
+Hill,0019,County Chairman,8,REP,Will Orr,84,1,8,6,36,33
+Hill,0019,County Chairman,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0019,County Chairman,8,REP,Under Votes,50,0,1,8,14,27
+Hill,0019,President,8,DEM,Bernie Sanders,8,0,0,1,7,0
+Hill,0019,President,8,DEM,Star Locke,0,0,0,0,0,0
+Hill,0019,President,8,DEM,"Roque ""Rocky"" De La Fuente",0,0,0,0,0,0
+Hill,0019,President,8,DEM,Willie L. Wilson,0,0,0,0,0,0
+Hill,0019,President,8,DEM,Calvis L. Hawes,0,0,0,0,0,0
+Hill,0019,President,8,DEM,Hillary Clinton,6,0,0,2,4,0
+Hill,0019,President,8,DEM,Keith Judd,0,0,0,0,0,0
+Hill,0019,President,8,DEM,Martin J. O'Malley,0,0,0,0,0,0
+Hill,0019,President,8,DEM,Over Votes,0,0,0,0,0,0
+Hill,0019,President,8,DEM,Under Votes,0,0,0,0,0,0
+Hill,0019,U.S. House,25,DEM,Kathi Thomas,10,0,0,3,7,0
+Hill,0019,U.S. House,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0019,U.S. House,25,DEM,Under Votes,4,0,0,0,4,0
+Hill,0019,Railroad Commissioner,25,DEM,Cody Garrett,3,0,0,3,0,0
+Hill,0019,Railroad Commissioner,25,DEM,Lon Burnam,6,0,0,0,6,0
+Hill,0019,Railroad Commissioner,25,DEM,Grady Yarbrough,4,0,0,0,4,0
+Hill,0019,Railroad Commissioner,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0019,Railroad Commissioner,25,DEM,Under Votes,1,0,0,0,1,0
+Hill,0019,"Justice, Supreme Court, Place 3",25,DEM,Mike Westergren,10,0,0,3,7,0
+Hill,0019,"Justice, Supreme Court, Place 3",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0019,"Justice, Supreme Court, Place 3",25,DEM,Under Votes,4,0,0,0,4,0
+Hill,0019,"Justice, Supreme Court, Place 5",25,DEM,Dori Contreras Garza,10,0,0,3,7,0
+Hill,0019,"Justice, Supreme Court, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0019,"Justice, Supreme Court, Place 5",25,DEM,Under Votes,4,0,0,0,4,0
+Hill,0019,"Justice, Supreme Court, Place 9",25,DEM,Savannah Robinson,11,0,0,3,8,0
+Hill,0019,"Justice, Supreme Court, Place 9",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0019,"Justice, Supreme Court, Place 9",25,DEM,Under Votes,3,0,0,0,3,0
+Hill,0019,"Judge, Court of Criminal Appeals, Place 2",25,DEM,"Lawrence ""Larry"" Meyers",9,0,0,3,6,0
+Hill,0019,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0019,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Under Votes,5,0,0,0,5,0
+Hill,0019,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Betsy Johnson,11,0,0,3,8,0
+Hill,0019,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0019,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Under Votes,3,0,0,0,3,0
+Hill,0019,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Robert Burns,10,0,0,3,7,0
+Hill,0019,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0019,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Under Votes,4,0,0,0,4,0
+Hill,0019,State Senator,22,DEM,Michael Collins,11,0,0,3,8,0
+Hill,0019,State Senator,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0019,State Senator,22,DEM,Under Votes,3,0,0,0,3,0
+Hill,0019,County Chairman,22,DEM,Thomas Hanson,11,0,0,3,8,0
+Hill,0019,County Chairman,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0019,County Chairman,22,DEM,Under Votes,3,0,0,0,3,0
+Hill,0019,Proposition 1,22,REP,Yes,97,1,6,10,36,44
+Hill,0019,Proposition 1,22,REP,No,23,0,2,4,7,10
+Hill,0019,Proposition 1,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0019,Proposition 1,22,REP,Under Votes,14,0,1,0,7,6
+Hill,0019,Proposition 2,22,REP,Yes,77,0,3,8,28,38
+Hill,0019,Proposition 2,22,REP,No,49,1,5,6,20,17
+Hill,0019,Proposition 2,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0019,Proposition 2,22,REP,Under Votes,8,0,1,0,2,5
+Hill,0019,Proposition 3,22,REP,Yes,88,0,4,10,30,44
+Hill,0019,Proposition 3,22,REP,No,33,1,4,3,15,10
+Hill,0019,Proposition 3,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0019,Proposition 3,22,REP,Under Votes,13,0,1,1,5,6
+Hill,0019,Proposition 4,22,REP,Yes,115,0,7,13,43,52
+Hill,0019,Proposition 4,22,REP,No,8,1,1,0,4,2
+Hill,0019,Proposition 4,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0019,Proposition 4,22,REP,Under Votes,11,0,1,1,3,6
+Hill,0019,Referenda Item #1,22,DEM,For,13,0,0,3,10,0
+Hill,0019,Referenda Item #1,22,DEM,Against,0,0,0,0,0,0
+Hill,0019,Referenda Item #1,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0019,Referenda Item #1,22,DEM,Under Votes,1,0,0,0,1,0
+Hill,0019,Referenda Item #2,22,DEM,For,12,0,0,2,10,0
+Hill,0019,Referenda Item #2,22,DEM,Against,1,0,0,1,0,0
+Hill,0019,Referenda Item #2,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0019,Referenda Item #2,22,DEM,Under Votes,1,0,0,0,1,0
+Hill,0019,Referenda Item #3,22,DEM,For,13,0,0,3,10,0
+Hill,0019,Referenda Item #3,22,DEM,Against,0,0,0,0,0,0
+Hill,0019,Referenda Item #3,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0019,Referenda Item #3,22,DEM,Under Votes,1,0,0,0,1,0
+Hill,0019,Referenda Item #4,22,DEM,For,12,0,0,2,10,0
+Hill,0019,Referenda Item #4,22,DEM,Against,1,0,0,1,0,0
+Hill,0019,Referenda Item #4,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0019,Referenda Item #4,22,DEM,Under Votes,1,0,0,0,1,0
+Hill,0019,Referenda Item #5,22,DEM,For,10,0,0,1,9,0
+Hill,0019,Referenda Item #5,22,DEM,Against,3,0,0,2,1,0
+Hill,0019,Referenda Item #5,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0019,Referenda Item #5,22,DEM,Under Votes,1,0,0,0,1,0
+Hill,0019,Referenda Item #6,22,DEM,For,12,0,0,3,9,0
+Hill,0019,Referenda Item #6,22,DEM,Against,1,0,0,0,1,0
+Hill,0019,Referenda Item #6,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0019,Referenda Item #6,22,DEM,Under Votes,1,0,0,0,1,0
+Hill,0020,Registered Voters - Total,,,,964,0,0,0,1,0
+Hill,0020,Ballots Cast - Total,,REP,,380,19,40,22,239,60
+Hill,0020,Ballots Cast - Total,,DEM,,36,0,3,2,26,5
+Hill,0020,President,,REP,Ted Cruz,198,8,21,12,126,31
+Hill,0020,President,,REP,Jeb Bush,9,2,2,0,3,2
+Hill,0020,President,,REP,Donald J. Trump,117,3,7,9,76,22
+Hill,0020,President,,REP,Ben Carson,15,0,1,0,12,2
+Hill,0020,President,,REP,Rand Paul,2,0,1,0,1,0
+Hill,0020,President,,REP,Rick Santorum,0,0,0,0,0,0
+Hill,0020,President,,REP,Elizabeth Gray,0,0,0,0,0,0
+Hill,0020,President,,REP,Carly Fiorina,0,0,0,0,0,0
+Hill,0020,President,,REP,Lindsey Graham,0,0,0,0,0,0
+Hill,0020,President,,REP,Marco Rubio,19,3,3,1,11,1
+Hill,0020,President,,REP,John R. Kasich,9,1,2,0,6,0
+Hill,0020,President,,REP,Mike Huckabee,0,0,0,0,0,0
+Hill,0020,President,,REP,Chris Christie,0,0,0,0,0,0
+Hill,0020,President,,REP,Uncommitted,3,1,1,0,1,0
+Hill,0020,President,,REP,Over Votes,0,0,0,0,0,0
+Hill,0020,President,,REP,Under Votes,8,1,2,0,3,2
+Hill,0020,U.S. House,25,REP,Roger Williams,299,18,35,20,183,43
+Hill,0020,U.S. House,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0020,U.S. House,25,REP,Under Votes,81,1,5,2,56,17
+Hill,0020,Railroad Commissioner,25,REP,Gary Gates,111,4,12,12,64,19
+Hill,0020,Railroad Commissioner,25,REP,Lance N. Christian,34,3,4,1,17,9
+Hill,0020,Railroad Commissioner,25,REP,Weston Martinez,22,2,2,2,11,5
+Hill,0020,Railroad Commissioner,25,REP,Wayne Christian,45,1,5,5,29,5
+Hill,0020,Railroad Commissioner,25,REP,Ron Hale,40,4,6,0,24,6
+Hill,0020,Railroad Commissioner,25,REP,Doug Jeffrey,24,2,3,0,17,2
+Hill,0020,Railroad Commissioner,25,REP,John Greytok,16,2,2,0,11,1
+Hill,0020,Railroad Commissioner,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0020,Railroad Commissioner,25,REP,Under Votes,88,1,6,2,66,13
+Hill,0020,"Justice, Supreme Court, Place 3",25,REP,Michael Massengale,188,7,18,16,110,37
+Hill,0020,"Justice, Supreme Court, Place 3",25,REP,Debra Lehrmann,117,9,17,4,75,12
+Hill,0020,"Justice, Supreme Court, Place 3",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0020,"Justice, Supreme Court, Place 3",25,REP,Under Votes,75,3,5,2,54,11
+Hill,0020,"Justice, Supreme Court, Place 5",25,REP,Paul Green,156,7,19,14,89,27
+Hill,0020,"Justice, Supreme Court, Place 5",25,REP,Rick Green,125,8,13,6,77,21
+Hill,0020,"Justice, Supreme Court, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0020,"Justice, Supreme Court, Place 5",25,REP,Under Votes,99,4,8,2,73,12
+Hill,0020,"Justice, Supreme Court, Place 9",25,REP,Joe Pool,193,8,21,11,117,36
+Hill,0020,"Justice, Supreme Court, Place 9",25,REP,Eva Guzman,119,11,17,9,69,13
+Hill,0020,"Justice, Supreme Court, Place 9",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0020,"Justice, Supreme Court, Place 9",25,REP,Under Votes,68,0,2,2,53,11
+Hill,0020,"Judge, Court of Criminal Appeals, Place 2",25,REP,Chris Oldner,109,1,10,10,64,24
+Hill,0020,"Judge, Court of Criminal Appeals, Place 2",25,REP,Ray Wheless,74,5,8,6,45,10
+Hill,0020,"Judge, Court of Criminal Appeals, Place 2",25,REP,Mary Lou Keel,91,9,13,4,55,10
+Hill,0020,"Judge, Court of Criminal Appeals, Place 2",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0020,"Judge, Court of Criminal Appeals, Place 2",25,REP,Under Votes,106,4,9,2,75,16
+Hill,0020,"Judge, Court of Criminal Appeals, Place 5",25,REP,Sid Harle,57,3,9,5,30,10
+Hill,0020,"Judge, Court of Criminal Appeals, Place 5",25,REP,Brent Webster,60,6,6,5,35,8
+Hill,0020,"Judge, Court of Criminal Appeals, Place 5",25,REP,Scott Walker,119,5,13,6,76,19
+Hill,0020,"Judge, Court of Criminal Appeals, Place 5",25,REP,Steve Smith,53,2,5,3,35,8
+Hill,0020,"Judge, Court of Criminal Appeals, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0020,"Judge, Court of Criminal Appeals, Place 5",25,REP,Under Votes,91,3,7,3,63,15
+Hill,0020,"Judge, Court of Criminal Appeals, Place 6",25,REP,Richard Davis,169,8,20,11,99,31
+Hill,0020,"Judge, Court of Criminal Appeals, Place 6",25,REP,Michael E. Keasler,99,6,10,8,62,13
+Hill,0020,"Judge, Court of Criminal Appeals, Place 6",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0020,"Judge, Court of Criminal Appeals, Place 6",25,REP,Under Votes,112,5,10,3,78,16
+Hill,0020,"Member, State Board of Education, District 14",25,REP,Sue Melton-Malone,256,14,27,19,155,41
+Hill,0020,"Member, State Board of Education, District 14",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0020,"Member, State Board of Education, District 14",25,REP,Under Votes,124,5,13,3,84,19
+Hill,0020,State Senator,22,REP,Brian Birdwell,288,17,32,19,175,45
+Hill,0020,State Senator,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0020,State Senator,22,REP,Under Votes,92,2,8,3,64,15
+Hill,0020,State Representative,8,REP,Thomas McNutt,140,7,12,12,82,27
+Hill,0020,State Representative,8,REP,Byron Cook,207,12,28,9,134,24
+Hill,0020,State Representative,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0020,State Representative,8,REP,Under Votes,33,0,0,1,23,9
+Hill,0020,"Justice, 10th Court of Appeals District, Place 3",8,REP,Al Scoggins,258,15,28,18,158,39
+Hill,0020,"Justice, 10th Court of Appeals District, Place 3",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0020,"Justice, 10th Court of Appeals District, Place 3",8,REP,Under Votes,122,4,12,4,81,21
+Hill,0020,"District Attorney, 66th Judicial District",8,REP,Mark F Pratt,283,16,34,18,172,43
+Hill,0020,"District Attorney, 66th Judicial District",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0020,"District Attorney, 66th Judicial District",8,REP,Under Votes,97,3,6,4,67,17
+Hill,0020,County Attorney,8,REP,R David Holmes,259,14,29,18,155,43
+Hill,0020,County Attorney,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0020,County Attorney,8,REP,Under Votes,121,5,11,4,84,17
+Hill,0020,Sheriff,8,REP,Jimmy Johnson,122,6,13,7,76,20
+Hill,0020,Sheriff,8,REP,Dedri Hafer,29,0,5,0,17,7
+Hill,0020,Sheriff,8,REP,Rodney Watson,109,4,7,11,68,19
+Hill,0020,Sheriff,8,REP,Kyle R Cox,34,5,6,1,17,5
+Hill,0020,Sheriff,8,REP,Ronnie Myers,43,3,5,3,26,6
+Hill,0020,Sheriff,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0020,Sheriff,8,REP,Under Votes,43,1,4,0,35,3
+Hill,0020,Tax Assessor-Collector,8,REP,Ray Mabry,174,8,20,11,101,34
+Hill,0020,Tax Assessor-Collector,8,REP,Krissi Hightower,145,11,17,9,88,20
+Hill,0020,Tax Assessor-Collector,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0020,Tax Assessor-Collector,8,REP,Under Votes,61,0,3,2,50,6
+Hill,0020,County Commissioner # 1,8,REP,Andrew Montgomery,168,10,15,15,98,30
+Hill,0020,County Commissioner # 1,8,REP,"Ted O' Neil, Jr",159,8,22,7,94,28
+Hill,0020,County Commissioner # 1,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0020,County Commissioner # 1,8,REP,Under Votes,53,1,3,0,47,2
+Hill,0020,"Constable, Precinct No. 1",8,REP,Bill Wilkins,210,8,19,11,131,41
+Hill,0020,"Constable, Precinct No. 1",8,REP,Daniel Roberson,88,8,14,9,46,11
+Hill,0020,"Constable, Precinct No. 1",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0020,"Constable, Precinct No. 1",8,REP,Under Votes,82,3,7,2,62,8
+Hill,0020,County Chairman,8,REP,Will Orr,267,16,31,19,160,41
+Hill,0020,County Chairman,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0020,County Chairman,8,REP,Under Votes,113,3,9,3,79,19
+Hill,0020,President,8,DEM,Bernie Sanders,13,0,3,0,8,2
+Hill,0020,President,8,DEM,Star Locke,0,0,0,0,0,0
+Hill,0020,President,8,DEM,"Roque ""Rocky"" De La Fuente",1,0,0,0,1,0
+Hill,0020,President,8,DEM,Willie L. Wilson,0,0,0,0,0,0
+Hill,0020,President,8,DEM,Calvis L. Hawes,0,0,0,0,0,0
+Hill,0020,President,8,DEM,Hillary Clinton,20,0,0,2,15,3
+Hill,0020,President,8,DEM,Keith Judd,0,0,0,0,0,0
+Hill,0020,President,8,DEM,Martin J. O'Malley,1,0,0,0,1,0
+Hill,0020,President,8,DEM,Over Votes,0,0,0,0,0,0
+Hill,0020,President,8,DEM,Under Votes,1,0,0,0,1,0
+Hill,0020,U.S. House,25,DEM,Kathi Thomas,26,0,3,2,17,4
+Hill,0020,U.S. House,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0020,U.S. House,25,DEM,Under Votes,10,0,0,0,9,1
+Hill,0020,Railroad Commissioner,25,DEM,Cody Garrett,8,0,0,0,7,1
+Hill,0020,Railroad Commissioner,25,DEM,Lon Burnam,6,0,2,1,3,0
+Hill,0020,Railroad Commissioner,25,DEM,Grady Yarbrough,15,0,1,1,9,4
+Hill,0020,Railroad Commissioner,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0020,Railroad Commissioner,25,DEM,Under Votes,7,0,0,0,7,0
+Hill,0020,"Justice, Supreme Court, Place 3",25,DEM,Mike Westergren,27,0,3,2,17,5
+Hill,0020,"Justice, Supreme Court, Place 3",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0020,"Justice, Supreme Court, Place 3",25,DEM,Under Votes,9,0,0,0,9,0
+Hill,0020,"Justice, Supreme Court, Place 5",25,DEM,Dori Contreras Garza,29,0,3,2,19,5
+Hill,0020,"Justice, Supreme Court, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0020,"Justice, Supreme Court, Place 5",25,DEM,Under Votes,7,0,0,0,7,0
+Hill,0020,"Justice, Supreme Court, Place 9",25,DEM,Savannah Robinson,28,0,3,2,18,5
+Hill,0020,"Justice, Supreme Court, Place 9",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0020,"Justice, Supreme Court, Place 9",25,DEM,Under Votes,8,0,0,0,8,0
+Hill,0020,"Judge, Court of Criminal Appeals, Place 2",25,DEM,"Lawrence ""Larry"" Meyers",27,0,3,2,17,5
+Hill,0020,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0020,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Under Votes,9,0,0,0,9,0
+Hill,0020,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Betsy Johnson,29,0,3,2,19,5
+Hill,0020,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0020,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Under Votes,7,0,0,0,7,0
+Hill,0020,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Robert Burns,29,0,3,2,19,5
+Hill,0020,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0020,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Under Votes,7,0,0,0,7,0
+Hill,0020,State Senator,22,DEM,Michael Collins,28,0,3,2,18,5
+Hill,0020,State Senator,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0020,State Senator,22,DEM,Under Votes,8,0,0,0,8,0
+Hill,0020,County Chairman,22,DEM,Thomas Hanson,27,0,3,2,17,5
+Hill,0020,County Chairman,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0020,County Chairman,22,DEM,Under Votes,9,0,0,0,9,0
+Hill,0020,Proposition 1,22,REP,Yes,230,7,21,19,143,40
+Hill,0020,Proposition 1,22,REP,No,118,12,19,3,69,15
+Hill,0020,Proposition 1,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0020,Proposition 1,22,REP,Under Votes,32,0,0,0,27,5
+Hill,0020,Proposition 2,22,REP,Yes,185,12,19,11,116,27
+Hill,0020,Proposition 2,22,REP,No,169,7,21,11,99,31
+Hill,0020,Proposition 2,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0020,Proposition 2,22,REP,Under Votes,26,0,0,0,24,2
+Hill,0020,Proposition 3,22,REP,Yes,280,17,32,14,171,46
+Hill,0020,Proposition 3,22,REP,No,66,2,7,7,40,10
+Hill,0020,Proposition 3,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0020,Proposition 3,22,REP,Under Votes,34,0,1,1,28,4
+Hill,0020,Proposition 4,22,REP,Yes,328,17,34,22,202,53
+Hill,0020,Proposition 4,22,REP,No,16,2,4,0,6,4
+Hill,0020,Proposition 4,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0020,Proposition 4,22,REP,Under Votes,36,0,2,0,31,3
+Hill,0020,Referenda Item #1,22,DEM,For,31,0,3,2,21,5
+Hill,0020,Referenda Item #1,22,DEM,Against,1,0,0,0,1,0
+Hill,0020,Referenda Item #1,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0020,Referenda Item #1,22,DEM,Under Votes,4,0,0,0,4,0
+Hill,0020,Referenda Item #2,22,DEM,For,30,0,3,2,20,5
+Hill,0020,Referenda Item #2,22,DEM,Against,1,0,0,0,1,0
+Hill,0020,Referenda Item #2,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0020,Referenda Item #2,22,DEM,Under Votes,5,0,0,0,5,0
+Hill,0020,Referenda Item #3,22,DEM,For,31,0,3,2,21,5
+Hill,0020,Referenda Item #3,22,DEM,Against,2,0,0,0,2,0
+Hill,0020,Referenda Item #3,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0020,Referenda Item #3,22,DEM,Under Votes,3,0,0,0,3,0
+Hill,0020,Referenda Item #4,22,DEM,For,27,0,3,2,17,5
+Hill,0020,Referenda Item #4,22,DEM,Against,2,0,0,0,2,0
+Hill,0020,Referenda Item #4,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0020,Referenda Item #4,22,DEM,Under Votes,7,0,0,0,7,0
+Hill,0020,Referenda Item #5,22,DEM,For,29,0,3,2,22,2
+Hill,0020,Referenda Item #5,22,DEM,Against,4,0,0,0,1,3
+Hill,0020,Referenda Item #5,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0020,Referenda Item #5,22,DEM,Under Votes,3,0,0,0,3,0
+Hill,0020,Referenda Item #6,22,DEM,For,26,0,3,2,17,4
+Hill,0020,Referenda Item #6,22,DEM,Against,2,0,0,0,2,0
+Hill,0020,Referenda Item #6,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0020,Referenda Item #6,22,DEM,Under Votes,8,0,0,0,7,1
+Hill,0021,Registered Voters - Total,,,,1844,0,0,0,7,1
+Hill,0021,Ballots Cast - Total,,REP,,884,77,112,206,209,280
+Hill,0021,Ballots Cast - Total,,DEM,,85,5,10,11,32,27
+Hill,0021,President,,REP,Ted Cruz,330,21,36,72,83,118
+Hill,0021,President,,REP,Jeb Bush,16,3,4,4,5,0
+Hill,0021,President,,REP,Donald J. Trump,314,31,45,57,80,101
+Hill,0021,President,,REP,Ben Carson,37,3,5,5,7,17
+Hill,0021,President,,REP,Rand Paul,0,0,0,0,0,0
+Hill,0021,President,,REP,Rick Santorum,0,0,0,0,0,0
+Hill,0021,President,,REP,Elizabeth Gray,0,0,0,0,0,0
+Hill,0021,President,,REP,Carly Fiorina,0,0,0,0,0,0
+Hill,0021,President,,REP,Lindsey Graham,0,0,0,0,0,0
+Hill,0021,President,,REP,Marco Rubio,130,15,17,47,21,30
+Hill,0021,President,,REP,John R. Kasich,41,4,5,15,8,9
+Hill,0021,President,,REP,Mike Huckabee,1,0,0,0,1,0
+Hill,0021,President,,REP,Chris Christie,5,0,0,3,0,2
+Hill,0021,President,,REP,Uncommitted,6,0,0,2,1,3
+Hill,0021,President,,REP,Over Votes,0,0,0,0,0,0
+Hill,0021,President,,REP,Under Votes,4,0,0,1,3,0
+Hill,0021,U.S. House,25,REP,Roger Williams,649,62,92,150,166,179
+Hill,0021,U.S. House,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0021,U.S. House,25,REP,Under Votes,235,15,20,56,43,101
+Hill,0021,Railroad Commissioner,25,REP,Gary Gates,313,41,51,64,77,80
+Hill,0021,Railroad Commissioner,25,REP,Lance N. Christian,86,2,7,26,20,31
+Hill,0021,Railroad Commissioner,25,REP,Weston Martinez,32,1,4,4,8,15
+Hill,0021,Railroad Commissioner,25,REP,Wayne Christian,102,8,10,29,22,33
+Hill,0021,Railroad Commissioner,25,REP,Ron Hale,69,2,7,18,16,26
+Hill,0021,Railroad Commissioner,25,REP,Doug Jeffrey,57,6,9,10,18,14
+Hill,0021,Railroad Commissioner,25,REP,John Greytok,20,2,3,4,5,6
+Hill,0021,Railroad Commissioner,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0021,Railroad Commissioner,25,REP,Under Votes,205,15,21,51,43,75
+Hill,0021,"Justice, Supreme Court, Place 3",25,REP,Michael Massengale,377,25,45,93,83,131
+Hill,0021,"Justice, Supreme Court, Place 3",25,REP,Debra Lehrmann,349,40,52,74,91,92
+Hill,0021,"Justice, Supreme Court, Place 3",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0021,"Justice, Supreme Court, Place 3",25,REP,Under Votes,158,12,15,39,35,57
+Hill,0021,"Justice, Supreme Court, Place 5",25,REP,Paul Green,373,23,35,111,77,127
+Hill,0021,"Justice, Supreme Court, Place 5",25,REP,Rick Green,300,31,47,56,79,87
+Hill,0021,"Justice, Supreme Court, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0021,"Justice, Supreme Court, Place 5",25,REP,Under Votes,211,23,30,39,53,66
+Hill,0021,"Justice, Supreme Court, Place 9",25,REP,Joe Pool,319,20,34,69,77,119
+Hill,0021,"Justice, Supreme Court, Place 9",25,REP,Eva Guzman,405,46,63,97,97,102
+Hill,0021,"Justice, Supreme Court, Place 9",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0021,"Justice, Supreme Court, Place 9",25,REP,Under Votes,160,11,15,40,35,59
+Hill,0021,"Judge, Court of Criminal Appeals, Place 2",25,REP,Chris Oldner,208,14,22,50,49,73
+Hill,0021,"Judge, Court of Criminal Appeals, Place 2",25,REP,Ray Wheless,208,18,27,48,50,65
+Hill,0021,"Judge, Court of Criminal Appeals, Place 2",25,REP,Mary Lou Keel,246,28,39,52,62,65
+Hill,0021,"Judge, Court of Criminal Appeals, Place 2",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0021,"Judge, Court of Criminal Appeals, Place 2",25,REP,Under Votes,222,17,24,56,48,77
+Hill,0021,"Judge, Court of Criminal Appeals, Place 5",25,REP,Sid Harle,181,21,30,39,44,47
+Hill,0021,"Judge, Court of Criminal Appeals, Place 5",25,REP,Brent Webster,113,11,16,27,33,26
+Hill,0021,"Judge, Court of Criminal Appeals, Place 5",25,REP,Scott Walker,233,16,22,64,45,86
+Hill,0021,"Judge, Court of Criminal Appeals, Place 5",25,REP,Steve Smith,124,8,17,25,37,37
+Hill,0021,"Judge, Court of Criminal Appeals, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0021,"Judge, Court of Criminal Appeals, Place 5",25,REP,Under Votes,233,21,27,51,50,84
+Hill,0021,"Judge, Court of Criminal Appeals, Place 6",25,REP,Richard Davis,288,13,27,69,62,117
+Hill,0021,"Judge, Court of Criminal Appeals, Place 6",25,REP,Michael E. Keasler,346,42,57,77,93,77
+Hill,0021,"Judge, Court of Criminal Appeals, Place 6",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0021,"Judge, Court of Criminal Appeals, Place 6",25,REP,Under Votes,250,22,28,60,54,86
+Hill,0021,"Member, State Board of Education, District 14",25,REP,Sue Melton-Malone,622,57,83,144,154,184
+Hill,0021,"Member, State Board of Education, District 14",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0021,"Member, State Board of Education, District 14",25,REP,Under Votes,262,20,29,62,55,96
+Hill,0021,State Senator,22,REP,Brian Birdwell,669,61,87,156,163,202
+Hill,0021,State Senator,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0021,State Senator,22,REP,Under Votes,215,16,25,50,46,78
+Hill,0021,State Representative,8,REP,Thomas McNutt,365,30,47,93,89,106
+Hill,0021,State Representative,8,REP,Byron Cook,434,41,55,102,99,137
+Hill,0021,State Representative,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0021,State Representative,8,REP,Under Votes,85,6,10,11,21,37
+Hill,0021,"Justice, 10th Court of Appeals District, Place 3",8,REP,Al Scoggins,582,52,75,145,141,169
+Hill,0021,"Justice, 10th Court of Appeals District, Place 3",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0021,"Justice, 10th Court of Appeals District, Place 3",8,REP,Under Votes,302,25,37,61,68,111
+Hill,0021,"District Attorney, 66th Judicial District",8,REP,Mark F Pratt,630,59,85,147,160,179
+Hill,0021,"District Attorney, 66th Judicial District",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0021,"District Attorney, 66th Judicial District",8,REP,Under Votes,254,18,27,59,49,101
+Hill,0021,County Attorney,8,REP,R David Holmes,599,55,78,145,139,182
+Hill,0021,County Attorney,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0021,County Attorney,8,REP,Under Votes,285,22,34,61,70,98
+Hill,0021,Sheriff,8,REP,Jimmy Johnson,351,39,53,77,78,104
+Hill,0021,Sheriff,8,REP,Dedri Hafer,72,3,3,23,9,34
+Hill,0021,Sheriff,8,REP,Rodney Watson,207,12,20,52,51,72
+Hill,0021,Sheriff,8,REP,Kyle R Cox,71,7,11,15,25,13
+Hill,0021,Sheriff,8,REP,Ronnie Myers,87,8,13,19,18,29
+Hill,0021,Sheriff,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0021,Sheriff,8,REP,Under Votes,96,8,12,20,28,28
+Hill,0021,Tax Assessor-Collector,8,REP,Ray Mabry,403,40,61,90,99,113
+Hill,0021,Tax Assessor-Collector,8,REP,Krissi Hightower,350,25,35,85,81,124
+Hill,0021,Tax Assessor-Collector,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0021,Tax Assessor-Collector,8,REP,Under Votes,131,12,16,31,29,43
+Hill,0021,County Commissioner # 1,8,REP,Andrew Montgomery,348,25,38,96,69,120
+Hill,0021,County Commissioner # 1,8,REP,"Ted O' Neil, Jr",422,45,63,86,111,117
+Hill,0021,County Commissioner # 1,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0021,County Commissioner # 1,8,REP,Under Votes,114,7,11,24,29,43
+Hill,0021,"Constable, Precinct No. 1",8,REP,Bill Wilkins,523,48,70,115,127,163
+Hill,0021,"Constable, Precinct No. 1",8,REP,Daniel Roberson,163,12,20,40,40,51
+Hill,0021,"Constable, Precinct No. 1",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0021,"Constable, Precinct No. 1",8,REP,Under Votes,198,17,22,51,42,66
+Hill,0021,County Chairman,8,REP,Will Orr,627,59,82,145,151,190
+Hill,0021,County Chairman,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0021,County Chairman,8,REP,Under Votes,257,18,30,61,58,90
+Hill,0021,President,8,DEM,Bernie Sanders,25,0,4,3,8,10
+Hill,0021,President,8,DEM,Star Locke,0,0,0,0,0,0
+Hill,0021,President,8,DEM,"Roque ""Rocky"" De La Fuente",0,0,0,0,0,0
+Hill,0021,President,8,DEM,Willie L. Wilson,0,0,0,0,0,0
+Hill,0021,President,8,DEM,Calvis L. Hawes,0,0,0,0,0,0
+Hill,0021,President,8,DEM,Hillary Clinton,60,5,6,8,24,17
+Hill,0021,President,8,DEM,Keith Judd,0,0,0,0,0,0
+Hill,0021,President,8,DEM,Martin J. O'Malley,0,0,0,0,0,0
+Hill,0021,President,8,DEM,Over Votes,0,0,0,0,0,0
+Hill,0021,President,8,DEM,Under Votes,0,0,0,0,0,0
+Hill,0021,U.S. House,25,DEM,Kathi Thomas,58,3,7,8,23,17
+Hill,0021,U.S. House,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0021,U.S. House,25,DEM,Under Votes,27,2,3,3,9,10
+Hill,0021,Railroad Commissioner,25,DEM,Cody Garrett,25,1,2,5,7,10
+Hill,0021,Railroad Commissioner,25,DEM,Lon Burnam,16,1,2,1,7,5
+Hill,0021,Railroad Commissioner,25,DEM,Grady Yarbrough,29,3,5,2,16,3
+Hill,0021,Railroad Commissioner,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0021,Railroad Commissioner,25,DEM,Under Votes,15,0,1,3,2,9
+Hill,0021,"Justice, Supreme Court, Place 3",25,DEM,Mike Westergren,53,3,7,6,24,13
+Hill,0021,"Justice, Supreme Court, Place 3",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0021,"Justice, Supreme Court, Place 3",25,DEM,Under Votes,32,2,3,5,8,14
+Hill,0021,"Justice, Supreme Court, Place 5",25,DEM,Dori Contreras Garza,58,4,9,6,27,12
+Hill,0021,"Justice, Supreme Court, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0021,"Justice, Supreme Court, Place 5",25,DEM,Under Votes,27,1,1,5,5,15
+Hill,0021,"Justice, Supreme Court, Place 9",25,DEM,Savannah Robinson,60,4,9,7,26,14
+Hill,0021,"Justice, Supreme Court, Place 9",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0021,"Justice, Supreme Court, Place 9",25,DEM,Under Votes,25,1,1,4,6,13
+Hill,0021,"Judge, Court of Criminal Appeals, Place 2",25,DEM,"Lawrence ""Larry"" Meyers",56,4,8,6,25,13
+Hill,0021,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0021,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Under Votes,29,1,2,5,7,14
+Hill,0021,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Betsy Johnson,63,4,9,7,27,16
+Hill,0021,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0021,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Under Votes,22,1,1,4,5,11
+Hill,0021,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Robert Burns,57,4,8,6,26,13
+Hill,0021,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0021,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Under Votes,28,1,2,5,6,14
+Hill,0021,State Senator,22,DEM,Michael Collins,60,4,8,8,26,14
+Hill,0021,State Senator,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0021,State Senator,22,DEM,Under Votes,25,1,2,3,6,13
+Hill,0021,County Chairman,22,DEM,Thomas Hanson,61,4,8,8,24,17
+Hill,0021,County Chairman,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0021,County Chairman,22,DEM,Under Votes,24,1,2,3,8,10
+Hill,0021,Precinct Chairman 21,22,DEM,Iva Howard,66,4,9,8,29,16
+Hill,0021,Precinct Chairman 21,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0021,Precinct Chairman 21,22,DEM,Under Votes,19,1,1,3,3,11
+Hill,0021,Proposition 1,22,REP,Yes,531,42,61,122,117,189
+Hill,0021,Proposition 1,22,REP,No,280,30,44,72,70,64
+Hill,0021,Proposition 1,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0021,Proposition 1,22,REP,Under Votes,73,5,7,12,22,27
+Hill,0021,Proposition 2,22,REP,Yes,521,46,66,117,119,173
+Hill,0021,Proposition 2,22,REP,No,315,26,40,82,71,96
+Hill,0021,Proposition 2,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0021,Proposition 2,22,REP,Under Votes,48,5,6,7,19,11
+Hill,0021,Proposition 3,22,REP,Yes,690,62,93,157,159,219
+Hill,0021,Proposition 3,22,REP,No,128,9,12,36,28,43
+Hill,0021,Proposition 3,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0021,Proposition 3,22,REP,Under Votes,66,6,7,13,22,18
+Hill,0021,Proposition 4,22,REP,Yes,788,68,102,184,180,254
+Hill,0021,Proposition 4,22,REP,No,32,3,3,10,6,10
+Hill,0021,Proposition 4,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0021,Proposition 4,22,REP,Under Votes,64,6,7,12,23,16
+Hill,0021,Referenda Item #1,22,DEM,For,73,5,9,11,26,22
+Hill,0021,Referenda Item #1,22,DEM,Against,6,0,0,0,4,2
+Hill,0021,Referenda Item #1,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0021,Referenda Item #1,22,DEM,Under Votes,6,0,1,0,2,3
+Hill,0021,Referenda Item #2,22,DEM,For,71,3,8,11,27,22
+Hill,0021,Referenda Item #2,22,DEM,Against,8,2,2,0,3,1
+Hill,0021,Referenda Item #2,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0021,Referenda Item #2,22,DEM,Under Votes,6,0,0,0,2,4
+Hill,0021,Referenda Item #3,22,DEM,For,77,5,9,10,28,25
+Hill,0021,Referenda Item #3,22,DEM,Against,3,0,0,1,1,1
+Hill,0021,Referenda Item #3,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0021,Referenda Item #3,22,DEM,Under Votes,5,0,1,0,3,1
+Hill,0021,Referenda Item #4,22,DEM,For,70,3,8,10,24,25
+Hill,0021,Referenda Item #4,22,DEM,Against,11,2,2,1,5,1
+Hill,0021,Referenda Item #4,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0021,Referenda Item #4,22,DEM,Under Votes,4,0,0,0,3,1
+Hill,0021,Referenda Item #5,22,DEM,For,64,5,9,10,23,17
+Hill,0021,Referenda Item #5,22,DEM,Against,17,0,1,1,7,8
+Hill,0021,Referenda Item #5,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0021,Referenda Item #5,22,DEM,Under Votes,4,0,0,0,2,2
+Hill,0021,Referenda Item #6,22,DEM,For,72,5,10,11,26,20
+Hill,0021,Referenda Item #6,22,DEM,Against,10,0,0,0,4,6
+Hill,0021,Referenda Item #6,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0021,Referenda Item #6,22,DEM,Under Votes,3,0,0,0,2,1
+Hill,0022,Registered Voters - Total,,,,1603,0,0,0,2,1
+Hill,0022,Ballots Cast - Total,,REP,,710,62,98,94,264,192
+Hill,0022,Ballots Cast - Total,,DEM,,70,1,3,8,36,22
+Hill,0022,President,,REP,Ted Cruz,307,25,39,31,118,94
+Hill,0022,President,,REP,Jeb Bush,22,3,7,3,8,1
+Hill,0022,President,,REP,Donald J. Trump,255,24,36,38,97,60
+Hill,0022,President,,REP,Ben Carson,30,3,3,5,10,9
+Hill,0022,President,,REP,Rand Paul,0,0,0,0,0,0
+Hill,0022,President,,REP,Rick Santorum,2,0,0,0,0,2
+Hill,0022,President,,REP,Elizabeth Gray,0,0,0,0,0,0
+Hill,0022,President,,REP,Carly Fiorina,0,0,0,0,0,0
+Hill,0022,President,,REP,Lindsey Graham,0,0,0,0,0,0
+Hill,0022,President,,REP,Marco Rubio,64,6,9,12,20,17
+Hill,0022,President,,REP,John R. Kasich,17,1,4,1,6,5
+Hill,0022,President,,REP,Mike Huckabee,0,0,0,0,0,0
+Hill,0022,President,,REP,Chris Christie,3,0,0,1,0,2
+Hill,0022,President,,REP,Uncommitted,9,0,0,2,5,2
+Hill,0022,President,,REP,Over Votes,0,0,0,0,0,0
+Hill,0022,President,,REP,Under Votes,1,0,0,1,0,0
+Hill,0022,U.S. House,25,REP,Roger Williams,526,53,84,53,207,129
+Hill,0022,U.S. House,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0022,U.S. House,25,REP,Under Votes,184,9,14,41,57,63
+Hill,0022,Railroad Commissioner,25,REP,Gary Gates,231,22,32,22,99,56
+Hill,0022,Railroad Commissioner,25,REP,Lance N. Christian,79,6,9,7,28,29
+Hill,0022,Railroad Commissioner,25,REP,Weston Martinez,19,1,3,2,9,4
+Hill,0022,Railroad Commissioner,25,REP,Wayne Christian,74,4,7,15,25,23
+Hill,0022,Railroad Commissioner,25,REP,Ron Hale,76,10,13,14,26,13
+Hill,0022,Railroad Commissioner,25,REP,Doug Jeffrey,51,4,8,8,15,16
+Hill,0022,Railroad Commissioner,25,REP,John Greytok,21,1,4,4,9,3
+Hill,0022,Railroad Commissioner,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0022,Railroad Commissioner,25,REP,Under Votes,159,14,22,22,53,48
+Hill,0022,"Justice, Supreme Court, Place 3",25,REP,Michael Massengale,305,22,41,40,114,88
+Hill,0022,"Justice, Supreme Court, Place 3",25,REP,Debra Lehrmann,270,28,40,35,104,63
+Hill,0022,"Justice, Supreme Court, Place 3",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0022,"Justice, Supreme Court, Place 3",25,REP,Under Votes,135,12,17,19,46,41
+Hill,0022,"Justice, Supreme Court, Place 5",25,REP,Paul Green,268,19,33,51,98,67
+Hill,0022,"Justice, Supreme Court, Place 5",25,REP,Rick Green,273,25,41,24,107,76
+Hill,0022,"Justice, Supreme Court, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0022,"Justice, Supreme Court, Place 5",25,REP,Under Votes,169,18,24,19,59,49
+Hill,0022,"Justice, Supreme Court, Place 9",25,REP,Joe Pool,274,20,36,37,104,77
+Hill,0022,"Justice, Supreme Court, Place 9",25,REP,Eva Guzman,288,28,43,38,112,67
+Hill,0022,"Justice, Supreme Court, Place 9",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0022,"Justice, Supreme Court, Place 9",25,REP,Under Votes,148,14,19,19,48,48
+Hill,0022,"Judge, Court of Criminal Appeals, Place 2",25,REP,Chris Oldner,178,18,27,26,66,41
+Hill,0022,"Judge, Court of Criminal Appeals, Place 2",25,REP,Ray Wheless,163,9,15,21,67,51
+Hill,0022,"Judge, Court of Criminal Appeals, Place 2",25,REP,Mary Lou Keel,192,20,34,24,72,42
+Hill,0022,"Judge, Court of Criminal Appeals, Place 2",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0022,"Judge, Court of Criminal Appeals, Place 2",25,REP,Under Votes,177,15,22,23,59,58
+Hill,0022,"Judge, Court of Criminal Appeals, Place 5",25,REP,Sid Harle,133,12,16,13,57,35
+Hill,0022,"Judge, Court of Criminal Appeals, Place 5",25,REP,Brent Webster,103,14,18,9,41,21
+Hill,0022,"Judge, Court of Criminal Appeals, Place 5",25,REP,Scott Walker,212,15,33,32,76,56
+Hill,0022,"Judge, Court of Criminal Appeals, Place 5",25,REP,Steve Smith,90,5,8,17,36,24
+Hill,0022,"Judge, Court of Criminal Appeals, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0022,"Judge, Court of Criminal Appeals, Place 5",25,REP,Under Votes,172,16,23,23,54,56
+Hill,0022,"Judge, Court of Criminal Appeals, Place 6",25,REP,Richard Davis,252,19,35,40,92,66
+Hill,0022,"Judge, Court of Criminal Appeals, Place 6",25,REP,Michael E. Keasler,267,27,37,29,108,66
+Hill,0022,"Judge, Court of Criminal Appeals, Place 6",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0022,"Judge, Court of Criminal Appeals, Place 6",25,REP,Under Votes,191,16,26,25,64,60
+Hill,0022,"Member, State Board of Education, District 14",25,REP,Sue Melton-Malone,517,50,80,65,194,128
+Hill,0022,"Member, State Board of Education, District 14",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0022,"Member, State Board of Education, District 14",25,REP,Under Votes,193,12,18,29,70,64
+Hill,0022,State Senator,22,REP,Brian Birdwell,552,54,84,69,206,139
+Hill,0022,State Senator,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0022,State Senator,22,REP,Under Votes,158,8,14,25,58,53
+Hill,0022,State Representative,8,REP,Thomas McNutt,335,28,44,46,132,85
+Hill,0022,State Representative,8,REP,Byron Cook,291,25,41,36,107,82
+Hill,0022,State Representative,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0022,State Representative,8,REP,Under Votes,84,9,13,12,25,25
+Hill,0022,"Justice, 10th Court of Appeals District, Place 3",8,REP,Al Scoggins,491,47,77,59,184,124
+Hill,0022,"Justice, 10th Court of Appeals District, Place 3",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0022,"Justice, 10th Court of Appeals District, Place 3",8,REP,Under Votes,219,15,21,35,80,68
+Hill,0022,"District Attorney, 66th Judicial District",8,REP,Mark F Pratt,536,50,80,65,203,138
+Hill,0022,"District Attorney, 66th Judicial District",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0022,"District Attorney, 66th Judicial District",8,REP,Under Votes,174,12,18,29,61,54
+Hill,0022,County Attorney,8,REP,R David Holmes,501,45,73,64,182,137
+Hill,0022,County Attorney,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0022,County Attorney,8,REP,Under Votes,209,17,25,30,82,55
+Hill,0022,Sheriff,8,REP,Jimmy Johnson,198,19,29,33,64,53
+Hill,0022,Sheriff,8,REP,Dedri Hafer,68,5,9,14,20,20
+Hill,0022,Sheriff,8,REP,Rodney Watson,162,11,16,20,67,48
+Hill,0022,Sheriff,8,REP,Kyle R Cox,53,5,7,4,23,14
+Hill,0022,Sheriff,8,REP,Ronnie Myers,147,11,21,14,63,38
+Hill,0022,Sheriff,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0022,Sheriff,8,REP,Under Votes,82,11,16,9,27,19
+Hill,0022,Tax Assessor-Collector,8,REP,Ray Mabry,325,35,44,34,126,86
+Hill,0022,Tax Assessor-Collector,8,REP,Krissi Hightower,283,13,36,49,102,83
+Hill,0022,Tax Assessor-Collector,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0022,Tax Assessor-Collector,8,REP,Under Votes,102,14,18,11,36,23
+Hill,0022,County Commissioner # 1,8,REP,Andrew Montgomery,306,20,40,41,117,88
+Hill,0022,County Commissioner # 1,8,REP,"Ted O' Neil, Jr",288,28,37,40,102,81
+Hill,0022,County Commissioner # 1,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0022,County Commissioner # 1,8,REP,Under Votes,116,14,21,13,45,23
+Hill,0022,"Constable, Precinct No. 1",8,REP,Bill Wilkins,421,37,54,50,168,112
+Hill,0022,"Constable, Precinct No. 1",8,REP,Daniel Roberson,166,6,20,28,54,58
+Hill,0022,"Constable, Precinct No. 1",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0022,"Constable, Precinct No. 1",8,REP,Under Votes,123,19,24,16,42,22
+Hill,0022,County Chairman,8,REP,Will Orr,520,46,75,66,195,138
+Hill,0022,County Chairman,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0022,County Chairman,8,REP,Under Votes,190,16,23,28,69,54
+Hill,0022,President,8,DEM,Bernie Sanders,14,0,0,2,8,4
+Hill,0022,President,8,DEM,Star Locke,0,0,0,0,0,0
+Hill,0022,President,8,DEM,"Roque ""Rocky"" De La Fuente",0,0,0,0,0,0
+Hill,0022,President,8,DEM,Willie L. Wilson,0,0,0,0,0,0
+Hill,0022,President,8,DEM,Calvis L. Hawes,0,0,0,0,0,0
+Hill,0022,President,8,DEM,Hillary Clinton,55,1,3,6,28,17
+Hill,0022,President,8,DEM,Keith Judd,1,0,0,0,0,1
+Hill,0022,President,8,DEM,Martin J. O'Malley,0,0,0,0,0,0
+Hill,0022,President,8,DEM,Over Votes,0,0,0,0,0,0
+Hill,0022,President,8,DEM,Under Votes,0,0,0,0,0,0
+Hill,0022,U.S. House,25,DEM,Kathi Thomas,43,0,2,4,26,11
+Hill,0022,U.S. House,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0022,U.S. House,25,DEM,Under Votes,27,1,1,4,10,11
+Hill,0022,Railroad Commissioner,25,DEM,Cody Garrett,18,0,0,0,12,6
+Hill,0022,Railroad Commissioner,25,DEM,Lon Burnam,13,0,2,1,8,2
+Hill,0022,Railroad Commissioner,25,DEM,Grady Yarbrough,23,0,0,3,12,8
+Hill,0022,Railroad Commissioner,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0022,Railroad Commissioner,25,DEM,Under Votes,16,1,1,4,4,6
+Hill,0022,"Justice, Supreme Court, Place 3",25,DEM,Mike Westergren,49,0,2,4,30,13
+Hill,0022,"Justice, Supreme Court, Place 3",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0022,"Justice, Supreme Court, Place 3",25,DEM,Under Votes,21,1,1,4,6,9
+Hill,0022,"Justice, Supreme Court, Place 5",25,DEM,Dori Contreras Garza,50,0,2,5,30,13
+Hill,0022,"Justice, Supreme Court, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0022,"Justice, Supreme Court, Place 5",25,DEM,Under Votes,20,1,1,3,6,9
+Hill,0022,"Justice, Supreme Court, Place 9",25,DEM,Savannah Robinson,50,0,2,4,30,14
+Hill,0022,"Justice, Supreme Court, Place 9",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0022,"Justice, Supreme Court, Place 9",25,DEM,Under Votes,20,1,1,4,6,8
+Hill,0022,"Judge, Court of Criminal Appeals, Place 2",25,DEM,"Lawrence ""Larry"" Meyers",51,0,2,5,30,14
+Hill,0022,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0022,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Under Votes,19,1,1,3,6,8
+Hill,0022,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Betsy Johnson,49,0,2,5,29,13
+Hill,0022,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0022,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Under Votes,21,1,1,3,7,9
+Hill,0022,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Robert Burns,48,0,2,4,29,13
+Hill,0022,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0022,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Under Votes,22,1,1,4,7,9
+Hill,0022,State Senator,22,DEM,Michael Collins,51,0,2,5,30,14
+Hill,0022,State Senator,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0022,State Senator,22,DEM,Under Votes,19,1,1,3,6,8
+Hill,0022,County Chairman,22,DEM,Thomas Hanson,50,0,2,5,30,13
+Hill,0022,County Chairman,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0022,County Chairman,22,DEM,Under Votes,20,1,1,3,6,9
+Hill,0022,Proposition 1,22,REP,Yes,451,35,57,71,160,128
+Hill,0022,Proposition 1,22,REP,No,197,22,33,14,83,45
+Hill,0022,Proposition 1,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0022,Proposition 1,22,REP,Under Votes,62,5,8,9,21,19
+Hill,0022,Proposition 2,22,REP,Yes,392,23,45,62,149,113
+Hill,0022,Proposition 2,22,REP,No,277,35,48,26,99,69
+Hill,0022,Proposition 2,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0022,Proposition 2,22,REP,Under Votes,41,4,5,6,16,10
+Hill,0022,Proposition 3,22,REP,Yes,575,53,84,74,205,159
+Hill,0022,Proposition 3,22,REP,No,82,5,9,12,37,19
+Hill,0022,Proposition 3,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0022,Proposition 3,22,REP,Under Votes,53,4,5,8,22,14
+Hill,0022,Proposition 4,22,REP,Yes,633,57,89,81,237,169
+Hill,0022,Proposition 4,22,REP,No,18,0,1,3,5,9
+Hill,0022,Proposition 4,22,REP,Over Votes,3,1,1,0,1,0
+Hill,0022,Proposition 4,22,REP,Under Votes,56,4,7,10,21,14
+Hill,0022,Referenda Item #1,22,DEM,For,58,1,3,4,30,20
+Hill,0022,Referenda Item #1,22,DEM,Against,6,0,0,2,4,0
+Hill,0022,Referenda Item #1,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0022,Referenda Item #1,22,DEM,Under Votes,6,0,0,2,2,2
+Hill,0022,Referenda Item #2,22,DEM,For,58,1,3,5,30,19
+Hill,0022,Referenda Item #2,22,DEM,Against,3,0,0,1,1,1
+Hill,0022,Referenda Item #2,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0022,Referenda Item #2,22,DEM,Under Votes,9,0,0,2,5,2
+Hill,0022,Referenda Item #3,22,DEM,For,55,1,3,4,29,18
+Hill,0022,Referenda Item #3,22,DEM,Against,5,0,0,2,2,1
+Hill,0022,Referenda Item #3,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0022,Referenda Item #3,22,DEM,Under Votes,10,0,0,2,5,3
+Hill,0022,Referenda Item #4,22,DEM,For,56,1,3,5,30,17
+Hill,0022,Referenda Item #4,22,DEM,Against,5,0,0,1,1,3
+Hill,0022,Referenda Item #4,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0022,Referenda Item #4,22,DEM,Under Votes,9,0,0,2,5,2
+Hill,0022,Referenda Item #5,22,DEM,For,53,1,3,6,28,15
+Hill,0022,Referenda Item #5,22,DEM,Against,10,0,0,1,3,6
+Hill,0022,Referenda Item #5,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0022,Referenda Item #5,22,DEM,Under Votes,7,0,0,1,5,1
+Hill,0022,Referenda Item #6,22,DEM,For,52,1,3,7,24,17
+Hill,0022,Referenda Item #6,22,DEM,Against,10,0,0,0,7,3
+Hill,0022,Referenda Item #6,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0022,Referenda Item #6,22,DEM,Under Votes,8,0,0,1,5,2
+Hill,0023,Registered Voters - Total,,,,449,0,0,1,5,2
+Hill,0023,Ballots Cast - Total,,REP,,203,6,10,11,100,76
+Hill,0023,Ballots Cast - Total,,DEM,,18,2,3,0,9,4
+Hill,0023,President,,REP,Ted Cruz,89,2,2,2,48,35
+Hill,0023,President,,REP,Jeb Bush,2,0,0,0,1,1
+Hill,0023,President,,REP,Donald J. Trump,59,3,6,6,23,21
+Hill,0023,President,,REP,Ben Carson,15,0,0,0,9,6
+Hill,0023,President,,REP,Rand Paul,1,0,0,0,1,0
+Hill,0023,President,,REP,Rick Santorum,0,0,0,0,0,0
+Hill,0023,President,,REP,Elizabeth Gray,0,0,0,0,0,0
+Hill,0023,President,,REP,Carly Fiorina,0,0,0,0,0,0
+Hill,0023,President,,REP,Lindsey Graham,0,0,0,0,0,0
+Hill,0023,President,,REP,Marco Rubio,15,0,0,3,6,6
+Hill,0023,President,,REP,John R. Kasich,3,0,1,0,2,0
+Hill,0023,President,,REP,Mike Huckabee,0,0,0,0,0,0
+Hill,0023,President,,REP,Chris Christie,2,0,0,0,0,2
+Hill,0023,President,,REP,Uncommitted,12,1,1,0,7,3
+Hill,0023,President,,REP,Over Votes,0,0,0,0,0,0
+Hill,0023,President,,REP,Under Votes,5,0,0,0,3,2
+Hill,0023,U.S. House,25,REP,Roger Williams,119,5,7,7,59,41
+Hill,0023,U.S. House,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0023,U.S. House,25,REP,Under Votes,84,1,3,4,41,35
+Hill,0023,Railroad Commissioner,25,REP,Gary Gates,48,2,2,3,20,21
+Hill,0023,Railroad Commissioner,25,REP,Lance N. Christian,16,0,0,1,3,12
+Hill,0023,Railroad Commissioner,25,REP,Weston Martinez,8,0,0,0,5,3
+Hill,0023,Railroad Commissioner,25,REP,Wayne Christian,28,0,1,2,17,8
+Hill,0023,Railroad Commissioner,25,REP,Ron Hale,15,1,1,1,8,4
+Hill,0023,Railroad Commissioner,25,REP,Doug Jeffrey,16,1,4,1,8,2
+Hill,0023,Railroad Commissioner,25,REP,John Greytok,8,0,0,0,5,3
+Hill,0023,Railroad Commissioner,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0023,Railroad Commissioner,25,REP,Under Votes,64,2,2,3,34,23
+Hill,0023,"Justice, Supreme Court, Place 3",25,REP,Michael Massengale,74,3,5,5,35,26
+Hill,0023,"Justice, Supreme Court, Place 3",25,REP,Debra Lehrmann,70,2,4,3,30,31
+Hill,0023,"Justice, Supreme Court, Place 3",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0023,"Justice, Supreme Court, Place 3",25,REP,Under Votes,59,1,1,3,35,19
+Hill,0023,"Justice, Supreme Court, Place 5",25,REP,Paul Green,74,2,4,5,34,29
+Hill,0023,"Justice, Supreme Court, Place 5",25,REP,Rick Green,59,2,2,2,29,24
+Hill,0023,"Justice, Supreme Court, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0023,"Justice, Supreme Court, Place 5",25,REP,Under Votes,70,2,4,4,37,23
+Hill,0023,"Justice, Supreme Court, Place 9",25,REP,Joe Pool,80,3,5,7,41,24
+Hill,0023,"Justice, Supreme Court, Place 9",25,REP,Eva Guzman,65,2,3,1,28,31
+Hill,0023,"Justice, Supreme Court, Place 9",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0023,"Justice, Supreme Court, Place 9",25,REP,Under Votes,58,1,2,3,31,21
+Hill,0023,"Judge, Court of Criminal Appeals, Place 2",25,REP,Chris Oldner,43,2,3,4,17,17
+Hill,0023,"Judge, Court of Criminal Appeals, Place 2",25,REP,Ray Wheless,41,0,1,1,24,15
+Hill,0023,"Judge, Court of Criminal Appeals, Place 2",25,REP,Mary Lou Keel,49,2,3,3,20,21
+Hill,0023,"Judge, Court of Criminal Appeals, Place 2",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0023,"Judge, Court of Criminal Appeals, Place 2",25,REP,Under Votes,70,2,3,3,39,23
+Hill,0023,"Judge, Court of Criminal Appeals, Place 5",25,REP,Sid Harle,25,1,2,2,8,12
+Hill,0023,"Judge, Court of Criminal Appeals, Place 5",25,REP,Brent Webster,27,1,2,1,12,11
+Hill,0023,"Judge, Court of Criminal Appeals, Place 5",25,REP,Scott Walker,56,2,2,2,31,19
+Hill,0023,"Judge, Court of Criminal Appeals, Place 5",25,REP,Steve Smith,27,0,1,3,14,9
+Hill,0023,"Judge, Court of Criminal Appeals, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0023,"Judge, Court of Criminal Appeals, Place 5",25,REP,Under Votes,68,2,3,3,35,25
+Hill,0023,"Judge, Court of Criminal Appeals, Place 6",25,REP,Richard Davis,80,2,5,6,39,28
+Hill,0023,"Judge, Court of Criminal Appeals, Place 6",25,REP,Michael E. Keasler,51,2,3,2,22,22
+Hill,0023,"Judge, Court of Criminal Appeals, Place 6",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0023,"Judge, Court of Criminal Appeals, Place 6",25,REP,Under Votes,72,2,2,3,39,26
+Hill,0023,"Member, State Board of Education, District 14",25,REP,Sue Melton-Malone,113,3,6,6,52,46
+Hill,0023,"Member, State Board of Education, District 14",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0023,"Member, State Board of Education, District 14",25,REP,Under Votes,90,3,4,5,48,30
+Hill,0023,State Senator,22,REP,Brian Birdwell,125,3,6,7,60,49
+Hill,0023,State Senator,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0023,State Senator,22,REP,Under Votes,78,3,4,4,40,27
+Hill,0023,State Representative,8,REP,Thomas McNutt,92,1,3,8,48,32
+Hill,0023,State Representative,8,REP,Byron Cook,77,5,7,1,35,29
+Hill,0023,State Representative,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0023,State Representative,8,REP,Under Votes,34,0,0,2,17,15
+Hill,0023,"Justice, 10th Court of Appeals District, Place 3",8,REP,Al Scoggins,115,3,6,7,53,46
+Hill,0023,"Justice, 10th Court of Appeals District, Place 3",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0023,"Justice, 10th Court of Appeals District, Place 3",8,REP,Under Votes,88,3,4,4,47,30
+Hill,0023,"District Attorney, 66th Judicial District",8,REP,Mark F Pratt,123,4,7,8,58,46
+Hill,0023,"District Attorney, 66th Judicial District",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0023,"District Attorney, 66th Judicial District",8,REP,Under Votes,80,2,3,3,42,30
+Hill,0023,County Attorney,8,REP,R David Holmes,122,4,7,6,56,49
+Hill,0023,County Attorney,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0023,County Attorney,8,REP,Under Votes,81,2,3,5,44,27
+Hill,0023,Sheriff,8,REP,Jimmy Johnson,102,5,9,7,46,35
+Hill,0023,Sheriff,8,REP,Dedri Hafer,8,0,0,1,5,2
+Hill,0023,Sheriff,8,REP,Rodney Watson,25,0,0,0,9,16
+Hill,0023,Sheriff,8,REP,Kyle R Cox,27,0,0,1,15,11
+Hill,0023,Sheriff,8,REP,Ronnie Myers,6,0,0,1,3,2
+Hill,0023,Sheriff,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0023,Sheriff,8,REP,Under Votes,35,1,1,1,22,10
+Hill,0023,Tax Assessor-Collector,8,REP,Ray Mabry,68,2,3,8,37,18
+Hill,0023,Tax Assessor-Collector,8,REP,Krissi Hightower,85,3,6,0,39,37
+Hill,0023,Tax Assessor-Collector,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0023,Tax Assessor-Collector,8,REP,Under Votes,50,1,1,3,24,21
+Hill,0023,County Commissioner # 3,8,REP,Scotty Hawkins,174,6,10,9,87,62
+Hill,0023,County Commissioner # 3,8,REP,Milton Stuckly,24,0,0,2,10,12
+Hill,0023,County Commissioner # 3,8,REP,"Ernest D McFarland, Jr",0,0,0,0,0,0
+Hill,0023,County Commissioner # 3,8,REP,David Bow,3,0,0,0,2,1
+Hill,0023,County Commissioner # 3,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0023,County Commissioner # 3,8,REP,Under Votes,2,0,0,0,1,1
+Hill,0023,"Constable, Precinct No. 3",8,REP,Larry Armstrong,106,0,3,7,51,45
+Hill,0023,"Constable, Precinct No. 3",8,REP,Brian Couch,48,2,3,0,22,21
+Hill,0023,"Constable, Precinct No. 3",8,REP,Stephen Nanny,28,3,3,2,15,5
+Hill,0023,"Constable, Precinct No. 3",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0023,"Constable, Precinct No. 3",8,REP,Under Votes,21,1,1,2,12,5
+Hill,0023,County Chairman,8,REP,Will Orr,125,4,7,7,57,50
+Hill,0023,County Chairman,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0023,County Chairman,8,REP,Under Votes,78,2,3,4,43,26
+Hill,0023,President,8,DEM,Bernie Sanders,8,2,2,0,3,1
+Hill,0023,President,8,DEM,Star Locke,0,0,0,0,0,0
+Hill,0023,President,8,DEM,"Roque ""Rocky"" De La Fuente",0,0,0,0,0,0
+Hill,0023,President,8,DEM,Willie L. Wilson,0,0,0,0,0,0
+Hill,0023,President,8,DEM,Calvis L. Hawes,0,0,0,0,0,0
+Hill,0023,President,8,DEM,Hillary Clinton,10,0,1,0,6,3
+Hill,0023,President,8,DEM,Keith Judd,0,0,0,0,0,0
+Hill,0023,President,8,DEM,Martin J. O'Malley,0,0,0,0,0,0
+Hill,0023,President,8,DEM,Over Votes,0,0,0,0,0,0
+Hill,0023,President,8,DEM,Under Votes,0,0,0,0,0,0
+Hill,0023,U.S. House,25,DEM,Kathi Thomas,16,2,3,0,8,3
+Hill,0023,U.S. House,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0023,U.S. House,25,DEM,Under Votes,2,0,0,0,1,1
+Hill,0023,Railroad Commissioner,25,DEM,Cody Garrett,6,0,1,0,4,1
+Hill,0023,Railroad Commissioner,25,DEM,Lon Burnam,1,0,0,0,1,0
+Hill,0023,Railroad Commissioner,25,DEM,Grady Yarbrough,10,2,2,0,4,2
+Hill,0023,Railroad Commissioner,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0023,Railroad Commissioner,25,DEM,Under Votes,1,0,0,0,0,1
+Hill,0023,"Justice, Supreme Court, Place 3",25,DEM,Mike Westergren,14,2,3,0,7,2
+Hill,0023,"Justice, Supreme Court, Place 3",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0023,"Justice, Supreme Court, Place 3",25,DEM,Under Votes,4,0,0,0,2,2
+Hill,0023,"Justice, Supreme Court, Place 5",25,DEM,Dori Contreras Garza,16,2,3,0,8,3
+Hill,0023,"Justice, Supreme Court, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0023,"Justice, Supreme Court, Place 5",25,DEM,Under Votes,2,0,0,0,1,1
+Hill,0023,"Justice, Supreme Court, Place 9",25,DEM,Savannah Robinson,14,2,3,0,7,2
+Hill,0023,"Justice, Supreme Court, Place 9",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0023,"Justice, Supreme Court, Place 9",25,DEM,Under Votes,4,0,0,0,2,2
+Hill,0023,"Judge, Court of Criminal Appeals, Place 2",25,DEM,"Lawrence ""Larry"" Meyers",16,2,3,0,8,3
+Hill,0023,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0023,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Under Votes,2,0,0,0,1,1
+Hill,0023,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Betsy Johnson,16,2,3,0,8,3
+Hill,0023,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0023,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Under Votes,2,0,0,0,1,1
+Hill,0023,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Robert Burns,14,2,3,0,7,2
+Hill,0023,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0023,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Under Votes,4,0,0,0,2,2
+Hill,0023,State Senator,22,DEM,Michael Collins,15,2,3,0,8,2
+Hill,0023,State Senator,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0023,State Senator,22,DEM,Under Votes,3,0,0,0,1,2
+Hill,0023,County Chairman,22,DEM,Thomas Hanson,16,2,3,0,8,3
+Hill,0023,County Chairman,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0023,County Chairman,22,DEM,Under Votes,2,0,0,0,1,1
+Hill,0023,Proposition 1,22,REP,Yes,124,5,8,5,60,46
+Hill,0023,Proposition 1,22,REP,No,49,1,1,6,21,20
+Hill,0023,Proposition 1,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0023,Proposition 1,22,REP,Under Votes,30,0,1,0,19,10
+Hill,0023,Proposition 2,22,REP,Yes,89,3,3,6,41,36
+Hill,0023,Proposition 2,22,REP,No,85,3,5,5,41,31
+Hill,0023,Proposition 2,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0023,Proposition 2,22,REP,Under Votes,29,0,2,0,18,9
+Hill,0023,Proposition 3,22,REP,Yes,114,3,5,11,58,37
+Hill,0023,Proposition 3,22,REP,No,56,3,4,0,21,28
+Hill,0023,Proposition 3,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0023,Proposition 3,22,REP,Under Votes,33,0,1,0,21,11
+Hill,0023,Proposition 4,22,REP,Yes,154,6,9,10,73,56
+Hill,0023,Proposition 4,22,REP,No,12,0,0,1,4,7
+Hill,0023,Proposition 4,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0023,Proposition 4,22,REP,Under Votes,37,0,1,0,23,13
+Hill,0023,Referenda Item #1,22,DEM,For,16,2,3,0,7,4
+Hill,0023,Referenda Item #1,22,DEM,Against,1,0,0,0,1,0
+Hill,0023,Referenda Item #1,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0023,Referenda Item #1,22,DEM,Under Votes,1,0,0,0,1,0
+Hill,0023,Referenda Item #2,22,DEM,For,15,2,3,0,6,4
+Hill,0023,Referenda Item #2,22,DEM,Against,0,0,0,0,0,0
+Hill,0023,Referenda Item #2,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0023,Referenda Item #2,22,DEM,Under Votes,3,0,0,0,3,0
+Hill,0023,Referenda Item #3,22,DEM,For,14,2,3,0,6,3
+Hill,0023,Referenda Item #3,22,DEM,Against,1,0,0,0,0,1
+Hill,0023,Referenda Item #3,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0023,Referenda Item #3,22,DEM,Under Votes,3,0,0,0,3,0
+Hill,0023,Referenda Item #4,22,DEM,For,14,2,3,0,5,4
+Hill,0023,Referenda Item #4,22,DEM,Against,1,0,0,0,1,0
+Hill,0023,Referenda Item #4,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0023,Referenda Item #4,22,DEM,Under Votes,3,0,0,0,3,0
+Hill,0023,Referenda Item #5,22,DEM,For,13,2,2,0,6,3
+Hill,0023,Referenda Item #5,22,DEM,Against,3,0,1,0,1,1
+Hill,0023,Referenda Item #5,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0023,Referenda Item #5,22,DEM,Under Votes,2,0,0,0,2,0
+Hill,0023,Referenda Item #6,22,DEM,For,11,1,2,0,6,2
+Hill,0023,Referenda Item #6,22,DEM,Against,5,1,1,0,1,2
+Hill,0023,Referenda Item #6,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0023,Referenda Item #6,22,DEM,Under Votes,2,0,0,0,2,0
+Hill,0024,Registered Voters - Total,,,,1327,0,0,0,2,0
+Hill,0024,Ballots Cast - Total,,REP,,449,22,28,34,86,279
+Hill,0024,Ballots Cast - Total,,DEM,,66,4,8,0,13,41
+Hill,0024,President,,REP,Ted Cruz,207,6,9,19,36,137
+Hill,0024,President,,REP,Jeb Bush,4,1,1,0,2,0
+Hill,0024,President,,REP,Donald J. Trump,144,11,13,10,30,80
+Hill,0024,President,,REP,Ben Carson,26,1,1,3,3,18
+Hill,0024,President,,REP,Rand Paul,2,0,0,0,0,2
+Hill,0024,President,,REP,Rick Santorum,0,0,0,0,0,0
+Hill,0024,President,,REP,Elizabeth Gray,0,0,0,0,0,0
+Hill,0024,President,,REP,Carly Fiorina,0,0,0,0,0,0
+Hill,0024,President,,REP,Lindsey Graham,0,0,0,0,0,0
+Hill,0024,President,,REP,Marco Rubio,30,0,0,1,3,26
+Hill,0024,President,,REP,John R. Kasich,9,0,0,1,2,6
+Hill,0024,President,,REP,Mike Huckabee,2,0,0,0,0,2
+Hill,0024,President,,REP,Chris Christie,7,2,2,0,2,1
+Hill,0024,President,,REP,Uncommitted,12,1,1,0,6,4
+Hill,0024,President,,REP,Over Votes,0,0,0,0,0,0
+Hill,0024,President,,REP,Under Votes,6,0,1,0,2,3
+Hill,0024,U.S. House,25,REP,Roger Williams,312,21,25,27,64,175
+Hill,0024,U.S. House,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0024,U.S. House,25,REP,Under Votes,136,1,3,7,21,104
+Hill,0024,Railroad Commissioner,25,REP,Gary Gates,150,7,8,11,28,96
+Hill,0024,Railroad Commissioner,25,REP,Lance N. Christian,37,1,1,6,7,22
+Hill,0024,Railroad Commissioner,25,REP,Weston Martinez,15,0,0,3,2,10
+Hill,0024,Railroad Commissioner,25,REP,Wayne Christian,66,6,7,9,11,33
+Hill,0024,Railroad Commissioner,25,REP,Ron Hale,30,1,1,1,7,20
+Hill,0024,Railroad Commissioner,25,REP,Doug Jeffrey,25,3,4,0,5,13
+Hill,0024,Railroad Commissioner,25,REP,John Greytok,8,0,0,1,2,5
+Hill,0024,Railroad Commissioner,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0024,Railroad Commissioner,25,REP,Under Votes,117,4,7,3,23,80
+Hill,0024,"Justice, Supreme Court, Place 3",25,REP,Michael Massengale,188,9,12,13,38,116
+Hill,0024,"Justice, Supreme Court, Place 3",25,REP,Debra Lehrmann,165,10,11,18,35,91
+Hill,0024,"Justice, Supreme Court, Place 3",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0024,"Justice, Supreme Court, Place 3",25,REP,Under Votes,96,3,5,3,13,72
+Hill,0024,"Justice, Supreme Court, Place 5",25,REP,Paul Green,180,7,8,17,28,120
+Hill,0024,"Justice, Supreme Court, Place 5",25,REP,Rick Green,154,12,14,13,38,77
+Hill,0024,"Justice, Supreme Court, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0024,"Justice, Supreme Court, Place 5",25,REP,Under Votes,114,3,6,4,19,82
+Hill,0024,"Justice, Supreme Court, Place 9",25,REP,Joe Pool,207,10,11,17,38,131
+Hill,0024,"Justice, Supreme Court, Place 9",25,REP,Eva Guzman,138,9,11,15,30,73
+Hill,0024,"Justice, Supreme Court, Place 9",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0024,"Justice, Supreme Court, Place 9",25,REP,Under Votes,104,3,6,2,18,75
+Hill,0024,"Judge, Court of Criminal Appeals, Place 2",25,REP,Chris Oldner,108,2,2,11,15,78
+Hill,0024,"Judge, Court of Criminal Appeals, Place 2",25,REP,Ray Wheless,102,8,10,8,23,53
+Hill,0024,"Judge, Court of Criminal Appeals, Place 2",25,REP,Mary Lou Keel,103,6,7,9,22,59
+Hill,0024,"Judge, Court of Criminal Appeals, Place 2",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0024,"Judge, Court of Criminal Appeals, Place 2",25,REP,Under Votes,136,6,9,6,26,89
+Hill,0024,"Judge, Court of Criminal Appeals, Place 5",25,REP,Sid Harle,72,2,2,7,14,47
+Hill,0024,"Judge, Court of Criminal Appeals, Place 5",25,REP,Brent Webster,49,4,5,4,8,28
+Hill,0024,"Judge, Court of Criminal Appeals, Place 5",25,REP,Scott Walker,151,7,8,15,32,89
+Hill,0024,"Judge, Court of Criminal Appeals, Place 5",25,REP,Steve Smith,51,4,5,4,12,26
+Hill,0024,"Judge, Court of Criminal Appeals, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0024,"Judge, Court of Criminal Appeals, Place 5",25,REP,Under Votes,126,5,8,4,20,89
+Hill,0024,"Judge, Court of Criminal Appeals, Place 6",25,REP,Richard Davis,189,9,10,15,40,115
+Hill,0024,"Judge, Court of Criminal Appeals, Place 6",25,REP,Michael E. Keasler,128,8,10,14,23,73
+Hill,0024,"Judge, Court of Criminal Appeals, Place 6",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0024,"Judge, Court of Criminal Appeals, Place 6",25,REP,Under Votes,131,5,8,5,22,91
+Hill,0024,"Member, State Board of Education, District 14",25,REP,Sue Melton-Malone,310,19,22,30,60,179
+Hill,0024,"Member, State Board of Education, District 14",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0024,"Member, State Board of Education, District 14",25,REP,Under Votes,138,3,6,4,25,100
+Hill,0024,State Senator,22,REP,Brian Birdwell,323,18,22,33,63,187
+Hill,0024,State Senator,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0024,State Senator,22,REP,Under Votes,125,4,6,1,22,92
+Hill,0024,State Representative,8,REP,Thomas McNutt,193,11,16,11,40,115
+Hill,0024,State Representative,8,REP,Byron Cook,222,11,12,22,44,133
+Hill,0024,State Representative,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0024,State Representative,8,REP,Under Votes,34,0,0,1,2,31
+Hill,0024,"Justice, 10th Court of Appeals District, Place 3",8,REP,Al Scoggins,298,18,21,29,58,172
+Hill,0024,"Justice, 10th Court of Appeals District, Place 3",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0024,"Justice, 10th Court of Appeals District, Place 3",8,REP,Under Votes,150,4,7,5,27,107
+Hill,0024,"District Attorney, 66th Judicial District",8,REP,Mark F Pratt,330,21,25,29,68,187
+Hill,0024,"District Attorney, 66th Judicial District",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0024,"District Attorney, 66th Judicial District",8,REP,Under Votes,118,1,3,5,17,92
+Hill,0024,County Attorney,8,REP,R David Holmes,315,19,23,29,60,184
+Hill,0024,County Attorney,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0024,County Attorney,8,REP,Under Votes,133,3,5,5,25,95
+Hill,0024,Sheriff,8,REP,Jimmy Johnson,194,16,20,13,45,100
+Hill,0024,Sheriff,8,REP,Dedri Hafer,15,0,0,1,1,13
+Hill,0024,Sheriff,8,REP,Rodney Watson,90,1,2,7,10,70
+Hill,0024,Sheriff,8,REP,Kyle R Cox,64,4,4,2,11,43
+Hill,0024,Sheriff,8,REP,Ronnie Myers,33,1,2,7,11,12
+Hill,0024,Sheriff,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0024,Sheriff,8,REP,Under Votes,52,0,0,4,7,41
+Hill,0024,Tax Assessor-Collector,8,REP,Ray Mabry,158,8,10,13,38,89
+Hill,0024,Tax Assessor-Collector,8,REP,Krissi Hightower,173,10,12,14,28,109
+Hill,0024,Tax Assessor-Collector,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0024,Tax Assessor-Collector,8,REP,Under Votes,117,4,6,7,19,81
+Hill,0024,County Commissioner # 3,8,REP,Scotty Hawkins,283,16,18,21,53,175
+Hill,0024,County Commissioner # 3,8,REP,Milton Stuckly,92,4,7,8,21,52
+Hill,0024,County Commissioner # 3,8,REP,"Ernest D McFarland, Jr",17,1,2,1,4,9
+Hill,0024,County Commissioner # 3,8,REP,David Bow,34,0,0,3,5,26
+Hill,0024,County Commissioner # 3,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0024,County Commissioner # 3,8,REP,Under Votes,22,1,1,1,2,17
+Hill,0024,"Constable, Precinct No. 3",8,REP,Larry Armstrong,275,17,21,26,52,159
+Hill,0024,"Constable, Precinct No. 3",8,REP,Brian Couch,90,5,6,0,21,58
+Hill,0024,"Constable, Precinct No. 3",8,REP,Stephen Nanny,57,0,1,7,8,41
+Hill,0024,"Constable, Precinct No. 3",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0024,"Constable, Precinct No. 3",8,REP,Under Votes,26,0,0,1,4,21
+Hill,0024,County Chairman,8,REP,Will Orr,327,20,24,29,64,190
+Hill,0024,County Chairman,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0024,County Chairman,8,REP,Under Votes,121,2,4,5,21,89
+Hill,0024,President,8,DEM,Bernie Sanders,17,1,3,0,5,8
+Hill,0024,President,8,DEM,Star Locke,0,0,0,0,0,0
+Hill,0024,President,8,DEM,"Roque ""Rocky"" De La Fuente",0,0,0,0,0,0
+Hill,0024,President,8,DEM,Willie L. Wilson,0,0,0,0,0,0
+Hill,0024,President,8,DEM,Calvis L. Hawes,2,0,0,0,0,2
+Hill,0024,President,8,DEM,Hillary Clinton,46,3,5,0,8,30
+Hill,0024,President,8,DEM,Keith Judd,0,0,0,0,0,0
+Hill,0024,President,8,DEM,Martin J. O'Malley,0,0,0,0,0,0
+Hill,0024,President,8,DEM,Over Votes,0,0,0,0,0,0
+Hill,0024,President,8,DEM,Under Votes,1,0,0,0,0,1
+Hill,0024,U.S. House,25,DEM,Kathi Thomas,35,2,6,0,9,18
+Hill,0024,U.S. House,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0024,U.S. House,25,DEM,Under Votes,31,2,2,0,4,23
+Hill,0024,Railroad Commissioner,25,DEM,Cody Garrett,18,2,2,0,4,10
+Hill,0024,Railroad Commissioner,25,DEM,Lon Burnam,13,0,3,0,3,7
+Hill,0024,Railroad Commissioner,25,DEM,Grady Yarbrough,9,0,1,0,2,6
+Hill,0024,Railroad Commissioner,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0024,Railroad Commissioner,25,DEM,Under Votes,26,2,2,0,4,18
+Hill,0024,"Justice, Supreme Court, Place 3",25,DEM,Mike Westergren,35,2,6,0,8,19
+Hill,0024,"Justice, Supreme Court, Place 3",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0024,"Justice, Supreme Court, Place 3",25,DEM,Under Votes,31,2,2,0,5,22
+Hill,0024,"Justice, Supreme Court, Place 5",25,DEM,Dori Contreras Garza,32,1,5,0,7,19
+Hill,0024,"Justice, Supreme Court, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0024,"Justice, Supreme Court, Place 5",25,DEM,Under Votes,34,3,3,0,6,22
+Hill,0024,"Justice, Supreme Court, Place 9",25,DEM,Savannah Robinson,45,4,8,0,11,22
+Hill,0024,"Justice, Supreme Court, Place 9",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0024,"Justice, Supreme Court, Place 9",25,DEM,Under Votes,21,0,0,0,2,19
+Hill,0024,"Judge, Court of Criminal Appeals, Place 2",25,DEM,"Lawrence ""Larry"" Meyers",40,4,8,0,10,18
+Hill,0024,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0024,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Under Votes,26,0,0,0,3,23
+Hill,0024,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Betsy Johnson,41,3,7,0,9,22
+Hill,0024,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0024,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Under Votes,25,1,1,0,4,19
+Hill,0024,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Robert Burns,43,4,8,0,10,21
+Hill,0024,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0024,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Under Votes,23,0,0,0,3,20
+Hill,0024,State Senator,22,DEM,Michael Collins,40,3,7,0,9,21
+Hill,0024,State Senator,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0024,State Senator,22,DEM,Under Votes,26,1,1,0,4,20
+Hill,0024,County Chairman,22,DEM,Thomas Hanson,45,4,8,0,10,23
+Hill,0024,County Chairman,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0024,County Chairman,22,DEM,Under Votes,21,0,0,0,3,18
+Hill,0024,Proposition 1,22,REP,Yes,300,15,18,21,61,185
+Hill,0024,Proposition 1,22,REP,No,99,4,4,11,12,68
+Hill,0024,Proposition 1,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0024,Proposition 1,22,REP,Under Votes,49,3,6,2,12,26
+Hill,0024,Proposition 2,22,REP,Yes,246,8,10,22,41,165
+Hill,0024,Proposition 2,22,REP,No,156,10,12,11,31,92
+Hill,0024,Proposition 2,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0024,Proposition 2,22,REP,Under Votes,46,4,6,1,13,22
+Hill,0024,Proposition 3,22,REP,Yes,322,19,22,25,62,194
+Hill,0024,Proposition 3,22,REP,No,74,1,1,8,10,54
+Hill,0024,Proposition 3,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0024,Proposition 3,22,REP,Under Votes,52,2,5,1,13,31
+Hill,0024,Proposition 4,22,REP,Yes,372,18,21,31,69,233
+Hill,0024,Proposition 4,22,REP,No,25,0,0,3,4,18
+Hill,0024,Proposition 4,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0024,Proposition 4,22,REP,Under Votes,51,4,7,0,12,28
+Hill,0024,Referenda Item #1,22,DEM,For,43,2,6,0,10,25
+Hill,0024,Referenda Item #1,22,DEM,Against,7,1,1,0,1,4
+Hill,0024,Referenda Item #1,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0024,Referenda Item #1,22,DEM,Under Votes,16,1,1,0,2,12
+Hill,0024,Referenda Item #2,22,DEM,For,49,4,7,0,11,27
+Hill,0024,Referenda Item #2,22,DEM,Against,2,0,0,0,0,2
+Hill,0024,Referenda Item #2,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0024,Referenda Item #2,22,DEM,Under Votes,15,0,1,0,2,12
+Hill,0024,Referenda Item #3,22,DEM,For,37,2,5,0,8,22
+Hill,0024,Referenda Item #3,22,DEM,Against,14,2,2,0,3,7
+Hill,0024,Referenda Item #3,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0024,Referenda Item #3,22,DEM,Under Votes,15,0,1,0,2,12
+Hill,0024,Referenda Item #4,22,DEM,For,49,4,7,0,11,27
+Hill,0024,Referenda Item #4,22,DEM,Against,3,0,0,0,0,3
+Hill,0024,Referenda Item #4,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0024,Referenda Item #4,22,DEM,Under Votes,14,0,1,0,2,11
+Hill,0024,Referenda Item #5,22,DEM,For,31,2,5,0,8,16
+Hill,0024,Referenda Item #5,22,DEM,Against,20,2,2,0,3,13
+Hill,0024,Referenda Item #5,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0024,Referenda Item #5,22,DEM,Under Votes,15,0,1,0,2,12
+Hill,0024,Referenda Item #6,22,DEM,For,47,4,7,0,11,25
+Hill,0024,Referenda Item #6,22,DEM,Against,3,0,0,0,0,3
+Hill,0024,Referenda Item #6,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0024,Referenda Item #6,22,DEM,Under Votes,16,0,1,0,2,13
+Hill,0027,Registered Voters - Total,,,,707,0,1,0,2,13
+Hill,0027,Ballots Cast - Total,,REP,,258,11,30,28,138,51
+Hill,0027,Ballots Cast - Total,,DEM,,41,1,3,2,30,5
+Hill,0027,President,,REP,Ted Cruz,125,5,14,16,64,26
+Hill,0027,President,,REP,Jeb Bush,4,1,1,0,1,1
+Hill,0027,President,,REP,Donald J. Trump,84,2,11,8,45,18
+Hill,0027,President,,REP,Ben Carson,15,0,0,2,9,4
+Hill,0027,President,,REP,Rand Paul,0,0,0,0,0,0
+Hill,0027,President,,REP,Rick Santorum,0,0,0,0,0,0
+Hill,0027,President,,REP,Elizabeth Gray,0,0,0,0,0,0
+Hill,0027,President,,REP,Carly Fiorina,0,0,0,0,0,0
+Hill,0027,President,,REP,Lindsey Graham,0,0,0,0,0,0
+Hill,0027,President,,REP,Marco Rubio,15,0,1,1,12,1
+Hill,0027,President,,REP,John R. Kasich,10,2,2,0,5,1
+Hill,0027,President,,REP,Mike Huckabee,3,1,1,0,1,0
+Hill,0027,President,,REP,Chris Christie,0,0,0,0,0,0
+Hill,0027,President,,REP,Uncommitted,0,0,0,0,0,0
+Hill,0027,President,,REP,Over Votes,0,0,0,0,0,0
+Hill,0027,President,,REP,Under Votes,2,0,0,1,1,0
+Hill,0027,U.S. House,25,REP,Roger Williams,191,9,23,16,108,35
+Hill,0027,U.S. House,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0027,U.S. House,25,REP,Under Votes,67,2,7,12,30,16
+Hill,0027,Railroad Commissioner,25,REP,Gary Gates,71,4,10,3,38,16
+Hill,0027,Railroad Commissioner,25,REP,Lance N. Christian,19,0,2,1,11,5
+Hill,0027,Railroad Commissioner,25,REP,Weston Martinez,10,1,1,1,6,1
+Hill,0027,Railroad Commissioner,25,REP,Wayne Christian,38,2,6,6,20,4
+Hill,0027,Railroad Commissioner,25,REP,Ron Hale,26,1,3,6,15,1
+Hill,0027,Railroad Commissioner,25,REP,Doug Jeffrey,15,0,1,1,7,6
+Hill,0027,Railroad Commissioner,25,REP,John Greytok,12,0,1,1,9,1
+Hill,0027,Railroad Commissioner,25,REP,Over Votes,0,0,0,0,0,0
+Hill,0027,Railroad Commissioner,25,REP,Under Votes,67,3,6,9,32,17
+Hill,0027,"Justice, Supreme Court, Place 3",25,REP,Michael Massengale,110,4,12,13,66,15
+Hill,0027,"Justice, Supreme Court, Place 3",25,REP,Debra Lehrmann,89,4,11,6,47,21
+Hill,0027,"Justice, Supreme Court, Place 3",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0027,"Justice, Supreme Court, Place 3",25,REP,Under Votes,59,3,7,9,25,15
+Hill,0027,"Justice, Supreme Court, Place 5",25,REP,Paul Green,107,5,15,8,61,18
+Hill,0027,"Justice, Supreme Court, Place 5",25,REP,Rick Green,86,3,8,9,48,18
+Hill,0027,"Justice, Supreme Court, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0027,"Justice, Supreme Court, Place 5",25,REP,Under Votes,65,3,7,11,29,15
+Hill,0027,"Justice, Supreme Court, Place 9",25,REP,Joe Pool,105,4,13,12,55,21
+Hill,0027,"Justice, Supreme Court, Place 9",25,REP,Eva Guzman,100,4,13,7,59,17
+Hill,0027,"Justice, Supreme Court, Place 9",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0027,"Justice, Supreme Court, Place 9",25,REP,Under Votes,53,3,4,9,24,13
+Hill,0027,"Judge, Court of Criminal Appeals, Place 2",25,REP,Chris Oldner,63,1,8,7,37,10
+Hill,0027,"Judge, Court of Criminal Appeals, Place 2",25,REP,Ray Wheless,57,2,6,5,35,9
+Hill,0027,"Judge, Court of Criminal Appeals, Place 2",25,REP,Mary Lou Keel,65,5,8,4,34,14
+Hill,0027,"Judge, Court of Criminal Appeals, Place 2",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0027,"Judge, Court of Criminal Appeals, Place 2",25,REP,Under Votes,73,3,8,12,32,18
+Hill,0027,"Judge, Court of Criminal Appeals, Place 5",25,REP,Sid Harle,46,4,6,0,26,10
+Hill,0027,"Judge, Court of Criminal Appeals, Place 5",25,REP,Brent Webster,40,0,5,2,27,6
+Hill,0027,"Judge, Court of Criminal Appeals, Place 5",25,REP,Scott Walker,87,4,11,14,43,15
+Hill,0027,"Judge, Court of Criminal Appeals, Place 5",25,REP,Steve Smith,19,0,1,1,12,5
+Hill,0027,"Judge, Court of Criminal Appeals, Place 5",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0027,"Judge, Court of Criminal Appeals, Place 5",25,REP,Under Votes,66,3,7,11,30,15
+Hill,0027,"Judge, Court of Criminal Appeals, Place 6",25,REP,Richard Davis,92,5,10,7,47,23
+Hill,0027,"Judge, Court of Criminal Appeals, Place 6",25,REP,Michael E. Keasler,95,3,12,10,58,12
+Hill,0027,"Judge, Court of Criminal Appeals, Place 6",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0027,"Judge, Court of Criminal Appeals, Place 6",25,REP,Under Votes,71,3,8,11,33,16
+Hill,0027,"Member, State Board of Education, District 14",25,REP,Sue Melton-Malone,178,9,22,12,101,34
+Hill,0027,"Member, State Board of Education, District 14",25,REP,Over Votes,0,0,0,0,0,0
+Hill,0027,"Member, State Board of Education, District 14",25,REP,Under Votes,80,2,8,16,37,17
+Hill,0027,State Senator,22,REP,Brian Birdwell,180,8,22,11,103,36
+Hill,0027,State Senator,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0027,State Senator,22,REP,Under Votes,78,3,8,17,35,15
+Hill,0027,State Representative,8,REP,Thomas McNutt,103,4,13,9,60,17
+Hill,0027,State Representative,8,REP,Byron Cook,114,4,13,14,59,24
+Hill,0027,State Representative,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0027,State Representative,8,REP,Under Votes,41,3,4,5,19,10
+Hill,0027,"Justice, 10th Court of Appeals District, Place 3",8,REP,Al Scoggins,166,8,21,10,96,31
+Hill,0027,"Justice, 10th Court of Appeals District, Place 3",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0027,"Justice, 10th Court of Appeals District, Place 3",8,REP,Under Votes,92,3,9,18,42,20
+Hill,0027,"District Attorney, 66th Judicial District",8,REP,Mark F Pratt,173,9,24,10,99,31
+Hill,0027,"District Attorney, 66th Judicial District",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0027,"District Attorney, 66th Judicial District",8,REP,Under Votes,85,2,6,18,39,20
+Hill,0027,County Attorney,8,REP,R David Holmes,169,8,22,11,97,31
+Hill,0027,County Attorney,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0027,County Attorney,8,REP,Under Votes,89,3,8,17,41,20
+Hill,0027,Sheriff,8,REP,Jimmy Johnson,107,3,12,11,53,28
+Hill,0027,Sheriff,8,REP,Dedri Hafer,15,1,2,3,6,3
+Hill,0027,Sheriff,8,REP,Rodney Watson,47,2,6,5,29,5
+Hill,0027,Sheriff,8,REP,Kyle R Cox,30,1,4,3,15,7
+Hill,0027,Sheriff,8,REP,Ronnie Myers,16,0,0,2,14,0
+Hill,0027,Sheriff,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0027,Sheriff,8,REP,Under Votes,43,4,6,4,21,8
+Hill,0027,Tax Assessor-Collector,8,REP,Ray Mabry,95,5,11,10,53,16
+Hill,0027,Tax Assessor-Collector,8,REP,Krissi Hightower,97,3,11,6,59,18
+Hill,0027,Tax Assessor-Collector,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0027,Tax Assessor-Collector,8,REP,Under Votes,66,3,8,12,26,17
+Hill,0027,County Commissioner # 1,8,REP,Andrew Montgomery,116,2,11,11,68,24
+Hill,0027,County Commissioner # 1,8,REP,"Ted O' Neil, Jr",79,6,11,7,43,12
+Hill,0027,County Commissioner # 1,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0027,County Commissioner # 1,8,REP,Under Votes,63,3,8,10,27,15
+Hill,0027,"Constable, Precinct No. 1",8,REP,Bill Wilkins,112,6,14,4,66,22
+Hill,0027,"Constable, Precinct No. 1",8,REP,Daniel Roberson,74,2,6,11,40,15
+Hill,0027,"Constable, Precinct No. 1",8,REP,Over Votes,0,0,0,0,0,0
+Hill,0027,"Constable, Precinct No. 1",8,REP,Under Votes,72,3,10,13,32,14
+Hill,0027,County Chairman,8,REP,Will Orr,170,9,22,12,98,29
+Hill,0027,County Chairman,8,REP,Over Votes,0,0,0,0,0,0
+Hill,0027,County Chairman,8,REP,Under Votes,88,2,8,16,40,22
+Hill,0027,President,8,DEM,Bernie Sanders,13,1,1,0,7,4
+Hill,0027,President,8,DEM,Star Locke,0,0,0,0,0,0
+Hill,0027,President,8,DEM,"Roque ""Rocky"" De La Fuente",0,0,0,0,0,0
+Hill,0027,President,8,DEM,Willie L. Wilson,0,0,0,0,0,0
+Hill,0027,President,8,DEM,Calvis L. Hawes,0,0,0,0,0,0
+Hill,0027,President,8,DEM,Hillary Clinton,26,0,2,2,21,1
+Hill,0027,President,8,DEM,Keith Judd,2,0,0,0,2,0
+Hill,0027,President,8,DEM,Martin J. O'Malley,0,0,0,0,0,0
+Hill,0027,President,8,DEM,Over Votes,0,0,0,0,0,0
+Hill,0027,President,8,DEM,Under Votes,0,0,0,0,0,0
+Hill,0027,U.S. House,25,DEM,Kathi Thomas,24,0,1,1,18,4
+Hill,0027,U.S. House,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0027,U.S. House,25,DEM,Under Votes,17,1,2,1,12,1
+Hill,0027,Railroad Commissioner,25,DEM,Cody Garrett,8,1,2,0,4,1
+Hill,0027,Railroad Commissioner,25,DEM,Lon Burnam,9,0,0,0,9,0
+Hill,0027,Railroad Commissioner,25,DEM,Grady Yarbrough,15,0,0,0,14,1
+Hill,0027,Railroad Commissioner,25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0027,Railroad Commissioner,25,DEM,Under Votes,9,0,1,2,3,3
+Hill,0027,"Justice, Supreme Court, Place 3",25,DEM,Mike Westergren,28,0,1,0,23,4
+Hill,0027,"Justice, Supreme Court, Place 3",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0027,"Justice, Supreme Court, Place 3",25,DEM,Under Votes,13,1,2,2,7,1
+Hill,0027,"Justice, Supreme Court, Place 5",25,DEM,Dori Contreras Garza,27,0,1,0,23,3
+Hill,0027,"Justice, Supreme Court, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0027,"Justice, Supreme Court, Place 5",25,DEM,Under Votes,14,1,2,2,7,2
+Hill,0027,"Justice, Supreme Court, Place 9",25,DEM,Savannah Robinson,28,0,1,0,24,3
+Hill,0027,"Justice, Supreme Court, Place 9",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0027,"Justice, Supreme Court, Place 9",25,DEM,Under Votes,13,1,2,2,6,2
+Hill,0027,"Judge, Court of Criminal Appeals, Place 2",25,DEM,"Lawrence ""Larry"" Meyers",26,0,1,0,23,2
+Hill,0027,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0027,"Judge, Court of Criminal Appeals, Place 2",25,DEM,Under Votes,15,1,2,2,7,3
+Hill,0027,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Betsy Johnson,28,0,1,0,24,3
+Hill,0027,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0027,"Judge, Court of Criminal Appeals, Place 5",25,DEM,Under Votes,13,1,2,2,6,2
+Hill,0027,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Robert Burns,26,0,1,0,23,2
+Hill,0027,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Over Votes,0,0,0,0,0,0
+Hill,0027,"Judge, Court of Criminal Appeals, Place 6",25,DEM,Under Votes,15,1,2,2,7,3
+Hill,0027,State Senator,22,DEM,Michael Collins,29,0,1,1,24,3
+Hill,0027,State Senator,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0027,State Senator,22,DEM,Under Votes,12,1,2,1,6,2
+Hill,0027,County Chairman,22,DEM,Thomas Hanson,28,0,1,0,24,3
+Hill,0027,County Chairman,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0027,County Chairman,22,DEM,Under Votes,13,1,2,2,6,2
+Hill,0027,Proposition 1,22,REP,Yes,172,8,21,18,97,28
+Hill,0027,Proposition 1,22,REP,No,62,2,8,5,33,14
+Hill,0027,Proposition 1,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0027,Proposition 1,22,REP,Under Votes,24,1,1,5,8,9
+Hill,0027,Proposition 2,22,REP,Yes,152,8,15,13,82,34
+Hill,0027,Proposition 2,22,REP,No,87,3,15,10,48,11
+Hill,0027,Proposition 2,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0027,Proposition 2,22,REP,Under Votes,19,0,0,5,8,6
+Hill,0027,Proposition 3,22,REP,Yes,192,9,24,19,109,31
+Hill,0027,Proposition 3,22,REP,No,44,2,6,4,21,11
+Hill,0027,Proposition 3,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0027,Proposition 3,22,REP,Under Votes,22,0,0,5,8,9
+Hill,0027,Proposition 4,22,REP,Yes,230,11,28,25,124,42
+Hill,0027,Proposition 4,22,REP,No,7,0,2,0,4,1
+Hill,0027,Proposition 4,22,REP,Over Votes,0,0,0,0,0,0
+Hill,0027,Proposition 4,22,REP,Under Votes,21,0,0,3,10,8
+Hill,0027,Referenda Item #1,22,DEM,For,31,0,2,2,24,3
+Hill,0027,Referenda Item #1,22,DEM,Against,6,1,1,0,4,0
+Hill,0027,Referenda Item #1,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0027,Referenda Item #1,22,DEM,Under Votes,4,0,0,0,2,2
+Hill,0027,Referenda Item #2,22,DEM,For,38,1,3,1,29,4
+Hill,0027,Referenda Item #2,22,DEM,Against,0,0,0,0,0,0
+Hill,0027,Referenda Item #2,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0027,Referenda Item #2,22,DEM,Under Votes,3,0,0,1,1,1
+Hill,0027,Referenda Item #3,22,DEM,For,37,1,3,2,26,5
+Hill,0027,Referenda Item #3,22,DEM,Against,2,0,0,0,2,0
+Hill,0027,Referenda Item #3,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0027,Referenda Item #3,22,DEM,Under Votes,2,0,0,0,2,0
+Hill,0027,Referenda Item #4,22,DEM,For,34,0,2,2,26,4
+Hill,0027,Referenda Item #4,22,DEM,Against,3,1,1,0,1,0
+Hill,0027,Referenda Item #4,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0027,Referenda Item #4,22,DEM,Under Votes,4,0,0,0,3,1
+Hill,0027,Referenda Item #5,22,DEM,For,28,0,2,1,21,4
+Hill,0027,Referenda Item #5,22,DEM,Against,11,1,1,1,7,1
+Hill,0027,Referenda Item #5,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0027,Referenda Item #5,22,DEM,Under Votes,2,0,0,0,2,0
+Hill,0027,Referenda Item #6,22,DEM,For,30,0,2,2,21,5
+Hill,0027,Referenda Item #6,22,DEM,Against,8,1,1,0,6,0
+Hill,0027,Referenda Item #6,22,DEM,Over Votes,0,0,0,0,0,0
+Hill,0027,Referenda Item #6,22,DEM,Under Votes,3,0,0,0,3,0


### PR DESCRIPTION
This county was a bit special - it broke out votes by `ABSENTEE`, `EV PAPER`, `EV IVO` (iVotronic), `ED PAPER`, and `ED IVO`.
I've listed them as `absentee`, `early_voting_paper`, `early_voting_dre` (direct recording electronic), `election_day_paper`, and `election_day_dre`, respectively.
If you want to consolidate them, just let me know.

BTW: a number of my PRs today have not matched the SoS's data, but have matched Clarity or the county's data. I have more faith in counties I've converted from ASC flat ascii files.