### PR TITLE
Properly quote judicial race name

### DIFF
--- a/2016/20160301__tx__primary__swisher__precinct.csv
+++ b/2016/20160301__tx__primary__swisher__precinct.csv
@@ -487,30 +487,30 @@ Swisher,0006,State Representative,88,REP,UNDER VOTES,17
 Swisher,0007,State Representative,88,REP,UNDER VOTES,48
 Swisher,0009,State Representative,88,REP,UNDER VOTES,1
 Swisher,0011,State Representative,88,REP,UNDER VOTES,19
-Swisher,0001,Justice, 7th Court of Appeals District, Place 4,,REP,Jim Campbell,79
-Swisher,0002,Justice, 7th Court of Appeals District, Place 4,,REP,Jim Campbell,144
-Swisher,0003,Justice, 7th Court of Appeals District, Place 4,,REP,Jim Campbell,150
-Swisher,0004,Justice, 7th Court of Appeals District, Place 4,,REP,Jim Campbell,40
-Swisher,0006,Justice, 7th Court of Appeals District, Place 4,,REP,Jim Campbell,65
-Swisher,0007,Justice, 7th Court of Appeals District, Place 4,,REP,Jim Campbell,86
-Swisher,0009,Justice, 7th Court of Appeals District, Place 4,,REP,Jim Campbell,6
-Swisher,0011,Justice, 7th Court of Appeals District, Place 4,,REP,Jim Campbell,55
-Swisher,0001,Justice, 7th Court of Appeals District, Place 4,,REP,OVER VOTES,0
-Swisher,0002,Justice, 7th Court of Appeals District, Place 4,,REP,OVER VOTES,0
-Swisher,0003,Justice, 7th Court of Appeals District, Place 4,,REP,OVER VOTES,0
-Swisher,0004,Justice, 7th Court of Appeals District, Place 4,,REP,OVER VOTES,0
-Swisher,0006,Justice, 7th Court of Appeals District, Place 4,,REP,OVER VOTES,0
-Swisher,0007,Justice, 7th Court of Appeals District, Place 4,,REP,OVER VOTES,0
-Swisher,0009,Justice, 7th Court of Appeals District, Place 4,,REP,OVER VOTES,0
-Swisher,0011,Justice, 7th Court of Appeals District, Place 4,,REP,OVER VOTES,0
-Swisher,0001,Justice, 7th Court of Appeals District, Place 4,,REP,UNDER VOTES,45
-Swisher,0002,Justice, 7th Court of Appeals District, Place 4,,REP,UNDER VOTES,59
-Swisher,0003,Justice, 7th Court of Appeals District, Place 4,,REP,UNDER VOTES,67
-Swisher,0004,Justice, 7th Court of Appeals District, Place 4,,REP,UNDER VOTES,15
-Swisher,0006,Justice, 7th Court of Appeals District, Place 4,,REP,UNDER VOTES,18
-Swisher,0007,Justice, 7th Court of Appeals District, Place 4,,REP,UNDER VOTES,56
-Swisher,0009,Justice, 7th Court of Appeals District, Place 4,,REP,UNDER VOTES,2
-Swisher,0011,Justice, 7th Court of Appeals District, Place 4,,REP,UNDER VOTES,27
+Swisher,0001,"Justice, 7th Court of Appeals District, Place 4",,REP,Jim Campbell,79
+Swisher,0002,"Justice, 7th Court of Appeals District, Place 4",,REP,Jim Campbell,144
+Swisher,0003,"Justice, 7th Court of Appeals District, Place 4",,REP,Jim Campbell,150
+Swisher,0004,"Justice, 7th Court of Appeals District, Place 4",,REP,Jim Campbell,40
+Swisher,0006,"Justice, 7th Court of Appeals District, Place 4",,REP,Jim Campbell,65
+Swisher,0007,"Justice, 7th Court of Appeals District, Place 4",,REP,Jim Campbell,86
+Swisher,0009,"Justice, 7th Court of Appeals District, Place 4",,REP,Jim Campbell,6
+Swisher,0011,"Justice, 7th Court of Appeals District, Place 4",,REP,Jim Campbell,55
+Swisher,0001,"Justice, 7th Court of Appeals District, Place 4",,REP,OVER VOTES,0
+Swisher,0002,"Justice, 7th Court of Appeals District, Place 4",,REP,OVER VOTES,0
+Swisher,0003,"Justice, 7th Court of Appeals District, Place 4",,REP,OVER VOTES,0
+Swisher,0004,"Justice, 7th Court of Appeals District, Place 4",,REP,OVER VOTES,0
+Swisher,0006,"Justice, 7th Court of Appeals District, Place 4",,REP,OVER VOTES,0
+Swisher,0007,"Justice, 7th Court of Appeals District, Place 4",,REP,OVER VOTES,0
+Swisher,0009,"Justice, 7th Court of Appeals District, Place 4",,REP,OVER VOTES,0
+Swisher,0011,"Justice, 7th Court of Appeals District, Place 4",,REP,OVER VOTES,0
+Swisher,0001,"Justice, 7th Court of Appeals District, Place 4",,REP,UNDER VOTES,45
+Swisher,0002,"Justice, 7th Court of Appeals District, Place 4",,REP,UNDER VOTES,59
+Swisher,0003,"Justice, 7th Court of Appeals District, Place 4",,REP,UNDER VOTES,67
+Swisher,0004,"Justice, 7th Court of Appeals District, Place 4",,REP,UNDER VOTES,15
+Swisher,0006,"Justice, 7th Court of Appeals District, Place 4",,REP,UNDER VOTES,18
+Swisher,0007,"Justice, 7th Court of Appeals District, Place 4",,REP,UNDER VOTES,56
+Swisher,0009,"Justice, 7th Court of Appeals District, Place 4",,REP,UNDER VOTES,2
+Swisher,0011,"Justice, 7th Court of Appeals District, Place 4",,REP,UNDER VOTES,27
 Swisher,0001,President,,DEM,Star Locke,0
 Swisher,0002,President,,DEM,Star Locke,0
 Swisher,0003,President,,DEM,Star Locke,0


### PR DESCRIPTION
I accidentally neglected quotation marks when reformatting this judicial race name. This PR fixes it.