### PR TITLE
Add precinct-level results for the 2016 primaries in Kleberg County

### DIFF
--- a/2016/20160301__tx__primary__kleberg__precinct.csv
+++ b/2016/20160301__tx__primary__kleberg__precinct.csv
@@ -1,0 +1,1386 @@
+county,precinct,office,district,party,candidate,votes,absentee,election_day,early_voting,absentee,provisional
+Kleberg,0011,Registered Voters - Total,,,,1557,,,,,
+Kleberg,0011,Ballots Cast - Total,,REP,,314,4,201,109,4,0
+Kleberg,0011,Ballots Cast - Total,,DEM,,159,7,100,52,7,0
+Kleberg,0011,President,,DEM,Bernie Sanders,35,0,25,10,0,0
+Kleberg,0011,President,,DEM,Star Locke,0,0,0,0,0,0
+Kleberg,0011,President,,DEM,Martin J. O'Malley,0,0,0,0,0,0
+Kleberg,0011,President,,DEM,Willie L. Wilson,1,0,0,1,0,0
+Kleberg,0011,President,,DEM,Calvis L. Hawes,1,0,1,0,0,0
+Kleberg,0011,President,,DEM,Hillary Clinton,113,7,68,38,7,0
+Kleberg,0011,President,,DEM,"Roque ""Rocky"" De La Fuente",2,0,2,0,0,0
+Kleberg,0011,President,,DEM,Keith Judd,1,0,0,1,0,0
+Kleberg,0011,U.S. House,34,DEM,Filemon B. Vela,126,6,82,38,6,0
+Kleberg,0011,Railroad Commissioner,,DEM,Grady Yarbrough,57,3,34,20,3,0
+Kleberg,0011,Railroad Commissioner,,DEM,Cody Garrett,44,0,33,11,0,0
+Kleberg,0011,Railroad Commissioner,,DEM,Lon Burnam,22,1,17,4,1,0
+Kleberg,0011,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,117,6,76,35,6,0
+Kleberg,0011,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,117,6,78,33,6,0
+Kleberg,0011,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,107,6,70,31,6,0
+Kleberg,0011,"Judge, Court of Criminal Appeals, Pl 2",,DEM,"Lawrence ""Larry"" Meyers",106,6,69,31,6,0
+Kleberg,0011,"Judge, Court of Criminal Appeals, Pl 5",,DEM,Betsy Johnson,107,6,71,30,6,0
+Kleberg,0011,"Judge, Court of Criminal Appeals, Pl 6",,DEM,Robert Burns,104,6,68,30,6,0
+Kleberg,0011,State Senator,27,DEM,Eddie Lucio Jr,119,5,79,35,5,0
+Kleberg,0011,State Senator,27,DEM,O. Rodriguez Haro III,19,1,11,7,1,0
+Kleberg,0011,State Representative,43,DEM,Marisa Yvette Garcia-Utley,117,6,78,33,6,0
+Kleberg,0011,"Justice, 13th Court of Appeals Dist, P3",,DEM,Leticia Hinojosa,80,3,54,23,3,0
+Kleberg,0011,"Justice, 13th Court of Appeals Dist, P3",,DEM,Carlos Valdez,66,3,39,24,3,0
+Kleberg,0011,District Attorney,,DEM,Nathan P. Fugate,122,6,80,36,6,0
+Kleberg,0011,County Attorney,,DEM,Kira Talip,118,6,76,36,6,0
+Kleberg,0011,Sheriff,,DEM,Alex Perez,37,0,22,15,0,0
+Kleberg,0011,Sheriff,,DEM,Juan J. Gonzalez,62,4,44,14,4,0
+Kleberg,0011,Sheriff,,DEM,Tim Camarillo,40,3,22,15,3,0
+Kleberg,0011,County Tax Assessor-Collector,,DEM,Melissa T. De La Garza,120,6,77,37,6,0
+Kleberg,0011,"County Commissioner, Precinct No. 1",,DEM,Mario A. Mendietta,116,6,75,35,6,0
+Kleberg,0011,"Constable, Precinct No. 1",,DEM,Bill Hack,44,3,21,20,3,0
+Kleberg,0011,"Constable, Precinct No. 1",,DEM,Albert Rene Cavazos,97,4,68,25,4,0
+Kleberg,0011,County Chairman,,DEM,Kyle Benson,113,6,72,35,6,0
+Kleberg,0011,Referenda Item #1,,DEM,For,114,6,80,28,6,0
+Kleberg,0011,Referenda Item #1,,DEM,Against,20,0,10,10,0,0
+Kleberg,0011,Referenda Item #2,,DEM,For,124,6,87,31,6,0
+Kleberg,0011,Referenda Item #2,,DEM,Against,11,0,6,5,0,0
+Kleberg,0011,Referenda Item #3,,DEM,For,123,7,83,33,7,0
+Kleberg,0011,Referenda Item #3,,DEM,Against,20,0,11,9,0,0
+Kleberg,0011,Referenda Item #4,,DEM,For,122,7,81,34,7,0
+Kleberg,0011,Referenda Item #4,,DEM,Against,10,0,5,5,0,0
+Kleberg,0011,Referenda Item #5,,DEM,For,103,6,67,30,6,0
+Kleberg,0011,Referenda Item #5,,DEM,Against,40,1,27,12,1,0
+Kleberg,0011,Referenda Item #6,,DEM,For,112,7,73,32,7,0
+Kleberg,0011,Referenda Item #6,,DEM,Against,28,0,18,10,0,0
+Kleberg,0012,Registered Voters - Total,,,,1261,,,,,
+Kleberg,0012,Ballots Cast - Total,,REP,,218,3,148,67,3,0
+Kleberg,0012,Ballots Cast - Total,,DEM,,160,16,99,45,16,0
+Kleberg,0012,President,,DEM,Bernie Sanders,48,2,33,13,2,0
+Kleberg,0012,President,,DEM,Star Locke,1,1,0,0,1,0
+Kleberg,0012,President,,DEM,Martin J. O'Malley,1,0,1,0,0,0
+Kleberg,0012,President,,DEM,Willie L. Wilson,1,0,1,0,0,0
+Kleberg,0012,President,,DEM,Calvis L. Hawes,0,0,0,0,0,0
+Kleberg,0012,President,,DEM,Hillary Clinton,103,13,61,29,13,0
+Kleberg,0012,President,,DEM,"Roque ""Rocky"" De La Fuente",4,0,2,2,0,0
+Kleberg,0012,President,,DEM,Keith Judd,0,0,0,0,0,0
+Kleberg,0012,U.S. House,34,DEM,Filemon B. Vela,113,11,70,32,11,0
+Kleberg,0012,Railroad Commissioner,,DEM,Grady Yarbrough,67,9,42,16,9,0
+Kleberg,0012,Railroad Commissioner,,DEM,Cody Garrett,50,2,30,18,2,0
+Kleberg,0012,Railroad Commissioner,,DEM,Lon Burnam,12,3,3,6,3,0
+Kleberg,0012,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,109,13,61,35,13,0
+Kleberg,0012,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,120,13,72,35,13,0
+Kleberg,0012,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,107,13,60,34,13,0
+Kleberg,0012,"Judge, Court of Criminal Appeals, Pl 2",,DEM,"Lawrence ""Larry"" Meyers",101,12,54,35,12,0
+Kleberg,0012,"Judge, Court of Criminal Appeals, Pl 5",,DEM,Betsy Johnson,104,12,58,34,12,0
+Kleberg,0012,"Judge, Court of Criminal Appeals, Pl 6",,DEM,Robert Burns,99,11,54,34,11,0
+Kleberg,0012,State Senator,27,DEM,Eddie Lucio Jr,119,13,68,38,13,0
+Kleberg,0012,State Senator,27,DEM,O. Rodriguez Haro III,21,2,13,6,2,0
+Kleberg,0012,State Representative,43,DEM,Marisa Yvette Garcia-Utley,108,13,61,34,13,0
+Kleberg,0012,"Justice, 13th Court of Appeals Dist, P3",,DEM,Leticia Hinojosa,81,7,49,25,7,0
+Kleberg,0012,"Justice, 13th Court of Appeals Dist, P3",,DEM,Carlos Valdez,66,8,39,19,8,0
+Kleberg,0012,District Attorney,,DEM,Nathan P. Fugate,119,11,74,34,11,0
+Kleberg,0012,County Attorney,,DEM,Kira Talip,115,12,65,38,12,0
+Kleberg,0012,Sheriff,,DEM,Alex Perez,40,5,25,10,5,0
+Kleberg,0012,Sheriff,,DEM,Juan J. Gonzalez,60,5,39,16,5,0
+Kleberg,0012,Sheriff,,DEM,Tim Camarillo,43,4,25,14,4,0
+Kleberg,0012,County Tax Assessor-Collector,,DEM,Melissa T. De La Garza,126,13,78,35,13,0
+Kleberg,0012,"County Commissioner, Precinct No. 1",,DEM,Mario A. Mendietta,117,14,70,33,14,0
+Kleberg,0012,"Constable, Precinct No. 1",,DEM,Bill Hack,40,3,19,18,3,0
+Kleberg,0012,"Constable, Precinct No. 1",,DEM,Albert Rene Cavazos,103,13,65,25,13,0
+Kleberg,0012,County Chairman,,DEM,Kyle Benson,102,12,57,33,12,0
+Kleberg,0012,Referenda Item #1,,DEM,For,114,14,64,36,14,0
+Kleberg,0012,Referenda Item #1,,DEM,Against,21,2,13,6,2,0
+Kleberg,0012,Referenda Item #2,,DEM,For,120,12,73,35,12,0
+Kleberg,0012,Referenda Item #2,,DEM,Against,11,2,4,5,2,0
+Kleberg,0012,Referenda Item #3,,DEM,For,115,13,70,32,13,0
+Kleberg,0012,Referenda Item #3,,DEM,Against,19,3,8,8,3,0
+Kleberg,0012,Referenda Item #4,,DEM,For,121,12,77,32,12,0
+Kleberg,0012,Referenda Item #4,,DEM,Against,15,3,4,8,3,0
+Kleberg,0012,Referenda Item #5,,DEM,For,106,12,61,33,12,0
+Kleberg,0012,Referenda Item #5,,DEM,Against,34,3,23,8,3,0
+Kleberg,0012,Referenda Item #6,,DEM,For,125,14,74,37,14,0
+Kleberg,0012,Referenda Item #6,,DEM,Against,16,1,10,5,1,0
+Kleberg,0013/0014,Registered Voters - Total,,,,1824,,,,,
+Kleberg,0013/0014,Ballots Cast - Total,,REP,,197,1,124,71,1,1
+Kleberg,0013/0014,Ballots Cast - Total,,DEM,,326,27,209,90,27,0
+Kleberg,0013/0014,President,,DEM,Bernie Sanders,75,0,49,26,0,0
+Kleberg,0013/0014,President,,DEM,Star Locke,1,0,1,0,0,0
+Kleberg,0013/0014,President,,DEM,Martin J. O'Malley,1,0,1,0,0,0
+Kleberg,0013/0014,President,,DEM,Willie L. Wilson,0,0,0,0,0,0
+Kleberg,0013/0014,President,,DEM,Calvis L. Hawes,2,0,2,0,0,0
+Kleberg,0013/0014,President,,DEM,Hillary Clinton,234,26,146,62,26,0
+Kleberg,0013/0014,President,,DEM,"Roque ""Rocky"" De La Fuente",3,0,3,0,0,0
+Kleberg,0013/0014,President,,DEM,Keith Judd,0,0,0,0,0,0
+Kleberg,0013/0014,U.S. House,34,DEM,Filemon B. Vela,251,20,152,79,20,0
+Kleberg,0013/0014,Railroad Commissioner,,DEM,Grady Yarbrough,134,12,85,37,12,0
+Kleberg,0013/0014,Railroad Commissioner,,DEM,Cody Garrett,103,7,63,33,7,0
+Kleberg,0013/0014,Railroad Commissioner,,DEM,Lon Burnam,21,2,11,8,2,0
+Kleberg,0013/0014,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,223,20,135,68,20,0
+Kleberg,0013/0014,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,241,19,146,76,19,0
+Kleberg,0013/0014,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,217,18,132,67,18,0
+Kleberg,0013/0014,"Judge, Court of Criminal Appeals, Pl 2",,DEM,"Lawrence ""Larry"" Meyers",208,18,126,64,18,0
+Kleberg,0013/0014,"Judge, Court of Criminal Appeals, Pl 5",,DEM,Betsy Johnson,212,17,129,66,17,0
+Kleberg,0013/0014,"Judge, Court of Criminal Appeals, Pl 6",,DEM,Robert Burns,207,17,125,65,17,0
+Kleberg,0013/0014,State Senator,27,DEM,Eddie Lucio Jr,249,24,160,65,24,0
+Kleberg,0013/0014,State Senator,27,DEM,O. Rodriguez Haro III,49,3,27,19,3,0
+Kleberg,0013/0014,State Representative,43,DEM,Marisa Yvette Garcia-Utley,223,18,139,66,18,0
+Kleberg,0013/0014,"Justice, 13th Court of Appeals Dist, P3",,DEM,Leticia Hinojosa,148,13,88,47,13,0
+Kleberg,0013/0014,"Justice, 13th Court of Appeals Dist, P3",,DEM,Carlos Valdez,154,14,100,40,14,0
+Kleberg,0013/0014,District Attorney,,DEM,Nathan P. Fugate,247,22,151,74,22,0
+Kleberg,0013/0014,County Attorney,,DEM,Kira Talip,240,21,148,71,21,0
+Kleberg,0013/0014,Sheriff,,DEM,Alex Perez,60,1,37,22,1,0
+Kleberg,0013/0014,Sheriff,,DEM,Juan J. Gonzalez,141,15,92,34,15,0
+Kleberg,0013/0014,Sheriff,,DEM,Tim Camarillo,92,10,52,30,10,0
+Kleberg,0013/0014,County Tax Assessor-Collector,,DEM,Melissa T. De La Garza,256,23,158,75,23,0
+Kleberg,0013/0014,"County Commissioner, Precinct No. 1",,DEM,Mario A. Mendietta,231,18,142,71,18,0
+Kleberg,0013/0014,"Constable, Precinct No. 1",,DEM,Bill Hack,64,4,43,17,4,0
+Kleberg,0013/0014,"Constable, Precinct No. 1",,DEM,Albert Rene Cavazos,220,19,136,65,19,0
+Kleberg,0013/0014,County Chairman,,DEM,Kyle Benson,214,18,129,67,18,0
+Kleberg,0013/0014,Referenda Item #1,,DEM,For,255,24,163,68,24,0
+Kleberg,0013/0014,Referenda Item #1,,DEM,Against,20,0,14,6,0,0
+Kleberg,0013/0014,Referenda Item #2,,DEM,For,260,22,165,73,22,0
+Kleberg,0013/0014,Referenda Item #2,,DEM,Against,11,1,8,2,1,0
+Kleberg,0013/0014,Referenda Item #3,,DEM,For,253,22,163,68,22,0
+Kleberg,0013/0014,Referenda Item #3,,DEM,Against,28,2,19,7,2,0
+Kleberg,0013/0014,Referenda Item #4,,DEM,For,274,27,175,72,27,0
+Kleberg,0013/0014,Referenda Item #4,,DEM,Against,13,0,9,4,0,0
+Kleberg,0013/0014,Referenda Item #5,,DEM,For,217,20,140,57,20,0
+Kleberg,0013/0014,Referenda Item #5,,DEM,Against,72,5,48,19,5,0
+Kleberg,0013/0014,Referenda Item #6,,DEM,For,259,21,165,73,21,0
+Kleberg,0013/0014,Referenda Item #6,,DEM,Against,31,2,25,4,2,0
+Kleberg,0021,Registered Voters - Total,,,,453,,,,,
+Kleberg,0021,Ballots Cast - Total,,REP,,14,0,5,9,0,0
+Kleberg,0021,Ballots Cast - Total,,DEM,,79,11,48,20,11,0
+Kleberg,0021,President,,DEM,Bernie Sanders,15,0,11,4,0,0
+Kleberg,0021,President,,DEM,Star Locke,0,0,0,0,0,0
+Kleberg,0021,President,,DEM,Martin J. O'Malley,0,0,0,0,0,0
+Kleberg,0021,President,,DEM,Willie L. Wilson,0,0,0,0,0,0
+Kleberg,0021,President,,DEM,Calvis L. Hawes,0,0,0,0,0,0
+Kleberg,0021,President,,DEM,Hillary Clinton,58,11,34,13,11,0
+Kleberg,0021,President,,DEM,"Roque ""Rocky"" De La Fuente",2,0,1,1,0,0
+Kleberg,0021,President,,DEM,Keith Judd,0,0,0,0,0,0
+Kleberg,0021,U.S. House,34,DEM,Filemon B. Vela,54,11,28,15,11,0
+Kleberg,0021,Railroad Commissioner,,DEM,Grady Yarbrough,40,6,23,11,6,0
+Kleberg,0021,Railroad Commissioner,,DEM,Cody Garrett,16,3,8,5,3,0
+Kleberg,0021,Railroad Commissioner,,DEM,Lon Burnam,3,0,3,0,0,0
+Kleberg,0021,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,47,9,25,13,9,0
+Kleberg,0021,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,57,11,30,16,11,0
+Kleberg,0021,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,50,10,27,13,10,0
+Kleberg,0021,"Judge, Court of Criminal Appeals, Pl 2",,DEM,"Lawrence ""Larry"" Meyers",48,10,25,13,10,0
+Kleberg,0021,"Judge, Court of Criminal Appeals, Pl 5",,DEM,Betsy Johnson,49,10,27,12,10,0
+Kleberg,0021,"Judge, Court of Criminal Appeals, Pl 6",,DEM,Robert Burns,51,10,28,13,10,0
+Kleberg,0021,State Senator,27,DEM,Eddie Lucio Jr,57,11,31,15,11,0
+Kleberg,0021,State Senator,27,DEM,O. Rodriguez Haro III,11,0,8,3,0,0
+Kleberg,0021,State Representative,43,DEM,Marisa Yvette Garcia-Utley,48,11,26,11,11,0
+Kleberg,0021,"Justice, 13th Court of Appeals Dist, P3",,DEM,Leticia Hinojosa,38,9,19,10,9,0
+Kleberg,0021,"Justice, 13th Court of Appeals Dist, P3",,DEM,Carlos Valdez,30,2,20,8,2,0
+Kleberg,0021,District Attorney,,DEM,Nathan P. Fugate,55,11,29,15,11,0
+Kleberg,0021,County Attorney,,DEM,Kira Talip,52,11,26,15,11,0
+Kleberg,0021,Sheriff,,DEM,Alex Perez,26,2,12,12,2,0
+Kleberg,0021,Sheriff,,DEM,Juan J. Gonzalez,35,8,20,7,8,0
+Kleberg,0021,Sheriff,,DEM,Tim Camarillo,12,1,10,1,1,0
+Kleberg,0021,County Tax Assessor-Collector,,DEM,Melissa T. De La Garza,60,11,34,15,11,0
+Kleberg,0021,"Constable, Precinct No. 2",,DEM,Pattie Garcia,26,5,16,5,5,0
+Kleberg,0021,"Constable, Precinct No. 2",,DEM,Omar Rosales,43,6,24,13,6,0
+Kleberg,0021,County Chairman,,DEM,Kyle Benson,47,11,25,11,11,0
+Kleberg,0021,Referenda Item #1,,DEM,For,53,9,31,13,9,0
+Kleberg,0021,Referenda Item #1,,DEM,Against,4,0,3,1,0,0
+Kleberg,0021,Referenda Item #2,,DEM,For,52,8,30,14,8,0
+Kleberg,0021,Referenda Item #2,,DEM,Against,5,1,4,0,1,0
+Kleberg,0021,Referenda Item #3,,DEM,For,53,8,31,14,8,0
+Kleberg,0021,Referenda Item #3,,DEM,Against,8,1,6,1,1,0
+Kleberg,0021,Referenda Item #4,,DEM,For,53,9,29,15,9,0
+Kleberg,0021,Referenda Item #4,,DEM,Against,6,0,6,0,0,0
+Kleberg,0021,Referenda Item #5,,DEM,For,46,7,28,11,7,0
+Kleberg,0021,Referenda Item #5,,DEM,Against,18,2,10,6,2,0
+Kleberg,0021,Referenda Item #6,,DEM,For,52,8,31,13,8,0
+Kleberg,0021,Referenda Item #6,,DEM,Against,10,1,6,3,1,0
+Kleberg,0022/0023,Registered Voters - Total,,,,2004,,,,,
+Kleberg,0022/0023,Ballots Cast - Total,,REP,,208,0,145,63,0,0
+Kleberg,0022/0023,Ballots Cast - Total,,DEM,,324,22,202,100,22,0
+Kleberg,0022/0023,President,,DEM,Bernie Sanders,100,3,63,34,3,0
+Kleberg,0022/0023,President,,DEM,Star Locke,0,0,0,0,0,0
+Kleberg,0022/0023,President,,DEM,Martin J. O'Malley,3,0,1,2,0,0
+Kleberg,0022/0023,President,,DEM,Willie L. Wilson,1,0,1,0,0,0
+Kleberg,0022/0023,President,,DEM,Calvis L. Hawes,0,0,0,0,0,0
+Kleberg,0022/0023,President,,DEM,Hillary Clinton,202,18,129,55,18,0
+Kleberg,0022/0023,President,,DEM,"Roque ""Rocky"" De La Fuente",7,0,3,4,0,0
+Kleberg,0022/0023,President,,DEM,Keith Judd,1,0,1,0,0,0
+Kleberg,0022/0023,U.S. House,34,DEM,Filemon B. Vela,251,19,149,83,19,0
+Kleberg,0022/0023,Railroad Commissioner,,DEM,Grady Yarbrough,145,8,90,47,8,0
+Kleberg,0022/0023,Railroad Commissioner,,DEM,Cody Garrett,84,2,55,27,2,0
+Kleberg,0022/0023,Railroad Commissioner,,DEM,Lon Burnam,28,2,16,10,2,0
+Kleberg,0022/0023,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,234,16,140,78,16,0
+Kleberg,0022/0023,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,252,18,151,83,18,0
+Kleberg,0022/0023,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,227,16,136,75,16,0
+Kleberg,0022/0023,"Judge, Court of Criminal Appeals, Pl 2",,DEM,"Lawrence ""Larry"" Meyers",227,16,135,76,16,0
+Kleberg,0022/0023,"Judge, Court of Criminal Appeals, Pl 5",,DEM,Betsy Johnson,227,16,136,75,16,0
+Kleberg,0022/0023,"Judge, Court of Criminal Appeals, Pl 6",,DEM,Robert Burns,229,16,136,77,16,0
+Kleberg,0022/0023,State Senator,27,DEM,Eddie Lucio Jr,233,19,136,78,19,0
+Kleberg,0022/0023,State Senator,27,DEM,O. Rodriguez Haro III,49,1,32,16,1,0
+Kleberg,0022/0023,State Representative,43,DEM,Marisa Yvette Garcia-Utley,237,16,141,80,16,0
+Kleberg,0022/0023,"Justice, 13th Court of Appeals Dist, P3",,DEM,Leticia Hinojosa,167,13,97,57,13,0
+Kleberg,0022/0023,"Justice, 13th Court of Appeals Dist, P3",,DEM,Carlos Valdez,120,7,79,34,7,0
+Kleberg,0022/0023,District Attorney,,DEM,Nathan P. Fugate,245,16,151,78,16,0
+Kleberg,0022/0023,County Attorney,,DEM,Kira Talip,238,16,143,79,16,0
+Kleberg,0022/0023,Sheriff,,DEM,Alex Perez,73,2,43,28,2,0
+Kleberg,0022/0023,Sheriff,,DEM,Juan J. Gonzalez,143,11,90,42,11,0
+Kleberg,0022/0023,Sheriff,,DEM,Tim Camarillo,65,5,42,18,5,0
+Kleberg,0022/0023,County Tax Assessor-Collector,,DEM,Melissa T. De La Garza,251,18,151,82,18,0
+Kleberg,0022/0023,"Constable, Precinct No. 2",,DEM,Pattie Garcia,113,9,67,37,9,0
+Kleberg,0022/0023,"Constable, Precinct No. 2",,DEM,Omar Rosales,181,10,114,57,10,0
+Kleberg,0022/0023,County Chairman,,DEM,Kyle Benson,234,18,137,79,18,0
+Kleberg,0022/0023,Referenda Item #1,,DEM,For,247,18,156,73,18,0
+Kleberg,0022/0023,Referenda Item #1,,DEM,Against,29,0,15,14,0,0
+Kleberg,0022/0023,Referenda Item #2,,DEM,For,247,17,145,85,17,0
+Kleberg,0022/0023,Referenda Item #2,,DEM,Against,22,1,18,3,1,0
+Kleberg,0022/0023,Referenda Item #3,,DEM,For,240,15,154,71,15,0
+Kleberg,0022/0023,Referenda Item #3,,DEM,Against,41,3,21,17,3,0
+Kleberg,0022/0023,Referenda Item #4,,DEM,For,241,18,147,76,18,0
+Kleberg,0022/0023,Referenda Item #4,,DEM,Against,27,0,18,9,0,0
+Kleberg,0022/0023,Referenda Item #5,,DEM,For,204,14,125,65,14,0
+Kleberg,0022/0023,Referenda Item #5,,DEM,Against,80,4,50,26,4,0
+Kleberg,0022/0023,Referenda Item #6,,DEM,For,252,19,154,79,19,0
+Kleberg,0022/0023,Referenda Item #6,,DEM,Against,30,0,20,10,0,0
+Kleberg,0024,Registered Voters - Total,,,,1231,,,,,
+Kleberg,0024,Ballots Cast - Total,,REP,,163,7,98,58,7,0
+Kleberg,0024,Ballots Cast - Total,,DEM,,172,10,107,55,10,0
+Kleberg,0024,President,,DEM,Bernie Sanders,66,3,48,15,3,0
+Kleberg,0024,President,,DEM,Star Locke,0,0,0,0,0,0
+Kleberg,0024,President,,DEM,Martin J. O'Malley,2,0,0,2,0,0
+Kleberg,0024,President,,DEM,Willie L. Wilson,0,0,0,0,0,0
+Kleberg,0024,President,,DEM,Calvis L. Hawes,0,0,0,0,0,0
+Kleberg,0024,President,,DEM,Hillary Clinton,95,7,54,34,7,0
+Kleberg,0024,President,,DEM,"Roque ""Rocky"" De La Fuente",3,0,0,3,0,0
+Kleberg,0024,President,,DEM,Keith Judd,0,0,0,0,0,0
+Kleberg,0024,U.S. House,34,DEM,Filemon B. Vela,141,9,87,45,9,0
+Kleberg,0024,Railroad Commissioner,,DEM,Grady Yarbrough,73,7,44,22,7,0
+Kleberg,0024,Railroad Commissioner,,DEM,Cody Garrett,55,2,37,16,2,0
+Kleberg,0024,Railroad Commissioner,,DEM,Lon Burnam,15,0,6,9,0,0
+Kleberg,0024,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,135,8,84,43,8,0
+Kleberg,0024,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,138,8,85,45,8,0
+Kleberg,0024,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,133,8,81,44,8,0
+Kleberg,0024,"Judge, Court of Criminal Appeals, Pl 2",,DEM,"Lawrence ""Larry"" Meyers",133,8,82,43,8,0
+Kleberg,0024,"Judge, Court of Criminal Appeals, Pl 5",,DEM,Betsy Johnson,133,8,81,44,8,0
+Kleberg,0024,"Judge, Court of Criminal Appeals, Pl 6",,DEM,Robert Burns,131,8,81,42,8,0
+Kleberg,0024,State Senator,27,DEM,Eddie Lucio Jr,134,9,77,48,9,0
+Kleberg,0024,State Senator,27,DEM,O. Rodriguez Haro III,24,1,19,4,1,0
+Kleberg,0024,State Representative,43,DEM,Marisa Yvette Garcia-Utley,135,9,82,44,9,0
+Kleberg,0024,"Justice, 13th Court of Appeals Dist, P3",,DEM,Leticia Hinojosa,92,5,59,28,5,0
+Kleberg,0024,"Justice, 13th Court of Appeals Dist, P3",,DEM,Carlos Valdez,65,5,36,24,5,0
+Kleberg,0024,District Attorney,,DEM,Nathan P. Fugate,135,9,81,45,9,0
+Kleberg,0024,County Attorney,,DEM,Kira Talip,141,8,86,47,8,0
+Kleberg,0024,Sheriff,,DEM,Alex Perez,38,7,19,12,7,0
+Kleberg,0024,Sheriff,,DEM,Juan J. Gonzalez,80,1,54,25,1,0
+Kleberg,0024,Sheriff,,DEM,Tim Camarillo,35,2,19,14,2,0
+Kleberg,0024,County Tax Assessor-Collector,,DEM,Melissa T. De La Garza,143,9,89,45,9,0
+Kleberg,0024,"Constable, Precinct No. 2",,DEM,Pattie Garcia,69,2,38,29,2,0
+Kleberg,0024,"Constable, Precinct No. 2",,DEM,Omar Rosales,92,8,61,23,8,0
+Kleberg,0024,County Chairman,,DEM,Kyle Benson,136,9,83,44,9,0
+Kleberg,0024,Referenda Item #1,,DEM,For,130,9,79,42,9,0
+Kleberg,0024,Referenda Item #1,,DEM,Against,17,0,12,5,0,0
+Kleberg,0024,Referenda Item #2,,DEM,For,139,9,85,45,9,0
+Kleberg,0024,Referenda Item #2,,DEM,Against,10,0,6,4,0,0
+Kleberg,0024,Referenda Item #3,,DEM,For,133,8,81,44,8,0
+Kleberg,0024,Referenda Item #3,,DEM,Against,16,1,11,4,1,0
+Kleberg,0024,Referenda Item #4,,DEM,For,133,8,82,43,8,0
+Kleberg,0024,Referenda Item #4,,DEM,Against,13,1,8,4,1,0
+Kleberg,0024,Referenda Item #5,,DEM,For,112,6,68,38,6,0
+Kleberg,0024,Referenda Item #5,,DEM,Against,34,3,21,10,3,0
+Kleberg,0024,Referenda Item #6,,DEM,For,134,9,84,41,9,0
+Kleberg,0024,Referenda Item #6,,DEM,Against,14,0,7,7,0,0
+Kleberg,0031,Registered Voters - Total,,,,1278,,,,,
+Kleberg,0031,Ballots Cast - Total,,REP,,253,4,158,91,4,0
+Kleberg,0031,Ballots Cast - Total,,DEM,,162,16,102,44,16,0
+Kleberg,0031,President,,DEM,Bernie Sanders,37,3,24,10,3,0
+Kleberg,0031,President,,DEM,Star Locke,2,2,0,0,2,0
+Kleberg,0031,President,,DEM,Martin J. O'Malley,2,0,0,2,0,0
+Kleberg,0031,President,,DEM,Willie L. Wilson,0,0,0,0,0,0
+Kleberg,0031,President,,DEM,Calvis L. Hawes,1,0,0,1,0,0
+Kleberg,0031,President,,DEM,Hillary Clinton,110,9,71,30,9,0
+Kleberg,0031,President,,DEM,"Roque ""Rocky"" De La Fuente",3,2,1,0,2,0
+Kleberg,0031,President,,DEM,Keith Judd,3,0,2,1,0,0
+Kleberg,0031,U.S. House,34,DEM,Filemon B. Vela,121,15,74,32,15,0
+Kleberg,0031,Railroad Commissioner,,DEM,Grady Yarbrough,59,7,37,15,7,0
+Kleberg,0031,Railroad Commissioner,,DEM,Cody Garrett,45,8,25,12,8,0
+Kleberg,0031,Railroad Commissioner,,DEM,Lon Burnam,13,0,7,6,0,0
+Kleberg,0031,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,116,15,71,30,15,0
+Kleberg,0031,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,118,15,73,30,15,0
+Kleberg,0031,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,105,14,65,26,14,0
+Kleberg,0031,"Judge, Court of Criminal Appeals, Pl 2",,DEM,"Lawrence ""Larry"" Meyers",106,14,65,27,14,0
+Kleberg,0031,"Judge, Court of Criminal Appeals, Pl 5",,DEM,Betsy Johnson,103,14,64,25,14,0
+Kleberg,0031,"Judge, Court of Criminal Appeals, Pl 6",,DEM,Robert Burns,104,14,64,26,14,0
+Kleberg,0031,State Senator,27,DEM,Eddie Lucio Jr,122,16,69,37,16,0
+Kleberg,0031,State Senator,27,DEM,O. Rodriguez Haro III,19,0,16,3,0,0
+Kleberg,0031,State Representative,43,DEM,Marisa Yvette Garcia-Utley,109,13,68,28,13,0
+Kleberg,0031,"Justice, 13th Court of Appeals Dist, P3",,DEM,Leticia Hinojosa,50,8,28,14,8,0
+Kleberg,0031,"Justice, 13th Court of Appeals Dist, P3",,DEM,Carlos Valdez,87,8,54,25,8,0
+Kleberg,0031,District Attorney,,DEM,Nathan P. Fugate,120,12,78,30,12,0
+Kleberg,0031,County Attorney,,DEM,Kira Talip,120,15,73,32,15,0
+Kleberg,0031,Sheriff,,DEM,Alex Perez,30,3,20,7,3,0
+Kleberg,0031,Sheriff,,DEM,Juan J. Gonzalez,67,7,38,22,7,0
+Kleberg,0031,Sheriff,,DEM,Tim Camarillo,36,4,20,12,4,0
+Kleberg,0031,County Tax Assessor-Collector,,DEM,Melissa T. De La Garza,120,16,72,32,16,0
+Kleberg,0031,"County Commissioner, Precinct No. 3",,DEM,Roy Cantu,83,9,46,28,9,0
+Kleberg,0031,"County Commissioner, Precinct No. 3",,DEM,Jesse Mendez Jr,56,6,38,12,6,0
+Kleberg,0031,"Constable, Precinct No. 3",,DEM,Valarie Enzenbacher,45,4,24,17,4,0
+Kleberg,0031,"Constable, Precinct No. 3",,DEM,Grace Moya Garcia,95,12,60,23,12,0
+Kleberg,0031,County Chairman,,DEM,Kyle Benson,108,15,65,28,15,0
+Kleberg,0031,Referenda Item #1,,DEM,For,113,10,78,25,10,0
+Kleberg,0031,Referenda Item #1,,DEM,Against,26,3,8,15,3,0
+Kleberg,0031,Referenda Item #2,,DEM,For,127,13,79,35,13,0
+Kleberg,0031,Referenda Item #2,,DEM,Against,9,1,3,5,1,0
+Kleberg,0031,Referenda Item #3,,DEM,For,121,15,78,28,15,0
+Kleberg,0031,Referenda Item #3,,DEM,Against,20,0,8,12,0,0
+Kleberg,0031,Referenda Item #4,,DEM,For,130,14,82,34,14,0
+Kleberg,0031,Referenda Item #4,,DEM,Against,9,0,4,5,0,0
+Kleberg,0031,Referenda Item #5,,DEM,For,103,8,67,28,8,0
+Kleberg,0031,Referenda Item #5,,DEM,Against,41,6,22,13,6,0
+Kleberg,0031,Referenda Item #6,,DEM,For,129,11,85,33,11,0
+Kleberg,0031,Referenda Item #6,,DEM,Against,19,3,7,9,3,0
+Kleberg,0032,Registered Voters - Total,,,,1066,,,,,
+Kleberg,0032,Ballots Cast - Total,,REP,,149,2,86,61,2,0
+Kleberg,0032,Ballots Cast - Total,,DEM,,127,5,86,36,5,0
+Kleberg,0032,President,,DEM,Bernie Sanders,30,2,13,15,2,0
+Kleberg,0032,President,,DEM,Star Locke,1,0,0,1,0,0
+Kleberg,0032,President,,DEM,Martin J. O'Malley,0,0,0,0,0,0
+Kleberg,0032,President,,DEM,Willie L. Wilson,0,0,0,0,0,0
+Kleberg,0032,President,,DEM,Calvis L. Hawes,0,0,0,0,0,0
+Kleberg,0032,President,,DEM,Hillary Clinton,90,3,70,17,3,0
+Kleberg,0032,President,,DEM,"Roque ""Rocky"" De La Fuente",2,0,0,2,0,0
+Kleberg,0032,President,,DEM,Keith Judd,1,0,0,1,0,0
+Kleberg,0032,U.S. House,34,DEM,Filemon B. Vela,98,4,64,30,4,0
+Kleberg,0032,Railroad Commissioner,,DEM,Grady Yarbrough,57,1,41,15,1,0
+Kleberg,0032,Railroad Commissioner,,DEM,Cody Garrett,35,2,23,10,2,0
+Kleberg,0032,Railroad Commissioner,,DEM,Lon Burnam,13,1,6,6,1,0
+Kleberg,0032,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,95,3,64,28,3,0
+Kleberg,0032,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,97,3,66,28,3,0
+Kleberg,0032,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,91,3,64,24,3,0
+Kleberg,0032,"Judge, Court of Criminal Appeals, Pl 2",,DEM,"Lawrence ""Larry"" Meyers",88,3,60,25,3,0
+Kleberg,0032,"Judge, Court of Criminal Appeals, Pl 5",,DEM,Betsy Johnson,88,3,60,25,3,0
+Kleberg,0032,"Judge, Court of Criminal Appeals, Pl 6",,DEM,Robert Burns,89,3,60,26,3,0
+Kleberg,0032,State Senator,27,DEM,Eddie Lucio Jr,100,4,67,29,4,0
+Kleberg,0032,State Senator,27,DEM,O. Rodriguez Haro III,15,0,8,7,0,0
+Kleberg,0032,State Representative,43,DEM,Marisa Yvette Garcia-Utley,93,3,64,26,3,0
+Kleberg,0032,"Justice, 13th Court of Appeals Dist, P3",,DEM,Leticia Hinojosa,71,1,48,22,1,0
+Kleberg,0032,"Justice, 13th Court of Appeals Dist, P3",,DEM,Carlos Valdez,42,2,28,12,2,0
+Kleberg,0032,District Attorney,,DEM,Nathan P. Fugate,99,3,70,26,3,0
+Kleberg,0032,County Attorney,,DEM,Kira Talip,98,3,68,27,3,0
+Kleberg,0032,Sheriff,,DEM,Alex Perez,30,1,21,8,1,0
+Kleberg,0032,Sheriff,,DEM,Juan J. Gonzalez,62,1,41,20,1,0
+Kleberg,0032,Sheriff,,DEM,Tim Camarillo,23,2,15,6,2,0
+Kleberg,0032,County Tax Assessor-Collector,,DEM,Melissa T. De La Garza,108,4,72,32,4,0
+Kleberg,0032,"County Commissioner, Precinct No. 3",,DEM,Roy Cantu,68,4,42,22,4,0
+Kleberg,0032,"County Commissioner, Precinct No. 3",,DEM,Jesse Mendez Jr,49,0,37,12,0,0
+Kleberg,0032,"Constable, Precinct No. 3",,DEM,Valarie Enzenbacher,30,2,17,11,2,0
+Kleberg,0032,"Constable, Precinct No. 3",,DEM,Grace Moya Garcia,80,2,56,22,2,0
+Kleberg,0032,County Chairman,,DEM,Kyle Benson,90,3,61,26,3,0
+Kleberg,0032,Referenda Item #1,,DEM,For,90,3,62,25,3,0
+Kleberg,0032,Referenda Item #1,,DEM,Against,18,0,10,8,0,0
+Kleberg,0032,Referenda Item #2,,DEM,For,92,2,64,26,2,0
+Kleberg,0032,Referenda Item #2,,DEM,Against,15,1,9,5,1,0
+Kleberg,0032,Referenda Item #3,,DEM,For,90,4,61,25,4,0
+Kleberg,0032,Referenda Item #3,,DEM,Against,21,0,13,8,0,0
+Kleberg,0032,Referenda Item #4,,DEM,For,100,4,70,26,4,0
+Kleberg,0032,Referenda Item #4,,DEM,Against,10,0,3,7,0,0
+Kleberg,0032,Referenda Item #5,,DEM,For,80,3,52,25,3,0
+Kleberg,0032,Referenda Item #5,,DEM,Against,34,1,23,10,1,0
+Kleberg,0032,Referenda Item #6,,DEM,For,101,4,68,29,4,0
+Kleberg,0032,Referenda Item #6,,DEM,Against,13,0,8,5,0,0
+Kleberg,0033/0034,Registered Voters - Total,,,,1179,,,,,
+Kleberg,0033/0034,Ballots Cast - Total,,REP,,252,1,202,49,1,0
+Kleberg,0033/0034,Ballots Cast - Total,,DEM,,223,4,168,51,4,0
+Kleberg,0033/0034,President,,DEM,Bernie Sanders,48,0,36,12,0,0
+Kleberg,0033/0034,President,,DEM,Star Locke,2,0,1,1,0,0
+Kleberg,0033/0034,President,,DEM,Martin J. O'Malley,1,1,0,0,1,0
+Kleberg,0033/0034,President,,DEM,Willie L. Wilson,0,0,0,0,0,0
+Kleberg,0033/0034,President,,DEM,Calvis L. Hawes,0,0,0,0,0,0
+Kleberg,0033/0034,President,,DEM,Hillary Clinton,135,1,103,31,1,0
+Kleberg,0033/0034,President,,DEM,"Roque ""Rocky"" De La Fuente",5,0,3,2,0,0
+Kleberg,0033/0034,President,,DEM,Keith Judd,4,1,2,1,1,0
+Kleberg,0033/0034,U.S. House,34,DEM,Filemon B. Vela,144,3,108,33,3,0
+Kleberg,0033/0034,Railroad Commissioner,,DEM,Grady Yarbrough,89,0,72,17,0,0
+Kleberg,0033/0034,Railroad Commissioner,,DEM,Cody Garrett,43,2,30,11,2,0
+Kleberg,0033/0034,Railroad Commissioner,,DEM,Lon Burnam,18,1,8,9,1,0
+Kleberg,0033/0034,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,135,3,98,34,3,0
+Kleberg,0033/0034,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,141,3,102,36,3,0
+Kleberg,0033/0034,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,132,3,97,32,3,0
+Kleberg,0033/0034,"Judge, Court of Criminal Appeals, Pl 2",,DEM,"Lawrence ""Larry"" Meyers",131,3,96,32,3,0
+Kleberg,0033/0034,"Judge, Court of Criminal Appeals, Pl 5",,DEM,Betsy Johnson,134,3,97,34,3,0
+Kleberg,0033/0034,"Judge, Court of Criminal Appeals, Pl 6",,DEM,Robert Burns,129,3,94,32,3,0
+Kleberg,0033/0034,State Senator,27,DEM,Eddie Lucio Jr,134,2,100,32,2,0
+Kleberg,0033/0034,State Senator,27,DEM,O. Rodriguez Haro III,35,1,26,8,1,0
+Kleberg,0033/0034,State Representative,43,DEM,Marisa Yvette Garcia-Utley,133,3,96,34,3,0
+Kleberg,0033/0034,"Justice, 13th Court of Appeals Dist, P3",,DEM,Leticia Hinojosa,92,1,66,25,1,0
+Kleberg,0033/0034,"Justice, 13th Court of Appeals Dist, P3",,DEM,Carlos Valdez,80,2,61,17,2,0
+Kleberg,0033/0034,District Attorney,,DEM,Nathan P. Fugate,142,3,102,37,3,0
+Kleberg,0033/0034,County Attorney,,DEM,Kira Talip,134,3,100,31,3,0
+Kleberg,0033/0034,Sheriff,,DEM,Alex Perez,50,2,39,9,2,0
+Kleberg,0033/0034,Sheriff,,DEM,Juan J. Gonzalez,77,0,56,21,0,0
+Kleberg,0033/0034,Sheriff,,DEM,Tim Camarillo,43,1,32,10,1,0
+Kleberg,0033/0034,County Tax Assessor-Collector,,DEM,Melissa T. De La Garza,159,3,115,41,3,0
+Kleberg,0033/0034,"County Commissioner, Precinct No. 3",,DEM,Roy Cantu,148,2,115,31,2,0
+Kleberg,0033/0034,"County Commissioner, Precinct No. 3",,DEM,Jesse Mendez Jr,73,2,51,20,2,0
+Kleberg,0033/0034,"Constable, Precinct No. 3",,DEM,Valarie Enzenbacher,82,3,57,22,3,0
+Kleberg,0033/0034,"Constable, Precinct No. 3",,DEM,Grace Moya Garcia,132,1,106,25,1,0
+Kleberg,0033/0034,County Chairman,,DEM,Kyle Benson,136,3,99,34,3,0
+Kleberg,0033/0034,Referenda Item #1,,DEM,For,133,0,96,37,0,0
+Kleberg,0033/0034,Referenda Item #1,,DEM,Against,30,2,23,5,2,0
+Kleberg,0033/0034,Referenda Item #2,,DEM,For,130,0,90,40,0,0
+Kleberg,0033/0034,Referenda Item #2,,DEM,Against,26,2,22,2,2,0
+Kleberg,0033/0034,Referenda Item #3,,DEM,For,120,0,83,37,0,0
+Kleberg,0033/0034,Referenda Item #3,,DEM,Against,44,2,36,6,2,0
+Kleberg,0033/0034,Referenda Item #4,,DEM,For,131,0,95,36,0,0
+Kleberg,0033/0034,Referenda Item #4,,DEM,Against,28,2,22,4,2,0
+Kleberg,0033/0034,Referenda Item #5,,DEM,For,99,0,69,30,0,0
+Kleberg,0033/0034,Referenda Item #5,,DEM,Against,67,2,52,13,2,0
+Kleberg,0033/0034,Referenda Item #6,,DEM,For,120,0,85,35,0,0
+Kleberg,0033/0034,Referenda Item #6,,DEM,Against,47,2,37,8,2,0
+Kleberg,0035,Registered Voters - Total,,,,992,,,,,
+Kleberg,0035,Ballots Cast - Total,,REP,,152,0,118,34,0,0
+Kleberg,0035,Ballots Cast - Total,,DEM,,179,9,130,40,9,0
+Kleberg,0035,President,,DEM,Bernie Sanders,59,3,43,13,3,0
+Kleberg,0035,President,,DEM,Star Locke,0,0,0,0,0,0
+Kleberg,0035,President,,DEM,Martin J. O'Malley,2,0,0,2,0,0
+Kleberg,0035,President,,DEM,Willie L. Wilson,1,0,1,0,0,0
+Kleberg,0035,President,,DEM,Calvis L. Hawes,0,0,0,0,0,0
+Kleberg,0035,President,,DEM,Hillary Clinton,103,6,77,20,6,0
+Kleberg,0035,President,,DEM,"Roque ""Rocky"" De La Fuente",4,0,3,1,0,0
+Kleberg,0035,President,,DEM,Keith Judd,0,0,0,0,0,0
+Kleberg,0035,U.S. House,34,DEM,Filemon B. Vela,132,9,94,29,9,0
+Kleberg,0035,Railroad Commissioner,,DEM,Grady Yarbrough,72,7,48,17,7,0
+Kleberg,0035,Railroad Commissioner,,DEM,Cody Garrett,56,1,45,10,1,0
+Kleberg,0035,Railroad Commissioner,,DEM,Lon Burnam,16,1,11,4,1,0
+Kleberg,0035,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,121,8,86,27,8,0
+Kleberg,0035,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,130,8,93,29,8,0
+Kleberg,0035,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,119,8,87,24,8,0
+Kleberg,0035,"Judge, Court of Criminal Appeals, Pl 2",,DEM,"Lawrence ""Larry"" Meyers",120,9,90,21,9,0
+Kleberg,0035,"Judge, Court of Criminal Appeals, Pl 5",,DEM,Betsy Johnson,119,8,89,22,8,0
+Kleberg,0035,"Judge, Court of Criminal Appeals, Pl 6",,DEM,Robert Burns,118,8,88,22,8,0
+Kleberg,0035,State Senator,27,DEM,Eddie Lucio Jr,122,5,90,27,5,0
+Kleberg,0035,State Senator,27,DEM,O. Rodriguez Haro III,31,4,19,8,4,0
+Kleberg,0035,State Representative,43,DEM,Marisa Yvette Garcia-Utley,130,8,94,28,8,0
+Kleberg,0035,"Justice, 13th Court of Appeals Dist, P3",,DEM,Leticia Hinojosa,80,4,54,22,4,0
+Kleberg,0035,"Justice, 13th Court of Appeals Dist, P3",,DEM,Carlos Valdez,74,5,57,12,5,0
+Kleberg,0035,District Attorney,,DEM,Nathan P. Fugate,134,8,100,26,8,0
+Kleberg,0035,County Attorney,,DEM,Kira Talip,132,8,95,29,8,0
+Kleberg,0035,Sheriff,,DEM,Alex Perez,35,4,23,8,4,0
+Kleberg,0035,Sheriff,,DEM,Juan J. Gonzalez,86,5,65,16,5,0
+Kleberg,0035,Sheriff,,DEM,Tim Camarillo,33,0,24,9,0,0
+Kleberg,0035,County Tax Assessor-Collector,,DEM,Melissa T. De La Garza,144,8,106,30,8,0
+Kleberg,0035,"County Commissioner, Precinct No. 3",,DEM,Roy Cantu,80,2,54,24,2,0
+Kleberg,0035,"County Commissioner, Precinct No. 3",,DEM,Jesse Mendez Jr,96,7,73,16,7,0
+Kleberg,0035,"Constable, Precinct No. 3",,DEM,Valarie Enzenbacher,39,1,31,7,1,0
+Kleberg,0035,"Constable, Precinct No. 3",,DEM,Grace Moya Garcia,126,8,86,32,8,0
+Kleberg,0035,County Chairman,,DEM,Kyle Benson,124,8,90,26,8,0
+Kleberg,0035,Referenda Item #1,,DEM,For,122,9,86,27,9,0
+Kleberg,0035,Referenda Item #1,,DEM,Against,20,0,13,7,0,0
+Kleberg,0035,Referenda Item #2,,DEM,For,126,8,90,28,8,0
+Kleberg,0035,Referenda Item #2,,DEM,Against,14,1,9,4,1,0
+Kleberg,0035,Referenda Item #3,,DEM,For,118,8,83,27,8,0
+Kleberg,0035,Referenda Item #3,,DEM,Against,23,1,17,5,1,0
+Kleberg,0035,Referenda Item #4,,DEM,For,122,9,84,29,9,0
+Kleberg,0035,Referenda Item #4,,DEM,Against,17,0,15,2,0,0
+Kleberg,0035,Referenda Item #5,,DEM,For,97,7,67,23,7,0
+Kleberg,0035,Referenda Item #5,,DEM,Against,48,2,37,9,2,0
+Kleberg,0035,Referenda Item #6,,DEM,For,129,8,93,28,8,0
+Kleberg,0035,Referenda Item #6,,DEM,Against,17,1,12,4,1,0
+Kleberg,0041/0042,Registered Voters - Total,,,,1430,,,,,
+Kleberg,0041/0042,Ballots Cast - Total,,REP,,59,0,45,14,0,0
+Kleberg,0041/0042,Ballots Cast - Total,,DEM,,204,25,132,47,25,0
+Kleberg,0041/0042,President,,DEM,Bernie Sanders,33,4,24,5,4,0
+Kleberg,0041/0042,President,,DEM,Star Locke,0,0,0,0,0,0
+Kleberg,0041/0042,President,,DEM,Martin J. O'Malley,0,0,0,0,0,0
+Kleberg,0041/0042,President,,DEM,Willie L. Wilson,1,0,1,0,0,0
+Kleberg,0041/0042,President,,DEM,Calvis L. Hawes,0,0,0,0,0,0
+Kleberg,0041/0042,President,,DEM,Hillary Clinton,164,20,103,41,20,0
+Kleberg,0041/0042,President,,DEM,"Roque ""Rocky"" De La Fuente",2,0,1,1,0,0
+Kleberg,0041/0042,President,,DEM,Keith Judd,0,0,0,0,0,0
+Kleberg,0041/0042,U.S. House,34,DEM,Filemon B. Vela,153,19,95,39,19,0
+Kleberg,0041/0042,Railroad Commissioner,,DEM,Grady Yarbrough,90,13,58,19,13,0
+Kleberg,0041/0042,Railroad Commissioner,,DEM,Cody Garrett,51,1,34,16,1,0
+Kleberg,0041/0042,Railroad Commissioner,,DEM,Lon Burnam,16,3,10,3,3,0
+Kleberg,0041/0042,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,142,18,89,35,18,0
+Kleberg,0041/0042,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,153,20,95,38,20,0
+Kleberg,0041/0042,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,133,17,84,32,17,0
+Kleberg,0041/0042,"Judge, Court of Criminal Appeals, Pl 2",,DEM,"Lawrence ""Larry"" Meyers",134,17,85,32,17,0
+Kleberg,0041/0042,"Judge, Court of Criminal Appeals, Pl 5",,DEM,Betsy Johnson,135,17,85,33,17,0
+Kleberg,0041/0042,"Judge, Court of Criminal Appeals, Pl 6",,DEM,Robert Burns,133,17,83,33,17,0
+Kleberg,0041/0042,State Senator,27,DEM,Eddie Lucio Jr,142,16,88,38,16,0
+Kleberg,0041/0042,State Senator,27,DEM,O. Rodriguez Haro III,33,6,23,4,6,0
+Kleberg,0041/0042,State Representative,43,DEM,Marisa Yvette Garcia-Utley,144,20,91,33,20,0
+Kleberg,0041/0042,"Justice, 13th Court of Appeals Dist, P3",,DEM,Leticia Hinojosa,90,6,57,27,6,0
+Kleberg,0041/0042,"Justice, 13th Court of Appeals Dist, P3",,DEM,Carlos Valdez,90,16,60,14,16,0
+Kleberg,0041/0042,District Attorney,,DEM,Nathan P. Fugate,163,23,101,39,23,0
+Kleberg,0041/0042,County Attorney,,DEM,Kira Talip,144,20,89,35,20,0
+Kleberg,0041/0042,Sheriff,,DEM,Alex Perez,38,5,23,10,5,0
+Kleberg,0041/0042,Sheriff,,DEM,Juan J. Gonzalez,81,13,50,18,13,0
+Kleberg,0041/0042,Sheriff,,DEM,Tim Camarillo,68,6,46,16,6,0
+Kleberg,0041/0042,County Tax Assessor-Collector,,DEM,Melissa T. De La Garza,173,19,112,42,19,0
+Kleberg,0041/0042,"Constable, Precinct No. 4",,DEM,Amando O. Vidal,164,19,104,41,19,0
+Kleberg,0041/0042,County Chairman,,DEM,Kyle Benson,141,18,86,37,18,0
+Kleberg,0041/0042,Referenda Item #1,,DEM,For,132,17,89,26,17,0
+Kleberg,0041/0042,Referenda Item #1,,DEM,Against,10,1,6,3,1,0
+Kleberg,0041/0042,Referenda Item #2,,DEM,For,126,16,84,26,16,0
+Kleberg,0041/0042,Referenda Item #2,,DEM,Against,10,1,7,2,1,0
+Kleberg,0041/0042,Referenda Item #3,,DEM,For,124,14,83,27,14,0
+Kleberg,0041/0042,Referenda Item #3,,DEM,Against,17,2,10,5,2,0
+Kleberg,0041/0042,Referenda Item #4,,DEM,For,133,18,84,31,18,0
+Kleberg,0041/0042,Referenda Item #4,,DEM,Against,10,1,7,2,1,0
+Kleberg,0041/0042,Referenda Item #5,,DEM,For,92,11,59,22,11,0
+Kleberg,0041/0042,Referenda Item #5,,DEM,Against,55,6,38,11,6,0
+Kleberg,0041/0042,Referenda Item #6,,DEM,For,140,17,92,31,17,0
+Kleberg,0041/0042,Referenda Item #6,,DEM,Against,10,1,8,1,1,0
+Kleberg,0043,Registered Voters - Total,,,,1473,,,,,
+Kleberg,0043,Ballots Cast - Total,,REP,,162,2,104,56,2,0
+Kleberg,0043,Ballots Cast - Total,,DEM,,212,18,135,59,18,0
+Kleberg,0043,President,,DEM,Bernie Sanders,40,2,27,11,2,0
+Kleberg,0043,President,,DEM,Star Locke,0,0,0,0,0,0
+Kleberg,0043,President,,DEM,Martin J. O'Malley,1,0,0,1,0,0
+Kleberg,0043,President,,DEM,Willie L. Wilson,0,0,0,0,0,0
+Kleberg,0043,President,,DEM,Calvis L. Hawes,0,0,0,0,0,0
+Kleberg,0043,President,,DEM,Hillary Clinton,161,13,106,42,13,0
+Kleberg,0043,President,,DEM,"Roque ""Rocky"" De La Fuente",7,3,0,4,3,0
+Kleberg,0043,President,,DEM,Keith Judd,1,0,1,0,0,0
+Kleberg,0043,U.S. House,34,DEM,Filemon B. Vela,161,15,94,52,15,0
+Kleberg,0043,Railroad Commissioner,,DEM,Grady Yarbrough,94,10,58,26,10,0
+Kleberg,0043,Railroad Commissioner,,DEM,Cody Garrett,60,4,37,19,4,0
+Kleberg,0043,Railroad Commissioner,,DEM,Lon Burnam,20,1,11,8,1,0
+Kleberg,0043,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,145,14,84,47,14,0
+Kleberg,0043,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,166,16,95,55,16,0
+Kleberg,0043,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,139,13,78,48,13,0
+Kleberg,0043,"Judge, Court of Criminal Appeals, Pl 2",,DEM,"Lawrence ""Larry"" Meyers",135,12,77,46,12,0
+Kleberg,0043,"Judge, Court of Criminal Appeals, Pl 5",,DEM,Betsy Johnson,139,13,79,47,13,0
+Kleberg,0043,"Judge, Court of Criminal Appeals, Pl 6",,DEM,Robert Burns,135,13,77,45,13,0
+Kleberg,0043,State Senator,27,DEM,Eddie Lucio Jr,153,13,99,41,13,0
+Kleberg,0043,State Senator,27,DEM,O. Rodriguez Haro III,33,3,17,13,3,0
+Kleberg,0043,State Representative,43,DEM,Marisa Yvette Garcia-Utley,146,13,83,50,13,0
+Kleberg,0043,"Justice, 13th Court of Appeals Dist, P3",,DEM,Leticia Hinojosa,93,8,64,21,8,0
+Kleberg,0043,"Justice, 13th Court of Appeals Dist, P3",,DEM,Carlos Valdez,95,8,56,31,8,0
+Kleberg,0043,District Attorney,,DEM,Nathan P. Fugate,159,15,95,49,15,0
+Kleberg,0043,County Attorney,,DEM,Kira Talip,153,16,88,49,16,0
+Kleberg,0043,Sheriff,,DEM,Alex Perez,59,5,33,21,5,0
+Kleberg,0043,Sheriff,,DEM,Juan J. Gonzalez,92,8,60,24,8,0
+Kleberg,0043,Sheriff,,DEM,Tim Camarillo,40,4,24,12,4,0
+Kleberg,0043,County Tax Assessor-Collector,,DEM,Melissa T. De La Garza,170,18,100,52,18,0
+Kleberg,0043,"Constable, Precinct No. 4",,DEM,Amando O. Vidal,169,17,99,53,17,0
+Kleberg,0043,County Chairman,,DEM,Kyle Benson,143,13,83,47,13,0
+Kleberg,0043,Referenda Item #1,,DEM,For,154,13,98,43,13,0
+Kleberg,0043,Referenda Item #1,,DEM,Against,16,1,11,4,1,0
+Kleberg,0043,Referenda Item #2,,DEM,For,153,14,95,44,14,0
+Kleberg,0043,Referenda Item #2,,DEM,Against,19,2,12,5,2,0
+Kleberg,0043,Referenda Item #3,,DEM,For,151,10,97,44,10,0
+Kleberg,0043,Referenda Item #3,,DEM,Against,21,5,12,4,5,0
+Kleberg,0043,Referenda Item #4,,DEM,For,160,13,105,42,13,0
+Kleberg,0043,Referenda Item #4,,DEM,Against,16,2,7,7,2,0
+Kleberg,0043,Referenda Item #5,,DEM,For,128,10,90,28,10,0
+Kleberg,0043,Referenda Item #5,,DEM,Against,51,6,25,20,6,0
+Kleberg,0043,Referenda Item #6,,DEM,For,160,16,99,45,16,0
+Kleberg,0043,Referenda Item #6,,DEM,Against,20,0,13,7,0,0
+Kleberg,0044,Registered Voters - Total,,,,511,,,,,
+Kleberg,0044,Ballots Cast - Total,,REP,,49,2,29,18,2,0
+Kleberg,0044,Ballots Cast - Total,,DEM,,67,15,39,13,15,0
+Kleberg,0044,President,,DEM,Bernie Sanders,11,2,9,0,2,0
+Kleberg,0044,President,,DEM,Star Locke,0,0,0,0,0,0
+Kleberg,0044,President,,DEM,Martin J. O'Malley,0,0,0,0,0,0
+Kleberg,0044,President,,DEM,Willie L. Wilson,1,0,1,0,0,0
+Kleberg,0044,President,,DEM,Calvis L. Hawes,0,0,0,0,0,0
+Kleberg,0044,President,,DEM,Hillary Clinton,55,13,29,13,13,0
+Kleberg,0044,President,,DEM,"Roque ""Rocky"" De La Fuente",0,0,0,0,0,0
+Kleberg,0044,President,,DEM,Keith Judd,0,0,0,0,0,0
+Kleberg,0044,U.S. House,34,DEM,Filemon B. Vela,51,13,28,10,13,0
+Kleberg,0044,Railroad Commissioner,,DEM,Grady Yarbrough,33,13,12,8,13,0
+Kleberg,0044,Railroad Commissioner,,DEM,Cody Garrett,20,0,17,3,0,0
+Kleberg,0044,Railroad Commissioner,,DEM,Lon Burnam,5,0,5,0,0,0
+Kleberg,0044,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,51,14,28,9,14,0
+Kleberg,0044,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,53,12,30,11,12,0
+Kleberg,0044,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,51,13,28,10,13,0
+Kleberg,0044,"Judge, Court of Criminal Appeals, Pl 2",,DEM,"Lawrence ""Larry"" Meyers",51,13,28,10,13,0
+Kleberg,0044,"Judge, Court of Criminal Appeals, Pl 5",,DEM,Betsy Johnson,50,13,27,10,13,0
+Kleberg,0044,"Judge, Court of Criminal Appeals, Pl 6",,DEM,Robert Burns,51,13,28,10,13,0
+Kleberg,0044,State Senator,27,DEM,Eddie Lucio Jr,51,12,26,13,12,0
+Kleberg,0044,State Senator,27,DEM,O. Rodriguez Haro III,9,1,8,0,1,0
+Kleberg,0044,State Representative,43,DEM,Marisa Yvette Garcia-Utley,51,12,28,11,12,0
+Kleberg,0044,"Justice, 13th Court of Appeals Dist, P3",,DEM,Leticia Hinojosa,36,5,22,9,5,0
+Kleberg,0044,"Justice, 13th Court of Appeals Dist, P3",,DEM,Carlos Valdez,24,9,13,2,9,0
+Kleberg,0044,District Attorney,,DEM,Nathan P. Fugate,53,13,30,10,13,0
+Kleberg,0044,County Attorney,,DEM,Kira Talip,51,12,28,11,12,0
+Kleberg,0044,Sheriff,,DEM,Alex Perez,14,2,8,4,2,0
+Kleberg,0044,Sheriff,,DEM,Juan J. Gonzalez,36,10,21,5,10,0
+Kleberg,0044,Sheriff,,DEM,Tim Camarillo,8,1,5,2,1,0
+Kleberg,0044,County Tax Assessor-Collector,,DEM,Melissa T. De La Garza,58,14,32,12,14,0
+Kleberg,0044,"Constable, Precinct No. 4",,DEM,Amando O. Vidal,52,13,28,11,13,0
+Kleberg,0044,County Chairman,,DEM,Kyle Benson,51,12,28,11,12,0
+Kleberg,0044,Referenda Item #1,,DEM,For,51,11,29,11,11,0
+Kleberg,0044,Referenda Item #1,,DEM,Against,6,1,5,0,1,0
+Kleberg,0044,Referenda Item #2,,DEM,For,53,12,31,10,12,0
+Kleberg,0044,Referenda Item #2,,DEM,Against,5,1,4,0,1,0
+Kleberg,0044,Referenda Item #3,,DEM,For,54,12,31,11,12,0
+Kleberg,0044,Referenda Item #3,,DEM,Against,6,1,4,1,1,0
+Kleberg,0044,Referenda Item #4,,DEM,For,53,12,30,11,12,0
+Kleberg,0044,Referenda Item #4,,DEM,Against,6,2,4,0,2,0
+Kleberg,0044,Referenda Item #5,,DEM,For,34,6,20,8,6,0
+Kleberg,0044,Referenda Item #5,,DEM,Against,24,6,14,4,6,0
+Kleberg,0044,Referenda Item #6,,DEM,For,56,13,31,12,13,0
+Kleberg,0044,Referenda Item #6,,DEM,Against,5,1,4,0,1,0
+Kleberg,0045,Registered Voters - Total,,,,832,,,,,
+Kleberg,0045,Ballots Cast - Total,,REP,,30,1,17,12,1,0
+Kleberg,0045,Ballots Cast - Total,,DEM,,157,21,99,37,21,0
+Kleberg,0045,President,,DEM,Bernie Sanders,33,7,22,4,7,0
+Kleberg,0045,President,,DEM,Star Locke,0,0,0,0,0,0
+Kleberg,0045,President,,DEM,Martin J. O'Malley,0,0,0,0,0,0
+Kleberg,0045,President,,DEM,Willie L. Wilson,0,0,0,0,0,0
+Kleberg,0045,President,,DEM,Calvis L. Hawes,2,0,2,0,0,0
+Kleberg,0045,President,,DEM,Hillary Clinton,117,14,71,32,14,0
+Kleberg,0045,President,,DEM,"Roque ""Rocky"" De La Fuente",2,0,1,1,0,0
+Kleberg,0045,President,,DEM,Keith Judd,1,0,1,0,0,0
+Kleberg,0045,U.S. House,34,DEM,Filemon B. Vela,127,17,81,29,17,0
+Kleberg,0045,Railroad Commissioner,,DEM,Grady Yarbrough,85,16,49,20,16,0
+Kleberg,0045,Railroad Commissioner,,DEM,Cody Garrett,37,1,28,8,1,0
+Kleberg,0045,Railroad Commissioner,,DEM,Lon Burnam,8,0,7,1,0,0
+Kleberg,0045,"Justice, Supreme Court, Place 3",,DEM,Mike Westergren,107,15,66,26,15,0
+Kleberg,0045,"Justice, Supreme Court, Place 5",,DEM,Dori Contreras Garza,123,16,79,28,16,0
+Kleberg,0045,"Justice, Supreme Court, Place 9",,DEM,Savannah Robinson,110,15,70,25,15,0
+Kleberg,0045,"Judge, Court of Criminal Appeals, Pl 2",,DEM,"Lawrence ""Larry"" Meyers",108,14,69,25,14,0
+Kleberg,0045,"Judge, Court of Criminal Appeals, Pl 5",,DEM,Betsy Johnson,107,14,68,25,14,0
+Kleberg,0045,"Judge, Court of Criminal Appeals, Pl 6",,DEM,Robert Burns,110,14,71,25,14,0
+Kleberg,0045,State Senator,27,DEM,Eddie Lucio Jr,114,19,67,28,19,0
+Kleberg,0045,State Senator,27,DEM,O. Rodriguez Haro III,27,1,20,6,1,0
+Kleberg,0045,State Representative,43,DEM,Marisa Yvette Garcia-Utley,119,13,77,29,13,0
+Kleberg,0045,"Justice, 13th Court of Appeals Dist, P3",,DEM,Leticia Hinojosa,68,8,42,18,8,0
+Kleberg,0045,"Justice, 13th Court of Appeals Dist, P3",,DEM,Carlos Valdez,74,12,47,15,12,0
+Kleberg,0045,District Attorney,,DEM,Nathan P. Fugate,122,16,78,28,16,0
+Kleberg,0045,County Attorney,,DEM,Kira Talip,121,15,79,27,15,0
+Kleberg,0045,Sheriff,,DEM,Alex Perez,29,6,17,6,6,0
+Kleberg,0045,Sheriff,,DEM,Juan J. Gonzalez,71,4,50,17,4,0
+Kleberg,0045,Sheriff,,DEM,Tim Camarillo,38,9,21,8,9,0
+Kleberg,0045,County Tax Assessor-Collector,,DEM,Melissa T. De La Garza,132,19,82,31,19,0
+Kleberg,0045,"Constable, Precinct No. 4",,DEM,Amando O. Vidal,132,18,84,30,18,0
+Kleberg,0045,County Chairman,,DEM,Kyle Benson,112,16,71,25,16,0
+Kleberg,0045,Referenda Item #1,,DEM,For,121,19,77,25,19,0
+Kleberg,0045,Referenda Item #1,,DEM,Against,9,0,3,6,0,0
+Kleberg,0045,Referenda Item #2,,DEM,For,121,20,72,29,20,0
+Kleberg,0045,Referenda Item #2,,DEM,Against,5,0,4,1,0,0
+Kleberg,0045,Referenda Item #3,,DEM,For,117,19,74,24,19,0
+Kleberg,0045,Referenda Item #3,,DEM,Against,14,1,7,6,1,0
+Kleberg,0045,Referenda Item #4,,DEM,For,124,20,77,27,20,0
+Kleberg,0045,Referenda Item #4,,DEM,Against,8,0,5,3,0,0
+Kleberg,0045,Referenda Item #5,,DEM,For,98,14,62,22,14,0
+Kleberg,0045,Referenda Item #5,,DEM,Against,35,7,21,7,7,0
+Kleberg,0045,Referenda Item #6,,DEM,For,123,20,76,27,20,0
+Kleberg,0045,Referenda Item #6,,DEM,Against,12,1,7,4,1,0
+county,precinct,office,district,party,candidate,votes,absentee,election_day,early_voting,absentee,provisional
+Kleberg,0011,President,,REP,Donald J. Trump,71,0,36,35,0,0
+Kleberg,0011,President,,REP,Mike Huckabee,1,0,1,0,0,0
+Kleberg,0011,President,,REP,Ted Cruz,135,0,93,42,0,0
+Kleberg,0011,President,,REP,Carly Fiorina,0,0,0,0,0,0
+Kleberg,0011,President,,REP,Rand Paul,0,0,0,0,0,0
+Kleberg,0011,President,,REP,Rick Santorum,0,0,0,0,0,0
+Kleberg,0011,President,,REP,Marco Rubio,66,3,42,21,3,0
+Kleberg,0011,President,,REP,Lindsey Graham,0,0,0,0,0,0
+Kleberg,0011,President,,REP,John R. Kasich,20,1,11,8,1,0
+Kleberg,0011,President,,REP,Jeb Bush,1,0,0,1,0,0
+Kleberg,0011,President,,REP,Elizabeth Gray,0,0,0,0,0,0
+Kleberg,0011,President,,REP,Ben Carson,16,0,14,2,0,0
+Kleberg,0011,President,,REP,Chris Christie,0,0,0,0,0,0
+Kleberg,0011,President,,REP,Uncommitted,2,0,2,0,0,0
+Kleberg,0011,U.S. House,34,REP,"William ""Willie"" Vaden",146,1,90,55,1,0
+Kleberg,0011,U.S. House,34,REP,Ray Gonzalez Jr,122,2,84,36,2,0
+Kleberg,0011,Railroad Commissioner,,REP,John Greytok,36,0,23,13,0,0
+Kleberg,0011,Railroad Commissioner,,REP,Weston Martinez,60,2,41,17,2,0
+Kleberg,0011,Railroad Commissioner,,REP,Lance N. Christian,35,0,22,13,0,0
+Kleberg,0011,Railroad Commissioner,,REP,Ron Hale,41,1,26,14,1,0
+Kleberg,0011,Railroad Commissioner,,REP,Wayne Christian,26,0,17,9,0,0
+Kleberg,0011,Railroad Commissioner,,REP,Doug Jeffrey,14,0,11,3,0,0
+Kleberg,0011,Railroad Commissioner,,REP,Gary Gates,42,0,19,23,0,0
+Kleberg,0011,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,148,0,100,48,0,0
+Kleberg,0011,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,97,1,60,36,1,0
+Kleberg,0011,"Justice, Supreme Court, Place 5",,REP,Rick Green,144,1,91,52,1,0
+Kleberg,0011,"Justice, Supreme Court, Place 5",,REP,Paul Green,96,0,66,30,0,0
+Kleberg,0011,"Justice, Supreme Court, Place 9",,REP,Joe Pool,114,1,70,43,1,0
+Kleberg,0011,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,136,2,91,43,2,0
+Kleberg,0011,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,77,0,46,31,0,0
+Kleberg,0011,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,93,0,62,31,0,0
+Kleberg,0011,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,64,1,44,19,1,0
+Kleberg,0011,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,57,0,35,22,0,0
+Kleberg,0011,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,119,1,70,48,1,0
+Kleberg,0011,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,27,0,22,5,0,0
+Kleberg,0011,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,36,0,28,8,0,0
+Kleberg,0011,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,129,1,87,41,1,0
+Kleberg,0011,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,100,0,64,36,0,0
+Kleberg,0011,State Representative,43,REP,J. M. Lozano,266,3,174,89,3,0
+Kleberg,0011,"Justice, 13th Court of Appeals District, Place 3",,REP,Greg Perkes,227,1,146,80,1,0
+Kleberg,0011,District Attorney,,REP,John T. Hubert,261,2,169,90,2,0
+Kleberg,0011,Sheriff,,REP,Richard Kirkpatrick,270,1,178,91,1,0
+Kleberg,0011,"County Commissioner, Precinct No. 1",,REP,David Rosse,265,3,169,93,3,0
+Kleberg,0011,"Constable, Precinct No. 1",,REP,Matthew D. Walbeck,229,1,150,78,1,0
+Kleberg,0011,Proposition 1,,REP,Yes,205,3,131,71,3,0
+Kleberg,0011,Proposition 1,,REP,No,86,0,60,26,0,0
+Kleberg,0011,Proposition 2,,REP,Yes,201,4,129,68,4,0
+Kleberg,0011,Proposition 2,,REP,No,98,0,66,32,0,0
+Kleberg,0011,Proposition 3,,REP,Yes,251,4,159,88,4,0
+Kleberg,0011,Proposition 3,,REP,No,49,0,35,14,0,0
+Kleberg,0011,Proposition 4,,REP,Yes,285,4,187,94,4,0
+Kleberg,0011,Proposition 4,,REP,No,11,0,4,7,0,0
+Kleberg,0012,President,,REP,Donald J. Trump,57,0,37,20,0,0
+Kleberg,0012,President,,REP,Mike Huckabee,0,0,0,0,0,0
+Kleberg,0012,President,,REP,Ted Cruz,99,0,71,28,0,0
+Kleberg,0012,President,,REP,Carly Fiorina,0,0,0,0,0,0
+Kleberg,0012,President,,REP,Rand Paul,0,0,0,0,0,0
+Kleberg,0012,President,,REP,Rick Santorum,0,0,0,0,0,0
+Kleberg,0012,President,,REP,Marco Rubio,44,2,27,15,2,0
+Kleberg,0012,President,,REP,Lindsey Graham,0,0,0,0,0,0
+Kleberg,0012,President,,REP,John R. Kasich,6,0,5,1,0,0
+Kleberg,0012,President,,REP,Jeb Bush,2,0,1,1,0,0
+Kleberg,0012,President,,REP,Elizabeth Gray,0,0,0,0,0,0
+Kleberg,0012,President,,REP,Ben Carson,8,0,6,2,0,0
+Kleberg,0012,President,,REP,Chris Christie,0,0,0,0,0,0
+Kleberg,0012,President,,REP,Uncommitted,2,1,1,0,1,0
+Kleberg,0012,U.S. House,34,REP,"William ""Willie"" Vaden",111,1,72,38,1,0
+Kleberg,0012,U.S. House,34,REP,Ray Gonzalez Jr,79,0,56,23,0,0
+Kleberg,0012,Railroad Commissioner,,REP,John Greytok,28,0,22,6,0,0
+Kleberg,0012,Railroad Commissioner,,REP,Weston Martinez,29,0,22,7,0,0
+Kleberg,0012,Railroad Commissioner,,REP,Lance N. Christian,15,1,10,4,1,0
+Kleberg,0012,Railroad Commissioner,,REP,Ron Hale,36,0,22,14,0,0
+Kleberg,0012,Railroad Commissioner,,REP,Wayne Christian,14,0,7,7,0,0
+Kleberg,0012,Railroad Commissioner,,REP,Doug Jeffrey,15,0,13,2,0,0
+Kleberg,0012,Railroad Commissioner,,REP,Gary Gates,35,2,20,13,2,0
+Kleberg,0012,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,108,3,64,41,3,0
+Kleberg,0012,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,66,0,50,16,0,0
+Kleberg,0012,"Justice, Supreme Court, Place 5",,REP,Rick Green,100,0,66,34,0,0
+Kleberg,0012,"Justice, Supreme Court, Place 5",,REP,Paul Green,62,3,41,18,3,0
+Kleberg,0012,"Justice, Supreme Court, Place 9",,REP,Joe Pool,81,1,51,29,1,0
+Kleberg,0012,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,87,2,59,26,2,0
+Kleberg,0012,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,60,0,39,21,0,0
+Kleberg,0012,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,65,3,43,19,3,0
+Kleberg,0012,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,31,0,21,10,0,0
+Kleberg,0012,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,42,0,31,11,0,0
+Kleberg,0012,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,84,2,52,30,2,0
+Kleberg,0012,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,16,0,11,5,0,0
+Kleberg,0012,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,21,1,13,7,1,0
+Kleberg,0012,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,73,0,50,23,0,0
+Kleberg,0012,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,83,3,56,24,3,0
+Kleberg,0012,State Representative,43,REP,J. M. Lozano,195,1,134,60,1,0
+Kleberg,0012,"Justice, 13th Court of Appeals District, Place 3",,REP,Greg Perkes,152,1,106,45,1,0
+Kleberg,0012,District Attorney,,REP,John T. Hubert,187,1,129,57,1,0
+Kleberg,0012,Sheriff,,REP,Richard Kirkpatrick,196,0,134,62,0,0
+Kleberg,0012,"County Commissioner, Precinct No. 1",,REP,David Rosse,190,1,130,59,1,0
+Kleberg,0012,"Constable, Precinct No. 1",,REP,Matthew D. Walbeck,157,1,105,51,1,0
+Kleberg,0012,County Chairman,,REP,Brandon Wayne Barrera,174,1,119,54,1,0
+Kleberg,0012,Proposition 1,,REP,Yes,140,2,88,50,2,0
+Kleberg,0012,Proposition 1,,REP,No,62,1,47,14,1,0
+Kleberg,0012,Proposition 2,,REP,Yes,148,2,101,45,2,0
+Kleberg,0012,Proposition 2,,REP,No,58,1,35,22,1,0
+Kleberg,0012,Proposition 3,,REP,Yes,180,3,116,61,3,0
+Kleberg,0012,Proposition 3,,REP,No,26,0,21,5,0,0
+Kleberg,0012,Proposition 4,,REP,Yes,194,3,127,64,3,0
+Kleberg,0012,Proposition 4,,REP,No,11,0,10,1,0,0
+Kleberg,0013/0014,President,,REP,Donald J. Trump,58,0,39,19,0,0
+Kleberg,0013/0014,President,,REP,Mike Huckabee,0,0,0,0,0,0
+Kleberg,0013/0014,President,,REP,Ted Cruz,93,0,65,27,0,1
+Kleberg,0013/0014,President,,REP,Carly Fiorina,0,0,0,0,0,0
+Kleberg,0013/0014,President,,REP,Rand Paul,0,0,0,0,0,0
+Kleberg,0013/0014,President,,REP,Rick Santorum,0,0,0,0,0,0
+Kleberg,0013/0014,President,,REP,Marco Rubio,51,1,34,16,1,0
+Kleberg,0013/0014,President,,REP,Lindsey Graham,2,0,2,0,0,0
+Kleberg,0013/0014,President,,REP,John R. Kasich,10,0,7,3,0,0
+Kleberg,0013/0014,President,,REP,Jeb Bush,2,0,0,2,0,0
+Kleberg,0013/0014,President,,REP,Elizabeth Gray,0,0,0,0,0,0
+Kleberg,0013/0014,President,,REP,Ben Carson,7,0,5,2,0,0
+Kleberg,0013/0014,President,,REP,Chris Christie,0,0,0,0,0,0
+Kleberg,0013/0014,President,,REP,Uncommitted,0,0,0,0,0,0
+Kleberg,0013/0014,U.S. House,34,REP,"William ""Willie"" Vaden",89,0,63,26,0,0
+Kleberg,0013/0014,U.S. House,34,REP,Ray Gonzalez Jr,101,1,61,38,1,1
+Kleberg,0013/0014,Railroad Commissioner,,REP,John Greytok,24,0,14,10,0,0
+Kleberg,0013/0014,Railroad Commissioner,,REP,Weston Martinez,55,1,35,19,1,0
+Kleberg,0013/0014,Railroad Commissioner,,REP,Lance N. Christian,23,0,16,6,0,1
+Kleberg,0013/0014,Railroad Commissioner,,REP,Ron Hale,20,0,15,5,0,0
+Kleberg,0013/0014,Railroad Commissioner,,REP,Wayne Christian,15,0,9,6,0,0
+Kleberg,0013/0014,Railroad Commissioner,,REP,Doug Jeffrey,6,0,4,2,0,0
+Kleberg,0013/0014,Railroad Commissioner,,REP,Gary Gates,28,0,20,8,0,0
+Kleberg,0013/0014,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,108,1,73,34,1,0
+Kleberg,0013/0014,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,61,0,40,20,0,1
+Kleberg,0013/0014,"Justice, Supreme Court, Place 5",,REP,Rick Green,100,0,69,30,0,1
+Kleberg,0013/0014,"Justice, Supreme Court, Place 5",,REP,Paul Green,60,1,35,24,1,0
+Kleberg,0013/0014,"Justice, Supreme Court, Place 9",,REP,Joe Pool,77,0,46,30,0,1
+Kleberg,0013/0014,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,98,1,66,31,1,0
+Kleberg,0013/0014,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,50,0,27,23,0,0
+Kleberg,0013/0014,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,87,1,62,24,1,0
+Kleberg,0013/0014,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,25,0,19,5,0,1
+Kleberg,0013/0014,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,30,0,16,13,0,1
+Kleberg,0013/0014,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,91,0,63,28,0,0
+Kleberg,0013/0014,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,18,1,13,4,1,0
+Kleberg,0013/0014,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,25,0,18,7,0,0
+Kleberg,0013/0014,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,83,0,55,27,0,1
+Kleberg,0013/0014,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,74,0,53,21,0,0
+Kleberg,0013/0014,State Representative,43,REP,J. M. Lozano,196,0,132,63,0,1
+Kleberg,0013/0014,"Justice, 13th Court of Appeals District, Place 3",,REP,Greg Perkes,149,0,98,50,0,1
+Kleberg,0013/0014,District Attorney,,REP,John T. Hubert,189,0,129,59,0,1
+Kleberg,0013/0014,Sheriff,,REP,Richard Kirkpatrick,196,1,134,60,1,1
+Kleberg,0013/0014,"County Commissioner, Precinct No. 1",,REP,David Rosse,190,1,126,62,1,1
+Kleberg,0013/0014,"Constable, Precinct No. 1",,REP,Matthew D. Walbeck,151,0,101,49,0,1
+Kleberg,0013/0014,County Chairman,,REP,Brandon Wayne Barrera,160,0,105,54,0,1
+Kleberg,0013/0014,Proposition 1,,REP,Yes,143,0,94,49,0,0
+Kleberg,0013/0014,Proposition 1,,REP,No,62,0,45,16,0,1
+Kleberg,0013/0014,Proposition 2,,REP,Yes,142,0,97,45,0,0
+Kleberg,0013/0014,Proposition 2,,REP,No,65,0,46,18,0,1
+Kleberg,0013/0014,Proposition 3,,REP,Yes,175,0,120,54,0,1
+Kleberg,0013/0014,Proposition 3,,REP,No,29,0,19,10,0,0
+Kleberg,0013/0014,Proposition 4,,REP,Yes,188,0,125,62,0,1
+Kleberg,0013/0014,Proposition 4,,REP,No,6,0,5,1,0,0
+Kleberg,0021,President,,REP,Donald J. Trump,4,0,0,4,0,0
+Kleberg,0021,President,,REP,Mike Huckabee,0,0,0,0,0,0
+Kleberg,0021,President,,REP,Ted Cruz,6,0,2,4,0,0
+Kleberg,0021,President,,REP,Carly Fiorina,0,0,0,0,0,0
+Kleberg,0021,President,,REP,Rand Paul,0,0,0,0,0,0
+Kleberg,0021,President,,REP,Rick Santorum,0,0,0,0,0,0
+Kleberg,0021,President,,REP,Marco Rubio,3,0,3,0,0,0
+Kleberg,0021,President,,REP,Lindsey Graham,0,0,0,0,0,0
+Kleberg,0021,President,,REP,John R. Kasich,0,0,0,0,0,0
+Kleberg,0021,President,,REP,Jeb Bush,1,0,0,1,0,0
+Kleberg,0021,President,,REP,Elizabeth Gray,0,0,0,0,0,0
+Kleberg,0021,President,,REP,Ben Carson,0,0,0,0,0,0
+Kleberg,0021,President,,REP,Chris Christie,0,0,0,0,0,0
+Kleberg,0021,President,,REP,Uncommitted,0,0,0,0,0,0
+Kleberg,0021,U.S. House,34,REP,"William ""Willie"" Vaden",4,0,1,3,0,0
+Kleberg,0021,U.S. House,34,REP,Ray Gonzalez Jr,7,0,3,4,0,0
+Kleberg,0021,Railroad Commissioner,,REP,John Greytok,1,0,1,0,0,0
+Kleberg,0021,Railroad Commissioner,,REP,Weston Martinez,8,0,2,6,0,0
+Kleberg,0021,Railroad Commissioner,,REP,Lance N. Christian,0,0,0,0,0,0
+Kleberg,0021,Railroad Commissioner,,REP,Ron Hale,0,0,0,0,0,0
+Kleberg,0021,Railroad Commissioner,,REP,Wayne Christian,0,0,0,0,0,0
+Kleberg,0021,Railroad Commissioner,,REP,Doug Jeffrey,1,0,1,0,0,0
+Kleberg,0021,Railroad Commissioner,,REP,Gary Gates,2,0,1,1,0,0
+Kleberg,0021,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,9,0,3,6,0,0
+Kleberg,0021,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,1,0,1,0,0,0
+Kleberg,0021,"Justice, Supreme Court, Place 5",,REP,Rick Green,6,0,3,3,0,0
+Kleberg,0021,"Justice, Supreme Court, Place 5",,REP,Paul Green,3,0,1,2,0,0
+Kleberg,0021,"Justice, Supreme Court, Place 9",,REP,Joe Pool,2,0,1,1,0,0
+Kleberg,0021,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,9,0,4,5,0,0
+Kleberg,0021,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,2,0,0,2,0,0
+Kleberg,0021,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,6,0,3,3,0,0
+Kleberg,0021,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,2,0,2,0,0,0
+Kleberg,0021,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,3,0,0,3,0,0
+Kleberg,0021,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,8,0,4,4,0,0
+Kleberg,0021,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,0,0,0,0,0,0
+Kleberg,0021,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,1,0,1,0,0,0
+Kleberg,0021,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,4,0,2,2,0,0
+Kleberg,0021,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,7,0,3,4,0,0
+Kleberg,0021,State Representative,43,REP,J. M. Lozano,10,0,5,5,0,0
+Kleberg,0021,"Justice, 13th Court of Appeals District, Place 3",,REP,Greg Perkes,8,0,5,3,0,0
+Kleberg,0021,District Attorney,,REP,John T. Hubert,11,0,5,6,0,0
+Kleberg,0021,Sheriff,,REP,Richard Kirkpatrick,12,0,5,7,0,0
+Kleberg,0021,County Chairman,,REP,Brandon Wayne Barrera,8,0,5,3,0,0
+Kleberg,0021,Proposition 1,,REP,Yes,10,0,5,5,0,0
+Kleberg,0021,Proposition 1,,REP,No,2,0,0,2,0,0
+Kleberg,0021,Proposition 2,,REP,Yes,8,0,3,5,0,0
+Kleberg,0021,Proposition 2,,REP,No,4,0,2,2,0,0
+Kleberg,0021,Proposition 3,,REP,Yes,11,0,5,6,0,0
+Kleberg,0021,Proposition 3,,REP,No,1,0,0,1,0,0
+Kleberg,0021,Proposition 4,,REP,Yes,11,0,5,6,0,0
+Kleberg,0021,Proposition 4,,REP,No,0,0,0,0,0,0
+Kleberg,0022/0023,President,,REP,Donald J. Trump,51,0,34,17,0,0
+Kleberg,0022/0023,President,,REP,Mike Huckabee,1,0,1,0,0,0
+Kleberg,0022/0023,President,,REP,Ted Cruz,102,0,73,29,0,0
+Kleberg,0022/0023,President,,REP,Carly Fiorina,1,0,1,0,0,0
+Kleberg,0022/0023,President,,REP,Rand Paul,0,0,0,0,0,0
+Kleberg,0022/0023,President,,REP,Rick Santorum,0,0,0,0,0,0
+Kleberg,0022/0023,President,,REP,Marco Rubio,37,0,27,10,0,0
+Kleberg,0022/0023,President,,REP,Lindsey Graham,0,0,0,0,0,0
+Kleberg,0022/0023,President,,REP,John R. Kasich,8,0,6,2,0,0
+Kleberg,0022/0023,President,,REP,Jeb Bush,5,0,3,2,0,0
+Kleberg,0022/0023,President,,REP,Elizabeth Gray,0,0,0,0,0,0
+Kleberg,0022/0023,President,,REP,Ben Carson,8,0,5,3,0,0
+Kleberg,0022/0023,President,,REP,Chris Christie,0,0,0,0,0,0
+Kleberg,0022/0023,President,,REP,Uncommitted,1,0,1,0,0,0
+Kleberg,0022/0023,U.S. House,34,REP,"William ""Willie"" Vaden",94,0,67,27,0,0
+Kleberg,0022/0023,U.S. House,34,REP,Ray Gonzalez Jr,82,0,56,26,0,0
+Kleberg,0022/0023,Railroad Commissioner,,REP,John Greytok,30,0,19,11,0,0
+Kleberg,0022/0023,Railroad Commissioner,,REP,Weston Martinez,38,0,28,10,0,0
+Kleberg,0022/0023,Railroad Commissioner,,REP,Lance N. Christian,25,0,15,10,0,0
+Kleberg,0022/0023,Railroad Commissioner,,REP,Ron Hale,32,0,23,9,0,0
+Kleberg,0022/0023,Railroad Commissioner,,REP,Wayne Christian,8,0,7,1,0,0
+Kleberg,0022/0023,Railroad Commissioner,,REP,Doug Jeffrey,10,0,7,3,0,0
+Kleberg,0022/0023,Railroad Commissioner,,REP,Gary Gates,25,0,19,6,0,0
+Kleberg,0022/0023,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,96,0,62,34,0,0
+Kleberg,0022/0023,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,66,0,52,14,0,0
+Kleberg,0022/0023,"Justice, Supreme Court, Place 5",,REP,Rick Green,92,0,65,27,0,0
+Kleberg,0022/0023,"Justice, Supreme Court, Place 5",,REP,Paul Green,59,0,40,19,0,0
+Kleberg,0022/0023,"Justice, Supreme Court, Place 9",,REP,Joe Pool,79,0,56,23,0,0
+Kleberg,0022/0023,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,85,0,58,27,0,0
+Kleberg,0022/0023,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,51,0,34,17,0,0
+Kleberg,0022/0023,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,59,0,39,20,0,0
+Kleberg,0022/0023,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,35,0,27,8,0,0
+Kleberg,0022/0023,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,33,0,21,12,0,0
+Kleberg,0022/0023,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,85,0,61,24,0,0
+Kleberg,0022/0023,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,18,0,12,6,0,0
+Kleberg,0022/0023,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,17,0,11,6,0,0
+Kleberg,0022/0023,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,80,0,49,31,0,0
+Kleberg,0022/0023,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,64,0,50,14,0,0
+Kleberg,0022/0023,State Representative,43,REP,J. M. Lozano,176,0,121,55,0,0
+Kleberg,0022/0023,"Justice, 13th Court of Appeals District, Place 3",,REP,Greg Perkes,131,0,87,44,0,0
+Kleberg,0022/0023,District Attorney,,REP,John T. Hubert,178,0,122,56,0,0
+Kleberg,0022/0023,Sheriff,,REP,Richard Kirkpatrick,183,0,125,58,0,0
+Kleberg,0022/0023,County Chairman,,REP,Brandon Wayne Barrera,145,0,101,44,0,0
+Kleberg,0022/0023,Proposition 1,,REP,Yes,143,0,98,45,0,0
+Kleberg,0022/0023,Proposition 1,,REP,No,46,0,31,15,0,0
+Kleberg,0022/0023,Proposition 2,,REP,Yes,130,0,87,43,0,0
+Kleberg,0022/0023,Proposition 2,,REP,No,62,0,44,18,0,0
+Kleberg,0022/0023,Proposition 3,,REP,Yes,164,0,107,57,0,0
+Kleberg,0022/0023,Proposition 3,,REP,No,26,0,23,3,0,0
+Kleberg,0022/0023,Proposition 4,,REP,Yes,174,0,116,58,0,0
+Kleberg,0022/0023,Proposition 4,,REP,No,6,0,5,1,0,0
+Kleberg,0024,President,,REP,Donald J. Trump,59,2,28,29,2,0
+Kleberg,0024,President,,REP,Mike Huckabee,0,0,0,0,0,0
+Kleberg,0024,President,,REP,Ted Cruz,47,0,34,13,0,0
+Kleberg,0024,President,,REP,Carly Fiorina,0,0,0,0,0,0
+Kleberg,0024,President,,REP,Rand Paul,2,1,1,0,1,0
+Kleberg,0024,President,,REP,Rick Santorum,0,0,0,0,0,0
+Kleberg,0024,President,,REP,Marco Rubio,30,1,21,8,1,0
+Kleberg,0024,President,,REP,Lindsey Graham,0,0,0,0,0,0
+Kleberg,0024,President,,REP,John R. Kasich,6,1,3,2,1,0
+Kleberg,0024,President,,REP,Jeb Bush,5,2,1,2,2,0
+Kleberg,0024,President,,REP,Elizabeth Gray,0,0,0,0,0,0
+Kleberg,0024,President,,REP,Ben Carson,7,0,3,4,0,0
+Kleberg,0024,President,,REP,Chris Christie,0,0,0,0,0,0
+Kleberg,0024,President,,REP,Uncommitted,2,0,2,0,0,0
+Kleberg,0024,U.S. House,34,REP,"William ""Willie"" Vaden",69,4,40,25,4,0
+Kleberg,0024,U.S. House,34,REP,Ray Gonzalez Jr,71,3,45,23,3,0
+Kleberg,0024,Railroad Commissioner,,REP,John Greytok,14,0,10,4,0,0
+Kleberg,0024,Railroad Commissioner,,REP,Weston Martinez,35,0,19,16,0,0
+Kleberg,0024,Railroad Commissioner,,REP,Lance N. Christian,18,0,13,5,0,0
+Kleberg,0024,Railroad Commissioner,,REP,Ron Hale,23,1,11,11,1,0
+Kleberg,0024,Railroad Commissioner,,REP,Wayne Christian,17,3,11,3,3,0
+Kleberg,0024,Railroad Commissioner,,REP,Doug Jeffrey,6,1,4,1,1,0
+Kleberg,0024,Railroad Commissioner,,REP,Gary Gates,24,1,16,7,1,0
+Kleberg,0024,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,82,6,48,28,6,0
+Kleberg,0024,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,50,0,30,20,0,0
+Kleberg,0024,"Justice, Supreme Court, Place 5",,REP,Rick Green,79,1,48,30,1,0
+Kleberg,0024,"Justice, Supreme Court, Place 5",,REP,Paul Green,44,5,24,15,5,0
+Kleberg,0024,"Justice, Supreme Court, Place 9",,REP,Joe Pool,58,0,34,24,0,0
+Kleberg,0024,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,74,6,44,24,6,0
+Kleberg,0024,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,49,3,31,15,3,0
+Kleberg,0024,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,55,3,30,22,3,0
+Kleberg,0024,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,26,0,17,9,0,0
+Kleberg,0024,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,33,1,17,15,1,0
+Kleberg,0024,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,64,4,40,20,4,0
+Kleberg,0024,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,9,0,6,3,0,0
+Kleberg,0024,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,24,1,13,10,1,0
+Kleberg,0024,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,62,3,33,26,3,0
+Kleberg,0024,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,62,3,41,18,3,0
+Kleberg,0024,State Representative,43,REP,J. M. Lozano,143,7,84,52,7,0
+Kleberg,0024,"Justice, 13th Court of Appeals District, Place 3",,REP,Greg Perkes,116,6,66,44,6,0
+Kleberg,0024,District Attorney,,REP,John T. Hubert,144,7,82,55,7,0
+Kleberg,0024,Sheriff,,REP,Richard Kirkpatrick,144,6,85,53,6,0
+Kleberg,0024,County Chairman,,REP,Brandon Wayne Barrera,136,6,82,48,6,0
+Kleberg,0024,Proposition 1,,REP,Yes,95,2,57,36,2,0
+Kleberg,0024,Proposition 1,,REP,No,56,5,31,20,5,0
+Kleberg,0024,Proposition 2,,REP,Yes,107,4,63,40,4,0
+Kleberg,0024,Proposition 2,,REP,No,51,3,30,18,3,0
+Kleberg,0024,Proposition 3,,REP,Yes,127,5,72,50,5,0
+Kleberg,0024,Proposition 3,,REP,No,26,2,16,8,2,0
+Kleberg,0024,Proposition 4,,REP,Yes,141,6,86,49,6,0
+Kleberg,0024,Proposition 4,,REP,No,7,1,2,4,1,0
+Kleberg,0031,President,,REP,Donald J. Trump,67,0,37,30,0,0
+Kleberg,0031,President,,REP,Mike Huckabee,2,0,0,2,0,0
+Kleberg,0031,President,,REP,Ted Cruz,114,1,85,28,1,0
+Kleberg,0031,President,,REP,Carly Fiorina,0,0,0,0,0,0
+Kleberg,0031,President,,REP,Rand Paul,2,1,1,0,1,0
+Kleberg,0031,President,,REP,Rick Santorum,0,0,0,0,0,0
+Kleberg,0031,President,,REP,Marco Rubio,43,2,25,16,2,0
+Kleberg,0031,President,,REP,Lindsey Graham,0,0,0,0,0,0
+Kleberg,0031,President,,REP,John R. Kasich,9,0,3,6,0,0
+Kleberg,0031,President,,REP,Jeb Bush,3,0,0,3,0,0
+Kleberg,0031,President,,REP,Elizabeth Gray,0,0,0,0,0,0
+Kleberg,0031,President,,REP,Ben Carson,6,0,3,3,0,0
+Kleberg,0031,President,,REP,Chris Christie,4,0,1,3,0,0
+Kleberg,0031,President,,REP,Uncommitted,3,0,3,0,0,0
+Kleberg,0031,U.S. House,34,REP,"William ""Willie"" Vaden",119,1,72,46,1,0
+Kleberg,0031,U.S. House,34,REP,Ray Gonzalez Jr,93,3,59,31,3,0
+Kleberg,0031,Railroad Commissioner,,REP,John Greytok,27,0,12,15,0,0
+Kleberg,0031,Railroad Commissioner,,REP,Weston Martinez,39,0,30,9,0,0
+Kleberg,0031,Railroad Commissioner,,REP,Lance N. Christian,19,2,12,5,2,0
+Kleberg,0031,Railroad Commissioner,,REP,Ron Hale,30,0,16,14,0,0
+Kleberg,0031,Railroad Commissioner,,REP,Wayne Christian,22,1,14,7,1,0
+Kleberg,0031,Railroad Commissioner,,REP,Doug Jeffrey,8,0,7,1,0,0
+Kleberg,0031,Railroad Commissioner,,REP,Gary Gates,40,1,22,17,1,0
+Kleberg,0031,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,111,3,68,40,3,0
+Kleberg,0031,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,79,1,50,28,1,0
+Kleberg,0031,"Justice, Supreme Court, Place 5",,REP,Rick Green,117,1,72,44,1,0
+Kleberg,0031,"Justice, Supreme Court, Place 5",,REP,Paul Green,57,3,36,18,3,0
+Kleberg,0031,"Justice, Supreme Court, Place 9",,REP,Joe Pool,98,1,60,37,1,0
+Kleberg,0031,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,87,3,57,27,3,0
+Kleberg,0031,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,63,0,41,22,0,0
+Kleberg,0031,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,76,3,42,31,3,0
+Kleberg,0031,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,35,1,24,10,1,0
+Kleberg,0031,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,40,0,26,14,0,0
+Kleberg,0031,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,99,1,66,32,1,0
+Kleberg,0031,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,19,3,10,6,3,0
+Kleberg,0031,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,30,0,18,12,0,0
+Kleberg,0031,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,100,4,62,34,4,0
+Kleberg,0031,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,72,0,44,28,0,0
+Kleberg,0031,State Representative,43,REP,J. M. Lozano,221,4,135,82,4,0
+Kleberg,0031,"Justice, 13th Court of Appeals District, Place 3",,REP,Greg Perkes,173,4,106,63,4,0
+Kleberg,0031,District Attorney,,REP,John T. Hubert,215,4,130,81,4,0
+Kleberg,0031,Sheriff,,REP,Richard Kirkpatrick,219,4,135,80,4,0
+Kleberg,0031,County Chairman,,REP,Brandon Wayne Barrera,184,4,111,69,4,0
+Kleberg,0031,Proposition 1,,REP,Yes,165,3,102,60,3,0
+Kleberg,0031,Proposition 1,,REP,No,67,1,42,24,1,0
+Kleberg,0031,Proposition 2,,REP,Yes,167,2,102,63,2,0
+Kleberg,0031,Proposition 2,,REP,No,75,2,48,25,2,0
+Kleberg,0031,Proposition 3,,REP,Yes,191,4,116,71,4,0
+Kleberg,0031,Proposition 3,,REP,No,40,0,27,13,0,0
+Kleberg,0031,Proposition 4,,REP,Yes,220,4,136,80,4,0
+Kleberg,0031,Proposition 4,,REP,No,9,0,6,3,0,0
+Kleberg,0032,President,,REP,Donald J. Trump,50,2,25,23,2,0
+Kleberg,0032,President,,REP,Mike Huckabee,1,0,0,1,0,0
+Kleberg,0032,President,,REP,Ted Cruz,75,0,48,27,0,0
+Kleberg,0032,President,,REP,Carly Fiorina,0,0,0,0,0,0
+Kleberg,0032,President,,REP,Rand Paul,0,0,0,0,0,0
+Kleberg,0032,President,,REP,Rick Santorum,0,0,0,0,0,0
+Kleberg,0032,President,,REP,Marco Rubio,12,0,7,5,0,0
+Kleberg,0032,President,,REP,Lindsey Graham,0,0,0,0,0,0
+Kleberg,0032,President,,REP,John R. Kasich,4,0,2,2,0,0
+Kleberg,0032,President,,REP,Jeb Bush,3,0,1,2,0,0
+Kleberg,0032,President,,REP,Elizabeth Gray,0,0,0,0,0,0
+Kleberg,0032,President,,REP,Ben Carson,1,0,1,0,0,0
+Kleberg,0032,President,,REP,Chris Christie,0,0,0,0,0,0
+Kleberg,0032,President,,REP,Uncommitted,1,0,0,1,0,0
+Kleberg,0032,U.S. House,34,REP,"William ""Willie"" Vaden",62,1,30,31,1,0
+Kleberg,0032,U.S. House,34,REP,Ray Gonzalez Jr,71,1,44,26,1,0
+Kleberg,0032,Railroad Commissioner,,REP,John Greytok,20,0,13,7,0,0
+Kleberg,0032,Railroad Commissioner,,REP,Weston Martinez,25,1,16,8,1,0
+Kleberg,0032,Railroad Commissioner,,REP,Lance N. Christian,14,0,7,7,0,0
+Kleberg,0032,Railroad Commissioner,,REP,Ron Hale,16,0,9,7,0,0
+Kleberg,0032,Railroad Commissioner,,REP,Wayne Christian,15,1,9,5,1,0
+Kleberg,0032,Railroad Commissioner,,REP,Doug Jeffrey,7,0,5,2,0,0
+Kleberg,0032,Railroad Commissioner,,REP,Gary Gates,22,0,8,14,0,0
+Kleberg,0032,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,57,2,35,20,2,0
+Kleberg,0032,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,59,0,30,29,0,0
+Kleberg,0032,"Justice, Supreme Court, Place 5",,REP,Rick Green,60,1,34,25,1,0
+Kleberg,0032,"Justice, Supreme Court, Place 5",,REP,Paul Green,55,1,31,23,1,0
+Kleberg,0032,"Justice, Supreme Court, Place 9",,REP,Joe Pool,65,0,32,33,0,0
+Kleberg,0032,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,56,2,35,19,2,0
+Kleberg,0032,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,35,0,19,16,0,0
+Kleberg,0032,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,45,2,31,12,2,0
+Kleberg,0032,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,33,0,14,19,0,0
+Kleberg,0032,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,22,1,15,6,1,0
+Kleberg,0032,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,75,0,42,33,0,0
+Kleberg,0032,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,13,1,6,6,1,0
+Kleberg,0032,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,10,0,5,5,0,0
+Kleberg,0032,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,62,2,36,24,2,0
+Kleberg,0032,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,51,0,30,21,0,0
+Kleberg,0032,State Representative,43,REP,J. M. Lozano,125,2,66,57,2,0
+Kleberg,0032,"Justice, 13th Court of Appeals District, Place 3",,REP,Greg Perkes,103,2,59,42,2,0
+Kleberg,0032,District Attorney,,REP,John T. Hubert,124,2,66,56,2,0
+Kleberg,0032,Sheriff,,REP,Richard Kirkpatrick,132,2,73,57,2,0
+Kleberg,0032,County Chairman,,REP,Brandon Wayne Barrera,116,2,63,51,2,0
+Kleberg,0032,Proposition 1,,REP,Yes,98,1,59,38,1,0
+Kleberg,0032,Proposition 1,,REP,No,40,1,20,19,1,0
+Kleberg,0032,Proposition 2,,REP,Yes,89,0,57,32,0,0
+Kleberg,0032,Proposition 2,,REP,No,46,2,19,25,2,0
+Kleberg,0032,Proposition 3,,REP,Yes,110,1,59,50,1,0
+Kleberg,0032,Proposition 3,,REP,No,28,1,20,7,1,0
+Kleberg,0032,Proposition 4,,REP,Yes,133,2,74,57,2,0
+Kleberg,0032,Proposition 4,,REP,No,5,0,5,0,0,0
+Kleberg,0033/0034,President,,REP,Donald J. Trump,69,0,54,15,0,0
+Kleberg,0033/0034,President,,REP,Mike Huckabee,1,0,1,0,0,0
+Kleberg,0033/0034,President,,REP,Ted Cruz,117,1,92,24,1,0
+Kleberg,0033/0034,President,,REP,Carly Fiorina,0,0,0,0,0,0
+Kleberg,0033/0034,President,,REP,Rand Paul,0,0,0,0,0,0
+Kleberg,0033/0034,President,,REP,Rick Santorum,0,0,0,0,0,0
+Kleberg,0033/0034,President,,REP,Marco Rubio,51,0,41,10,0,0
+Kleberg,0033/0034,President,,REP,Lindsey Graham,0,0,0,0,0,0
+Kleberg,0033/0034,President,,REP,John R. Kasich,7,0,7,0,0,0
+Kleberg,0033/0034,President,,REP,Jeb Bush,2,0,2,0,0,0
+Kleberg,0033/0034,President,,REP,Elizabeth Gray,0,0,0,0,0,0
+Kleberg,0033/0034,President,,REP,Ben Carson,3,0,3,0,0,0
+Kleberg,0033/0034,President,,REP,Chris Christie,0,0,0,0,0,0
+Kleberg,0033/0034,President,,REP,Uncommitted,0,0,0,0,0,0
+Kleberg,0033/0034,U.S. House,34,REP,"William ""Willie"" Vaden",140,0,114,26,0,0
+Kleberg,0033/0034,U.S. House,34,REP,Ray Gonzalez Jr,71,1,53,17,1,0
+Kleberg,0033/0034,Railroad Commissioner,,REP,John Greytok,30,0,23,7,0,0
+Kleberg,0033/0034,Railroad Commissioner,,REP,Weston Martinez,12,0,11,1,0,0
+Kleberg,0033/0034,Railroad Commissioner,,REP,Lance N. Christian,23,0,16,7,0,0
+Kleberg,0033/0034,Railroad Commissioner,,REP,Ron Hale,46,0,38,8,0,0
+Kleberg,0033/0034,Railroad Commissioner,,REP,Wayne Christian,19,0,15,4,0,0
+Kleberg,0033/0034,Railroad Commissioner,,REP,Doug Jeffrey,9,0,9,0,0,0
+Kleberg,0033/0034,Railroad Commissioner,,REP,Gary Gates,46,0,35,11,0,0
+Kleberg,0033/0034,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,101,0,82,19,0,0
+Kleberg,0033/0034,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,82,0,63,19,0,0
+Kleberg,0033/0034,"Justice, Supreme Court, Place 5",,REP,Rick Green,113,0,89,24,0,0
+Kleberg,0033/0034,"Justice, Supreme Court, Place 5",,REP,Paul Green,59,0,47,12,0,0
+Kleberg,0033/0034,"Justice, Supreme Court, Place 9",,REP,Joe Pool,132,0,101,31,0,0
+Kleberg,0033/0034,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,55,0,45,10,0,0
+Kleberg,0033/0034,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,68,0,55,13,0,0
+Kleberg,0033/0034,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,52,0,42,10,0,0
+Kleberg,0033/0034,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,53,0,40,13,0,0
+Kleberg,0033/0034,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,50,0,42,8,0,0
+Kleberg,0033/0034,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,99,0,80,19,0,0
+Kleberg,0033/0034,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,13,0,9,4,0,0
+Kleberg,0033/0034,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,14,0,10,4,0,0
+Kleberg,0033/0034,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,94,0,81,13,0,0
+Kleberg,0033/0034,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,79,0,58,21,0,0
+Kleberg,0033/0034,State Representative,43,REP,J. M. Lozano,172,0,130,42,0,0
+Kleberg,0033/0034,"Justice, 13th Court of Appeals District, Place 3",,REP,Greg Perkes,147,0,112,35,0,0
+Kleberg,0033/0034,District Attorney,,REP,John T. Hubert,188,1,142,45,1,0
+Kleberg,0033/0034,Sheriff,,REP,Richard Kirkpatrick,189,0,144,45,0,0
+Kleberg,0033/0034,County Chairman,,REP,Brandon Wayne Barrera,162,1,122,39,1,0
+Kleberg,0033/0034,Proposition 1,,REP,Yes,160,1,126,33,1,0
+Kleberg,0033/0034,Proposition 1,,REP,No,61,0,47,14,0,0
+Kleberg,0033/0034,Proposition 2,,REP,Yes,156,1,121,34,1,0
+Kleberg,0033/0034,Proposition 2,,REP,No,69,0,56,13,0,0
+Kleberg,0033/0034,Proposition 3,,REP,Yes,185,1,143,41,1,0
+Kleberg,0033/0034,Proposition 3,,REP,No,35,0,29,6,0,0
+Kleberg,0033/0034,Proposition 4,,REP,Yes,208,1,161,46,1,0
+Kleberg,0033/0034,Proposition 4,,REP,No,8,0,8,0,0,0
+Kleberg,0035,President,,REP,Donald J. Trump,60,0,47,13,0,0
+Kleberg,0035,President,,REP,Mike Huckabee,0,0,0,0,0,0
+Kleberg,0035,President,,REP,Ted Cruz,63,0,49,14,0,0
+Kleberg,0035,President,,REP,Carly Fiorina,0,0,0,0,0,0
+Kleberg,0035,President,,REP,Rand Paul,1,0,0,1,0,0
+Kleberg,0035,President,,REP,Rick Santorum,0,0,0,0,0,0
+Kleberg,0035,President,,REP,Marco Rubio,17,0,13,4,0,0
+Kleberg,0035,President,,REP,Lindsey Graham,0,0,0,0,0,0
+Kleberg,0035,President,,REP,John R. Kasich,4,0,4,0,0,0
+Kleberg,0035,President,,REP,Jeb Bush,0,0,0,0,0,0
+Kleberg,0035,President,,REP,Elizabeth Gray,0,0,0,0,0,0
+Kleberg,0035,President,,REP,Ben Carson,6,0,4,2,0,0
+Kleberg,0035,President,,REP,Chris Christie,0,0,0,0,0,0
+Kleberg,0035,President,,REP,Uncommitted,1,0,1,0,0,0
+Kleberg,0035,U.S. House,34,REP,"William ""Willie"" Vaden",73,0,58,15,0,0
+Kleberg,0035,U.S. House,34,REP,Ray Gonzalez Jr,61,0,49,12,0,0
+Kleberg,0035,Railroad Commissioner,,REP,John Greytok,29,0,22,7,0,0
+Kleberg,0035,Railroad Commissioner,,REP,Weston Martinez,25,0,21,4,0,0
+Kleberg,0035,Railroad Commissioner,,REP,Lance N. Christian,15,0,11,4,0,0
+Kleberg,0035,Railroad Commissioner,,REP,Ron Hale,21,0,15,6,0,0
+Kleberg,0035,Railroad Commissioner,,REP,Wayne Christian,16,0,15,1,0,0
+Kleberg,0035,Railroad Commissioner,,REP,Doug Jeffrey,3,0,2,1,0,0
+Kleberg,0035,Railroad Commissioner,,REP,Gary Gates,20,0,15,5,0,0
+Kleberg,0035,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,77,0,59,18,0,0
+Kleberg,0035,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,46,0,37,9,0,0
+Kleberg,0035,"Justice, Supreme Court, Place 5",,REP,Rick Green,79,0,62,17,0,0
+Kleberg,0035,"Justice, Supreme Court, Place 5",,REP,Paul Green,37,0,28,9,0,0
+Kleberg,0035,"Justice, Supreme Court, Place 9",,REP,Joe Pool,73,0,55,18,0,0
+Kleberg,0035,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,47,0,39,8,0,0
+Kleberg,0035,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,49,0,37,12,0,0
+Kleberg,0035,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,46,0,38,8,0,0
+Kleberg,0035,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,23,0,17,6,0,0
+Kleberg,0035,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,39,0,32,7,0,0
+Kleberg,0035,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,66,0,48,18,0,0
+Kleberg,0035,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,5,0,5,0,0,0
+Kleberg,0035,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,12,0,10,2,0,0
+Kleberg,0035,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,76,0,63,13,0,0
+Kleberg,0035,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,44,0,31,13,0,0
+Kleberg,0035,State Representative,43,REP,J. M. Lozano,137,0,105,32,0,0
+Kleberg,0035,"Justice, 13th Court of Appeals District, Place 3",,REP,Greg Perkes,113,0,88,25,0,0
+Kleberg,0035,District Attorney,,REP,John T. Hubert,136,0,106,30,0,0
+Kleberg,0035,Sheriff,,REP,Richard Kirkpatrick,140,0,108,32,0,0
+Kleberg,0035,County Chairman,,REP,Brandon Wayne Barrera,125,0,99,26,0,0
+Kleberg,0035,Proposition 1,,REP,Yes,106,0,81,25,0,0
+Kleberg,0035,Proposition 1,,REP,No,31,0,23,8,0,0
+Kleberg,0035,Proposition 2,,REP,Yes,102,0,79,23,0,0
+Kleberg,0035,Proposition 2,,REP,No,37,0,26,11,0,0
+Kleberg,0035,Proposition 3,,REP,Yes,112,0,84,28,0,0
+Kleberg,0035,Proposition 3,,REP,No,22,0,19,3,0,0
+Kleberg,0035,Proposition 4,,REP,Yes,131,0,100,31,0,0
+Kleberg,0035,Proposition 4,,REP,No,3,0,2,1,0,0
+Kleberg,0041/0042,President,,REP,Donald J. Trump,12,0,10,2,0,0
+Kleberg,0041/0042,President,,REP,Mike Huckabee,0,0,0,0,0,0
+Kleberg,0041/0042,President,,REP,Ted Cruz,32,0,23,9,0,0
+Kleberg,0041/0042,President,,REP,Carly Fiorina,0,0,0,0,0,0
+Kleberg,0041/0042,President,,REP,Rand Paul,0,0,0,0,0,0
+Kleberg,0041/0042,President,,REP,Rick Santorum,0,0,0,0,0,0
+Kleberg,0041/0042,President,,REP,Marco Rubio,9,0,7,2,0,0
+Kleberg,0041/0042,President,,REP,Lindsey Graham,0,0,0,0,0,0
+Kleberg,0041/0042,President,,REP,John R. Kasich,1,0,1,0,0,0
+Kleberg,0041/0042,President,,REP,Jeb Bush,2,0,2,0,0,0
+Kleberg,0041/0042,President,,REP,Elizabeth Gray,0,0,0,0,0,0
+Kleberg,0041/0042,President,,REP,Ben Carson,1,0,1,0,0,0
+Kleberg,0041/0042,President,,REP,Chris Christie,0,0,0,0,0,0
+Kleberg,0041/0042,President,,REP,Uncommitted,1,0,0,1,0,0
+Kleberg,0041/0042,U.S. House,34,REP,"William ""Willie"" Vaden",24,0,18,6,0,0
+Kleberg,0041/0042,U.S. House,34,REP,Ray Gonzalez Jr,31,0,24,7,0,0
+Kleberg,0041/0042,Railroad Commissioner,,REP,John Greytok,7,0,4,3,0,0
+Kleberg,0041/0042,Railroad Commissioner,,REP,Weston Martinez,23,0,18,5,0,0
+Kleberg,0041/0042,Railroad Commissioner,,REP,Lance N. Christian,6,0,5,1,0,0
+Kleberg,0041/0042,Railroad Commissioner,,REP,Ron Hale,4,0,2,2,0,0
+Kleberg,0041/0042,Railroad Commissioner,,REP,Wayne Christian,3,0,2,1,0,0
+Kleberg,0041/0042,Railroad Commissioner,,REP,Doug Jeffrey,1,0,1,0,0,0
+Kleberg,0041/0042,Railroad Commissioner,,REP,Gary Gates,7,0,6,1,0,0
+Kleberg,0041/0042,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,29,0,20,9,0,0
+Kleberg,0041/0042,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,20,0,18,2,0,0
+Kleberg,0041/0042,"Justice, Supreme Court, Place 5",,REP,Rick Green,27,0,22,5,0,0
+Kleberg,0041/0042,"Justice, Supreme Court, Place 5",,REP,Paul Green,19,0,15,4,0,0
+Kleberg,0041/0042,"Justice, Supreme Court, Place 9",,REP,Joe Pool,20,0,18,2,0,0
+Kleberg,0041/0042,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,31,0,22,9,0,0
+Kleberg,0041/0042,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,18,0,16,2,0,0
+Kleberg,0041/0042,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,22,0,16,6,0,0
+Kleberg,0041/0042,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,6,0,3,3,0,0
+Kleberg,0041/0042,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,17,0,13,4,0,0
+Kleberg,0041/0042,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,18,0,12,6,0,0
+Kleberg,0041/0042,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,6,0,5,1,0,0
+Kleberg,0041/0042,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,6,0,6,0,0,0
+Kleberg,0041/0042,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,20,0,17,3,0,0
+Kleberg,0041/0042,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,26,0,19,7,0,0
+Kleberg,0041/0042,State Representative,43,REP,J. M. Lozano,52,0,40,12,0,0
+Kleberg,0041/0042,"Justice, 13th Court of Appeals District, Place 3",,REP,Greg Perkes,42,0,33,9,0,0
+Kleberg,0041/0042,District Attorney,,REP,John T. Hubert,46,0,35,11,0,0
+Kleberg,0041/0042,Sheriff,,REP,Richard Kirkpatrick,51,0,39,12,0,0
+Kleberg,0041/0042,County Chairman,,REP,Brandon Wayne Barrera,43,0,33,10,0,0
+Kleberg,0041/0042,Proposition 1,,REP,Yes,31,0,24,7,0,0
+Kleberg,0041/0042,Proposition 1,,REP,No,16,0,12,4,0,0
+Kleberg,0041/0042,Proposition 2,,REP,Yes,33,0,26,7,0,0
+Kleberg,0041/0042,Proposition 2,,REP,No,13,0,9,4,0,0
+Kleberg,0041/0042,Proposition 3,,REP,Yes,35,0,28,7,0,0
+Kleberg,0041/0042,Proposition 3,,REP,No,10,0,6,4,0,0
+Kleberg,0041/0042,Proposition 4,,REP,Yes,43,0,33,10,0,0
+Kleberg,0041/0042,Proposition 4,,REP,No,1,0,0,1,0,0
+Kleberg,0043,President,,REP,Donald J. Trump,37,0,21,16,0,0
+Kleberg,0043,President,,REP,Mike Huckabee,1,0,0,1,0,0
+Kleberg,0043,President,,REP,Ted Cruz,75,2,47,26,2,0
+Kleberg,0043,President,,REP,Carly Fiorina,0,0,0,0,0,0
+Kleberg,0043,President,,REP,Rand Paul,0,0,0,0,0,0
+Kleberg,0043,President,,REP,Rick Santorum,0,0,0,0,0,0
+Kleberg,0043,President,,REP,Marco Rubio,30,0,24,6,0,0
+Kleberg,0043,President,,REP,Lindsey Graham,0,0,0,0,0,0
+Kleberg,0043,President,,REP,John R. Kasich,5,0,3,2,0,0
+Kleberg,0043,President,,REP,Jeb Bush,5,0,2,3,0,0
+Kleberg,0043,President,,REP,Elizabeth Gray,0,0,0,0,0,0
+Kleberg,0043,President,,REP,Ben Carson,10,0,8,2,0,0
+Kleberg,0043,President,,REP,Chris Christie,0,0,0,0,0,0
+Kleberg,0043,President,,REP,Uncommitted,0,0,0,0,0,0
+Kleberg,0043,U.S. House,34,REP,"William ""Willie"" Vaden",70,0,40,30,0,0
+Kleberg,0043,U.S. House,34,REP,Ray Gonzalez Jr,67,1,45,21,1,0
+Kleberg,0043,Railroad Commissioner,,REP,John Greytok,21,0,12,9,0,0
+Kleberg,0043,Railroad Commissioner,,REP,Weston Martinez,36,1,26,9,1,0
+Kleberg,0043,Railroad Commissioner,,REP,Lance N. Christian,13,0,10,3,0,0
+Kleberg,0043,Railroad Commissioner,,REP,Ron Hale,25,0,12,13,0,0
+Kleberg,0043,Railroad Commissioner,,REP,Wayne Christian,19,0,11,8,0,0
+Kleberg,0043,Railroad Commissioner,,REP,Doug Jeffrey,3,0,1,2,0,0
+Kleberg,0043,Railroad Commissioner,,REP,Gary Gates,13,0,8,5,0,0
+Kleberg,0043,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,82,1,58,23,1,0
+Kleberg,0043,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,46,0,24,22,0,0
+Kleberg,0043,"Justice, Supreme Court, Place 5",,REP,Rick Green,82,1,50,31,1,0
+Kleberg,0043,"Justice, Supreme Court, Place 5",,REP,Paul Green,42,0,28,14,0,0
+Kleberg,0043,"Justice, Supreme Court, Place 9",,REP,Joe Pool,67,0,38,29,0,0
+Kleberg,0043,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,69,1,47,21,1,0
+Kleberg,0043,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,45,0,29,16,0,0
+Kleberg,0043,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,56,1,38,17,1,0
+Kleberg,0043,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,25,0,13,12,0,0
+Kleberg,0043,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,38,0,26,12,0,0
+Kleberg,0043,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,69,1,42,26,1,0
+Kleberg,0043,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,6,0,3,3,0,0
+Kleberg,0043,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,13,0,9,4,0,0
+Kleberg,0043,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,67,0,43,24,0,0
+Kleberg,0043,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,57,1,37,19,1,0
+Kleberg,0043,State Representative,43,REP,J. M. Lozano,140,2,88,50,2,0
+Kleberg,0043,"Justice, 13th Court of Appeals District, Place 3",,REP,Greg Perkes,113,1,70,42,1,0
+Kleberg,0043,District Attorney,,REP,John T. Hubert,136,2,85,49,2,0
+Kleberg,0043,Sheriff,,REP,Richard Kirkpatrick,139,0,89,50,0,0
+Kleberg,0043,County Chairman,,REP,Brandon Wayne Barrera,124,1,79,44,1,0
+Kleberg,0043,Proposition 1,,REP,Yes,93,1,57,35,1,0
+Kleberg,0043,Proposition 1,,REP,No,60,1,42,17,1,0
+Kleberg,0043,Proposition 2,,REP,Yes,87,1,57,29,1,0
+Kleberg,0043,Proposition 2,,REP,No,64,1,41,22,1,0
+Kleberg,0043,Proposition 3,,REP,Yes,113,2,76,35,2,0
+Kleberg,0043,Proposition 3,,REP,No,38,0,22,16,0,0
+Kleberg,0043,Proposition 4,,REP,Yes,138,2,89,47,2,0
+Kleberg,0043,Proposition 4,,REP,No,14,0,9,5,0,0
+Kleberg,0044,President,,REP,Donald J. Trump,9,0,5,4,0,0
+Kleberg,0044,President,,REP,Mike Huckabee,0,0,0,0,0,0
+Kleberg,0044,President,,REP,Ted Cruz,25,2,15,8,2,0
+Kleberg,0044,President,,REP,Carly Fiorina,0,0,0,0,0,0
+Kleberg,0044,President,,REP,Rand Paul,2,0,2,0,0,0
+Kleberg,0044,President,,REP,Rick Santorum,0,0,0,0,0,0
+Kleberg,0044,President,,REP,Marco Rubio,11,0,6,5,0,0
+Kleberg,0044,President,,REP,Lindsey Graham,0,0,0,0,0,0
+Kleberg,0044,President,,REP,John R. Kasich,0,0,0,0,0,0
+Kleberg,0044,President,,REP,Jeb Bush,1,0,0,1,0,0
+Kleberg,0044,President,,REP,Elizabeth Gray,0,0,0,0,0,0
+Kleberg,0044,President,,REP,Ben Carson,1,0,1,0,0,0
+Kleberg,0044,President,,REP,Chris Christie,0,0,0,0,0,0
+Kleberg,0044,President,,REP,Uncommitted,0,0,0,0,0,0
+Kleberg,0044,U.S. House,34,REP,"William ""Willie"" Vaden",19,0,12,7,0,0
+Kleberg,0044,U.S. House,34,REP,Ray Gonzalez Jr,20,1,11,8,1,0
+Kleberg,0044,Railroad Commissioner,,REP,John Greytok,8,0,6,2,0,0
+Kleberg,0044,Railroad Commissioner,,REP,Weston Martinez,7,0,3,4,0,0
+Kleberg,0044,Railroad Commissioner,,REP,Lance N. Christian,3,1,1,1,1,0
+Kleberg,0044,Railroad Commissioner,,REP,Ron Hale,7,0,3,4,0,0
+Kleberg,0044,Railroad Commissioner,,REP,Wayne Christian,1,0,1,0,0,0
+Kleberg,0044,Railroad Commissioner,,REP,Doug Jeffrey,2,0,2,0,0,0
+Kleberg,0044,Railroad Commissioner,,REP,Gary Gates,9,1,6,2,1,0
+Kleberg,0044,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,21,1,11,9,1,0
+Kleberg,0044,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,11,0,7,4,0,0
+Kleberg,0044,"Justice, Supreme Court, Place 5",,REP,Rick Green,20,2,11,7,2,0
+Kleberg,0044,"Justice, Supreme Court, Place 5",,REP,Paul Green,13,0,8,5,0,0
+Kleberg,0044,"Justice, Supreme Court, Place 9",,REP,Joe Pool,17,1,9,7,1,0
+Kleberg,0044,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,20,1,13,6,1,0
+Kleberg,0044,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,11,0,7,4,0,0
+Kleberg,0044,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,16,2,9,5,2,0
+Kleberg,0044,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,7,0,3,4,0,0
+Kleberg,0044,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,9,0,5,4,0,0
+Kleberg,0044,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,16,2,7,7,2,0
+Kleberg,0044,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,2,0,2,0,0,0
+Kleberg,0044,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,5,0,3,2,0,0
+Kleberg,0044,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,14,2,8,4,2,0
+Kleberg,0044,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,16,0,9,7,0,0
+Kleberg,0044,State Representative,43,REP,J. M. Lozano,40,1,24,15,1,0
+Kleberg,0044,"Justice, 13th Court of Appeals District, Place 3",,REP,Greg Perkes,28,2,15,11,2,0
+Kleberg,0044,District Attorney,,REP,John T. Hubert,35,2,21,12,2,0
+Kleberg,0044,Sheriff,,REP,Richard Kirkpatrick,41,2,23,16,2,0
+Kleberg,0044,County Chairman,,REP,Brandon Wayne Barrera,36,2,21,13,2,0
+Kleberg,0044,Proposition 1,,REP,Yes,31,2,20,9,2,0
+Kleberg,0044,Proposition 1,,REP,No,14,0,7,7,0,0
+Kleberg,0044,Proposition 2,,REP,Yes,30,1,21,8,1,0
+Kleberg,0044,Proposition 2,,REP,No,17,1,7,9,1,0
+Kleberg,0044,Proposition 3,,REP,Yes,38,2,22,14,2,0
+Kleberg,0044,Proposition 3,,REP,No,7,0,5,2,0,0
+Kleberg,0044,Proposition 4,,REP,Yes,41,2,24,15,2,0
+Kleberg,0044,Proposition 4,,REP,No,1,0,0,1,0,0
+Kleberg,0045,President,,REP,Donald J. Trump,6,1,3,2,1,0
+Kleberg,0045,President,,REP,Mike Huckabee,0,0,0,0,0,0
+Kleberg,0045,President,,REP,Ted Cruz,14,0,9,5,0,0
+Kleberg,0045,President,,REP,Carly Fiorina,0,0,0,0,0,0
+Kleberg,0045,President,,REP,Rand Paul,0,0,0,0,0,0
+Kleberg,0045,President,,REP,Rick Santorum,0,0,0,0,0,0
+Kleberg,0045,President,,REP,Marco Rubio,7,0,4,3,0,0
+Kleberg,0045,President,,REP,Lindsey Graham,0,0,0,0,0,0
+Kleberg,0045,President,,REP,John R. Kasich,0,0,0,0,0,0
+Kleberg,0045,President,,REP,Jeb Bush,1,0,0,1,0,0
+Kleberg,0045,President,,REP,Elizabeth Gray,0,0,0,0,0,0
+Kleberg,0045,President,,REP,Ben Carson,1,0,1,0,0,0
+Kleberg,0045,President,,REP,Chris Christie,0,0,0,0,0,0
+Kleberg,0045,President,,REP,Uncommitted,0,0,0,0,0,0
+Kleberg,0045,U.S. House,34,REP,"William ""Willie"" Vaden",6,0,5,1,0,0
+Kleberg,0045,U.S. House,34,REP,Ray Gonzalez Jr,14,1,9,4,1,0
+Kleberg,0045,Railroad Commissioner,,REP,John Greytok,3,0,1,2,0,0
+Kleberg,0045,Railroad Commissioner,,REP,Weston Martinez,9,1,6,2,1,0
+Kleberg,0045,Railroad Commissioner,,REP,Lance N. Christian,2,0,2,0,0,0
+Kleberg,0045,Railroad Commissioner,,REP,Ron Hale,2,0,2,0,0,0
+Kleberg,0045,Railroad Commissioner,,REP,Wayne Christian,1,0,0,1,0,0
+Kleberg,0045,Railroad Commissioner,,REP,Doug Jeffrey,1,0,0,1,0,0
+Kleberg,0045,Railroad Commissioner,,REP,Gary Gates,3,0,3,0,0,0
+Kleberg,0045,"Justice, Supreme Court, Place 3",,REP,Debra Lehrmann,15,1,10,4,1,0
+Kleberg,0045,"Justice, Supreme Court, Place 3",,REP,Michael Massengale,5,0,4,1,0,0
+Kleberg,0045,"Justice, Supreme Court, Place 5",,REP,Rick Green,12,0,9,3,0,0
+Kleberg,0045,"Justice, Supreme Court, Place 5",,REP,Paul Green,9,1,5,3,1,0
+Kleberg,0045,"Justice, Supreme Court, Place 9",,REP,Joe Pool,3,0,2,1,0,0
+Kleberg,0045,"Justice, Supreme Court, Place 9",,REP,Eva Guzman,18,1,13,4,1,0
+Kleberg,0045,"Judge, Court of Criminal Appeals, Place 2",,REP,Ray Wheless,3,0,3,0,0,0
+Kleberg,0045,"Judge, Court of Criminal Appeals, Place 2",,REP,Mary Lou Keel,15,1,9,5,1,0
+Kleberg,0045,"Judge, Court of Criminal Appeals, Place 2",,REP,Chris Oldner,3,0,3,0,0,0
+Kleberg,0045,"Judge, Court of Criminal Appeals, Place 5",,REP,Steve Smith,7,0,4,3,0,0
+Kleberg,0045,"Judge, Court of Criminal Appeals, Place 5",,REP,Scott Walker,8,1,4,3,1,0
+Kleberg,0045,"Judge, Court of Criminal Appeals, Place 5",,REP,Sid Harle,1,0,1,0,0,0
+Kleberg,0045,"Judge, Court of Criminal Appeals, Place 5",,REP,Brent Webster,5,0,5,0,0,0
+Kleberg,0045,"Judge, Court of Criminal Appeals, Place 6",,REP,Michael E. Keasler,9,0,5,4,0,0
+Kleberg,0045,"Judge, Court of Criminal Appeals, Place 6",,REP,Richard Davis,12,1,9,2,1,0
+Kleberg,0045,State Representative,43,REP,J. M. Lozano,27,1,14,12,1,0
+Kleberg,0045,"Justice, 13th Court of Appeals District, Place 3",,REP,Greg Perkes,18,1,13,4,1,0
+Kleberg,0045,District Attorney,,REP,John T. Hubert,25,1,13,11,1,0
+Kleberg,0045,Sheriff,,REP,Richard Kirkpatrick,26,1,13,12,1,0
+Kleberg,0045,County Chairman,,REP,Brandon Wayne Barrera,22,1,13,8,1,0
+Kleberg,0045,Proposition 1,,REP,Yes,12,1,7,4,1,0
+Kleberg,0045,Proposition 1,,REP,No,13,0,7,6,0,0
+Kleberg,0045,Proposition 2,,REP,Yes,15,1,10,4,1,0
+Kleberg,0045,Proposition 2,,REP,No,11,0,5,6,0,0
+Kleberg,0045,Proposition 3,,REP,Yes,16,1,10,5,1,0
+Kleberg,0045,Proposition 3,,REP,No,9,0,5,4,0,0
+Kleberg,0045,Proposition 4,,REP,Yes,19,1,11,7,1,0
+Kleberg,0045,Proposition 4,,REP,No,4,0,3,1,0,0


### PR DESCRIPTION
Precincts 13/14, 22/23, 33/34, and 41/42 are lumped together.