### PR TITLE
Fix up malformed CSV headers

### DIFF
--- a/2016/20160301__tx__primary__angelina__precinct.csv
+++ b/2016/20160301__tx__primary__angelina__precinct.csv
@@ -1,4 +1,4 @@
-﻿county,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Angelina,1,Registered Voters - Total,,,,548
 Angelina,2,Registered Voters - Total,,,,2552
 Angelina,3,Registered Voters - Total,,,,1863

--- a/2016/20160301__tx__primary__baylor__precinct.csv
+++ b/2016/20160301__tx__primary__baylor__precinct.csv
@@ -1,4 +1,4 @@
-﻿county,precinct,office,district,party,candidate,votes,early_voting,election_day
+county,precinct,office,district,party,candidate,votes,early_voting,election_day
 Baylor,1,Ballots Cast - Election Day,,DEM,,,,13
 Baylor,1,President,,DEM,Martin J. O'Malley,,,0
 Baylor,1,President,,DEM,Calvis L. Hawes,,,0

--- a/2016/20161108__tx__general__garza__precinct.csv
+++ b/2016/20161108__tx__general__garza__precinct.csv
@@ -1,4 +1,4 @@
-68,,office,district,party,candidate,early_voting,election_day,votes
+county,precinct,office,district,party,candidate,early_voting,election_day,votes
 Garza,1,Ballots Cast,,,,217,126,343
 Garza,1,Straight Party,,Republican,,91,62,153
 Garza,1,Straight Party,,Democratic,,13,3,16


### PR DESCRIPTION
Angelina and Baylor had an invisible [byte order mark](https://en.wikipedia.org/wiki/Byte_order_mark) as the first character.

Garza had incorrect header fields.