### PR TITLE
Add precinct-level results for the 2018 general election in Tom Green County

### DIFF
--- a/2018/20181106__tx__general__tom_green__precinct.csv
+++ b/2018/20181106__tx__general__tom_green__precinct.csv
@@ -1,0 +1,4577 @@
+county,precinct,office,district,party,candidate,votes,early_voting,election_day,absentee
+Tom Green,106 BS1,STRAIGHT PARTY,,REP,,144,100,27,17
+Tom Green,106 BS1,STRAIGHT PARTY,,DEM,,115,82,23,10
+Tom Green,106 BS1,STRAIGHT PARTY,,LIB,,5,4,1,0
+Tom Green,106 BS1,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,106 BS1,STRAIGHT PARTY,,,Under Votes,153,87,23,43
+Tom Green,106 BS1,U.S. Senate,,REP,Ted Cruz,236,152,45,39
+Tom Green,106 BS1,U.S. Senate,,DEM,Beto O'Rourke,173,117,27,29
+Tom Green,106 BS1,U.S. Senate,,LIB,Neal M. Dikeman,3,0,2,1
+Tom Green,106 BS1,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,106 BS1,U.S. Senate,,,Under Votes,5,4,0,1
+Tom Green,106 BS1,U.S. House,11,REP,Mike Conaway,258,166,46,46
+Tom Green,106 BS1,U.S. House,11,DEM,Jennie Lou Leeder,148,101,25,22
+Tom Green,106 BS1,U.S. House,11,LIB,Rhett Rosenquest Smith,2,1,1,0
+Tom Green,106 BS1,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,106 BS1,U.S. House,11,,Under Votes,9,5,2,2
+Tom Green,106 BS1,Governor,,REP,Greg Abbott,246,155,50,41
+Tom Green,106 BS1,Governor,,DEM,Lupe Valdez,156,109,22,25
+Tom Green,106 BS1,Governor,,LIB,Mark Jay Tippetts,9,6,1,2
+Tom Green,106 BS1,Governor,,,Over Votes,0,0,0,0
+Tom Green,106 BS1,Governor,,,Under Votes,6,3,1,2
+Tom Green,106 BS1,Lieutenant Governor,,REP,Dan Patrick,226,148,42,36
+Tom Green,106 BS1,Lieutenant Governor,,DEM,Mike Collier,172,117,27,28
+Tom Green,106 BS1,Lieutenant Governor,,LIB,Kerry Douglas McKennon,9,4,2,3
+Tom Green,106 BS1,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,106 BS1,Lieutenant Governor,,,Under Votes,10,4,3,3
+Tom Green,106 BS1,Attorney General,,REP,Ken Paxton,217,143,40,34
+Tom Green,106 BS1,Attorney General,,DEM,Justin Nelson,174,114,29,31
+Tom Green,106 BS1,Attorney General,,LIB,Michael Ray Harris,16,12,3,1
+Tom Green,106 BS1,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,106 BS1,Attorney General,,,Under Votes,10,4,2,4
+Tom Green,106 BS1,Comptroller of Public Accounts,,REP,Glenn Hegar,226,148,40,38
+Tom Green,106 BS1,Comptroller of Public Accounts,,DEM,Joi Chevalier,157,106,25,26
+Tom Green,106 BS1,Comptroller of Public Accounts,,LIB,Ben Sanders,20,14,3,3
+Tom Green,106 BS1,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,106 BS1,Comptroller of Public Accounts,,,Under Votes,14,5,6,3
+Tom Green,106 BS1,Commissioner of the General Land Office,,REP,George P. Bush,234,153,41,40
+Tom Green,106 BS1,Commissioner of the General Land Office,,DEM,Miguel Suazo,158,105,28,25
+Tom Green,106 BS1,Commissioner of the General Land Office,,LIB,Matt Pina,11,10,1,0
+Tom Green,106 BS1,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,106 BS1,Commissioner of the General Land Office,,,Under Votes,14,5,4,5
+Tom Green,106 BS1,Commissioner of Agriculture,,REP,Sid Miller,228,152,39,37
+Tom Green,106 BS1,Commissioner of Agriculture,,DEM,Kim Olson,164,106,27,31
+Tom Green,106 BS1,Commissioner of Agriculture,,LIB,Richard Carpenter,15,12,3,0
+Tom Green,106 BS1,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,106 BS1,Commissioner of Agriculture,,,Under Votes,10,3,5,2
+Tom Green,106 BS1,Railroad Commissioner,,REP,Christi Craddick,236,155,40,41
+Tom Green,106 BS1,Railroad Commissioner,,DEM,Roman McAllen,158,108,26,24
+Tom Green,106 BS1,Railroad Commissioner,,LIB,Mike Wright,14,7,5,2
+Tom Green,106 BS1,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,106 BS1,Railroad Commissioner,,,Under Votes,9,3,3,3
+Tom Green,106 BS1,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,233,150,44,39
+Tom Green,106 BS1,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,168,117,26,25
+Tom Green,106 BS1,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,106 BS1,"Justice, Supreme Court, Place 2",,,Under Votes,16,6,4,6
+Tom Green,106 BS1,"Justice, Supreme Court, Place 4",,REP,John Devine,239,154,45,40
+Tom Green,106 BS1,"Justice, Supreme Court, Place 4",,,R. K. Sandill,166,115,26,25
+Tom Green,106 BS1,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,106 BS1,"Justice, Supreme Court, Place 4",,,Under Votes,12,4,3,5
+Tom Green,106 BS1,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,239,151,47,41
+Tom Green,106 BS1,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,164,115,25,24
+Tom Green,106 BS1,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,106 BS1,"Justice, Supreme Court, Place 6",,,Under Votes,14,7,2,5
+Tom Green,106 BS1,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,227,147,41,39
+Tom Green,106 BS1,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,167,115,27,25
+Tom Green,106 BS1,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,11,7,1,3
+Tom Green,106 BS1,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,106 BS1,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,12,4,5,3
+Tom Green,106 BS1,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,233,151,43,39
+Tom Green,106 BS1,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,167,113,27,27
+Tom Green,106 BS1,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,106 BS1,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,17,9,4,4
+Tom Green,106 BS1,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,250,161,49,40
+Tom Green,106 BS1,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,60,38,8,14
+Tom Green,106 BS1,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,106 BS1,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,107,74,17,16
+Tom Green,106 BS1,State Representative,72,REP,Drew Darby,276,176,53,47
+Tom Green,106 BS1,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,106 BS1,State Representative,72,,Under Votes,141,97,21,23
+Tom Green,106 BS1,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,239,155,44,40
+Tom Green,106 BS1,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,159,109,25,25
+Tom Green,106 BS1,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,106 BS1,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,19,9,5,5
+Tom Green,106 BS1,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,239,156,43,40
+Tom Green,106 BS1,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,158,109,26,23
+Tom Green,106 BS1,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,106 BS1,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,20,8,5,7
+Tom Green,106 BS1,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,236,153,43,40
+Tom Green,106 BS1,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,162,112,27,23
+Tom Green,106 BS1,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,106 BS1,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,19,8,4,7
+Tom Green,106 BS1,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",229,151,41,37
+Tom Green,106 BS1,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,165,114,28,23
+Tom Green,106 BS1,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),0,0,0,0
+Tom Green,106 BS1,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,106 BS1,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,23,8,5,10
+Tom Green,106 BS1,Justice of the Peace Pct. 1,,REP,Susan Werner,238,154,43,41
+Tom Green,106 BS1,Justice of the Peace Pct. 1,,DEM,Sally Ayana,165,115,26,24
+Tom Green,106 BS1,Justice of the Peace Pct. 1,,,Over Votes,0,0,0,0
+Tom Green,106 BS1,Justice of the Peace Pct. 1,,,Under Votes,14,4,5,5
+Tom Green,106 BS1,San Angelo Independent School District Proposition A,,,FOR,187,114,29,44
+Tom Green,106 BS1,San Angelo Independent School District Proposition A,,,AGAINST,193,131,41,21
+Tom Green,106 BS1,San Angelo Independent School District Proposition A,,,Over Votes,0,0,0,0
+Tom Green,106 BS1,San Angelo Independent School District Proposition A,,,Under Votes,37,28,4,5
+Tom Green,106 BS1,San Angelo Independent School District Proposition B,,,FOR,180,115,27,38
+Tom Green,106 BS1,San Angelo Independent School District Proposition B,,,AGAINST,208,135,44,29
+Tom Green,106 BS1,San Angelo Independent School District Proposition B,,,Over Votes,0,0,0,0
+Tom Green,106 BS1,San Angelo Independent School District Proposition B,,,Under Votes,29,23,3,3
+Tom Green,106 BS1,Ballots Cast,,,,417,273,74,70
+Tom Green,107 BS2,STRAIGHT PARTY,,REP,,167,64,99,4
+Tom Green,107 BS2,STRAIGHT PARTY,,DEM,,90,20,69,1
+Tom Green,107 BS2,STRAIGHT PARTY,,LIB,,2,0,2,0
+Tom Green,107 BS2,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,107 BS2,STRAIGHT PARTY,,,Under Votes,138,55,74,9
+Tom Green,107 BS2,U.S. Senate,,REP,Ted Cruz,255,101,144,10
+Tom Green,107 BS2,U.S. Senate,,DEM,Beto O'Rourke,130,32,94,4
+Tom Green,107 BS2,U.S. Senate,,LIB,Neal M. Dikeman,7,4,3,0
+Tom Green,107 BS2,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,107 BS2,U.S. Senate,,,Under Votes,5,2,3,0
+Tom Green,107 BS2,U.S. House,11,REP,Mike Conaway,266,109,146,11
+Tom Green,107 BS2,U.S. House,11,DEM,Jennie Lou Leeder,115,26,86,3
+Tom Green,107 BS2,U.S. House,11,LIB,Rhett Rosenquest Smith,8,3,5,0
+Tom Green,107 BS2,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,107 BS2,U.S. House,11,,Under Votes,8,1,7,0
+Tom Green,107 BS2,Governor,,REP,Greg Abbott,270,107,152,11
+Tom Green,107 BS2,Governor,,DEM,Lupe Valdez,112,26,83,3
+Tom Green,107 BS2,Governor,,LIB,Mark Jay Tippetts,8,4,4,0
+Tom Green,107 BS2,Governor,,,Over Votes,0,0,0,0
+Tom Green,107 BS2,Governor,,,Under Votes,7,2,5,0
+Tom Green,107 BS2,Lieutenant Governor,,REP,Dan Patrick,248,103,136,9
+Tom Green,107 BS2,Lieutenant Governor,,DEM,Mike Collier,126,32,89,5
+Tom Green,107 BS2,Lieutenant Governor,,LIB,Kerry Douglas McKennon,14,3,11,0
+Tom Green,107 BS2,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,107 BS2,Lieutenant Governor,,,Under Votes,9,1,8,0
+Tom Green,107 BS2,Attorney General,,REP,Ken Paxton,243,98,136,9
+Tom Green,107 BS2,Attorney General,,DEM,Justin Nelson,138,39,94,5
+Tom Green,107 BS2,Attorney General,,LIB,Michael Ray Harris,8,0,8,0
+Tom Green,107 BS2,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,107 BS2,Attorney General,,,Under Votes,8,2,6,0
+Tom Green,107 BS2,Comptroller of Public Accounts,,REP,Glenn Hegar,251,105,135,11
+Tom Green,107 BS2,Comptroller of Public Accounts,,DEM,Joi Chevalier,121,30,88,3
+Tom Green,107 BS2,Comptroller of Public Accounts,,LIB,Ben Sanders,13,2,11,0
+Tom Green,107 BS2,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,107 BS2,Comptroller of Public Accounts,,,Under Votes,12,2,10,0
+Tom Green,107 BS2,Commissioner of the General Land Office,,REP,George P. Bush,254,105,138,11
+Tom Green,107 BS2,Commissioner of the General Land Office,,DEM,Miguel Suazo,118,29,86,3
+Tom Green,107 BS2,Commissioner of the General Land Office,,LIB,Matt Pina,16,3,13,0
+Tom Green,107 BS2,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,107 BS2,Commissioner of the General Land Office,,,Under Votes,9,2,7,0
+Tom Green,107 BS2,Commissioner of Agriculture,,REP,Sid Miller,246,102,134,10
+Tom Green,107 BS2,Commissioner of Agriculture,,DEM,Kim Olson,131,34,93,4
+Tom Green,107 BS2,Commissioner of Agriculture,,LIB,Richard Carpenter,10,1,9,0
+Tom Green,107 BS2,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,107 BS2,Commissioner of Agriculture,,,Under Votes,10,2,8,0
+Tom Green,107 BS2,Railroad Commissioner,,REP,Christi Craddick,252,107,136,9
+Tom Green,107 BS2,Railroad Commissioner,,DEM,Roman McAllen,125,30,90,5
+Tom Green,107 BS2,Railroad Commissioner,,LIB,Mike Wright,12,0,12,0
+Tom Green,107 BS2,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,107 BS2,Railroad Commissioner,,,Under Votes,8,2,6,0
+Tom Green,107 BS2,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,256,108,138,10
+Tom Green,107 BS2,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,131,30,97,4
+Tom Green,107 BS2,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,107 BS2,"Justice, Supreme Court, Place 2",,,Under Votes,10,1,9,0
+Tom Green,107 BS2,"Justice, Supreme Court, Place 4",,REP,John Devine,256,104,143,9
+Tom Green,107 BS2,"Justice, Supreme Court, Place 4",,,R. K. Sandill,131,34,92,5
+Tom Green,107 BS2,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,107 BS2,"Justice, Supreme Court, Place 4",,,Under Votes,10,1,9,0
+Tom Green,107 BS2,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,254,103,141,10
+Tom Green,107 BS2,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,132,34,94,4
+Tom Green,107 BS2,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,107 BS2,"Justice, Supreme Court, Place 6",,,Under Votes,11,2,9,0
+Tom Green,107 BS2,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,251,105,136,10
+Tom Green,107 BS2,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,125,31,90,4
+Tom Green,107 BS2,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,11,1,10,0
+Tom Green,107 BS2,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,107 BS2,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,10,2,8,0
+Tom Green,107 BS2,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,256,106,141,9
+Tom Green,107 BS2,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,131,31,95,5
+Tom Green,107 BS2,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,107 BS2,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,10,2,8,0
+Tom Green,107 BS2,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,269,109,149,11
+Tom Green,107 BS2,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,44,10,32,2
+Tom Green,107 BS2,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,107 BS2,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,84,20,63,1
+Tom Green,107 BS2,State Representative,72,REP,Drew Darby,299,117,171,11
+Tom Green,107 BS2,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,107 BS2,State Representative,72,,Under Votes,98,22,73,3
+Tom Green,107 BS2,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,254,105,140,9
+Tom Green,107 BS2,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,130,32,93,5
+Tom Green,107 BS2,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,107 BS2,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,13,2,11,0
+Tom Green,107 BS2,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,254,107,138,9
+Tom Green,107 BS2,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,131,30,96,5
+Tom Green,107 BS2,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,107 BS2,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,12,2,10,0
+Tom Green,107 BS2,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,250,103,138,9
+Tom Green,107 BS2,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,133,34,95,4
+Tom Green,107 BS2,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,107 BS2,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,14,2,11,1
+Tom Green,107 BS2,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",250,102,139,9
+Tom Green,107 BS2,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,132,33,94,5
+Tom Green,107 BS2,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),0,0,0,0
+Tom Green,107 BS2,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,107 BS2,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,15,4,11,0
+Tom Green,107 BS2,Justice of the Peace Pct. 1,,REP,Susan Werner,264,105,149,10
+Tom Green,107 BS2,Justice of the Peace Pct. 1,,DEM,Sally Ayana,125,32,89,4
+Tom Green,107 BS2,Justice of the Peace Pct. 1,,,Over Votes,0,0,0,0
+Tom Green,107 BS2,Justice of the Peace Pct. 1,,,Under Votes,8,2,6,0
+Tom Green,107 BS2,San Angelo Independent School District Proposition A,,,FOR,128,40,81,7
+Tom Green,107 BS2,San Angelo Independent School District Proposition A,,,AGAINST,233,85,142,6
+Tom Green,107 BS2,San Angelo Independent School District Proposition A,,,Over Votes,0,0,0,0
+Tom Green,107 BS2,San Angelo Independent School District Proposition A,,,Under Votes,36,14,21,1
+Tom Green,107 BS2,San Angelo Independent School District Proposition B,,,FOR,133,39,87,7
+Tom Green,107 BS2,San Angelo Independent School District Proposition B,,,AGAINST,232,90,136,6
+Tom Green,107 BS2,San Angelo Independent School District Proposition B,,,Over Votes,0,0,0,0
+Tom Green,107 BS2,San Angelo Independent School District Proposition B,,,Under Votes,32,10,21,1
+Tom Green,107 BS2,Ballots Cast,,,,397,139,244,14
+Tom Green,108 BS3,STRAIGHT PARTY,,REP,,261,140,96,25
+Tom Green,108 BS3,STRAIGHT PARTY,,DEM,,30,19,10,1
+Tom Green,108 BS3,STRAIGHT PARTY,,LIB,,1,0,1,0
+Tom Green,108 BS3,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,108 BS3,STRAIGHT PARTY,,,Under Votes,192,122,56,14
+Tom Green,108 BS3,U.S. Senate,,REP,Ted Cruz,426,242,147,37
+Tom Green,108 BS3,U.S. Senate,,DEM,Beto O'Rourke,54,38,13,3
+Tom Green,108 BS3,U.S. Senate,,LIB,Neal M. Dikeman,2,1,1,0
+Tom Green,108 BS3,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,108 BS3,U.S. Senate,,,Under Votes,2,0,2,0
+Tom Green,108 BS3,U.S. House,11,REP,Mike Conaway,423,240,146,37
+Tom Green,108 BS3,U.S. House,11,DEM,Jennie Lou Leeder,45,31,11,3
+Tom Green,108 BS3,U.S. House,11,LIB,Rhett Rosenquest Smith,9,6,3,0
+Tom Green,108 BS3,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,108 BS3,U.S. House,11,,Under Votes,7,4,3,0
+Tom Green,108 BS3,Governor,,REP,Greg Abbott,431,246,148,37
+Tom Green,108 BS3,Governor,,DEM,Lupe Valdez,44,29,12,3
+Tom Green,108 BS3,Governor,,LIB,Mark Jay Tippetts,5,4,1,0
+Tom Green,108 BS3,Governor,,,Over Votes,0,0,0,0
+Tom Green,108 BS3,Governor,,,Under Votes,4,2,2,0
+Tom Green,108 BS3,Lieutenant Governor,,REP,Dan Patrick,386,213,136,37
+Tom Green,108 BS3,Lieutenant Governor,,DEM,Mike Collier,79,54,22,3
+Tom Green,108 BS3,Lieutenant Governor,,LIB,Kerry Douglas McKennon,10,8,2,0
+Tom Green,108 BS3,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,108 BS3,Lieutenant Governor,,,Under Votes,9,6,3,0
+Tom Green,108 BS3,Attorney General,,REP,Ken Paxton,411,233,143,35
+Tom Green,108 BS3,Attorney General,,DEM,Justin Nelson,63,41,17,5
+Tom Green,108 BS3,Attorney General,,LIB,Michael Ray Harris,9,6,3,0
+Tom Green,108 BS3,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,108 BS3,Attorney General,,,Under Votes,1,1,0,0
+Tom Green,108 BS3,Comptroller of Public Accounts,,REP,Glenn Hegar,420,241,143,36
+Tom Green,108 BS3,Comptroller of Public Accounts,,DEM,Joi Chevalier,47,33,11,3
+Tom Green,108 BS3,Comptroller of Public Accounts,,LIB,Ben Sanders,9,4,5,0
+Tom Green,108 BS3,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,108 BS3,Comptroller of Public Accounts,,,Under Votes,8,3,4,1
+Tom Green,108 BS3,Commissioner of the General Land Office,,REP,George P. Bush,399,226,138,35
+Tom Green,108 BS3,Commissioner of the General Land Office,,DEM,Miguel Suazo,51,35,13,3
+Tom Green,108 BS3,Commissioner of the General Land Office,,LIB,Matt Pina,25,16,9,0
+Tom Green,108 BS3,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,108 BS3,Commissioner of the General Land Office,,,Under Votes,9,4,3,2
+Tom Green,108 BS3,Commissioner of Agriculture,,REP,Sid Miller,415,236,142,37
+Tom Green,108 BS3,Commissioner of Agriculture,,DEM,Kim Olson,57,40,14,3
+Tom Green,108 BS3,Commissioner of Agriculture,,LIB,Richard Carpenter,6,2,4,0
+Tom Green,108 BS3,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,108 BS3,Commissioner of Agriculture,,,Under Votes,6,3,3,0
+Tom Green,108 BS3,Railroad Commissioner,,REP,Christi Craddick,416,239,140,37
+Tom Green,108 BS3,Railroad Commissioner,,DEM,Roman McAllen,46,31,13,2
+Tom Green,108 BS3,Railroad Commissioner,,LIB,Mike Wright,16,8,7,1
+Tom Green,108 BS3,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,108 BS3,Railroad Commissioner,,,Under Votes,6,3,3,0
+Tom Green,108 BS3,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,423,242,145,36
+Tom Green,108 BS3,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,50,34,14,2
+Tom Green,108 BS3,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,108 BS3,"Justice, Supreme Court, Place 2",,,Under Votes,11,5,4,2
+Tom Green,108 BS3,"Justice, Supreme Court, Place 4",,REP,John Devine,424,243,145,36
+Tom Green,108 BS3,"Justice, Supreme Court, Place 4",,,R. K. Sandill,50,33,14,3
+Tom Green,108 BS3,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,108 BS3,"Justice, Supreme Court, Place 4",,,Under Votes,10,5,4,1
+Tom Green,108 BS3,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,427,245,146,36
+Tom Green,108 BS3,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,47,31,13,3
+Tom Green,108 BS3,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,108 BS3,"Justice, Supreme Court, Place 6",,,Under Votes,10,5,4,1
+Tom Green,108 BS3,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,418,241,142,35
+Tom Green,108 BS3,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,46,29,15,2
+Tom Green,108 BS3,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,11,7,3,1
+Tom Green,108 BS3,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,108 BS3,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,9,4,3,2
+Tom Green,108 BS3,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,431,247,148,36
+Tom Green,108 BS3,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,42,28,12,2
+Tom Green,108 BS3,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,108 BS3,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,11,6,3,2
+Tom Green,108 BS3,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,426,246,144,36
+Tom Green,108 BS3,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,23,14,9,0
+Tom Green,108 BS3,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,108 BS3,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,35,21,10,4
+Tom Green,108 BS3,State Representative,72,REP,Drew Darby,435,253,145,37
+Tom Green,108 BS3,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,108 BS3,State Representative,72,,Under Votes,49,28,18,3
+Tom Green,108 BS3,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,422,243,144,35
+Tom Green,108 BS3,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,49,31,15,3
+Tom Green,108 BS3,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,108 BS3,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,13,7,4,2
+Tom Green,108 BS3,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,421,241,144,36
+Tom Green,108 BS3,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,52,35,14,3
+Tom Green,108 BS3,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,108 BS3,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,11,5,5,1
+Tom Green,108 BS3,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,430,248,146,36
+Tom Green,108 BS3,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,43,29,13,1
+Tom Green,108 BS3,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,108 BS3,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,11,4,4,3
+Tom Green,108 BS3,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",422,241,145,36
+Tom Green,108 BS3,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,49,34,13,2
+Tom Green,108 BS3,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),0,0,0,0
+Tom Green,108 BS3,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,108 BS3,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,13,6,5,2
+Tom Green,108 BS3,Justice of the Peace Pct. 1,,REP,Susan Werner,435,249,149,37
+Tom Green,108 BS3,Justice of the Peace Pct. 1,,DEM,Sally Ayana,44,29,12,3
+Tom Green,108 BS3,Justice of the Peace Pct. 1,,,Over Votes,0,0,0,0
+Tom Green,108 BS3,Justice of the Peace Pct. 1,,,Under Votes,5,3,2,0
+Tom Green,108 BS3,Ballots Cast,,,,484,281,163,40
+Tom Green,112 BS4,STRAIGHT PARTY,,REP,,319,153,141,25
+Tom Green,112 BS4,STRAIGHT PARTY,,DEM,,47,13,26,8
+Tom Green,112 BS4,STRAIGHT PARTY,,LIB,,0,0,0,0
+Tom Green,112 BS4,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,112 BS4,STRAIGHT PARTY,,,Under Votes,242,112,116,14
+Tom Green,112 BS4,U.S. Senate,,REP,Ted Cruz,530,244,249,37
+Tom Green,112 BS4,U.S. Senate,,DEM,Beto O'Rourke,72,31,31,10
+Tom Green,112 BS4,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Tom Green,112 BS4,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,112 BS4,U.S. Senate,,,Under Votes,6,3,3,0
+Tom Green,112 BS4,U.S. House,11,REP,Mike Conaway,540,247,254,39
+Tom Green,112 BS4,U.S. House,11,DEM,Jennie Lou Leeder,56,24,25,7
+Tom Green,112 BS4,U.S. House,11,LIB,Rhett Rosenquest Smith,6,5,0,1
+Tom Green,112 BS4,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,112 BS4,U.S. House,11,,Under Votes,6,2,4,0
+Tom Green,112 BS4,Governor,,REP,Greg Abbott,534,246,250,38
+Tom Green,112 BS4,Governor,,DEM,Lupe Valdez,64,28,27,9
+Tom Green,112 BS4,Governor,,LIB,Mark Jay Tippetts,4,4,0,0
+Tom Green,112 BS4,Governor,,,Over Votes,0,0,0,0
+Tom Green,112 BS4,Governor,,,Under Votes,6,0,6,0
+Tom Green,112 BS4,Lieutenant Governor,,REP,Dan Patrick,467,214,219,34
+Tom Green,112 BS4,Lieutenant Governor,,DEM,Mike Collier,117,51,53,13
+Tom Green,112 BS4,Lieutenant Governor,,LIB,Kerry Douglas McKennon,8,5,3,0
+Tom Green,112 BS4,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,112 BS4,Lieutenant Governor,,,Under Votes,16,8,8,0
+Tom Green,112 BS4,Attorney General,,REP,Ken Paxton,504,232,237,35
+Tom Green,112 BS4,Attorney General,,DEM,Justin Nelson,75,31,34,10
+Tom Green,112 BS4,Attorney General,,LIB,Michael Ray Harris,8,5,2,1
+Tom Green,112 BS4,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,112 BS4,Attorney General,,,Under Votes,21,10,10,1
+Tom Green,112 BS4,Comptroller of Public Accounts,,REP,Glenn Hegar,514,239,241,34
+Tom Green,112 BS4,Comptroller of Public Accounts,,DEM,Joi Chevalier,68,27,31,10
+Tom Green,112 BS4,Comptroller of Public Accounts,,LIB,Ben Sanders,6,5,0,1
+Tom Green,112 BS4,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,112 BS4,Comptroller of Public Accounts,,,Under Votes,20,7,11,2
+Tom Green,112 BS4,Commissioner of the General Land Office,,REP,George P. Bush,508,237,236,35
+Tom Green,112 BS4,Commissioner of the General Land Office,,DEM,Miguel Suazo,66,26,31,9
+Tom Green,112 BS4,Commissioner of the General Land Office,,LIB,Matt Pina,17,10,6,1
+Tom Green,112 BS4,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,112 BS4,Commissioner of the General Land Office,,,Under Votes,17,5,10,2
+Tom Green,112 BS4,Commissioner of Agriculture,,REP,Sid Miller,510,239,235,36
+Tom Green,112 BS4,Commissioner of Agriculture,,DEM,Kim Olson,72,26,36,10
+Tom Green,112 BS4,Commissioner of Agriculture,,LIB,Richard Carpenter,7,6,0,1
+Tom Green,112 BS4,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,112 BS4,Commissioner of Agriculture,,,Under Votes,19,7,12,0
+Tom Green,112 BS4,Railroad Commissioner,,REP,Christi Craddick,519,241,242,36
+Tom Green,112 BS4,Railroad Commissioner,,DEM,Roman McAllen,61,25,27,9
+Tom Green,112 BS4,Railroad Commissioner,,LIB,Mike Wright,8,6,2,0
+Tom Green,112 BS4,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,112 BS4,Railroad Commissioner,,,Under Votes,20,6,12,2
+Tom Green,112 BS4,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,515,244,237,34
+Tom Green,112 BS4,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,72,28,35,9
+Tom Green,112 BS4,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,112 BS4,"Justice, Supreme Court, Place 2",,,Under Votes,21,6,11,4
+Tom Green,112 BS4,"Justice, Supreme Court, Place 4",,REP,John Devine,512,238,240,34
+Tom Green,112 BS4,"Justice, Supreme Court, Place 4",,,R. K. Sandill,72,31,31,10
+Tom Green,112 BS4,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,112 BS4,"Justice, Supreme Court, Place 4",,,Under Votes,24,9,12,3
+Tom Green,112 BS4,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,513,244,235,34
+Tom Green,112 BS4,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,74,29,35,10
+Tom Green,112 BS4,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,112 BS4,"Justice, Supreme Court, Place 6",,,Under Votes,21,5,13,3
+Tom Green,112 BS4,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,509,238,237,34
+Tom Green,112 BS4,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,70,27,33,10
+Tom Green,112 BS4,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,7,6,1,0
+Tom Green,112 BS4,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,112 BS4,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,22,7,12,3
+Tom Green,112 BS4,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,515,244,237,34
+Tom Green,112 BS4,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,70,28,32,10
+Tom Green,112 BS4,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,112 BS4,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,23,6,14,3
+Tom Green,112 BS4,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,524,245,244,35
+Tom Green,112 BS4,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,30,13,15,2
+Tom Green,112 BS4,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,112 BS4,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,54,20,24,10
+Tom Green,112 BS4,State Representative,72,REP,Drew Darby,544,245,259,40
+Tom Green,112 BS4,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,112 BS4,State Representative,72,,Under Votes,64,33,24,7
+Tom Green,112 BS4,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,512,239,239,34
+Tom Green,112 BS4,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,72,31,31,10
+Tom Green,112 BS4,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,112 BS4,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,24,8,13,3
+Tom Green,112 BS4,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,510,241,236,33
+Tom Green,112 BS4,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,73,30,33,10
+Tom Green,112 BS4,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,112 BS4,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,25,7,14,4
+Tom Green,112 BS4,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,505,236,236,33
+Tom Green,112 BS4,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,73,31,33,9
+Tom Green,112 BS4,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,112 BS4,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,30,11,14,5
+Tom Green,112 BS4,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",510,238,239,33
+Tom Green,112 BS4,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,71,30,31,10
+Tom Green,112 BS4,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),0,0,0,0
+Tom Green,112 BS4,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,112 BS4,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,27,10,13,4
+Tom Green,112 BS4,Justice of the Peace Pct. 1,,REP,Susan Werner,534,252,245,37
+Tom Green,112 BS4,Justice of the Peace Pct. 1,,DEM,Sally Ayana,65,24,32,9
+Tom Green,112 BS4,Justice of the Peace Pct. 1,,,Over Votes,0,0,0,0
+Tom Green,112 BS4,Justice of the Peace Pct. 1,,,Under Votes,9,2,6,1
+Tom Green,112 BS4,Ballots Cast,,,,608,278,283,47
+Tom Green,114 BS5,STRAIGHT PARTY,,REP,,52,16,32,4
+Tom Green,114 BS5,STRAIGHT PARTY,,DEM,,141,60,67,14
+Tom Green,114 BS5,STRAIGHT PARTY,,LIB,,1,1,0,0
+Tom Green,114 BS5,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,114 BS5,STRAIGHT PARTY,,,Under Votes,110,39,49,22
+Tom Green,114 BS5,U.S. Senate,,REP,Ted Cruz,85,27,49,9
+Tom Green,114 BS5,U.S. Senate,,DEM,Beto O'Rourke,210,87,94,29
+Tom Green,114 BS5,U.S. Senate,,LIB,Neal M. Dikeman,1,0,1,0
+Tom Green,114 BS5,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,114 BS5,U.S. Senate,,,Under Votes,8,2,4,2
+Tom Green,114 BS5,U.S. House,11,REP,Mike Conaway,105,35,56,14
+Tom Green,114 BS5,U.S. House,11,DEM,Jennie Lou Leeder,183,74,84,25
+Tom Green,114 BS5,U.S. House,11,LIB,Rhett Rosenquest Smith,5,3,2,0
+Tom Green,114 BS5,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,114 BS5,U.S. House,11,,Under Votes,11,4,6,1
+Tom Green,114 BS5,Governor,,REP,Greg Abbott,93,31,53,9
+Tom Green,114 BS5,Governor,,DEM,Lupe Valdez,200,81,91,28
+Tom Green,114 BS5,Governor,,LIB,Mark Jay Tippetts,5,3,0,2
+Tom Green,114 BS5,Governor,,,Over Votes,0,0,0,0
+Tom Green,114 BS5,Governor,,,Under Votes,6,1,4,1
+Tom Green,114 BS5,Lieutenant Governor,,REP,Dan Patrick,76,22,49,5
+Tom Green,114 BS5,Lieutenant Governor,,DEM,Mike Collier,208,87,91,30
+Tom Green,114 BS5,Lieutenant Governor,,LIB,Kerry Douglas McKennon,8,5,3,0
+Tom Green,114 BS5,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,114 BS5,Lieutenant Governor,,,Under Votes,12,2,5,5
+Tom Green,114 BS5,Attorney General,,REP,Ken Paxton,83,26,53,4
+Tom Green,114 BS5,Attorney General,,DEM,Justin Nelson,205,82,90,33
+Tom Green,114 BS5,Attorney General,,LIB,Michael Ray Harris,7,4,3,0
+Tom Green,114 BS5,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,114 BS5,Attorney General,,,Under Votes,9,4,2,3
+Tom Green,114 BS5,Comptroller of Public Accounts,,REP,Glenn Hegar,77,24,49,4
+Tom Green,114 BS5,Comptroller of Public Accounts,,DEM,Joi Chevalier,196,78,89,29
+Tom Green,114 BS5,Comptroller of Public Accounts,,LIB,Ben Sanders,11,7,4,0
+Tom Green,114 BS5,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,114 BS5,Comptroller of Public Accounts,,,Under Votes,20,7,6,7
+Tom Green,114 BS5,Commissioner of the General Land Office,,REP,George P. Bush,83,28,48,7
+Tom Green,114 BS5,Commissioner of the General Land Office,,DEM,Miguel Suazo,202,82,91,29
+Tom Green,114 BS5,Commissioner of the General Land Office,,LIB,Matt Pina,6,3,3,0
+Tom Green,114 BS5,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,114 BS5,Commissioner of the General Land Office,,,Under Votes,13,3,6,4
+Tom Green,114 BS5,Commissioner of Agriculture,,REP,Sid Miller,78,23,50,5
+Tom Green,114 BS5,Commissioner of Agriculture,,DEM,Kim Olson,203,84,90,29
+Tom Green,114 BS5,Commissioner of Agriculture,,LIB,Richard Carpenter,7,4,3,0
+Tom Green,114 BS5,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,114 BS5,Commissioner of Agriculture,,,Under Votes,16,5,5,6
+Tom Green,114 BS5,Railroad Commissioner,,REP,Christi Craddick,78,26,48,4
+Tom Green,114 BS5,Railroad Commissioner,,DEM,Roman McAllen,203,81,91,31
+Tom Green,114 BS5,Railroad Commissioner,,LIB,Mike Wright,11,5,6,0
+Tom Green,114 BS5,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,114 BS5,Railroad Commissioner,,,Under Votes,12,4,3,5
+Tom Green,114 BS5,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,82,26,50,6
+Tom Green,114 BS5,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,206,85,92,29
+Tom Green,114 BS5,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,114 BS5,"Justice, Supreme Court, Place 2",,,Under Votes,16,5,6,5
+Tom Green,114 BS5,"Justice, Supreme Court, Place 4",,REP,John Devine,80,23,50,7
+Tom Green,114 BS5,"Justice, Supreme Court, Place 4",,,R. K. Sandill,204,87,91,26
+Tom Green,114 BS5,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,114 BS5,"Justice, Supreme Court, Place 4",,,Under Votes,20,6,7,7
+Tom Green,114 BS5,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,78,24,48,6
+Tom Green,114 BS5,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,209,87,94,28
+Tom Green,114 BS5,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,114 BS5,"Justice, Supreme Court, Place 6",,,Under Votes,17,5,6,6
+Tom Green,114 BS5,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,73,23,46,4
+Tom Green,114 BS5,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,208,86,92,30
+Tom Green,114 BS5,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,8,4,4,0
+Tom Green,114 BS5,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,114 BS5,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,15,3,6,6
+Tom Green,114 BS5,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,77,23,49,5
+Tom Green,114 BS5,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,210,87,92,31
+Tom Green,114 BS5,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,114 BS5,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,17,6,7,4
+Tom Green,114 BS5,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,105,37,60,8
+Tom Green,114 BS5,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,68,29,29,10
+Tom Green,114 BS5,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,114 BS5,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,131,50,59,22
+Tom Green,114 BS5,State Representative,72,REP,Drew Darby,140,48,72,20
+Tom Green,114 BS5,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,114 BS5,State Representative,72,,Under Votes,164,68,76,20
+Tom Green,114 BS5,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,78,25,48,5
+Tom Green,114 BS5,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,209,86,92,31
+Tom Green,114 BS5,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,114 BS5,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,17,5,8,4
+Tom Green,114 BS5,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,79,25,49,5
+Tom Green,114 BS5,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,207,86,91,30
+Tom Green,114 BS5,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,114 BS5,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,18,5,8,5
+Tom Green,114 BS5,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,74,22,48,4
+Tom Green,114 BS5,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,208,86,93,29
+Tom Green,114 BS5,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,114 BS5,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,22,8,7,7
+Tom Green,114 BS5,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",74,23,46,5
+Tom Green,114 BS5,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,205,87,90,28
+Tom Green,114 BS5,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),0,0,0,0
+Tom Green,114 BS5,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,114 BS5,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,25,6,12,7
+Tom Green,114 BS5,Justice of the Peace Pct. 1,,REP,Susan Werner,76,25,47,4
+Tom Green,114 BS5,Justice of the Peace Pct. 1,,DEM,Sally Ayana,211,85,95,31
+Tom Green,114 BS5,Justice of the Peace Pct. 1,,,Over Votes,0,0,0,0
+Tom Green,114 BS5,Justice of the Peace Pct. 1,,,Under Votes,17,6,6,5
+Tom Green,114 BS5,San Angelo Independent School District Proposition A,,,FOR,118,43,51,24
+Tom Green,114 BS5,San Angelo Independent School District Proposition A,,,AGAINST,152,57,81,14
+Tom Green,114 BS5,San Angelo Independent School District Proposition A,,,Over Votes,0,0,0,0
+Tom Green,114 BS5,San Angelo Independent School District Proposition A,,,Under Votes,34,16,16,2
+Tom Green,114 BS5,San Angelo Independent School District Proposition B,,,FOR,121,45,54,22
+Tom Green,114 BS5,San Angelo Independent School District Proposition B,,,AGAINST,148,54,82,12
+Tom Green,114 BS5,San Angelo Independent School District Proposition B,,,Over Votes,0,0,0,0
+Tom Green,114 BS5,San Angelo Independent School District Proposition B,,,Under Votes,35,17,12,6
+Tom Green,114 BS5,Ballots Cast,,,,304,116,148,40
+Tom Green,124 BS6,STRAIGHT PARTY,,REP,,105,61,36,8
+Tom Green,124 BS6,STRAIGHT PARTY,,DEM,,241,101,105,35
+Tom Green,124 BS6,STRAIGHT PARTY,,LIB,,2,1,0,1
+Tom Green,124 BS6,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,124 BS6,STRAIGHT PARTY,,,Under Votes,115,53,46,16
+Tom Green,124 BS6,U.S. Senate,,REP,Ted Cruz,140,75,53,12
+Tom Green,124 BS6,U.S. Senate,,DEM,Beto O'Rourke,308,133,128,47
+Tom Green,124 BS6,U.S. Senate,,LIB,Neal M. Dikeman,3,2,1,0
+Tom Green,124 BS6,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,124 BS6,U.S. Senate,,,Under Votes,12,6,5,1
+Tom Green,124 BS6,U.S. House,11,REP,Mike Conaway,153,83,59,11
+Tom Green,124 BS6,U.S. House,11,DEM,Jennie Lou Leeder,298,130,121,47
+Tom Green,124 BS6,U.S. House,11,LIB,Rhett Rosenquest Smith,1,0,1,0
+Tom Green,124 BS6,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,124 BS6,U.S. House,11,,Under Votes,11,3,6,2
+Tom Green,124 BS6,Governor,,REP,Greg Abbott,160,89,60,11
+Tom Green,124 BS6,Governor,,DEM,Lupe Valdez,289,125,119,45
+Tom Green,124 BS6,Governor,,LIB,Mark Jay Tippetts,5,0,3,2
+Tom Green,124 BS6,Governor,,,Over Votes,0,0,0,0
+Tom Green,124 BS6,Governor,,,Under Votes,9,2,5,2
+Tom Green,124 BS6,Lieutenant Governor,,REP,Dan Patrick,140,76,53,11
+Tom Green,124 BS6,Lieutenant Governor,,DEM,Mike Collier,302,133,123,46
+Tom Green,124 BS6,Lieutenant Governor,,LIB,Kerry Douglas McKennon,8,4,4,0
+Tom Green,124 BS6,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,124 BS6,Lieutenant Governor,,,Under Votes,13,3,7,3
+Tom Green,124 BS6,Attorney General,,REP,Ken Paxton,136,74,53,9
+Tom Green,124 BS6,Attorney General,,DEM,Justin Nelson,304,133,125,46
+Tom Green,124 BS6,Attorney General,,LIB,Michael Ray Harris,10,5,4,1
+Tom Green,124 BS6,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,124 BS6,Attorney General,,,Under Votes,13,4,5,4
+Tom Green,124 BS6,Comptroller of Public Accounts,,REP,Glenn Hegar,137,77,51,9
+Tom Green,124 BS6,Comptroller of Public Accounts,,DEM,Joi Chevalier,302,129,126,47
+Tom Green,124 BS6,Comptroller of Public Accounts,,LIB,Ben Sanders,7,4,3,0
+Tom Green,124 BS6,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,124 BS6,Comptroller of Public Accounts,,,Under Votes,17,6,7,4
+Tom Green,124 BS6,Commissioner of the General Land Office,,REP,George P. Bush,143,78,54,11
+Tom Green,124 BS6,Commissioner of the General Land Office,,DEM,Miguel Suazo,302,130,125,47
+Tom Green,124 BS6,Commissioner of the General Land Office,,LIB,Matt Pina,3,1,2,0
+Tom Green,124 BS6,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,124 BS6,Commissioner of the General Land Office,,,Under Votes,15,7,6,2
+Tom Green,124 BS6,Commissioner of Agriculture,,REP,Sid Miller,134,76,49,9
+Tom Green,124 BS6,Commissioner of Agriculture,,DEM,Kim Olson,307,130,129,48
+Tom Green,124 BS6,Commissioner of Agriculture,,LIB,Richard Carpenter,4,2,2,0
+Tom Green,124 BS6,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,124 BS6,Commissioner of Agriculture,,,Under Votes,18,8,7,3
+Tom Green,124 BS6,Railroad Commissioner,,REP,Christi Craddick,139,77,52,10
+Tom Green,124 BS6,Railroad Commissioner,,DEM,Roman McAllen,304,130,127,47
+Tom Green,124 BS6,Railroad Commissioner,,LIB,Mike Wright,6,4,2,0
+Tom Green,124 BS6,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,124 BS6,Railroad Commissioner,,,Under Votes,14,5,6,3
+Tom Green,124 BS6,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,140,78,52,10
+Tom Green,124 BS6,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,307,133,128,46
+Tom Green,124 BS6,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,124 BS6,"Justice, Supreme Court, Place 2",,,Under Votes,16,5,7,4
+Tom Green,124 BS6,"Justice, Supreme Court, Place 4",,REP,John Devine,141,75,55,11
+Tom Green,124 BS6,"Justice, Supreme Court, Place 4",,,R. K. Sandill,302,133,124,45
+Tom Green,124 BS6,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,124 BS6,"Justice, Supreme Court, Place 4",,,Under Votes,20,8,8,4
+Tom Green,124 BS6,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,138,75,54,9
+Tom Green,124 BS6,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,309,135,126,48
+Tom Green,124 BS6,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,124 BS6,"Justice, Supreme Court, Place 6",,,Under Votes,16,6,7,3
+Tom Green,124 BS6,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,139,76,53,10
+Tom Green,124 BS6,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,305,131,128,46
+Tom Green,124 BS6,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,6,4,1,1
+Tom Green,124 BS6,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,124 BS6,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,13,5,5,3
+Tom Green,124 BS6,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,140,76,55,9
+Tom Green,124 BS6,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,304,131,125,48
+Tom Green,124 BS6,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,124 BS6,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,19,9,7,3
+Tom Green,124 BS6,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,160,85,64,11
+Tom Green,124 BS6,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,99,49,36,14
+Tom Green,124 BS6,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,124 BS6,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,204,82,87,35
+Tom Green,124 BS6,State Representative,72,REP,Drew Darby,203,108,77,18
+Tom Green,124 BS6,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,124 BS6,State Representative,72,,Under Votes,260,108,110,42
+Tom Green,124 BS6,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,147,81,56,10
+Tom Green,124 BS6,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,297,128,124,45
+Tom Green,124 BS6,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,124 BS6,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,19,7,7,5
+Tom Green,124 BS6,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,141,76,55,10
+Tom Green,124 BS6,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,302,132,125,45
+Tom Green,124 BS6,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,124 BS6,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,20,8,7,5
+Tom Green,124 BS6,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,140,76,54,10
+Tom Green,124 BS6,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,305,131,128,46
+Tom Green,124 BS6,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,124 BS6,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,18,9,5,4
+Tom Green,124 BS6,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",137,77,52,8
+Tom Green,124 BS6,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,301,129,125,47
+Tom Green,124 BS6,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),3,0,1,2
+Tom Green,124 BS6,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,124 BS6,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,22,10,9,3
+Tom Green,124 BS6,Justice of the Peace Pct. 1,,REP,Susan Werner,147,82,55,10
+Tom Green,124 BS6,Justice of the Peace Pct. 1,,DEM,Sally Ayana,305,129,127,49
+Tom Green,124 BS6,Justice of the Peace Pct. 1,,,Over Votes,0,0,0,0
+Tom Green,124 BS6,Justice of the Peace Pct. 1,,,Under Votes,11,5,5,1
+Tom Green,124 BS6,San Angelo Independent School District Proposition A,,,FOR,209,92,77,40
+Tom Green,124 BS6,San Angelo Independent School District Proposition A,,,AGAINST,192,94,83,15
+Tom Green,124 BS6,San Angelo Independent School District Proposition A,,,Over Votes,0,0,0,0
+Tom Green,124 BS6,San Angelo Independent School District Proposition A,,,Under Votes,62,30,27,5
+Tom Green,124 BS6,San Angelo Independent School District Proposition B,,,FOR,210,93,77,40
+Tom Green,124 BS6,San Angelo Independent School District Proposition B,,,AGAINST,187,95,80,12
+Tom Green,124 BS6,San Angelo Independent School District Proposition B,,,Over Votes,0,0,0,0
+Tom Green,124 BS6,San Angelo Independent School District Proposition B,,,Under Votes,66,28,30,8
+Tom Green,124 BS6,Ballots Cast,,,,463,216,187,60
+Tom Green,137 BS7,STRAIGHT PARTY,,REP,,324,180,106,38
+Tom Green,137 BS7,STRAIGHT PARTY,,DEM,,305,166,109,30
+Tom Green,137 BS7,STRAIGHT PARTY,,LIB,,9,7,2,0
+Tom Green,137 BS7,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,137 BS7,STRAIGHT PARTY,,,Under Votes,415,227,137,51
+Tom Green,137 BS7,U.S. Senate,,REP,Ted Cruz,518,290,165,63
+Tom Green,137 BS7,U.S. Senate,,DEM,Beto O'Rourke,507,280,178,49
+Tom Green,137 BS7,U.S. Senate,,LIB,Neal M. Dikeman,13,4,7,2
+Tom Green,137 BS7,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,137 BS7,U.S. Senate,,,Under Votes,15,6,4,5
+Tom Green,137 BS7,U.S. House,11,REP,Mike Conaway,571,310,192,69
+Tom Green,137 BS7,U.S. House,11,DEM,Jennie Lou Leeder,443,246,151,46
+Tom Green,137 BS7,U.S. House,11,LIB,Rhett Rosenquest Smith,15,9,5,1
+Tom Green,137 BS7,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,137 BS7,U.S. House,11,,Under Votes,24,15,6,3
+Tom Green,137 BS7,Governor,,REP,Greg Abbott,557,297,190,70
+Tom Green,137 BS7,Governor,,DEM,Lupe Valdez,462,261,155,46
+Tom Green,137 BS7,Governor,,LIB,Mark Jay Tippetts,15,11,4,0
+Tom Green,137 BS7,Governor,,,Over Votes,0,0,0,0
+Tom Green,137 BS7,Governor,,,Under Votes,19,11,5,3
+Tom Green,137 BS7,Lieutenant Governor,,REP,Dan Patrick,502,278,160,64
+Tom Green,137 BS7,Lieutenant Governor,,DEM,Mike Collier,495,272,172,51
+Tom Green,137 BS7,Lieutenant Governor,,LIB,Kerry Douglas McKennon,27,15,12,0
+Tom Green,137 BS7,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,137 BS7,Lieutenant Governor,,,Under Votes,29,15,10,4
+Tom Green,137 BS7,Attorney General,,REP,Ken Paxton,500,276,163,61
+Tom Green,137 BS7,Attorney General,,DEM,Justin Nelson,505,278,175,52
+Tom Green,137 BS7,Attorney General,,LIB,Michael Ray Harris,23,14,8,1
+Tom Green,137 BS7,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,137 BS7,Attorney General,,,Under Votes,25,12,8,5
+Tom Green,137 BS7,Comptroller of Public Accounts,,REP,Glenn Hegar,500,278,159,63
+Tom Green,137 BS7,Comptroller of Public Accounts,,DEM,Joi Chevalier,462,255,159,48
+Tom Green,137 BS7,Comptroller of Public Accounts,,LIB,Ben Sanders,50,25,23,2
+Tom Green,137 BS7,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,137 BS7,Comptroller of Public Accounts,,,Under Votes,41,22,13,6
+Tom Green,137 BS7,Commissioner of the General Land Office,,REP,George P. Bush,530,285,179,66
+Tom Green,137 BS7,Commissioner of the General Land Office,,DEM,Miguel Suazo,465,259,157,49
+Tom Green,137 BS7,Commissioner of the General Land Office,,LIB,Matt Pina,26,19,7,0
+Tom Green,137 BS7,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,137 BS7,Commissioner of the General Land Office,,,Under Votes,32,17,11,4
+Tom Green,137 BS7,Commissioner of Agriculture,,REP,Sid Miller,482,269,153,60
+Tom Green,137 BS7,Commissioner of Agriculture,,DEM,Kim Olson,508,278,177,53
+Tom Green,137 BS7,Commissioner of Agriculture,,LIB,Richard Carpenter,24,12,11,1
+Tom Green,137 BS7,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,137 BS7,Commissioner of Agriculture,,,Under Votes,39,21,13,5
+Tom Green,137 BS7,Railroad Commissioner,,REP,Christi Craddick,507,284,162,61
+Tom Green,137 BS7,Railroad Commissioner,,DEM,Roman McAllen,476,265,162,49
+Tom Green,137 BS7,Railroad Commissioner,,LIB,Mike Wright,34,12,17,5
+Tom Green,137 BS7,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,137 BS7,Railroad Commissioner,,,Under Votes,36,19,13,4
+Tom Green,137 BS7,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,498,280,158,60
+Tom Green,137 BS7,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,509,277,180,52
+Tom Green,137 BS7,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,137 BS7,"Justice, Supreme Court, Place 2",,,Under Votes,46,23,16,7
+Tom Green,137 BS7,"Justice, Supreme Court, Place 4",,REP,John Devine,503,278,162,63
+Tom Green,137 BS7,"Justice, Supreme Court, Place 4",,,R. K. Sandill,502,276,177,49
+Tom Green,137 BS7,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,137 BS7,"Justice, Supreme Court, Place 4",,,Under Votes,48,26,15,7
+Tom Green,137 BS7,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,496,275,159,62
+Tom Green,137 BS7,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,511,281,181,49
+Tom Green,137 BS7,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,137 BS7,"Justice, Supreme Court, Place 6",,,Under Votes,46,24,14,8
+Tom Green,137 BS7,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,492,278,154,60
+Tom Green,137 BS7,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,495,271,175,49
+Tom Green,137 BS7,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,27,12,12,3
+Tom Green,137 BS7,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,137 BS7,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,39,19,13,7
+Tom Green,137 BS7,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,504,278,167,59
+Tom Green,137 BS7,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,502,278,174,50
+Tom Green,137 BS7,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,137 BS7,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,47,24,13,10
+Tom Green,137 BS7,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,557,303,189,65
+Tom Green,137 BS7,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,196,112,65,19
+Tom Green,137 BS7,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,137 BS7,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,300,165,100,35
+Tom Green,137 BS7,State Representative,72,REP,Drew Darby,649,351,221,77
+Tom Green,137 BS7,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,137 BS7,State Representative,72,,Under Votes,404,229,133,42
+Tom Green,137 BS7,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,519,287,167,65
+Tom Green,137 BS7,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,485,265,172,48
+Tom Green,137 BS7,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,137 BS7,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,49,28,15,6
+Tom Green,137 BS7,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,512,281,169,62
+Tom Green,137 BS7,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,492,271,171,50
+Tom Green,137 BS7,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,137 BS7,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,49,28,14,7
+Tom Green,137 BS7,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,493,272,159,62
+Tom Green,137 BS7,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,505,275,180,50
+Tom Green,137 BS7,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,137 BS7,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,55,33,15,7
+Tom Green,137 BS7,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",502,277,159,66
+Tom Green,137 BS7,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,493,272,175,46
+Tom Green,137 BS7,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),2,1,0,1
+Tom Green,137 BS7,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,137 BS7,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,56,30,20,6
+Tom Green,137 BS7,Justice of the Peace Pct. 1,,REP,Susan Werner,526,289,175,62
+Tom Green,137 BS7,Justice of the Peace Pct. 1,,DEM,Sally Ayana,484,272,162,50
+Tom Green,137 BS7,Justice of the Peace Pct. 1,,,Over Votes,0,0,0,0
+Tom Green,137 BS7,Justice of the Peace Pct. 1,,,Under Votes,43,19,17,7
+Tom Green,137 BS7,San Angelo Independent School District Proposition A,,,FOR,430,248,134,48
+Tom Green,137 BS7,San Angelo Independent School District Proposition A,,,AGAINST,500,269,174,57
+Tom Green,137 BS7,San Angelo Independent School District Proposition A,,,Over Votes,0,0,0,0
+Tom Green,137 BS7,San Angelo Independent School District Proposition A,,,Under Votes,123,63,46,14
+Tom Green,137 BS7,San Angelo Independent School District Proposition B,,,FOR,434,244,141,49
+Tom Green,137 BS7,San Angelo Independent School District Proposition B,,,AGAINST,508,283,172,53
+Tom Green,137 BS7,San Angelo Independent School District Proposition B,,,Over Votes,0,0,0,0
+Tom Green,137 BS7,San Angelo Independent School District Proposition B,,,Under Votes,111,53,41,17
+Tom Green,137 BS7,Ballots Cast,,,,1053,580,354,119
+Tom Green,144 BS8,STRAIGHT PARTY,,REP,,188,96,85,7
+Tom Green,144 BS8,STRAIGHT PARTY,,DEM,,159,56,96,7
+Tom Green,144 BS8,STRAIGHT PARTY,,LIB,,3,2,1,0
+Tom Green,144 BS8,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,144 BS8,STRAIGHT PARTY,,,Under Votes,255,138,89,28
+Tom Green,144 BS8,U.S. Senate,,REP,Ted Cruz,306,171,120,15
+Tom Green,144 BS8,U.S. Senate,,DEM,Beto O'Rourke,289,118,147,24
+Tom Green,144 BS8,U.S. Senate,,LIB,Neal M. Dikeman,3,1,1,1
+Tom Green,144 BS8,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,144 BS8,U.S. Senate,,,Under Votes,7,2,3,2
+Tom Green,144 BS8,U.S. House,11,REP,Mike Conaway,338,189,131,18
+Tom Green,144 BS8,U.S. House,11,DEM,Jennie Lou Leeder,243,97,124,22
+Tom Green,144 BS8,U.S. House,11,LIB,Rhett Rosenquest Smith,8,3,4,1
+Tom Green,144 BS8,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,144 BS8,U.S. House,11,,Under Votes,16,3,12,1
+Tom Green,144 BS8,Governor,,REP,Greg Abbott,330,183,129,18
+Tom Green,144 BS8,Governor,,DEM,Lupe Valdez,257,104,129,24
+Tom Green,144 BS8,Governor,,LIB,Mark Jay Tippetts,6,3,3,0
+Tom Green,144 BS8,Governor,,,Over Votes,0,0,0,0
+Tom Green,144 BS8,Governor,,,Under Votes,12,2,10,0
+Tom Green,144 BS8,Lieutenant Governor,,REP,Dan Patrick,294,167,110,17
+Tom Green,144 BS8,Lieutenant Governor,,DEM,Mike Collier,272,112,137,23
+Tom Green,144 BS8,Lieutenant Governor,,LIB,Kerry Douglas McKennon,17,8,8,1
+Tom Green,144 BS8,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,144 BS8,Lieutenant Governor,,,Under Votes,22,5,16,1
+Tom Green,144 BS8,Attorney General,,REP,Ken Paxton,293,161,116,16
+Tom Green,144 BS8,Attorney General,,DEM,Justin Nelson,282,119,138,25
+Tom Green,144 BS8,Attorney General,,LIB,Michael Ray Harris,14,7,7,0
+Tom Green,144 BS8,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,144 BS8,Attorney General,,,Under Votes,16,5,10,1
+Tom Green,144 BS8,Comptroller of Public Accounts,,REP,Glenn Hegar,297,173,111,13
+Tom Green,144 BS8,Comptroller of Public Accounts,,DEM,Joi Chevalier,257,103,131,23
+Tom Green,144 BS8,Comptroller of Public Accounts,,LIB,Ben Sanders,21,9,12,0
+Tom Green,144 BS8,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,144 BS8,Comptroller of Public Accounts,,,Under Votes,30,7,17,6
+Tom Green,144 BS8,Commissioner of the General Land Office,,REP,George P. Bush,311,172,121,18
+Tom Green,144 BS8,Commissioner of the General Land Office,,DEM,Miguel Suazo,250,106,124,20
+Tom Green,144 BS8,Commissioner of the General Land Office,,LIB,Matt Pina,17,6,11,0
+Tom Green,144 BS8,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,144 BS8,Commissioner of the General Land Office,,,Under Votes,27,8,15,4
+Tom Green,144 BS8,Commissioner of Agriculture,,REP,Sid Miller,297,169,113,15
+Tom Green,144 BS8,Commissioner of Agriculture,,DEM,Kim Olson,267,111,133,23
+Tom Green,144 BS8,Commissioner of Agriculture,,LIB,Richard Carpenter,15,6,8,1
+Tom Green,144 BS8,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,144 BS8,Commissioner of Agriculture,,,Under Votes,26,6,17,3
+Tom Green,144 BS8,Railroad Commissioner,,REP,Christi Craddick,300,170,116,14
+Tom Green,144 BS8,Railroad Commissioner,,DEM,Roman McAllen,260,108,130,22
+Tom Green,144 BS8,Railroad Commissioner,,LIB,Mike Wright,20,8,11,1
+Tom Green,144 BS8,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,144 BS8,Railroad Commissioner,,,Under Votes,25,6,14,5
+Tom Green,144 BS8,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,299,168,116,15
+Tom Green,144 BS8,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,284,120,139,25
+Tom Green,144 BS8,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,144 BS8,"Justice, Supreme Court, Place 2",,,Under Votes,22,4,16,2
+Tom Green,144 BS8,"Justice, Supreme Court, Place 4",,REP,John Devine,303,171,119,13
+Tom Green,144 BS8,"Justice, Supreme Court, Place 4",,,R. K. Sandill,278,119,136,23
+Tom Green,144 BS8,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,144 BS8,"Justice, Supreme Court, Place 4",,,Under Votes,24,2,16,6
+Tom Green,144 BS8,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,307,176,118,13
+Tom Green,144 BS8,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,272,113,136,23
+Tom Green,144 BS8,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,144 BS8,"Justice, Supreme Court, Place 6",,,Under Votes,26,3,17,6
+Tom Green,144 BS8,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,297,170,113,14
+Tom Green,144 BS8,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,267,109,135,23
+Tom Green,144 BS8,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,17,10,7,0
+Tom Green,144 BS8,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,144 BS8,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,24,3,16,5
+Tom Green,144 BS8,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,303,172,118,13
+Tom Green,144 BS8,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,278,118,137,23
+Tom Green,144 BS8,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,144 BS8,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,24,2,16,6
+Tom Green,144 BS8,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,351,193,141,17
+Tom Green,144 BS8,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,107,47,51,9
+Tom Green,144 BS8,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,144 BS8,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,147,52,79,16
+Tom Green,144 BS8,State Representative,72,REP,Drew Darby,407,218,168,21
+Tom Green,144 BS8,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,144 BS8,State Representative,72,,Under Votes,198,74,103,21
+Tom Green,144 BS8,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,310,176,120,14
+Tom Green,144 BS8,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,266,109,135,22
+Tom Green,144 BS8,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,144 BS8,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,29,7,16,6
+Tom Green,144 BS8,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,302,169,119,14
+Tom Green,144 BS8,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,273,115,136,22
+Tom Green,144 BS8,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,144 BS8,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,30,8,16,6
+Tom Green,144 BS8,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,296,167,115,14
+Tom Green,144 BS8,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,278,117,141,20
+Tom Green,144 BS8,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,144 BS8,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,31,8,15,8
+Tom Green,144 BS8,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",300,168,118,14
+Tom Green,144 BS8,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,272,114,136,22
+Tom Green,144 BS8,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),1,0,0,1
+Tom Green,144 BS8,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,144 BS8,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,32,10,17,5
+Tom Green,144 BS8,Justice of the Peace Pct. 1,,REP,Susan Werner,316,178,123,15
+Tom Green,144 BS8,Justice of the Peace Pct. 1,,DEM,Sally Ayana,262,108,132,22
+Tom Green,144 BS8,Justice of the Peace Pct. 1,,,Over Votes,0,0,0,0
+Tom Green,144 BS8,Justice of the Peace Pct. 1,,,Under Votes,27,6,16,5
+Tom Green,144 BS8,San Angelo Independent School District Proposition A,,,FOR,253,107,122,24
+Tom Green,144 BS8,San Angelo Independent School District Proposition A,,,AGAINST,316,170,129,17
+Tom Green,144 BS8,San Angelo Independent School District Proposition A,,,Over Votes,0,0,0,0
+Tom Green,144 BS8,San Angelo Independent School District Proposition A,,,Under Votes,36,15,20,1
+Tom Green,144 BS8,San Angelo Independent School District Proposition B,,,FOR,248,108,119,21
+Tom Green,144 BS8,San Angelo Independent School District Proposition B,,,AGAINST,320,169,131,20
+Tom Green,144 BS8,San Angelo Independent School District Proposition B,,,Over Votes,0,0,0,0
+Tom Green,144 BS8,San Angelo Independent School District Proposition B,,,Under Votes,37,15,21,1
+Tom Green,144 BS8,Ballots Cast,,,,605,292,271,42
+Tom Green,144 BS9,STRAIGHT PARTY,,REP,,14,6,6,2
+Tom Green,144 BS9,STRAIGHT PARTY,,DEM,,6,2,2,2
+Tom Green,144 BS9,STRAIGHT PARTY,,LIB,,0,0,0,0
+Tom Green,144 BS9,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,144 BS9,STRAIGHT PARTY,,,Under Votes,10,5,2,3
+Tom Green,144 BS9,U.S. Senate,,REP,Ted Cruz,20,9,8,3
+Tom Green,144 BS9,U.S. Senate,,DEM,Beto O'Rourke,10,4,2,4
+Tom Green,144 BS9,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Tom Green,144 BS9,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,144 BS9,U.S. Senate,,,Under Votes,0,0,0,0
+Tom Green,144 BS9,U.S. House,11,REP,Mike Conaway,19,8,8,3
+Tom Green,144 BS9,U.S. House,11,DEM,Jennie Lou Leeder,9,3,2,4
+Tom Green,144 BS9,U.S. House,11,LIB,Rhett Rosenquest Smith,1,1,0,0
+Tom Green,144 BS9,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,144 BS9,U.S. House,11,,Under Votes,1,1,0,0
+Tom Green,144 BS9,Governor,,REP,Greg Abbott,19,9,7,3
+Tom Green,144 BS9,Governor,,DEM,Lupe Valdez,10,4,2,4
+Tom Green,144 BS9,Governor,,LIB,Mark Jay Tippetts,1,0,1,0
+Tom Green,144 BS9,Governor,,,Over Votes,0,0,0,0
+Tom Green,144 BS9,Governor,,,Under Votes,0,0,0,0
+Tom Green,144 BS9,Lieutenant Governor,,REP,Dan Patrick,18,8,7,3
+Tom Green,144 BS9,Lieutenant Governor,,DEM,Mike Collier,10,4,2,4
+Tom Green,144 BS9,Lieutenant Governor,,LIB,Kerry Douglas McKennon,2,1,1,0
+Tom Green,144 BS9,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,144 BS9,Lieutenant Governor,,,Under Votes,0,0,0,0
+Tom Green,144 BS9,Attorney General,,REP,Ken Paxton,19,9,7,3
+Tom Green,144 BS9,Attorney General,,DEM,Justin Nelson,9,3,2,4
+Tom Green,144 BS9,Attorney General,,LIB,Michael Ray Harris,2,1,1,0
+Tom Green,144 BS9,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,144 BS9,Attorney General,,,Under Votes,0,0,0,0
+Tom Green,144 BS9,Comptroller of Public Accounts,,REP,Glenn Hegar,17,7,7,3
+Tom Green,144 BS9,Comptroller of Public Accounts,,DEM,Joi Chevalier,9,4,2,3
+Tom Green,144 BS9,Comptroller of Public Accounts,,LIB,Ben Sanders,3,2,1,0
+Tom Green,144 BS9,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,144 BS9,Comptroller of Public Accounts,,,Under Votes,1,0,0,1
+Tom Green,144 BS9,Commissioner of the General Land Office,,REP,George P. Bush,17,7,7,3
+Tom Green,144 BS9,Commissioner of the General Land Office,,DEM,Miguel Suazo,8,3,2,3
+Tom Green,144 BS9,Commissioner of the General Land Office,,LIB,Matt Pina,4,3,1,0
+Tom Green,144 BS9,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,144 BS9,Commissioner of the General Land Office,,,Under Votes,1,0,0,1
+Tom Green,144 BS9,Commissioner of Agriculture,,REP,Sid Miller,17,8,7,2
+Tom Green,144 BS9,Commissioner of Agriculture,,DEM,Kim Olson,9,3,2,4
+Tom Green,144 BS9,Commissioner of Agriculture,,LIB,Richard Carpenter,3,2,1,0
+Tom Green,144 BS9,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,144 BS9,Commissioner of Agriculture,,,Under Votes,1,0,0,1
+Tom Green,144 BS9,Railroad Commissioner,,REP,Christi Craddick,17,8,7,2
+Tom Green,144 BS9,Railroad Commissioner,,DEM,Roman McAllen,9,3,2,4
+Tom Green,144 BS9,Railroad Commissioner,,LIB,Mike Wright,3,2,1,0
+Tom Green,144 BS9,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,144 BS9,Railroad Commissioner,,,Under Votes,1,0,0,1
+Tom Green,144 BS9,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,19,9,8,2
+Tom Green,144 BS9,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,10,4,2,4
+Tom Green,144 BS9,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,144 BS9,"Justice, Supreme Court, Place 2",,,Under Votes,1,0,0,1
+Tom Green,144 BS9,"Justice, Supreme Court, Place 4",,REP,John Devine,19,9,8,2
+Tom Green,144 BS9,"Justice, Supreme Court, Place 4",,,R. K. Sandill,10,4,2,4
+Tom Green,144 BS9,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,144 BS9,"Justice, Supreme Court, Place 4",,,Under Votes,1,0,0,1
+Tom Green,144 BS9,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,19,9,8,2
+Tom Green,144 BS9,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,10,4,2,4
+Tom Green,144 BS9,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,144 BS9,"Justice, Supreme Court, Place 6",,,Under Votes,1,0,0,1
+Tom Green,144 BS9,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,18,9,7,2
+Tom Green,144 BS9,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,9,3,2,4
+Tom Green,144 BS9,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,2,1,1,0
+Tom Green,144 BS9,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,144 BS9,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,1,0,0,1
+Tom Green,144 BS9,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,19,9,8,2
+Tom Green,144 BS9,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,10,4,2,4
+Tom Green,144 BS9,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,144 BS9,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,1,0,0,1
+Tom Green,144 BS9,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,20,8,9,3
+Tom Green,144 BS9,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,5,4,0,1
+Tom Green,144 BS9,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,144 BS9,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,5,1,1,3
+Tom Green,144 BS9,State Representative,72,REP,Drew Darby,22,10,8,4
+Tom Green,144 BS9,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,144 BS9,State Representative,72,,Under Votes,8,3,2,3
+Tom Green,144 BS9,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,19,9,8,2
+Tom Green,144 BS9,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,9,3,2,4
+Tom Green,144 BS9,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,144 BS9,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,2,1,0,1
+Tom Green,144 BS9,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,19,9,8,2
+Tom Green,144 BS9,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,9,3,2,4
+Tom Green,144 BS9,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,144 BS9,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,2,1,0,1
+Tom Green,144 BS9,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,19,9,8,2
+Tom Green,144 BS9,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,9,3,2,4
+Tom Green,144 BS9,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,144 BS9,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,2,1,0,1
+Tom Green,144 BS9,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",19,9,8,2
+Tom Green,144 BS9,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,9,3,2,4
+Tom Green,144 BS9,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),0,0,0,0
+Tom Green,144 BS9,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,144 BS9,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,2,1,0,1
+Tom Green,144 BS9,Justice of the Peace Pct. 1,,REP,Susan Werner,19,9,8,2
+Tom Green,144 BS9,Justice of the Peace Pct. 1,,DEM,Sally Ayana,9,3,2,4
+Tom Green,144 BS9,Justice of the Peace Pct. 1,,,Over Votes,0,0,0,0
+Tom Green,144 BS9,Justice of the Peace Pct. 1,,,Under Votes,2,1,0,1
+Tom Green,144 BS9,Ballots Cast,,,,30,13,10,7
+Tom Green,146 BS10,STRAIGHT PARTY,,REP,,429,229,124,76
+Tom Green,146 BS10,STRAIGHT PARTY,,DEM,,337,167,131,39
+Tom Green,146 BS10,STRAIGHT PARTY,,LIB,,9,8,1,0
+Tom Green,146 BS10,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,146 BS10,STRAIGHT PARTY,,,Under Votes,356,207,95,54
+Tom Green,146 BS10,U.S. Senate,,REP,Ted Cruz,601,327,171,103
+Tom Green,146 BS10,U.S. Senate,,DEM,Beto O'Rourke,509,276,171,62
+Tom Green,146 BS10,U.S. Senate,,LIB,Neal M. Dikeman,5,2,3,0
+Tom Green,146 BS10,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,146 BS10,U.S. Senate,,,Under Votes,16,6,6,4
+Tom Green,146 BS10,U.S. House,11,REP,Mike Conaway,652,363,182,107
+Tom Green,146 BS10,U.S. House,11,DEM,Jennie Lou Leeder,444,232,154,58
+Tom Green,146 BS10,U.S. House,11,LIB,Rhett Rosenquest Smith,14,6,7,1
+Tom Green,146 BS10,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,146 BS10,U.S. House,11,,Under Votes,21,10,8,3
+Tom Green,146 BS10,Governor,,REP,Greg Abbott,638,353,178,107
+Tom Green,146 BS10,Governor,,DEM,Lupe Valdez,460,244,162,54
+Tom Green,146 BS10,Governor,,LIB,Mark Jay Tippetts,12,7,3,2
+Tom Green,146 BS10,Governor,,,Over Votes,0,0,0,0
+Tom Green,146 BS10,Governor,,,Under Votes,21,7,8,6
+Tom Green,146 BS10,Lieutenant Governor,,REP,Dan Patrick,595,327,169,99
+Tom Green,146 BS10,Lieutenant Governor,,DEM,Mike Collier,487,256,167,64
+Tom Green,146 BS10,Lieutenant Governor,,LIB,Kerry Douglas McKennon,26,15,8,3
+Tom Green,146 BS10,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,146 BS10,Lieutenant Governor,,,Under Votes,23,13,7,3
+Tom Green,146 BS10,Attorney General,,REP,Ken Paxton,582,316,168,98
+Tom Green,146 BS10,Attorney General,,DEM,Justin Nelson,505,268,169,68
+Tom Green,146 BS10,Attorney General,,LIB,Michael Ray Harris,26,17,7,2
+Tom Green,146 BS10,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,146 BS10,Attorney General,,,Under Votes,18,10,7,1
+Tom Green,146 BS10,Comptroller of Public Accounts,,REP,Glenn Hegar,601,330,167,104
+Tom Green,146 BS10,Comptroller of Public Accounts,,DEM,Joi Chevalier,467,248,162,57
+Tom Green,146 BS10,Comptroller of Public Accounts,,LIB,Ben Sanders,35,18,14,3
+Tom Green,146 BS10,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,146 BS10,Comptroller of Public Accounts,,,Under Votes,28,15,8,5
+Tom Green,146 BS10,Commissioner of the General Land Office,,REP,George P. Bush,613,337,170,106
+Tom Green,146 BS10,Commissioner of the General Land Office,,DEM,Miguel Suazo,468,247,166,55
+Tom Green,146 BS10,Commissioner of the General Land Office,,LIB,Matt Pina,26,17,8,1
+Tom Green,146 BS10,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,146 BS10,Commissioner of the General Land Office,,,Under Votes,24,10,7,7
+Tom Green,146 BS10,Commissioner of Agriculture,,REP,Sid Miller,598,330,164,104
+Tom Green,146 BS10,Commissioner of Agriculture,,DEM,Kim Olson,486,255,169,62
+Tom Green,146 BS10,Commissioner of Agriculture,,LIB,Richard Carpenter,21,11,9,1
+Tom Green,146 BS10,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,146 BS10,Commissioner of Agriculture,,,Under Votes,26,15,9,2
+Tom Green,146 BS10,Railroad Commissioner,,REP,Christi Craddick,605,332,170,103
+Tom Green,146 BS10,Railroad Commissioner,,DEM,Roman McAllen,467,247,159,61
+Tom Green,146 BS10,Railroad Commissioner,,LIB,Mike Wright,34,19,13,2
+Tom Green,146 BS10,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,146 BS10,Railroad Commissioner,,,Under Votes,25,13,9,3
+Tom Green,146 BS10,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,607,339,165,103
+Tom Green,146 BS10,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,495,257,176,62
+Tom Green,146 BS10,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,146 BS10,"Justice, Supreme Court, Place 2",,,Under Votes,29,15,10,4
+Tom Green,146 BS10,"Justice, Supreme Court, Place 4",,REP,John Devine,609,333,172,104
+Tom Green,146 BS10,"Justice, Supreme Court, Place 4",,,R. K. Sandill,486,258,168,60
+Tom Green,146 BS10,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,146 BS10,"Justice, Supreme Court, Place 4",,,Under Votes,36,20,11,5
+Tom Green,146 BS10,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,610,336,170,104
+Tom Green,146 BS10,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,487,256,170,61
+Tom Green,146 BS10,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,146 BS10,"Justice, Supreme Court, Place 6",,,Under Votes,34,19,11,4
+Tom Green,146 BS10,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,594,325,166,103
+Tom Green,146 BS10,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,483,258,165,60
+Tom Green,146 BS10,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,24,13,10,1
+Tom Green,146 BS10,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,146 BS10,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,30,15,10,5
+Tom Green,146 BS10,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,608,334,169,105
+Tom Green,146 BS10,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,488,258,170,60
+Tom Green,146 BS10,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,146 BS10,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,35,19,12,4
+Tom Green,146 BS10,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,642,354,181,107
+Tom Green,146 BS10,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,201,115,60,26
+Tom Green,146 BS10,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,146 BS10,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,288,142,110,36
+Tom Green,146 BS10,State Representative,72,REP,Drew Darby,728,400,209,119
+Tom Green,146 BS10,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,146 BS10,State Representative,72,,Under Votes,403,211,142,50
+Tom Green,146 BS10,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,610,338,168,104
+Tom Green,146 BS10,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,484,254,168,62
+Tom Green,146 BS10,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,146 BS10,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,37,19,15,3
+Tom Green,146 BS10,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,605,333,169,103
+Tom Green,146 BS10,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,489,258,169,62
+Tom Green,146 BS10,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,146 BS10,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,37,20,13,4
+Tom Green,146 BS10,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,592,330,159,103
+Tom Green,146 BS10,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,499,264,176,59
+Tom Green,146 BS10,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,146 BS10,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,40,17,16,7
+Tom Green,146 BS10,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",592,323,167,102
+Tom Green,146 BS10,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,490,264,168,58
+Tom Green,146 BS10,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),4,0,0,4
+Tom Green,146 BS10,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,146 BS10,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,45,24,16,5
+Tom Green,146 BS10,Justice of the Peace Pct. 1,,REP,Susan Werner,606,338,165,103
+Tom Green,146 BS10,Justice of the Peace Pct. 1,,DEM,Sally Ayana,498,257,176,65
+Tom Green,146 BS10,Justice of the Peace Pct. 1,,,Over Votes,0,0,0,0
+Tom Green,146 BS10,Justice of the Peace Pct. 1,,,Under Votes,27,16,10,1
+Tom Green,146 BS10,San Angelo Independent School District Proposition A,,,FOR,466,244,144,78
+Tom Green,146 BS10,San Angelo Independent School District Proposition A,,,AGAINST,521,297,163,61
+Tom Green,146 BS10,San Angelo Independent School District Proposition A,,,Over Votes,0,0,0,0
+Tom Green,146 BS10,San Angelo Independent School District Proposition A,,,Under Votes,144,70,44,30
+Tom Green,146 BS10,San Angelo Independent School District Proposition B,,,FOR,456,234,142,80
+Tom Green,146 BS10,San Angelo Independent School District Proposition B,,,AGAINST,536,305,171,60
+Tom Green,146 BS10,San Angelo Independent School District Proposition B,,,Over Votes,0,0,0,0
+Tom Green,146 BS10,San Angelo Independent School District Proposition B,,,Under Votes,139,72,38,29
+Tom Green,146 BS10,Ballots Cast,,,,1131,611,351,169
+Tom Green,213 BS11,STRAIGHT PARTY,,REP,,926,500,376,50
+Tom Green,213 BS11,STRAIGHT PARTY,,DEM,,71,48,17,6
+Tom Green,213 BS11,STRAIGHT PARTY,,LIB,,0,0,0,0
+Tom Green,213 BS11,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,213 BS11,STRAIGHT PARTY,,,Under Votes,689,383,282,24
+Tom Green,213 BS11,U.S. Senate,,REP,Ted Cruz,1518,819,633,66
+Tom Green,213 BS11,U.S. Senate,,DEM,Beto O'Rourke,151,107,33,11
+Tom Green,213 BS11,U.S. Senate,,LIB,Neal M. Dikeman,6,2,4,0
+Tom Green,213 BS11,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,213 BS11,U.S. Senate,,,Under Votes,11,3,5,3
+Tom Green,213 BS11,U.S. House,11,REP,Mike Conaway,1538,830,642,66
+Tom Green,213 BS11,U.S. House,11,DEM,Jennie Lou Leeder,118,82,23,13
+Tom Green,213 BS11,U.S. House,11,LIB,Rhett Rosenquest Smith,18,11,6,1
+Tom Green,213 BS11,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,213 BS11,U.S. House,11,,Under Votes,12,8,4,0
+Tom Green,213 BS11,Governor,,REP,Greg Abbott,1536,829,640,67
+Tom Green,213 BS11,Governor,,DEM,Lupe Valdez,129,91,27,11
+Tom Green,213 BS11,Governor,,LIB,Mark Jay Tippetts,13,7,5,1
+Tom Green,213 BS11,Governor,,,Over Votes,0,0,0,0
+Tom Green,213 BS11,Governor,,,Under Votes,8,4,3,1
+Tom Green,213 BS11,Lieutenant Governor,,REP,Dan Patrick,1361,737,558,66
+Tom Green,213 BS11,Lieutenant Governor,,DEM,Mike Collier,268,160,95,13
+Tom Green,213 BS11,Lieutenant Governor,,LIB,Kerry Douglas McKennon,36,23,13,0
+Tom Green,213 BS11,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,213 BS11,Lieutenant Governor,,,Under Votes,21,11,9,1
+Tom Green,213 BS11,Attorney General,,REP,Ken Paxton,1456,779,612,65
+Tom Green,213 BS11,Attorney General,,DEM,Justin Nelson,163,115,36,12
+Tom Green,213 BS11,Attorney General,,LIB,Michael Ray Harris,37,22,14,1
+Tom Green,213 BS11,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,213 BS11,Attorney General,,,Under Votes,30,15,13,2
+Tom Green,213 BS11,Comptroller of Public Accounts,,REP,Glenn Hegar,1498,807,626,65
+Tom Green,213 BS11,Comptroller of Public Accounts,,DEM,Joi Chevalier,132,95,26,11
+Tom Green,213 BS11,Comptroller of Public Accounts,,LIB,Ben Sanders,27,15,10,2
+Tom Green,213 BS11,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,213 BS11,Comptroller of Public Accounts,,,Under Votes,29,14,13,2
+Tom Green,213 BS11,Commissioner of the General Land Office,,REP,George P. Bush,1476,800,612,64
+Tom Green,213 BS11,Commissioner of the General Land Office,,DEM,Miguel Suazo,137,89,37,11
+Tom Green,213 BS11,Commissioner of the General Land Office,,LIB,Matt Pina,54,33,19,2
+Tom Green,213 BS11,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,213 BS11,Commissioner of the General Land Office,,,Under Votes,19,9,7,3
+Tom Green,213 BS11,Commissioner of Agriculture,,REP,Sid Miller,1481,796,621,64
+Tom Green,213 BS11,Commissioner of Agriculture,,DEM,Kim Olson,155,105,38,12
+Tom Green,213 BS11,Commissioner of Agriculture,,LIB,Richard Carpenter,26,18,6,2
+Tom Green,213 BS11,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,213 BS11,Commissioner of Agriculture,,,Under Votes,24,12,10,2
+Tom Green,213 BS11,Railroad Commissioner,,REP,Christi Craddick,1495,804,627,64
+Tom Green,213 BS11,Railroad Commissioner,,DEM,Roman McAllen,133,95,26,12
+Tom Green,213 BS11,Railroad Commissioner,,LIB,Mike Wright,39,22,14,3
+Tom Green,213 BS11,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,213 BS11,Railroad Commissioner,,,Under Votes,19,10,8,1
+Tom Green,213 BS11,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1513,818,630,65
+Tom Green,213 BS11,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,141,98,31,12
+Tom Green,213 BS11,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,213 BS11,"Justice, Supreme Court, Place 2",,,Under Votes,32,15,14,3
+Tom Green,213 BS11,"Justice, Supreme Court, Place 4",,REP,John Devine,1516,817,632,67
+Tom Green,213 BS11,"Justice, Supreme Court, Place 4",,,R. K. Sandill,140,99,31,10
+Tom Green,213 BS11,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,213 BS11,"Justice, Supreme Court, Place 4",,,Under Votes,30,15,12,3
+Tom Green,213 BS11,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1513,817,632,64
+Tom Green,213 BS11,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,143,98,33,12
+Tom Green,213 BS11,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,213 BS11,"Justice, Supreme Court, Place 6",,,Under Votes,30,16,10,4
+Tom Green,213 BS11,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1490,805,622,63
+Tom Green,213 BS11,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,139,95,30,14
+Tom Green,213 BS11,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,28,15,11,2
+Tom Green,213 BS11,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,213 BS11,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,29,16,12,1
+Tom Green,213 BS11,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1510,810,633,67
+Tom Green,213 BS11,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,143,102,29,12
+Tom Green,213 BS11,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,213 BS11,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,33,19,13,1
+Tom Green,213 BS11,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1524,824,632,68
+Tom Green,213 BS11,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,71,48,21,2
+Tom Green,213 BS11,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,213 BS11,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,91,59,22,10
+Tom Green,213 BS11,State Representative,72,REP,Drew Darby,1566,854,643,69
+Tom Green,213 BS11,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,213 BS11,State Representative,72,,Under Votes,120,77,32,11
+Tom Green,213 BS11,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,1512,812,634,66
+Tom Green,213 BS11,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,135,93,29,13
+Tom Green,213 BS11,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,213 BS11,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,39,26,12,1
+Tom Green,213 BS11,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,1507,810,632,65
+Tom Green,213 BS11,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,140,95,31,14
+Tom Green,213 BS11,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,213 BS11,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,39,26,12,1
+Tom Green,213 BS11,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,1503,808,629,66
+Tom Green,213 BS11,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,142,97,33,12
+Tom Green,213 BS11,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,213 BS11,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,41,26,13,2
+Tom Green,213 BS11,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",1506,810,633,63
+Tom Green,213 BS11,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,140,96,30,14
+Tom Green,213 BS11,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),0,0,0,0
+Tom Green,213 BS11,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,213 BS11,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,40,25,12,3
+Tom Green,213 BS11,Ballots Cast,,,,1686,931,675,80
+Tom Green,213 BS12,STRAIGHT PARTY,,REP,,51,24,12,15
+Tom Green,213 BS12,STRAIGHT PARTY,,DEM,,16,3,0,13
+Tom Green,213 BS12,STRAIGHT PARTY,,LIB,,1,1,0,0
+Tom Green,213 BS12,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,213 BS12,STRAIGHT PARTY,,,Under Votes,51,15,7,29
+Tom Green,213 BS12,U.S. Senate,,REP,Ted Cruz,73,36,16,21
+Tom Green,213 BS12,U.S. Senate,,DEM,Beto O'Rourke,44,7,2,35
+Tom Green,213 BS12,U.S. Senate,,LIB,Neal M. Dikeman,1,0,1,0
+Tom Green,213 BS12,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,213 BS12,U.S. Senate,,,Under Votes,1,0,0,1
+Tom Green,213 BS12,U.S. House,11,REP,Mike Conaway,78,38,16,24
+Tom Green,213 BS12,U.S. House,11,DEM,Jennie Lou Leeder,36,5,0,31
+Tom Green,213 BS12,U.S. House,11,LIB,Rhett Rosenquest Smith,4,0,3,1
+Tom Green,213 BS12,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,213 BS12,U.S. House,11,,Under Votes,1,0,0,1
+Tom Green,213 BS12,Governor,,REP,Greg Abbott,78,38,16,24
+Tom Green,213 BS12,Governor,,DEM,Lupe Valdez,38,5,1,32
+Tom Green,213 BS12,Governor,,LIB,Mark Jay Tippetts,2,0,2,0
+Tom Green,213 BS12,Governor,,,Over Votes,0,0,0,0
+Tom Green,213 BS12,Governor,,,Under Votes,1,0,0,1
+Tom Green,213 BS12,Lieutenant Governor,,REP,Dan Patrick,74,35,15,24
+Tom Green,213 BS12,Lieutenant Governor,,DEM,Mike Collier,39,7,3,29
+Tom Green,213 BS12,Lieutenant Governor,,LIB,Kerry Douglas McKennon,3,0,1,2
+Tom Green,213 BS12,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,213 BS12,Lieutenant Governor,,,Under Votes,3,1,0,2
+Tom Green,213 BS12,Attorney General,,REP,Ken Paxton,73,35,15,23
+Tom Green,213 BS12,Attorney General,,DEM,Justin Nelson,43,7,3,33
+Tom Green,213 BS12,Attorney General,,LIB,Michael Ray Harris,1,0,1,0
+Tom Green,213 BS12,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,213 BS12,Attorney General,,,Under Votes,2,1,0,1
+Tom Green,213 BS12,Comptroller of Public Accounts,,REP,Glenn Hegar,79,38,17,24
+Tom Green,213 BS12,Comptroller of Public Accounts,,DEM,Joi Chevalier,33,5,1,27
+Tom Green,213 BS12,Comptroller of Public Accounts,,LIB,Ben Sanders,2,0,1,1
+Tom Green,213 BS12,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,213 BS12,Comptroller of Public Accounts,,,Under Votes,5,0,0,5
+Tom Green,213 BS12,Commissioner of the General Land Office,,REP,George P. Bush,77,39,16,22
+Tom Green,213 BS12,Commissioner of the General Land Office,,DEM,Miguel Suazo,34,3,3,28
+Tom Green,213 BS12,Commissioner of the General Land Office,,LIB,Matt Pina,3,1,0,2
+Tom Green,213 BS12,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,213 BS12,Commissioner of the General Land Office,,,Under Votes,5,0,0,5
+Tom Green,213 BS12,Commissioner of Agriculture,,REP,Sid Miller,76,37,16,23
+Tom Green,213 BS12,Commissioner of Agriculture,,DEM,Kim Olson,37,6,2,29
+Tom Green,213 BS12,Commissioner of Agriculture,,LIB,Richard Carpenter,1,0,1,0
+Tom Green,213 BS12,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,213 BS12,Commissioner of Agriculture,,,Under Votes,5,0,0,5
+Tom Green,213 BS12,Railroad Commissioner,,REP,Christi Craddick,77,37,16,24
+Tom Green,213 BS12,Railroad Commissioner,,DEM,Roman McAllen,34,6,1,27
+Tom Green,213 BS12,Railroad Commissioner,,LIB,Mike Wright,2,0,2,0
+Tom Green,213 BS12,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,213 BS12,Railroad Commissioner,,,Under Votes,6,0,0,6
+Tom Green,213 BS12,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,76,36,17,23
+Tom Green,213 BS12,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,39,6,2,31
+Tom Green,213 BS12,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,213 BS12,"Justice, Supreme Court, Place 2",,,Under Votes,4,1,0,3
+Tom Green,213 BS12,"Justice, Supreme Court, Place 4",,REP,John Devine,76,36,17,23
+Tom Green,213 BS12,"Justice, Supreme Court, Place 4",,,R. K. Sandill,38,6,2,30
+Tom Green,213 BS12,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,213 BS12,"Justice, Supreme Court, Place 4",,,Under Votes,5,1,0,4
+Tom Green,213 BS12,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,77,36,17,24
+Tom Green,213 BS12,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,38,6,2,30
+Tom Green,213 BS12,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,213 BS12,"Justice, Supreme Court, Place 6",,,Under Votes,4,1,0,3
+Tom Green,213 BS12,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,74,36,15,23
+Tom Green,213 BS12,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,35,6,2,27
+Tom Green,213 BS12,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,4,0,2,2
+Tom Green,213 BS12,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,213 BS12,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,6,1,0,5
+Tom Green,213 BS12,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,78,36,17,25
+Tom Green,213 BS12,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,36,6,2,28
+Tom Green,213 BS12,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,213 BS12,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,5,1,0,4
+Tom Green,213 BS12,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,81,39,16,26
+Tom Green,213 BS12,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,19,1,3,15
+Tom Green,213 BS12,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,213 BS12,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,19,3,0,16
+Tom Green,213 BS12,State Representative,72,REP,Drew Darby,81,39,17,25
+Tom Green,213 BS12,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,213 BS12,State Representative,72,,Under Votes,38,4,2,32
+Tom Green,213 BS12,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,81,37,17,27
+Tom Green,213 BS12,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,32,5,2,25
+Tom Green,213 BS12,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,213 BS12,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,6,1,0,5
+Tom Green,213 BS12,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,75,36,17,22
+Tom Green,213 BS12,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,36,6,2,28
+Tom Green,213 BS12,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,213 BS12,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,8,1,0,7
+Tom Green,213 BS12,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,77,37,17,23
+Tom Green,213 BS12,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,34,5,2,27
+Tom Green,213 BS12,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,213 BS12,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,8,1,0,7
+Tom Green,213 BS12,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",77,36,17,24
+Tom Green,213 BS12,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,34,5,1,28
+Tom Green,213 BS12,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),0,0,0,0
+Tom Green,213 BS12,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,213 BS12,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,8,2,1,5
+Tom Green,213 BS12,San Angelo Independent School District Proposition A,,,FOR,55,13,6,36
+Tom Green,213 BS12,San Angelo Independent School District Proposition A,,,AGAINST,55,27,12,16
+Tom Green,213 BS12,San Angelo Independent School District Proposition A,,,Over Votes,0,0,0,0
+Tom Green,213 BS12,San Angelo Independent School District Proposition A,,,Under Votes,9,3,1,5
+Tom Green,213 BS12,San Angelo Independent School District Proposition B,,,FOR,59,15,7,37
+Tom Green,213 BS12,San Angelo Independent School District Proposition B,,,AGAINST,53,25,11,17
+Tom Green,213 BS12,San Angelo Independent School District Proposition B,,,Over Votes,0,0,0,0
+Tom Green,213 BS12,San Angelo Independent School District Proposition B,,,Under Votes,7,3,1,3
+Tom Green,213 BS12,Ballots Cast,,,,119,43,19,57
+Tom Green,215 BS13,STRAIGHT PARTY,,REP,,681,454,153,74
+Tom Green,215 BS13,STRAIGHT PARTY,,DEM,,138,94,30,14
+Tom Green,215 BS13,STRAIGHT PARTY,,LIB,,3,2,1,0
+Tom Green,215 BS13,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,215 BS13,STRAIGHT PARTY,,,Under Votes,679,493,139,47
+Tom Green,215 BS13,U.S. Senate,,REP,Ted Cruz,1164,817,243,104
+Tom Green,215 BS13,U.S. Senate,,DEM,Beto O'Rourke,308,213,68,27
+Tom Green,215 BS13,U.S. Senate,,LIB,Neal M. Dikeman,15,6,8,1
+Tom Green,215 BS13,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,215 BS13,U.S. Senate,,,Under Votes,14,7,4,3
+Tom Green,215 BS13,U.S. House,11,REP,Mike Conaway,1217,847,258,112
+Tom Green,215 BS13,U.S. House,11,DEM,Jennie Lou Leeder,247,171,54,22
+Tom Green,215 BS13,U.S. House,11,LIB,Rhett Rosenquest Smith,17,12,5,0
+Tom Green,215 BS13,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,215 BS13,U.S. House,11,,Under Votes,20,13,6,1
+Tom Green,215 BS13,Governor,,REP,Greg Abbott,1188,822,257,109
+Tom Green,215 BS13,Governor,,DEM,Lupe Valdez,272,195,54,23
+Tom Green,215 BS13,Governor,,LIB,Mark Jay Tippetts,24,17,7,0
+Tom Green,215 BS13,Governor,,,Over Votes,0,0,0,0
+Tom Green,215 BS13,Governor,,,Under Votes,17,9,5,3
+Tom Green,215 BS13,Lieutenant Governor,,REP,Dan Patrick,1079,742,234,103
+Tom Green,215 BS13,Lieutenant Governor,,DEM,Mike Collier,356,255,72,29
+Tom Green,215 BS13,Lieutenant Governor,,LIB,Kerry Douglas McKennon,39,27,12,0
+Tom Green,215 BS13,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,215 BS13,Lieutenant Governor,,,Under Votes,27,19,5,3
+Tom Green,215 BS13,Attorney General,,REP,Ken Paxton,1098,757,239,102
+Tom Green,215 BS13,Attorney General,,DEM,Justin Nelson,318,226,62,30
+Tom Green,215 BS13,Attorney General,,LIB,Michael Ray Harris,46,31,14,1
+Tom Green,215 BS13,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,215 BS13,Attorney General,,,Under Votes,39,29,8,2
+Tom Green,215 BS13,Comptroller of Public Accounts,,REP,Glenn Hegar,1132,789,239,104
+Tom Green,215 BS13,Comptroller of Public Accounts,,DEM,Joi Chevalier,265,186,56,23
+Tom Green,215 BS13,Comptroller of Public Accounts,,LIB,Ben Sanders,49,29,18,2
+Tom Green,215 BS13,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,215 BS13,Comptroller of Public Accounts,,,Under Votes,55,39,10,6
+Tom Green,215 BS13,Commissioner of the General Land Office,,REP,George P. Bush,1163,802,254,107
+Tom Green,215 BS13,Commissioner of the General Land Office,,DEM,Miguel Suazo,261,185,52,24
+Tom Green,215 BS13,Commissioner of the General Land Office,,LIB,Matt Pina,44,33,10,1
+Tom Green,215 BS13,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,215 BS13,Commissioner of the General Land Office,,,Under Votes,33,23,7,3
+Tom Green,215 BS13,Commissioner of Agriculture,,REP,Sid Miller,1114,778,235,101
+Tom Green,215 BS13,Commissioner of Agriculture,,DEM,Kim Olson,297,202,67,28
+Tom Green,215 BS13,Commissioner of Agriculture,,LIB,Richard Carpenter,42,28,12,2
+Tom Green,215 BS13,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,215 BS13,Commissioner of Agriculture,,,Under Votes,48,35,9,4
+Tom Green,215 BS13,Railroad Commissioner,,REP,Christi Craddick,1135,791,243,101
+Tom Green,215 BS13,Railroad Commissioner,,DEM,Roman McAllen,270,190,54,26
+Tom Green,215 BS13,Railroad Commissioner,,LIB,Mike Wright,49,31,16,2
+Tom Green,215 BS13,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,215 BS13,Railroad Commissioner,,,Under Votes,47,31,10,6
+Tom Green,215 BS13,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1154,803,247,104
+Tom Green,215 BS13,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,294,203,65,26
+Tom Green,215 BS13,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,215 BS13,"Justice, Supreme Court, Place 2",,,Under Votes,53,37,11,5
+Tom Green,215 BS13,"Justice, Supreme Court, Place 4",,REP,John Devine,1159,808,247,104
+Tom Green,215 BS13,"Justice, Supreme Court, Place 4",,,R. K. Sandill,288,197,64,27
+Tom Green,215 BS13,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,215 BS13,"Justice, Supreme Court, Place 4",,,Under Votes,54,38,12,4
+Tom Green,215 BS13,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1154,808,240,106
+Tom Green,215 BS13,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,293,197,71,25
+Tom Green,215 BS13,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,215 BS13,"Justice, Supreme Court, Place 6",,,Under Votes,54,38,12,4
+Tom Green,215 BS13,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1125,781,242,102
+Tom Green,215 BS13,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,283,199,61,23
+Tom Green,215 BS13,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,42,29,10,3
+Tom Green,215 BS13,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,215 BS13,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,51,34,10,7
+Tom Green,215 BS13,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1157,808,246,103
+Tom Green,215 BS13,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,283,195,63,25
+Tom Green,215 BS13,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,215 BS13,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,61,40,14,7
+Tom Green,215 BS13,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1188,827,257,104
+Tom Green,215 BS13,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,151,104,36,11
+Tom Green,215 BS13,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,215 BS13,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,162,112,30,20
+Tom Green,215 BS13,State Representative,72,REP,Drew Darby,1271,877,281,113
+Tom Green,215 BS13,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,215 BS13,State Representative,72,,Under Votes,230,166,42,22
+Tom Green,215 BS13,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,1158,804,251,103
+Tom Green,215 BS13,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,276,193,58,25
+Tom Green,215 BS13,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,215 BS13,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,67,46,14,7
+Tom Green,215 BS13,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,1148,800,247,101
+Tom Green,215 BS13,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,292,201,63,28
+Tom Green,215 BS13,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,215 BS13,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,61,42,13,6
+Tom Green,215 BS13,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,1141,796,245,100
+Tom Green,215 BS13,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,297,202,67,28
+Tom Green,215 BS13,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,215 BS13,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,63,45,11,7
+Tom Green,215 BS13,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",1151,801,248,102
+Tom Green,215 BS13,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,284,195,62,27
+Tom Green,215 BS13,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),2,1,0,1
+Tom Green,215 BS13,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,215 BS13,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,64,46,13,5
+Tom Green,215 BS13,San Angelo Independent School District Proposition A,,,FOR,569,406,116,47
+Tom Green,215 BS13,San Angelo Independent School District Proposition A,,,AGAINST,848,584,188,76
+Tom Green,215 BS13,San Angelo Independent School District Proposition A,,,Over Votes,0,0,0,0
+Tom Green,215 BS13,San Angelo Independent School District Proposition A,,,Under Votes,84,53,19,12
+Tom Green,215 BS13,San Angelo Independent School District Proposition B,,,FOR,540,378,123,39
+Tom Green,215 BS13,San Angelo Independent School District Proposition B,,,AGAINST,874,617,179,78
+Tom Green,215 BS13,San Angelo Independent School District Proposition B,,,Over Votes,0,0,0,0
+Tom Green,215 BS13,San Angelo Independent School District Proposition B,,,Under Votes,87,48,21,18
+Tom Green,215 BS13,Ballots Cast,,,,1501,1043,323,135
+Tom Green,225 BS14,STRAIGHT PARTY,,REP,,35,25,9,1
+Tom Green,225 BS14,STRAIGHT PARTY,,DEM,,1,1,0,0
+Tom Green,225 BS14,STRAIGHT PARTY,,LIB,,0,0,0,0
+Tom Green,225 BS14,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,225 BS14,STRAIGHT PARTY,,,Under Votes,27,19,8,0
+Tom Green,225 BS14,U.S. Senate,,REP,Ted Cruz,55,43,11,1
+Tom Green,225 BS14,U.S. Senate,,DEM,Beto O'Rourke,6,2,4,0
+Tom Green,225 BS14,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Tom Green,225 BS14,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,225 BS14,U.S. Senate,,,Under Votes,2,0,2,0
+Tom Green,225 BS14,U.S. House,11,REP,Mike Conaway,58,43,14,1
+Tom Green,225 BS14,U.S. House,11,DEM,Jennie Lou Leeder,3,2,1,0
+Tom Green,225 BS14,U.S. House,11,LIB,Rhett Rosenquest Smith,1,0,1,0
+Tom Green,225 BS14,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,225 BS14,U.S. House,11,,Under Votes,1,0,1,0
+Tom Green,225 BS14,Governor,,REP,Greg Abbott,59,43,15,1
+Tom Green,225 BS14,Governor,,DEM,Lupe Valdez,2,2,0,0
+Tom Green,225 BS14,Governor,,LIB,Mark Jay Tippetts,1,0,1,0
+Tom Green,225 BS14,Governor,,,Over Votes,0,0,0,0
+Tom Green,225 BS14,Governor,,,Under Votes,1,0,1,0
+Tom Green,225 BS14,Lieutenant Governor,,REP,Dan Patrick,48,36,11,1
+Tom Green,225 BS14,Lieutenant Governor,,DEM,Mike Collier,11,8,3,0
+Tom Green,225 BS14,Lieutenant Governor,,LIB,Kerry Douglas McKennon,1,1,0,0
+Tom Green,225 BS14,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,225 BS14,Lieutenant Governor,,,Under Votes,3,0,3,0
+Tom Green,225 BS14,Attorney General,,REP,Ken Paxton,52,37,14,1
+Tom Green,225 BS14,Attorney General,,DEM,Justin Nelson,7,7,0,0
+Tom Green,225 BS14,Attorney General,,LIB,Michael Ray Harris,1,1,0,0
+Tom Green,225 BS14,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,225 BS14,Attorney General,,,Under Votes,3,0,3,0
+Tom Green,225 BS14,Comptroller of Public Accounts,,REP,Glenn Hegar,53,39,13,1
+Tom Green,225 BS14,Comptroller of Public Accounts,,DEM,Joi Chevalier,3,3,0,0
+Tom Green,225 BS14,Comptroller of Public Accounts,,LIB,Ben Sanders,4,3,1,0
+Tom Green,225 BS14,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,225 BS14,Comptroller of Public Accounts,,,Under Votes,3,0,3,0
+Tom Green,225 BS14,Commissioner of the General Land Office,,REP,George P. Bush,55,41,13,1
+Tom Green,225 BS14,Commissioner of the General Land Office,,DEM,Miguel Suazo,3,3,0,0
+Tom Green,225 BS14,Commissioner of the General Land Office,,LIB,Matt Pina,3,1,2,0
+Tom Green,225 BS14,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,225 BS14,Commissioner of the General Land Office,,,Under Votes,2,0,2,0
+Tom Green,225 BS14,Commissioner of Agriculture,,REP,Sid Miller,54,41,12,1
+Tom Green,225 BS14,Commissioner of Agriculture,,DEM,Kim Olson,3,2,1,0
+Tom Green,225 BS14,Commissioner of Agriculture,,LIB,Richard Carpenter,3,1,2,0
+Tom Green,225 BS14,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,225 BS14,Commissioner of Agriculture,,,Under Votes,3,1,2,0
+Tom Green,225 BS14,Railroad Commissioner,,REP,Christi Craddick,56,42,13,1
+Tom Green,225 BS14,Railroad Commissioner,,DEM,Roman McAllen,2,2,0,0
+Tom Green,225 BS14,Railroad Commissioner,,LIB,Mike Wright,3,1,2,0
+Tom Green,225 BS14,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,225 BS14,Railroad Commissioner,,,Under Votes,2,0,2,0
+Tom Green,225 BS14,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,57,42,14,1
+Tom Green,225 BS14,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,3,3,0,0
+Tom Green,225 BS14,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,225 BS14,"Justice, Supreme Court, Place 2",,,Under Votes,3,0,3,0
+Tom Green,225 BS14,"Justice, Supreme Court, Place 4",,REP,John Devine,55,40,14,1
+Tom Green,225 BS14,"Justice, Supreme Court, Place 4",,,R. K. Sandill,5,5,0,0
+Tom Green,225 BS14,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,225 BS14,"Justice, Supreme Court, Place 4",,,Under Votes,3,0,3,0
+Tom Green,225 BS14,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,59,43,15,1
+Tom Green,225 BS14,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,2,2,0,0
+Tom Green,225 BS14,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,225 BS14,"Justice, Supreme Court, Place 6",,,Under Votes,2,0,2,0
+Tom Green,225 BS14,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,56,42,13,1
+Tom Green,225 BS14,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,2,2,0,0
+Tom Green,225 BS14,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,3,1,2,0
+Tom Green,225 BS14,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,225 BS14,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,2,0,2,0
+Tom Green,225 BS14,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,55,40,14,1
+Tom Green,225 BS14,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,4,4,0,0
+Tom Green,225 BS14,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,225 BS14,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,4,1,3,0
+Tom Green,225 BS14,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,56,42,13,1
+Tom Green,225 BS14,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,3,1,2,0
+Tom Green,225 BS14,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,225 BS14,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,4,2,2,0
+Tom Green,225 BS14,State Representative,72,REP,Drew Darby,57,41,15,1
+Tom Green,225 BS14,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,225 BS14,State Representative,72,,Under Votes,6,4,2,0
+Tom Green,225 BS14,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,58,43,14,1
+Tom Green,225 BS14,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,2,2,0,0
+Tom Green,225 BS14,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,225 BS14,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,3,0,3,0
+Tom Green,225 BS14,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,56,41,14,1
+Tom Green,225 BS14,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,3,3,0,0
+Tom Green,225 BS14,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,225 BS14,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,4,1,3,0
+Tom Green,225 BS14,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,55,40,14,1
+Tom Green,225 BS14,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,6,5,1,0
+Tom Green,225 BS14,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,225 BS14,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,2,0,2,0
+Tom Green,225 BS14,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",56,41,14,1
+Tom Green,225 BS14,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,2,2,0,0
+Tom Green,225 BS14,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),0,0,0,0
+Tom Green,225 BS14,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,225 BS14,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,5,2,3,0
+Tom Green,225 BS14,San Angelo Independent School District Proposition A,,,FOR,23,14,9,0
+Tom Green,225 BS14,San Angelo Independent School District Proposition A,,,AGAINST,36,28,7,1
+Tom Green,225 BS14,San Angelo Independent School District Proposition A,,,Over Votes,0,0,0,0
+Tom Green,225 BS14,San Angelo Independent School District Proposition A,,,Under Votes,4,3,1,0
+Tom Green,225 BS14,San Angelo Independent School District Proposition B,,,FOR,22,13,9,0
+Tom Green,225 BS14,San Angelo Independent School District Proposition B,,,AGAINST,38,30,7,1
+Tom Green,225 BS14,San Angelo Independent School District Proposition B,,,Over Votes,0,0,0,0
+Tom Green,225 BS14,San Angelo Independent School District Proposition B,,,Under Votes,3,2,1,0
+Tom Green,225 BS14,Ballots Cast,,,,63,45,17,1
+Tom Green,228 BS15,STRAIGHT PARTY,,REP,,577,333,146,98
+Tom Green,228 BS15,STRAIGHT PARTY,,DEM,,181,109,58,14
+Tom Green,228 BS15,STRAIGHT PARTY,,LIB,,4,2,2,0
+Tom Green,228 BS15,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,228 BS15,STRAIGHT PARTY,,,Under Votes,653,411,151,91
+Tom Green,228 BS15,U.S. Senate,,REP,Ted Cruz,977,600,229,148
+Tom Green,228 BS15,U.S. Senate,,DEM,Beto O'Rourke,415,247,124,44
+Tom Green,228 BS15,U.S. Senate,,LIB,Neal M. Dikeman,9,1,3,5
+Tom Green,228 BS15,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,228 BS15,U.S. Senate,,,Under Votes,14,7,1,6
+Tom Green,228 BS15,U.S. House,11,REP,Mike Conaway,1027,626,242,159
+Tom Green,228 BS15,U.S. House,11,DEM,Jennie Lou Leeder,341,200,99,42
+Tom Green,228 BS15,U.S. House,11,LIB,Rhett Rosenquest Smith,22,11,10,1
+Tom Green,228 BS15,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,228 BS15,U.S. House,11,,Under Votes,25,18,6,1
+Tom Green,228 BS15,Governor,,REP,Greg Abbott,1023,621,243,159
+Tom Green,228 BS15,Governor,,DEM,Lupe Valdez,365,220,105,40
+Tom Green,228 BS15,Governor,,LIB,Mark Jay Tippetts,16,8,5,3
+Tom Green,228 BS15,Governor,,,Over Votes,0,0,0,0
+Tom Green,228 BS15,Governor,,,Under Votes,11,6,4,1
+Tom Green,228 BS15,Lieutenant Governor,,REP,Dan Patrick,922,558,211,153
+Tom Green,228 BS15,Lieutenant Governor,,DEM,Mike Collier,435,265,121,49
+Tom Green,228 BS15,Lieutenant Governor,,LIB,Kerry Douglas McKennon,37,20,17,0
+Tom Green,228 BS15,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,228 BS15,Lieutenant Governor,,,Under Votes,21,12,8,1
+Tom Green,228 BS15,Attorney General,,REP,Ken Paxton,936,567,224,145
+Tom Green,228 BS15,Attorney General,,DEM,Justin Nelson,419,253,114,52
+Tom Green,228 BS15,Attorney General,,LIB,Michael Ray Harris,33,18,10,5
+Tom Green,228 BS15,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,228 BS15,Attorney General,,,Under Votes,27,17,9,1
+Tom Green,228 BS15,Comptroller of Public Accounts,,REP,Glenn Hegar,968,593,227,148
+Tom Green,228 BS15,Comptroller of Public Accounts,,DEM,Joi Chevalier,360,206,106,48
+Tom Green,228 BS15,Comptroller of Public Accounts,,LIB,Ben Sanders,46,30,14,2
+Tom Green,228 BS15,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,228 BS15,Comptroller of Public Accounts,,,Under Votes,41,26,10,5
+Tom Green,228 BS15,Commissioner of the General Land Office,,REP,George P. Bush,976,595,228,153
+Tom Green,228 BS15,Commissioner of the General Land Office,,DEM,Miguel Suazo,351,207,104,40
+Tom Green,228 BS15,Commissioner of the General Land Office,,LIB,Matt Pina,59,38,17,4
+Tom Green,228 BS15,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,228 BS15,Commissioner of the General Land Office,,,Under Votes,29,15,8,6
+Tom Green,228 BS15,Commissioner of Agriculture,,REP,Sid Miller,952,581,223,148
+Tom Green,228 BS15,Commissioner of Agriculture,,DEM,Kim Olson,386,230,106,50
+Tom Green,228 BS15,Commissioner of Agriculture,,LIB,Richard Carpenter,44,22,19,3
+Tom Green,228 BS15,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,228 BS15,Commissioner of Agriculture,,,Under Votes,33,22,9,2
+Tom Green,228 BS15,Railroad Commissioner,,REP,Christi Craddick,988,608,229,151
+Tom Green,228 BS15,Railroad Commissioner,,DEM,Roman McAllen,348,203,98,47
+Tom Green,228 BS15,Railroad Commissioner,,LIB,Mike Wright,42,22,19,1
+Tom Green,228 BS15,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,228 BS15,Railroad Commissioner,,,Under Votes,37,22,11,4
+Tom Green,228 BS15,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,990,605,233,152
+Tom Green,228 BS15,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,384,226,114,44
+Tom Green,228 BS15,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,228 BS15,"Justice, Supreme Court, Place 2",,,Under Votes,41,24,10,7
+Tom Green,228 BS15,"Justice, Supreme Court, Place 4",,REP,John Devine,989,604,235,150
+Tom Green,228 BS15,"Justice, Supreme Court, Place 4",,,R. K. Sandill,383,224,112,47
+Tom Green,228 BS15,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,228 BS15,"Justice, Supreme Court, Place 4",,,Under Votes,43,27,10,6
+Tom Green,228 BS15,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,986,604,232,150
+Tom Green,228 BS15,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,386,226,116,44
+Tom Green,228 BS15,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,228 BS15,"Justice, Supreme Court, Place 6",,,Under Votes,43,25,9,9
+Tom Green,228 BS15,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,972,597,228,147
+Tom Green,228 BS15,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,371,219,107,45
+Tom Green,228 BS15,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,26,15,10,1
+Tom Green,228 BS15,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,228 BS15,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,46,24,12,10
+Tom Green,228 BS15,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,990,609,233,148
+Tom Green,228 BS15,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,370,216,112,42
+Tom Green,228 BS15,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,228 BS15,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,55,30,12,13
+Tom Green,228 BS15,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1032,635,244,153
+Tom Green,228 BS15,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,195,112,62,21
+Tom Green,228 BS15,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,228 BS15,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,188,108,51,29
+Tom Green,228 BS15,State Representative,72,REP,Drew Darby,1115,680,273,162
+Tom Green,228 BS15,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,228 BS15,State Representative,72,,Under Votes,300,175,84,41
+Tom Green,228 BS15,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,997,612,236,149
+Tom Green,228 BS15,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,368,212,109,47
+Tom Green,228 BS15,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,228 BS15,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,50,31,12,7
+Tom Green,228 BS15,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,980,600,229,151
+Tom Green,228 BS15,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,382,223,115,44
+Tom Green,228 BS15,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,228 BS15,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,53,32,13,8
+Tom Green,228 BS15,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,980,600,231,149
+Tom Green,228 BS15,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,376,221,113,42
+Tom Green,228 BS15,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,228 BS15,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,59,34,13,12
+Tom Green,228 BS15,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",989,607,231,151
+Tom Green,228 BS15,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,362,213,107,42
+Tom Green,228 BS15,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),4,1,1,2
+Tom Green,228 BS15,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,228 BS15,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,60,34,18,8
+Tom Green,228 BS15,San Angelo Independent School District Proposition A,,,FOR,649,375,169,105
+Tom Green,228 BS15,San Angelo Independent School District Proposition A,,,AGAINST,662,426,162,74
+Tom Green,228 BS15,San Angelo Independent School District Proposition A,,,Over Votes,0,0,0,0
+Tom Green,228 BS15,San Angelo Independent School District Proposition A,,,Under Votes,104,54,26,24
+Tom Green,228 BS15,San Angelo Independent School District Proposition B,,,FOR,632,349,175,108
+Tom Green,228 BS15,San Angelo Independent School District Proposition B,,,AGAINST,677,449,157,71
+Tom Green,228 BS15,San Angelo Independent School District Proposition B,,,Over Votes,0,0,0,0
+Tom Green,228 BS15,San Angelo Independent School District Proposition B,,,Under Votes,106,57,25,24
+Tom Green,228 BS15,Ballots Cast,,,,1415,855,357,203
+Tom Green,230 BS16,STRAIGHT PARTY,,REP,,1170,783,319,68
+Tom Green,230 BS16,STRAIGHT PARTY,,DEM,,306,173,102,31
+Tom Green,230 BS16,STRAIGHT PARTY,,LIB,,11,7,2,2
+Tom Green,230 BS16,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,230 BS16,STRAIGHT PARTY,,,Under Votes,1191,780,301,110
+Tom Green,230 BS16,U.S. Senate,,REP,Ted Cruz,1888,1272,500,116
+Tom Green,230 BS16,U.S. Senate,,DEM,Beto O'Rourke,739,440,212,87
+Tom Green,230 BS16,U.S. Senate,,LIB,Neal M. Dikeman,31,16,10,5
+Tom Green,230 BS16,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,230 BS16,U.S. Senate,,,Under Votes,20,15,2,3
+Tom Green,230 BS16,U.S. House,11,REP,Mike Conaway,1994,1334,536,124
+Tom Green,230 BS16,U.S. House,11,DEM,Jennie Lou Leeder,599,351,171,77
+Tom Green,230 BS16,U.S. House,11,LIB,Rhett Rosenquest Smith,45,27,12,6
+Tom Green,230 BS16,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,230 BS16,U.S. House,11,,Under Votes,40,31,5,4
+Tom Green,230 BS16,Governor,,REP,Greg Abbott,2006,1347,533,126
+Tom Green,230 BS16,Governor,,DEM,Lupe Valdez,618,357,182,79
+Tom Green,230 BS16,Governor,,LIB,Mark Jay Tippetts,38,25,7,6
+Tom Green,230 BS16,Governor,,,Over Votes,0,0,0,0
+Tom Green,230 BS16,Governor,,,Under Votes,16,14,2,0
+Tom Green,230 BS16,Lieutenant Governor,,REP,Dan Patrick,1806,1210,479,117
+Tom Green,230 BS16,Lieutenant Governor,,DEM,Mike Collier,748,458,207,83
+Tom Green,230 BS16,Lieutenant Governor,,LIB,Kerry Douglas McKennon,80,48,25,7
+Tom Green,230 BS16,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,230 BS16,Lieutenant Governor,,,Under Votes,44,27,13,4
+Tom Green,230 BS16,Attorney General,,REP,Ken Paxton,1821,1219,486,116
+Tom Green,230 BS16,Attorney General,,DEM,Justin Nelson,714,435,199,80
+Tom Green,230 BS16,Attorney General,,LIB,Michael Ray Harris,85,53,28,4
+Tom Green,230 BS16,Attorney General,,,Over Votes,1,1,0,0
+Tom Green,230 BS16,Attorney General,,,Under Votes,57,35,11,11
+Tom Green,230 BS16,Comptroller of Public Accounts,,REP,Glenn Hegar,1892,1277,502,113
+Tom Green,230 BS16,Comptroller of Public Accounts,,DEM,Joi Chevalier,608,358,173,77
+Tom Green,230 BS16,Comptroller of Public Accounts,,LIB,Ben Sanders,99,62,28,9
+Tom Green,230 BS16,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,230 BS16,Comptroller of Public Accounts,,,Under Votes,79,46,21,12
+Tom Green,230 BS16,Commissioner of the General Land Office,,REP,George P. Bush,1901,1274,506,121
+Tom Green,230 BS16,Commissioner of the General Land Office,,DEM,Miguel Suazo,618,368,176,74
+Tom Green,230 BS16,Commissioner of the General Land Office,,LIB,Matt Pina,97,62,27,8
+Tom Green,230 BS16,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,230 BS16,Commissioner of the General Land Office,,,Under Votes,62,39,15,8
+Tom Green,230 BS16,Commissioner of Agriculture,,REP,Sid Miller,1854,1251,493,110
+Tom Green,230 BS16,Commissioner of Agriculture,,DEM,Kim Olson,662,396,186,80
+Tom Green,230 BS16,Commissioner of Agriculture,,LIB,Richard Carpenter,83,49,25,9
+Tom Green,230 BS16,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,230 BS16,Commissioner of Agriculture,,,Under Votes,79,47,20,12
+Tom Green,230 BS16,Railroad Commissioner,,REP,Christi Craddick,1892,1273,501,118
+Tom Green,230 BS16,Railroad Commissioner,,DEM,Roman McAllen,612,365,173,74
+Tom Green,230 BS16,Railroad Commissioner,,LIB,Mike Wright,96,60,29,7
+Tom Green,230 BS16,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,230 BS16,Railroad Commissioner,,,Under Votes,78,45,21,12
+Tom Green,230 BS16,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1908,1288,503,117
+Tom Green,230 BS16,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,690,407,203,80
+Tom Green,230 BS16,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,230 BS16,"Justice, Supreme Court, Place 2",,,Under Votes,80,48,18,14
+Tom Green,230 BS16,"Justice, Supreme Court, Place 4",,REP,John Devine,1922,1294,505,123
+Tom Green,230 BS16,"Justice, Supreme Court, Place 4",,,R. K. Sandill,673,398,197,78
+Tom Green,230 BS16,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,230 BS16,"Justice, Supreme Court, Place 4",,,Under Votes,83,51,22,10
+Tom Green,230 BS16,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1905,1280,503,122
+Tom Green,230 BS16,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,686,411,199,76
+Tom Green,230 BS16,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,230 BS16,"Justice, Supreme Court, Place 6",,,Under Votes,87,52,22,13
+Tom Green,230 BS16,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1875,1268,495,112
+Tom Green,230 BS16,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,643,380,182,81
+Tom Green,230 BS16,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,80,45,27,8
+Tom Green,230 BS16,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,230 BS16,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,80,50,20,10
+Tom Green,230 BS16,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1942,1306,516,120
+Tom Green,230 BS16,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,641,381,181,79
+Tom Green,230 BS16,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,230 BS16,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,95,56,27,12
+Tom Green,230 BS16,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,2016,1353,535,128
+Tom Green,230 BS16,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,346,205,94,47
+Tom Green,230 BS16,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,230 BS16,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,316,185,95,36
+Tom Green,230 BS16,State Representative,72,REP,Drew Darby,2182,1458,585,139
+Tom Green,230 BS16,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,230 BS16,State Representative,72,,Under Votes,496,285,139,72
+Tom Green,230 BS16,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,1934,1295,513,126
+Tom Green,230 BS16,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,637,377,183,77
+Tom Green,230 BS16,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,230 BS16,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,107,71,28,8
+Tom Green,230 BS16,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,1904,1278,507,119
+Tom Green,230 BS16,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,663,391,189,83
+Tom Green,230 BS16,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,230 BS16,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,111,74,28,9
+Tom Green,230 BS16,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,1926,1291,513,122
+Tom Green,230 BS16,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,648,382,186,80
+Tom Green,230 BS16,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,230 BS16,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,104,70,25,9
+Tom Green,230 BS16,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",1898,1272,505,121
+Tom Green,230 BS16,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,650,386,186,78
+Tom Green,230 BS16,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),4,1,1,2
+Tom Green,230 BS16,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,230 BS16,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,126,84,32,10
+Tom Green,230 BS16,San Angelo Independent School District Proposition A,,,FOR,1080,671,303,106
+Tom Green,230 BS16,San Angelo Independent School District Proposition A,,,AGAINST,1441,974,384,83
+Tom Green,230 BS16,San Angelo Independent School District Proposition A,,,Over Votes,0,0,0,0
+Tom Green,230 BS16,San Angelo Independent School District Proposition A,,,Under Votes,157,98,37,22
+Tom Green,230 BS16,San Angelo Independent School District Proposition B,,,FOR,1047,634,307,106
+Tom Green,230 BS16,San Angelo Independent School District Proposition B,,,AGAINST,1466,1006,379,81
+Tom Green,230 BS16,San Angelo Independent School District Proposition B,,,Over Votes,0,0,0,0
+Tom Green,230 BS16,San Angelo Independent School District Proposition B,,,Under Votes,165,103,38,24
+Tom Green,230 BS16,Ballots Cast,,,,2678,1743,724,211
+Tom Green,230 BS17,STRAIGHT PARTY,,REP,,70,43,24,3
+Tom Green,230 BS17,STRAIGHT PARTY,,DEM,,9,4,5,0
+Tom Green,230 BS17,STRAIGHT PARTY,,LIB,,0,0,0,0
+Tom Green,230 BS17,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,230 BS17,STRAIGHT PARTY,,,Under Votes,54,31,22,1
+Tom Green,230 BS17,U.S. Senate,,REP,Ted Cruz,113,68,41,4
+Tom Green,230 BS17,U.S. Senate,,DEM,Beto O'Rourke,17,9,8,0
+Tom Green,230 BS17,U.S. Senate,,LIB,Neal M. Dikeman,3,1,2,0
+Tom Green,230 BS17,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,230 BS17,U.S. Senate,,,Under Votes,0,0,0,0
+Tom Green,230 BS17,U.S. House,11,REP,Mike Conaway,119,72,43,4
+Tom Green,230 BS17,U.S. House,11,DEM,Jennie Lou Leeder,11,6,5,0
+Tom Green,230 BS17,U.S. House,11,LIB,Rhett Rosenquest Smith,2,0,2,0
+Tom Green,230 BS17,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,230 BS17,U.S. House,11,,Under Votes,1,0,1,0
+Tom Green,230 BS17,Governor,,REP,Greg Abbott,117,70,43,4
+Tom Green,230 BS17,Governor,,DEM,Lupe Valdez,12,7,5,0
+Tom Green,230 BS17,Governor,,LIB,Mark Jay Tippetts,3,1,2,0
+Tom Green,230 BS17,Governor,,,Over Votes,0,0,0,0
+Tom Green,230 BS17,Governor,,,Under Votes,1,0,1,0
+Tom Green,230 BS17,Lieutenant Governor,,REP,Dan Patrick,98,62,32,4
+Tom Green,230 BS17,Lieutenant Governor,,DEM,Mike Collier,29,14,15,0
+Tom Green,230 BS17,Lieutenant Governor,,LIB,Kerry Douglas McKennon,5,1,4,0
+Tom Green,230 BS17,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,230 BS17,Lieutenant Governor,,,Under Votes,1,1,0,0
+Tom Green,230 BS17,Attorney General,,REP,Ken Paxton,111,67,40,4
+Tom Green,230 BS17,Attorney General,,DEM,Justin Nelson,16,9,7,0
+Tom Green,230 BS17,Attorney General,,LIB,Michael Ray Harris,4,1,3,0
+Tom Green,230 BS17,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,230 BS17,Attorney General,,,Under Votes,2,1,1,0
+Tom Green,230 BS17,Comptroller of Public Accounts,,REP,Glenn Hegar,114,70,40,4
+Tom Green,230 BS17,Comptroller of Public Accounts,,DEM,Joi Chevalier,13,6,7,0
+Tom Green,230 BS17,Comptroller of Public Accounts,,LIB,Ben Sanders,4,1,3,0
+Tom Green,230 BS17,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,230 BS17,Comptroller of Public Accounts,,,Under Votes,2,1,1,0
+Tom Green,230 BS17,Commissioner of the General Land Office,,REP,George P. Bush,113,70,39,4
+Tom Green,230 BS17,Commissioner of the General Land Office,,DEM,Miguel Suazo,13,6,7,0
+Tom Green,230 BS17,Commissioner of the General Land Office,,LIB,Matt Pina,6,2,4,0
+Tom Green,230 BS17,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,230 BS17,Commissioner of the General Land Office,,,Under Votes,1,0,1,0
+Tom Green,230 BS17,Commissioner of Agriculture,,REP,Sid Miller,114,70,40,4
+Tom Green,230 BS17,Commissioner of Agriculture,,DEM,Kim Olson,15,8,7,0
+Tom Green,230 BS17,Commissioner of Agriculture,,LIB,Richard Carpenter,3,0,3,0
+Tom Green,230 BS17,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,230 BS17,Commissioner of Agriculture,,,Under Votes,1,0,1,0
+Tom Green,230 BS17,Railroad Commissioner,,REP,Christi Craddick,113,70,39,4
+Tom Green,230 BS17,Railroad Commissioner,,DEM,Roman McAllen,13,7,6,0
+Tom Green,230 BS17,Railroad Commissioner,,LIB,Mike Wright,5,1,4,0
+Tom Green,230 BS17,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,230 BS17,Railroad Commissioner,,,Under Votes,2,0,2,0
+Tom Green,230 BS17,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,118,71,43,4
+Tom Green,230 BS17,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,12,6,6,0
+Tom Green,230 BS17,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,230 BS17,"Justice, Supreme Court, Place 2",,,Under Votes,3,1,2,0
+Tom Green,230 BS17,"Justice, Supreme Court, Place 4",,REP,John Devine,119,73,42,4
+Tom Green,230 BS17,"Justice, Supreme Court, Place 4",,,R. K. Sandill,12,5,7,0
+Tom Green,230 BS17,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,230 BS17,"Justice, Supreme Court, Place 4",,,Under Votes,2,0,2,0
+Tom Green,230 BS17,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,117,71,42,4
+Tom Green,230 BS17,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,14,7,7,0
+Tom Green,230 BS17,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,230 BS17,"Justice, Supreme Court, Place 6",,,Under Votes,2,0,2,0
+Tom Green,230 BS17,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,115,70,41,4
+Tom Green,230 BS17,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,12,6,6,0
+Tom Green,230 BS17,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,3,1,2,0
+Tom Green,230 BS17,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,230 BS17,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,3,1,2,0
+Tom Green,230 BS17,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,116,70,42,4
+Tom Green,230 BS17,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,14,7,7,0
+Tom Green,230 BS17,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,230 BS17,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,3,1,2,0
+Tom Green,230 BS17,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,116,70,42,4
+Tom Green,230 BS17,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,7,2,5,0
+Tom Green,230 BS17,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,230 BS17,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,10,6,4,0
+Tom Green,230 BS17,State Representative,72,REP,Drew Darby,122,72,46,4
+Tom Green,230 BS17,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,230 BS17,State Representative,72,,Under Votes,11,6,5,0
+Tom Green,230 BS17,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,113,69,40,4
+Tom Green,230 BS17,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,17,8,9,0
+Tom Green,230 BS17,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,230 BS17,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,3,1,2,0
+Tom Green,230 BS17,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,116,69,43,4
+Tom Green,230 BS17,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,14,7,7,0
+Tom Green,230 BS17,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,230 BS17,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,3,2,1,0
+Tom Green,230 BS17,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,116,70,42,4
+Tom Green,230 BS17,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,14,6,8,0
+Tom Green,230 BS17,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,230 BS17,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,3,2,1,0
+Tom Green,230 BS17,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",117,70,43,4
+Tom Green,230 BS17,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,12,6,6,0
+Tom Green,230 BS17,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),0,0,0,0
+Tom Green,230 BS17,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,230 BS17,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,4,2,2,0
+Tom Green,230 BS17,Ballots Cast,,,,133,78,51,4
+Tom Green,241 BS18,STRAIGHT PARTY,,REP,,1479,1020,325,134
+Tom Green,241 BS18,STRAIGHT PARTY,,DEM,,269,186,56,27
+Tom Green,241 BS18,STRAIGHT PARTY,,LIB,,8,5,3,0
+Tom Green,241 BS18,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,241 BS18,STRAIGHT PARTY,,,Under Votes,1387,982,271,134
+Tom Green,241 BS18,U.S. Senate,,REP,Ted Cruz,2399,1697,490,212
+Tom Green,241 BS18,U.S. Senate,,DEM,Beto O'Rourke,684,456,152,76
+Tom Green,241 BS18,U.S. Senate,,LIB,Neal M. Dikeman,23,14,6,3
+Tom Green,241 BS18,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,241 BS18,U.S. Senate,,,Under Votes,37,26,7,4
+Tom Green,241 BS18,U.S. House,11,REP,Mike Conaway,2524,1790,515,219
+Tom Green,241 BS18,U.S. House,11,DEM,Jennie Lou Leeder,527,344,116,67
+Tom Green,241 BS18,U.S. House,11,LIB,Rhett Rosenquest Smith,45,25,16,4
+Tom Green,241 BS18,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,241 BS18,U.S. House,11,,Under Votes,47,34,8,5
+Tom Green,241 BS18,Governor,,REP,Greg Abbott,2515,1776,520,219
+Tom Green,241 BS18,Governor,,DEM,Lupe Valdez,553,374,111,68
+Tom Green,241 BS18,Governor,,LIB,Mark Jay Tippetts,41,23,14,4
+Tom Green,241 BS18,Governor,,,Over Votes,0,0,0,0
+Tom Green,241 BS18,Governor,,,Under Votes,34,20,10,4
+Tom Green,241 BS18,Lieutenant Governor,,REP,Dan Patrick,2279,1595,481,203
+Tom Green,241 BS18,Lieutenant Governor,,DEM,Mike Collier,723,510,139,74
+Tom Green,241 BS18,Lieutenant Governor,,LIB,Kerry Douglas McKennon,80,48,23,9
+Tom Green,241 BS18,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,241 BS18,Lieutenant Governor,,,Under Votes,61,40,12,9
+Tom Green,241 BS18,Attorney General,,REP,Ken Paxton,2334,1644,487,203
+Tom Green,241 BS18,Attorney General,,DEM,Justin Nelson,687,474,132,81
+Tom Green,241 BS18,Attorney General,,LIB,Michael Ray Harris,69,43,22,4
+Tom Green,241 BS18,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,241 BS18,Attorney General,,,Under Votes,53,32,14,7
+Tom Green,241 BS18,Comptroller of Public Accounts,,REP,Glenn Hegar,2449,1739,495,215
+Tom Green,241 BS18,Comptroller of Public Accounts,,DEM,Joi Chevalier,535,358,114,63
+Tom Green,241 BS18,Comptroller of Public Accounts,,LIB,Ben Sanders,74,38,28,8
+Tom Green,241 BS18,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,241 BS18,Comptroller of Public Accounts,,,Under Votes,85,58,18,9
+Tom Green,241 BS18,Commissioner of the General Land Office,,REP,George P. Bush,2451,1735,500,216
+Tom Green,241 BS18,Commissioner of the General Land Office,,DEM,Miguel Suazo,526,353,110,63
+Tom Green,241 BS18,Commissioner of the General Land Office,,LIB,Matt Pina,101,60,32,9
+Tom Green,241 BS18,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,241 BS18,Commissioner of the General Land Office,,,Under Votes,65,45,13,7
+Tom Green,241 BS18,Commissioner of Agriculture,,REP,Sid Miller,2404,1694,497,213
+Tom Green,241 BS18,Commissioner of Agriculture,,DEM,Kim Olson,605,406,128,71
+Tom Green,241 BS18,Commissioner of Agriculture,,LIB,Richard Carpenter,57,40,13,4
+Tom Green,241 BS18,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,241 BS18,Commissioner of Agriculture,,,Under Votes,77,53,17,7
+Tom Green,241 BS18,Railroad Commissioner,,REP,Christi Craddick,2448,1735,500,213
+Tom Green,241 BS18,Railroad Commissioner,,DEM,Roman McAllen,534,360,112,62
+Tom Green,241 BS18,Railroad Commissioner,,LIB,Mike Wright,74,44,23,7
+Tom Green,241 BS18,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,241 BS18,Railroad Commissioner,,,Under Votes,87,54,20,13
+Tom Green,241 BS18,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,2449,1737,502,210
+Tom Green,241 BS18,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,605,396,136,73
+Tom Green,241 BS18,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,241 BS18,"Justice, Supreme Court, Place 2",,,Under Votes,89,60,17,12
+Tom Green,241 BS18,"Justice, Supreme Court, Place 4",,REP,John Devine,2460,1741,510,209
+Tom Green,241 BS18,"Justice, Supreme Court, Place 4",,,R. K. Sandill,587,389,127,71
+Tom Green,241 BS18,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,241 BS18,"Justice, Supreme Court, Place 4",,,Under Votes,96,63,18,15
+Tom Green,241 BS18,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,2445,1732,500,213
+Tom Green,241 BS18,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,598,394,135,69
+Tom Green,241 BS18,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,241 BS18,"Justice, Supreme Court, Place 6",,,Under Votes,100,67,20,13
+Tom Green,241 BS18,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,2416,1720,489,207
+Tom Green,241 BS18,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,578,381,128,69
+Tom Green,241 BS18,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,55,28,19,8
+Tom Green,241 BS18,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,241 BS18,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,94,64,19,11
+Tom Green,241 BS18,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,2472,1753,508,211
+Tom Green,241 BS18,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,568,371,129,68
+Tom Green,241 BS18,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,241 BS18,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,103,69,18,16
+Tom Green,241 BS18,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,2552,1803,529,220
+Tom Green,241 BS18,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,255,152,70,33
+Tom Green,241 BS18,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,241 BS18,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,336,238,56,42
+Tom Green,241 BS18,State Representative,72,REP,Drew Darby,2694,1885,564,245
+Tom Green,241 BS18,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,241 BS18,State Representative,72,,Under Votes,449,308,91,50
+Tom Green,241 BS18,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,2478,1750,517,211
+Tom Green,241 BS18,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,544,359,115,70
+Tom Green,241 BS18,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,241 BS18,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,121,84,23,14
+Tom Green,241 BS18,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,2435,1724,499,212
+Tom Green,241 BS18,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,589,385,134,70
+Tom Green,241 BS18,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,241 BS18,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,119,84,22,13
+Tom Green,241 BS18,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,2450,1735,505,210
+Tom Green,241 BS18,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,576,375,129,72
+Tom Green,241 BS18,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,241 BS18,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,117,83,21,13
+Tom Green,241 BS18,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",2427,1716,497,214
+Tom Green,241 BS18,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,577,378,131,68
+Tom Green,241 BS18,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),5,0,1,4
+Tom Green,241 BS18,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,241 BS18,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,134,99,26,9
+Tom Green,241 BS18,San Angelo Independent School District Proposition A,,,FOR,1428,1027,280,121
+Tom Green,241 BS18,San Angelo Independent School District Proposition A,,,AGAINST,1534,1061,329,144
+Tom Green,241 BS18,San Angelo Independent School District Proposition A,,,Over Votes,1,1,0,0
+Tom Green,241 BS18,San Angelo Independent School District Proposition A,,,Under Votes,180,104,46,30
+Tom Green,241 BS18,San Angelo Independent School District Proposition B,,,FOR,1324,937,257,130
+Tom Green,241 BS18,San Angelo Independent School District Proposition B,,,AGAINST,1630,1140,352,138
+Tom Green,241 BS18,San Angelo Independent School District Proposition B,,,Over Votes,1,1,0,0
+Tom Green,241 BS18,San Angelo Independent School District Proposition B,,,Under Votes,188,115,46,27
+Tom Green,241 BS18,Ballots Cast,,,,3143,2193,655,295
+Tom Green,304 BS19,STRAIGHT PARTY,,REP,,683,437,196,50
+Tom Green,304 BS19,STRAIGHT PARTY,,DEM,,223,117,92,14
+Tom Green,304 BS19,STRAIGHT PARTY,,LIB,,9,4,5,0
+Tom Green,304 BS19,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,304 BS19,STRAIGHT PARTY,,,Under Votes,627,430,147,50
+Tom Green,304 BS19,U.S. Senate,,REP,Ted Cruz,1076,718,284,74
+Tom Green,304 BS19,U.S. Senate,,DEM,Beto O'Rourke,431,252,144,35
+Tom Green,304 BS19,U.S. Senate,,LIB,Neal M. Dikeman,13,8,5,0
+Tom Green,304 BS19,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,304 BS19,U.S. Senate,,,Under Votes,22,10,7,5
+Tom Green,304 BS19,U.S. House,11,REP,Mike Conaway,1138,743,307,88
+Tom Green,304 BS19,U.S. House,11,DEM,Jennie Lou Leeder,365,216,125,24
+Tom Green,304 BS19,U.S. House,11,LIB,Rhett Rosenquest Smith,20,14,4,2
+Tom Green,304 BS19,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,304 BS19,U.S. House,11,,Under Votes,19,15,4,0
+Tom Green,304 BS19,Governor,,REP,Greg Abbott,1145,752,310,83
+Tom Green,304 BS19,Governor,,DEM,Lupe Valdez,359,209,122,28
+Tom Green,304 BS19,Governor,,LIB,Mark Jay Tippetts,23,17,4,2
+Tom Green,304 BS19,Governor,,,Over Votes,0,0,0,0
+Tom Green,304 BS19,Governor,,,Under Votes,15,10,4,1
+Tom Green,304 BS19,Lieutenant Governor,,REP,Dan Patrick,1025,676,271,78
+Tom Green,304 BS19,Lieutenant Governor,,DEM,Mike Collier,449,270,148,31
+Tom Green,304 BS19,Lieutenant Governor,,LIB,Kerry Douglas McKennon,36,24,10,2
+Tom Green,304 BS19,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,304 BS19,Lieutenant Governor,,,Under Votes,32,18,11,3
+Tom Green,304 BS19,Attorney General,,REP,Ken Paxton,1041,683,282,76
+Tom Green,304 BS19,Attorney General,,DEM,Justin Nelson,426,258,138,30
+Tom Green,304 BS19,Attorney General,,LIB,Michael Ray Harris,38,27,10,1
+Tom Green,304 BS19,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,304 BS19,Attorney General,,,Under Votes,37,20,10,7
+Tom Green,304 BS19,Comptroller of Public Accounts,,REP,Glenn Hegar,1059,704,278,77
+Tom Green,304 BS19,Comptroller of Public Accounts,,DEM,Joi Chevalier,382,224,131,27
+Tom Green,304 BS19,Comptroller of Public Accounts,,LIB,Ben Sanders,49,32,15,2
+Tom Green,304 BS19,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,304 BS19,Comptroller of Public Accounts,,,Under Votes,52,28,16,8
+Tom Green,304 BS19,Commissioner of the General Land Office,,REP,George P. Bush,1074,703,291,80
+Tom Green,304 BS19,Commissioner of the General Land Office,,DEM,Miguel Suazo,377,226,125,26
+Tom Green,304 BS19,Commissioner of the General Land Office,,LIB,Matt Pina,55,38,12,5
+Tom Green,304 BS19,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,304 BS19,Commissioner of the General Land Office,,,Under Votes,36,21,12,3
+Tom Green,304 BS19,Commissioner of Agriculture,,REP,Sid Miller,1057,698,278,81
+Tom Green,304 BS19,Commissioner of Agriculture,,DEM,Kim Olson,414,252,135,27
+Tom Green,304 BS19,Commissioner of Agriculture,,LIB,Richard Carpenter,32,19,12,1
+Tom Green,304 BS19,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,304 BS19,Commissioner of Agriculture,,,Under Votes,39,19,15,5
+Tom Green,304 BS19,Railroad Commissioner,,REP,Christi Craddick,1064,702,283,79
+Tom Green,304 BS19,Railroad Commissioner,,DEM,Roman McAllen,391,233,132,26
+Tom Green,304 BS19,Railroad Commissioner,,LIB,Mike Wright,40,29,9,2
+Tom Green,304 BS19,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,304 BS19,Railroad Commissioner,,,Under Votes,47,24,16,7
+Tom Green,304 BS19,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1078,719,283,76
+Tom Green,304 BS19,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,422,247,144,31
+Tom Green,304 BS19,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,304 BS19,"Justice, Supreme Court, Place 2",,,Under Votes,42,22,13,7
+Tom Green,304 BS19,"Justice, Supreme Court, Place 4",,REP,John Devine,1083,721,285,77
+Tom Green,304 BS19,"Justice, Supreme Court, Place 4",,,R. K. Sandill,408,238,142,28
+Tom Green,304 BS19,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,304 BS19,"Justice, Supreme Court, Place 4",,,Under Votes,51,29,13,9
+Tom Green,304 BS19,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1076,718,284,74
+Tom Green,304 BS19,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,414,240,144,30
+Tom Green,304 BS19,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,304 BS19,"Justice, Supreme Court, Place 6",,,Under Votes,52,30,12,10
+Tom Green,304 BS19,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1055,702,276,77
+Tom Green,304 BS19,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,411,234,146,31
+Tom Green,304 BS19,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,33,28,5,0
+Tom Green,304 BS19,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,304 BS19,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,43,24,13,6
+Tom Green,304 BS19,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1082,721,284,77
+Tom Green,304 BS19,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,406,237,138,31
+Tom Green,304 BS19,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,304 BS19,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,54,30,18,6
+Tom Green,304 BS19,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1125,741,302,82
+Tom Green,304 BS19,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,199,130,56,13
+Tom Green,304 BS19,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,304 BS19,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,218,117,82,19
+Tom Green,304 BS19,State Representative,72,REP,Drew Darby,1227,804,333,90
+Tom Green,304 BS19,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,304 BS19,State Representative,72,,Under Votes,315,184,107,24
+Tom Green,304 BS19,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,1071,710,284,77
+Tom Green,304 BS19,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,410,243,138,29
+Tom Green,304 BS19,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,304 BS19,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,61,35,18,8
+Tom Green,304 BS19,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,1058,704,279,75
+Tom Green,304 BS19,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,421,246,145,30
+Tom Green,304 BS19,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,304 BS19,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,63,38,16,9
+Tom Green,304 BS19,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,1054,697,281,76
+Tom Green,304 BS19,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,427,257,140,30
+Tom Green,304 BS19,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,304 BS19,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,61,34,19,8
+Tom Green,304 BS19,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",1062,705,280,77
+Tom Green,304 BS19,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,417,245,144,28
+Tom Green,304 BS19,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),1,0,0,1
+Tom Green,304 BS19,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,304 BS19,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,62,38,16,8
+Tom Green,304 BS19,San Angelo Independent School District Proposition A,,,FOR,495,315,133,47
+Tom Green,304 BS19,San Angelo Independent School District Proposition A,,,AGAINST,947,620,272,55
+Tom Green,304 BS19,San Angelo Independent School District Proposition A,,,Over Votes,0,0,0,0
+Tom Green,304 BS19,San Angelo Independent School District Proposition A,,,Under Votes,100,53,35,12
+Tom Green,304 BS19,San Angelo Independent School District Proposition B,,,FOR,450,285,119,46
+Tom Green,304 BS19,San Angelo Independent School District Proposition B,,,AGAINST,989,652,280,57
+Tom Green,304 BS19,San Angelo Independent School District Proposition B,,,Over Votes,0,0,0,0
+Tom Green,304 BS19,San Angelo Independent School District Proposition B,,,Under Votes,103,51,41,11
+Tom Green,304 BS19,Ballots Cast,,,,1542,988,440,114
+Tom Green,305 BS20,STRAIGHT PARTY,,REP,,9,6,3,0
+Tom Green,305 BS20,STRAIGHT PARTY,,DEM,,4,1,3,0
+Tom Green,305 BS20,STRAIGHT PARTY,,LIB,,0,0,0,0
+Tom Green,305 BS20,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,305 BS20,STRAIGHT PARTY,,,Under Votes,13,8,1,4
+Tom Green,305 BS20,U.S. Senate,,REP,Ted Cruz,14,10,3,1
+Tom Green,305 BS20,U.S. Senate,,DEM,Beto O'Rourke,11,4,4,3
+Tom Green,305 BS20,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Tom Green,305 BS20,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,305 BS20,U.S. Senate,,,Under Votes,1,1,0,0
+Tom Green,305 BS20,U.S. House,11,REP,Mike Conaway,17,12,3,2
+Tom Green,305 BS20,U.S. House,11,DEM,Jennie Lou Leeder,9,3,4,2
+Tom Green,305 BS20,U.S. House,11,LIB,Rhett Rosenquest Smith,0,0,0,0
+Tom Green,305 BS20,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,305 BS20,U.S. House,11,,Under Votes,0,0,0,0
+Tom Green,305 BS20,Governor,,REP,Greg Abbott,16,11,3,2
+Tom Green,305 BS20,Governor,,DEM,Lupe Valdez,10,4,4,2
+Tom Green,305 BS20,Governor,,LIB,Mark Jay Tippetts,0,0,0,0
+Tom Green,305 BS20,Governor,,,Over Votes,0,0,0,0
+Tom Green,305 BS20,Governor,,,Under Votes,0,0,0,0
+Tom Green,305 BS20,Lieutenant Governor,,REP,Dan Patrick,14,10,3,1
+Tom Green,305 BS20,Lieutenant Governor,,DEM,Mike Collier,12,5,4,3
+Tom Green,305 BS20,Lieutenant Governor,,LIB,Kerry Douglas McKennon,0,0,0,0
+Tom Green,305 BS20,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,305 BS20,Lieutenant Governor,,,Under Votes,0,0,0,0
+Tom Green,305 BS20,Attorney General,,REP,Ken Paxton,13,9,3,1
+Tom Green,305 BS20,Attorney General,,DEM,Justin Nelson,12,5,4,3
+Tom Green,305 BS20,Attorney General,,LIB,Michael Ray Harris,1,1,0,0
+Tom Green,305 BS20,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,305 BS20,Attorney General,,,Under Votes,0,0,0,0
+Tom Green,305 BS20,Comptroller of Public Accounts,,REP,Glenn Hegar,14,10,3,1
+Tom Green,305 BS20,Comptroller of Public Accounts,,DEM,Joi Chevalier,10,4,4,2
+Tom Green,305 BS20,Comptroller of Public Accounts,,LIB,Ben Sanders,2,1,0,1
+Tom Green,305 BS20,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,305 BS20,Comptroller of Public Accounts,,,Under Votes,0,0,0,0
+Tom Green,305 BS20,Commissioner of the General Land Office,,REP,George P. Bush,15,10,3,2
+Tom Green,305 BS20,Commissioner of the General Land Office,,DEM,Miguel Suazo,11,5,4,2
+Tom Green,305 BS20,Commissioner of the General Land Office,,LIB,Matt Pina,0,0,0,0
+Tom Green,305 BS20,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,305 BS20,Commissioner of the General Land Office,,,Under Votes,0,0,0,0
+Tom Green,305 BS20,Commissioner of Agriculture,,REP,Sid Miller,15,10,3,2
+Tom Green,305 BS20,Commissioner of Agriculture,,DEM,Kim Olson,11,5,4,2
+Tom Green,305 BS20,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0,0
+Tom Green,305 BS20,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,305 BS20,Commissioner of Agriculture,,,Under Votes,0,0,0,0
+Tom Green,305 BS20,Railroad Commissioner,,REP,Christi Craddick,14,10,3,1
+Tom Green,305 BS20,Railroad Commissioner,,DEM,Roman McAllen,12,5,4,3
+Tom Green,305 BS20,Railroad Commissioner,,LIB,Mike Wright,0,0,0,0
+Tom Green,305 BS20,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,305 BS20,Railroad Commissioner,,,Under Votes,0,0,0,0
+Tom Green,305 BS20,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,15,10,3,2
+Tom Green,305 BS20,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,11,5,4,2
+Tom Green,305 BS20,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,305 BS20,"Justice, Supreme Court, Place 2",,,Under Votes,0,0,0,0
+Tom Green,305 BS20,"Justice, Supreme Court, Place 4",,REP,John Devine,15,11,3,1
+Tom Green,305 BS20,"Justice, Supreme Court, Place 4",,,R. K. Sandill,11,4,4,3
+Tom Green,305 BS20,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,305 BS20,"Justice, Supreme Court, Place 4",,,Under Votes,0,0,0,0
+Tom Green,305 BS20,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,16,11,3,2
+Tom Green,305 BS20,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,10,4,4,2
+Tom Green,305 BS20,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,305 BS20,"Justice, Supreme Court, Place 6",,,Under Votes,0,0,0,0
+Tom Green,305 BS20,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,15,11,3,1
+Tom Green,305 BS20,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,10,4,4,2
+Tom Green,305 BS20,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,1,0,0,1
+Tom Green,305 BS20,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,305 BS20,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,0,0,0,0
+Tom Green,305 BS20,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,15,10,3,2
+Tom Green,305 BS20,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,11,5,4,2
+Tom Green,305 BS20,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,305 BS20,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,0,0,0,0
+Tom Green,305 BS20,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,16,12,3,1
+Tom Green,305 BS20,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,6,2,1,3
+Tom Green,305 BS20,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,305 BS20,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,4,1,3,0
+Tom Green,305 BS20,State Representative,72,REP,Drew Darby,20,14,3,3
+Tom Green,305 BS20,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,305 BS20,State Representative,72,,Under Votes,6,1,4,1
+Tom Green,305 BS20,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,14,10,3,1
+Tom Green,305 BS20,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,11,5,4,2
+Tom Green,305 BS20,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,305 BS20,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,1,0,0,1
+Tom Green,305 BS20,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,16,11,3,2
+Tom Green,305 BS20,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,10,4,4,2
+Tom Green,305 BS20,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,305 BS20,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,0,0,0,0
+Tom Green,305 BS20,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,14,10,3,1
+Tom Green,305 BS20,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,12,5,4,3
+Tom Green,305 BS20,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,305 BS20,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,0,0,0,0
+Tom Green,305 BS20,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",14,9,3,2
+Tom Green,305 BS20,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,11,5,4,2
+Tom Green,305 BS20,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),0,0,0,0
+Tom Green,305 BS20,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,305 BS20,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,1,1,0,0
+Tom Green,305 BS20,San Angelo Independent School District Proposition A,,,FOR,16,10,3,3
+Tom Green,305 BS20,San Angelo Independent School District Proposition A,,,AGAINST,9,4,4,1
+Tom Green,305 BS20,San Angelo Independent School District Proposition A,,,Over Votes,0,0,0,0
+Tom Green,305 BS20,San Angelo Independent School District Proposition A,,,Under Votes,1,1,0,0
+Tom Green,305 BS20,San Angelo Independent School District Proposition B,,,FOR,14,8,4,2
+Tom Green,305 BS20,San Angelo Independent School District Proposition B,,,AGAINST,11,6,3,2
+Tom Green,305 BS20,San Angelo Independent School District Proposition B,,,Over Votes,0,0,0,0
+Tom Green,305 BS20,San Angelo Independent School District Proposition B,,,Under Votes,1,1,0,0
+Tom Green,305 BS20,Ballots Cast,,,,26,15,7,4
+Tom Green,306 BS21,STRAIGHT PARTY,,REP,,0,0,0,0
+Tom Green,306 BS21,STRAIGHT PARTY,,DEM,,0,0,0,0
+Tom Green,306 BS21,STRAIGHT PARTY,,LIB,,0,0,0,0
+Tom Green,306 BS21,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,306 BS21,STRAIGHT PARTY,,,Under Votes,5,5,0,0
+Tom Green,306 BS21,U.S. Senate,,REP,Ted Cruz,4,4,0,0
+Tom Green,306 BS21,U.S. Senate,,DEM,Beto O'Rourke,1,1,0,0
+Tom Green,306 BS21,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Tom Green,306 BS21,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,306 BS21,U.S. Senate,,,Under Votes,0,0,0,0
+Tom Green,306 BS21,U.S. House,11,REP,Mike Conaway,4,4,0,0
+Tom Green,306 BS21,U.S. House,11,DEM,Jennie Lou Leeder,1,1,0,0
+Tom Green,306 BS21,U.S. House,11,LIB,Rhett Rosenquest Smith,0,0,0,0
+Tom Green,306 BS21,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,306 BS21,U.S. House,11,,Under Votes,0,0,0,0
+Tom Green,306 BS21,Governor,,REP,Greg Abbott,4,4,0,0
+Tom Green,306 BS21,Governor,,DEM,Lupe Valdez,1,1,0,0
+Tom Green,306 BS21,Governor,,LIB,Mark Jay Tippetts,0,0,0,0
+Tom Green,306 BS21,Governor,,,Over Votes,0,0,0,0
+Tom Green,306 BS21,Governor,,,Under Votes,0,0,0,0
+Tom Green,306 BS21,Lieutenant Governor,,REP,Dan Patrick,2,2,0,0
+Tom Green,306 BS21,Lieutenant Governor,,DEM,Mike Collier,3,3,0,0
+Tom Green,306 BS21,Lieutenant Governor,,LIB,Kerry Douglas McKennon,0,0,0,0
+Tom Green,306 BS21,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,306 BS21,Lieutenant Governor,,,Under Votes,0,0,0,0
+Tom Green,306 BS21,Attorney General,,REP,Ken Paxton,4,4,0,0
+Tom Green,306 BS21,Attorney General,,DEM,Justin Nelson,1,1,0,0
+Tom Green,306 BS21,Attorney General,,LIB,Michael Ray Harris,0,0,0,0
+Tom Green,306 BS21,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,306 BS21,Attorney General,,,Under Votes,0,0,0,0
+Tom Green,306 BS21,Comptroller of Public Accounts,,REP,Glenn Hegar,4,4,0,0
+Tom Green,306 BS21,Comptroller of Public Accounts,,DEM,Joi Chevalier,1,1,0,0
+Tom Green,306 BS21,Comptroller of Public Accounts,,LIB,Ben Sanders,0,0,0,0
+Tom Green,306 BS21,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,306 BS21,Comptroller of Public Accounts,,,Under Votes,0,0,0,0
+Tom Green,306 BS21,Commissioner of the General Land Office,,REP,George P. Bush,3,3,0,0
+Tom Green,306 BS21,Commissioner of the General Land Office,,DEM,Miguel Suazo,1,1,0,0
+Tom Green,306 BS21,Commissioner of the General Land Office,,LIB,Matt Pina,1,1,0,0
+Tom Green,306 BS21,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,306 BS21,Commissioner of the General Land Office,,,Under Votes,0,0,0,0
+Tom Green,306 BS21,Commissioner of Agriculture,,REP,Sid Miller,4,4,0,0
+Tom Green,306 BS21,Commissioner of Agriculture,,DEM,Kim Olson,1,1,0,0
+Tom Green,306 BS21,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0,0
+Tom Green,306 BS21,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,306 BS21,Commissioner of Agriculture,,,Under Votes,0,0,0,0
+Tom Green,306 BS21,Railroad Commissioner,,REP,Christi Craddick,4,4,0,0
+Tom Green,306 BS21,Railroad Commissioner,,DEM,Roman McAllen,1,1,0,0
+Tom Green,306 BS21,Railroad Commissioner,,LIB,Mike Wright,0,0,0,0
+Tom Green,306 BS21,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,306 BS21,Railroad Commissioner,,,Under Votes,0,0,0,0
+Tom Green,306 BS21,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,4,4,0,0
+Tom Green,306 BS21,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,1,1,0,0
+Tom Green,306 BS21,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,306 BS21,"Justice, Supreme Court, Place 2",,,Under Votes,0,0,0,0
+Tom Green,306 BS21,"Justice, Supreme Court, Place 4",,REP,John Devine,4,4,0,0
+Tom Green,306 BS21,"Justice, Supreme Court, Place 4",,,R. K. Sandill,1,1,0,0
+Tom Green,306 BS21,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,306 BS21,"Justice, Supreme Court, Place 4",,,Under Votes,0,0,0,0
+Tom Green,306 BS21,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,4,4,0,0
+Tom Green,306 BS21,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,1,1,0,0
+Tom Green,306 BS21,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,306 BS21,"Justice, Supreme Court, Place 6",,,Under Votes,0,0,0,0
+Tom Green,306 BS21,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,4,4,0,0
+Tom Green,306 BS21,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,1,1,0,0
+Tom Green,306 BS21,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,0,0,0,0
+Tom Green,306 BS21,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,306 BS21,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,0,0,0,0
+Tom Green,306 BS21,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,4,4,0,0
+Tom Green,306 BS21,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,1,1,0,0
+Tom Green,306 BS21,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,306 BS21,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,0,0,0,0
+Tom Green,306 BS21,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,4,4,0,0
+Tom Green,306 BS21,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,0,0,0,0
+Tom Green,306 BS21,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,306 BS21,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,1,1,0,0
+Tom Green,306 BS21,State Representative,72,REP,Drew Darby,4,4,0,0
+Tom Green,306 BS21,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,306 BS21,State Representative,72,,Under Votes,1,1,0,0
+Tom Green,306 BS21,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,4,4,0,0
+Tom Green,306 BS21,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,1,1,0,0
+Tom Green,306 BS21,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,306 BS21,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,0,0,0,0
+Tom Green,306 BS21,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,4,4,0,0
+Tom Green,306 BS21,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,1,1,0,0
+Tom Green,306 BS21,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,306 BS21,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,0,0,0,0
+Tom Green,306 BS21,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,4,4,0,0
+Tom Green,306 BS21,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,1,1,0,0
+Tom Green,306 BS21,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,306 BS21,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,0,0,0,0
+Tom Green,306 BS21,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",4,4,0,0
+Tom Green,306 BS21,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,1,1,0,0
+Tom Green,306 BS21,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),0,0,0,0
+Tom Green,306 BS21,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,306 BS21,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,0,0,0,0
+Tom Green,306 BS21,Ballots Cast,,,,5,5,0,0
+Tom Green,306 BS22,STRAIGHT PARTY,,REP,,328,153,160,15
+Tom Green,306 BS22,STRAIGHT PARTY,,DEM,,109,44,58,7
+Tom Green,306 BS22,STRAIGHT PARTY,,LIB,,5,1,4,0
+Tom Green,306 BS22,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,306 BS22,STRAIGHT PARTY,,,Under Votes,339,188,136,15
+Tom Green,306 BS22,U.S. Senate,,REP,Ted Cruz,529,262,244,23
+Tom Green,306 BS22,U.S. Senate,,DEM,Beto O'Rourke,244,123,107,14
+Tom Green,306 BS22,U.S. Senate,,LIB,Neal M. Dikeman,5,1,4,0
+Tom Green,306 BS22,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,306 BS22,U.S. Senate,,,Under Votes,3,0,3,0
+Tom Green,306 BS22,U.S. House,11,REP,Mike Conaway,556,275,256,25
+Tom Green,306 BS22,U.S. House,11,DEM,Jennie Lou Leeder,192,92,89,11
+Tom Green,306 BS22,U.S. House,11,LIB,Rhett Rosenquest Smith,13,7,6,0
+Tom Green,306 BS22,U.S. House,11,,Over Votes,1,1,0,0
+Tom Green,306 BS22,U.S. House,11,,Under Votes,19,11,7,1
+Tom Green,306 BS22,Governor,,REP,Greg Abbott,567,283,259,25
+Tom Green,306 BS22,Governor,,DEM,Lupe Valdez,194,96,86,12
+Tom Green,306 BS22,Governor,,LIB,Mark Jay Tippetts,12,5,7,0
+Tom Green,306 BS22,Governor,,,Over Votes,0,0,0,0
+Tom Green,306 BS22,Governor,,,Under Votes,8,2,6,0
+Tom Green,306 BS22,Lieutenant Governor,,REP,Dan Patrick,508,255,231,22
+Tom Green,306 BS22,Lieutenant Governor,,DEM,Mike Collier,233,115,105,13
+Tom Green,306 BS22,Lieutenant Governor,,LIB,Kerry Douglas McKennon,26,11,13,2
+Tom Green,306 BS22,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,306 BS22,Lieutenant Governor,,,Under Votes,14,5,9,0
+Tom Green,306 BS22,Attorney General,,REP,Ken Paxton,522,259,240,23
+Tom Green,306 BS22,Attorney General,,DEM,Justin Nelson,226,113,100,13
+Tom Green,306 BS22,Attorney General,,LIB,Michael Ray Harris,21,9,11,1
+Tom Green,306 BS22,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,306 BS22,Attorney General,,,Under Votes,12,5,7,0
+Tom Green,306 BS22,Comptroller of Public Accounts,,REP,Glenn Hegar,536,268,244,24
+Tom Green,306 BS22,Comptroller of Public Accounts,,DEM,Joi Chevalier,207,100,95,12
+Tom Green,306 BS22,Comptroller of Public Accounts,,LIB,Ben Sanders,21,11,10,0
+Tom Green,306 BS22,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,306 BS22,Comptroller of Public Accounts,,,Under Votes,17,7,9,1
+Tom Green,306 BS22,Commissioner of the General Land Office,,REP,George P. Bush,535,267,248,20
+Tom Green,306 BS22,Commissioner of the General Land Office,,DEM,Miguel Suazo,196,95,89,12
+Tom Green,306 BS22,Commissioner of the General Land Office,,LIB,Matt Pina,34,18,12,4
+Tom Green,306 BS22,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,306 BS22,Commissioner of the General Land Office,,,Under Votes,16,6,9,1
+Tom Green,306 BS22,Commissioner of Agriculture,,REP,Sid Miller,521,262,237,22
+Tom Green,306 BS22,Commissioner of Agriculture,,DEM,Kim Olson,223,110,101,12
+Tom Green,306 BS22,Commissioner of Agriculture,,LIB,Richard Carpenter,20,7,11,2
+Tom Green,306 BS22,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,306 BS22,Commissioner of Agriculture,,,Under Votes,17,7,9,1
+Tom Green,306 BS22,Railroad Commissioner,,REP,Christi Craddick,536,269,245,22
+Tom Green,306 BS22,Railroad Commissioner,,DEM,Roman McAllen,204,102,91,11
+Tom Green,306 BS22,Railroad Commissioner,,LIB,Mike Wright,23,10,11,2
+Tom Green,306 BS22,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,306 BS22,Railroad Commissioner,,,Under Votes,18,5,11,2
+Tom Green,306 BS22,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,533,272,238,23
+Tom Green,306 BS22,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,224,106,106,12
+Tom Green,306 BS22,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,306 BS22,"Justice, Supreme Court, Place 2",,,Under Votes,24,8,14,2
+Tom Green,306 BS22,"Justice, Supreme Court, Place 4",,REP,John Devine,543,275,244,24
+Tom Green,306 BS22,"Justice, Supreme Court, Place 4",,,R. K. Sandill,212,103,98,11
+Tom Green,306 BS22,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,306 BS22,"Justice, Supreme Court, Place 4",,,Under Votes,26,8,16,2
+Tom Green,306 BS22,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,537,271,243,23
+Tom Green,306 BS22,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,220,107,101,12
+Tom Green,306 BS22,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,306 BS22,"Justice, Supreme Court, Place 6",,,Under Votes,24,8,14,2
+Tom Green,306 BS22,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,531,267,242,22
+Tom Green,306 BS22,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,213,107,94,12
+Tom Green,306 BS22,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,18,6,11,1
+Tom Green,306 BS22,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,306 BS22,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,19,6,11,2
+Tom Green,306 BS22,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,540,274,243,23
+Tom Green,306 BS22,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,215,103,100,12
+Tom Green,306 BS22,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,306 BS22,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,26,9,15,2
+Tom Green,306 BS22,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,576,289,264,23
+Tom Green,306 BS22,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,108,58,45,5
+Tom Green,306 BS22,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,306 BS22,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,97,39,49,9
+Tom Green,306 BS22,State Representative,72,REP,Drew Darby,628,317,285,26
+Tom Green,306 BS22,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,306 BS22,State Representative,72,,Under Votes,153,69,73,11
+Tom Green,306 BS22,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,536,270,245,21
+Tom Green,306 BS22,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,208,99,96,13
+Tom Green,306 BS22,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,306 BS22,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,37,17,17,3
+Tom Green,306 BS22,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,534,269,242,23
+Tom Green,306 BS22,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,215,101,102,12
+Tom Green,306 BS22,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,306 BS22,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,32,16,14,2
+Tom Green,306 BS22,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,533,272,239,22
+Tom Green,306 BS22,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,215,99,103,13
+Tom Green,306 BS22,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,306 BS22,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,33,15,16,2
+Tom Green,306 BS22,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",535,269,243,23
+Tom Green,306 BS22,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,209,100,97,12
+Tom Green,306 BS22,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),1,1,0,0
+Tom Green,306 BS22,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,306 BS22,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,36,16,18,2
+Tom Green,306 BS22,San Angelo Independent School District Proposition A,,,FOR,284,150,125,9
+Tom Green,306 BS22,San Angelo Independent School District Proposition A,,,AGAINST,432,214,200,18
+Tom Green,306 BS22,San Angelo Independent School District Proposition A,,,Over Votes,0,0,0,0
+Tom Green,306 BS22,San Angelo Independent School District Proposition A,,,Under Votes,65,22,33,10
+Tom Green,306 BS22,San Angelo Independent School District Proposition B,,,FOR,274,143,118,13
+Tom Green,306 BS22,San Angelo Independent School District Proposition B,,,AGAINST,438,216,207,15
+Tom Green,306 BS22,San Angelo Independent School District Proposition B,,,Over Votes,0,0,0,0
+Tom Green,306 BS22,San Angelo Independent School District Proposition B,,,Under Votes,69,27,33,9
+Tom Green,306 BS22,Ballots Cast,,,,781,386,358,37
+Tom Green,308 BS23,STRAIGHT PARTY,,REP,,52,31,18,3
+Tom Green,308 BS23,STRAIGHT PARTY,,DEM,,37,23,11,3
+Tom Green,308 BS23,STRAIGHT PARTY,,LIB,,0,0,0,0
+Tom Green,308 BS23,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,308 BS23,STRAIGHT PARTY,,,Under Votes,45,22,16,7
+Tom Green,308 BS23,U.S. Senate,,REP,Ted Cruz,71,37,26,8
+Tom Green,308 BS23,U.S. Senate,,DEM,Beto O'Rourke,59,36,18,5
+Tom Green,308 BS23,U.S. Senate,,LIB,Neal M. Dikeman,1,1,0,0
+Tom Green,308 BS23,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,308 BS23,U.S. Senate,,,Under Votes,3,2,1,0
+Tom Green,308 BS23,U.S. House,11,REP,Mike Conaway,82,44,29,9
+Tom Green,308 BS23,U.S. House,11,DEM,Jennie Lou Leeder,48,30,14,4
+Tom Green,308 BS23,U.S. House,11,LIB,Rhett Rosenquest Smith,0,0,0,0
+Tom Green,308 BS23,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,308 BS23,U.S. House,11,,Under Votes,4,2,2,0
+Tom Green,308 BS23,Governor,,REP,Greg Abbott,76,40,28,8
+Tom Green,308 BS23,Governor,,DEM,Lupe Valdez,55,34,16,5
+Tom Green,308 BS23,Governor,,LIB,Mark Jay Tippetts,0,0,0,0
+Tom Green,308 BS23,Governor,,,Over Votes,0,0,0,0
+Tom Green,308 BS23,Governor,,,Under Votes,3,2,1,0
+Tom Green,308 BS23,Lieutenant Governor,,REP,Dan Patrick,74,38,28,8
+Tom Green,308 BS23,Lieutenant Governor,,DEM,Mike Collier,56,36,15,5
+Tom Green,308 BS23,Lieutenant Governor,,LIB,Kerry Douglas McKennon,0,0,0,0
+Tom Green,308 BS23,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,308 BS23,Lieutenant Governor,,,Under Votes,4,2,2,0
+Tom Green,308 BS23,Attorney General,,REP,Ken Paxton,70,38,25,7
+Tom Green,308 BS23,Attorney General,,DEM,Justin Nelson,56,34,17,5
+Tom Green,308 BS23,Attorney General,,LIB,Michael Ray Harris,5,2,2,1
+Tom Green,308 BS23,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,308 BS23,Attorney General,,,Under Votes,3,2,1,0
+Tom Green,308 BS23,Comptroller of Public Accounts,,REP,Glenn Hegar,74,40,26,8
+Tom Green,308 BS23,Comptroller of Public Accounts,,DEM,Joi Chevalier,53,32,17,4
+Tom Green,308 BS23,Comptroller of Public Accounts,,LIB,Ben Sanders,2,1,0,1
+Tom Green,308 BS23,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,308 BS23,Comptroller of Public Accounts,,,Under Votes,5,3,2,0
+Tom Green,308 BS23,Commissioner of the General Land Office,,REP,George P. Bush,72,38,26,8
+Tom Green,308 BS23,Commissioner of the General Land Office,,DEM,Miguel Suazo,54,32,17,5
+Tom Green,308 BS23,Commissioner of the General Land Office,,LIB,Matt Pina,4,3,1,0
+Tom Green,308 BS23,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,308 BS23,Commissioner of the General Land Office,,,Under Votes,4,3,1,0
+Tom Green,308 BS23,Commissioner of Agriculture,,REP,Sid Miller,74,39,27,8
+Tom Green,308 BS23,Commissioner of Agriculture,,DEM,Kim Olson,55,34,16,5
+Tom Green,308 BS23,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0,0
+Tom Green,308 BS23,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,308 BS23,Commissioner of Agriculture,,,Under Votes,5,3,2,0
+Tom Green,308 BS23,Railroad Commissioner,,REP,Christi Craddick,78,43,27,8
+Tom Green,308 BS23,Railroad Commissioner,,DEM,Roman McAllen,49,30,15,4
+Tom Green,308 BS23,Railroad Commissioner,,LIB,Mike Wright,2,0,1,1
+Tom Green,308 BS23,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,308 BS23,Railroad Commissioner,,,Under Votes,5,3,2,0
+Tom Green,308 BS23,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,71,39,23,9
+Tom Green,308 BS23,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,56,35,17,4
+Tom Green,308 BS23,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,308 BS23,"Justice, Supreme Court, Place 2",,,Under Votes,7,2,5,0
+Tom Green,308 BS23,"Justice, Supreme Court, Place 4",,REP,John Devine,71,39,24,8
+Tom Green,308 BS23,"Justice, Supreme Court, Place 4",,,R. K. Sandill,54,33,16,5
+Tom Green,308 BS23,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,308 BS23,"Justice, Supreme Court, Place 4",,,Under Votes,9,4,5,0
+Tom Green,308 BS23,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,71,39,23,9
+Tom Green,308 BS23,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,54,33,17,4
+Tom Green,308 BS23,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,308 BS23,"Justice, Supreme Court, Place 6",,,Under Votes,9,4,5,0
+Tom Green,308 BS23,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,71,40,23,8
+Tom Green,308 BS23,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,56,32,19,5
+Tom Green,308 BS23,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,1,1,0,0
+Tom Green,308 BS23,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,308 BS23,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,6,3,3,0
+Tom Green,308 BS23,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,72,41,23,8
+Tom Green,308 BS23,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,55,32,18,5
+Tom Green,308 BS23,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,308 BS23,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,7,3,4,0
+Tom Green,308 BS23,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,79,43,27,9
+Tom Green,308 BS23,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,19,13,5,1
+Tom Green,308 BS23,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,308 BS23,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,36,20,13,3
+Tom Green,308 BS23,State Representative,72,REP,Drew Darby,89,48,32,9
+Tom Green,308 BS23,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,308 BS23,State Representative,72,,Under Votes,45,28,13,4
+Tom Green,308 BS23,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,73,41,24,8
+Tom Green,308 BS23,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,53,32,17,4
+Tom Green,308 BS23,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,308 BS23,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,8,3,4,1
+Tom Green,308 BS23,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,72,40,24,8
+Tom Green,308 BS23,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,55,33,17,5
+Tom Green,308 BS23,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,308 BS23,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,7,3,4,0
+Tom Green,308 BS23,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,70,39,23,8
+Tom Green,308 BS23,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,57,34,18,5
+Tom Green,308 BS23,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,308 BS23,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,7,3,4,0
+Tom Green,308 BS23,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",72,40,24,8
+Tom Green,308 BS23,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,55,33,17,5
+Tom Green,308 BS23,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),0,0,0,0
+Tom Green,308 BS23,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,308 BS23,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,7,3,4,0
+Tom Green,308 BS23,San Angelo Independent School District Proposition A,,,FOR,48,27,13,8
+Tom Green,308 BS23,San Angelo Independent School District Proposition A,,,AGAINST,72,47,22,3
+Tom Green,308 BS23,San Angelo Independent School District Proposition A,,,Over Votes,0,0,0,0
+Tom Green,308 BS23,San Angelo Independent School District Proposition A,,,Under Votes,14,2,10,2
+Tom Green,308 BS23,San Angelo Independent School District Proposition B,,,FOR,50,29,14,7
+Tom Green,308 BS23,San Angelo Independent School District Proposition B,,,AGAINST,72,45,24,3
+Tom Green,308 BS23,San Angelo Independent School District Proposition B,,,Over Votes,0,0,0,0
+Tom Green,308 BS23,San Angelo Independent School District Proposition B,,,Under Votes,12,2,7,3
+Tom Green,308 BS23,Ballots Cast,,,,134,76,45,13
+Tom Green,319 BS24,STRAIGHT PARTY,,REP,,929,571,211,147
+Tom Green,319 BS24,STRAIGHT PARTY,,DEM,,220,128,71,21
+Tom Green,319 BS24,STRAIGHT PARTY,,LIB,,10,5,4,1
+Tom Green,319 BS24,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,319 BS24,STRAIGHT PARTY,,,Under Votes,882,569,195,118
+Tom Green,319 BS24,U.S. Senate,,REP,Ted Cruz,1482,940,318,224
+Tom Green,319 BS24,U.S. Senate,,DEM,Beto O'Rourke,513,308,150,55
+Tom Green,319 BS24,U.S. Senate,,LIB,Neal M. Dikeman,22,13,7,2
+Tom Green,319 BS24,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,319 BS24,U.S. Senate,,,Under Votes,24,12,6,6
+Tom Green,319 BS24,U.S. House,11,REP,Mike Conaway,1573,985,352,236
+Tom Green,319 BS24,U.S. House,11,DEM,Jennie Lou Leeder,422,259,116,47
+Tom Green,319 BS24,U.S. House,11,LIB,Rhett Rosenquest Smith,29,20,8,1
+Tom Green,319 BS24,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,319 BS24,U.S. House,11,,Under Votes,17,9,5,3
+Tom Green,319 BS24,Governor,,REP,Greg Abbott,1562,980,343,239
+Tom Green,319 BS24,Governor,,DEM,Lupe Valdez,430,264,119,47
+Tom Green,319 BS24,Governor,,LIB,Mark Jay Tippetts,35,23,11,1
+Tom Green,319 BS24,Governor,,,Over Votes,0,0,0,0
+Tom Green,319 BS24,Governor,,,Under Votes,14,6,8,0
+Tom Green,319 BS24,Lieutenant Governor,,REP,Dan Patrick,1417,883,313,221
+Tom Green,319 BS24,Lieutenant Governor,,DEM,Mike Collier,539,343,138,58
+Tom Green,319 BS24,Lieutenant Governor,,LIB,Kerry Douglas McKennon,53,34,19,0
+Tom Green,319 BS24,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,319 BS24,Lieutenant Governor,,,Under Votes,32,13,11,8
+Tom Green,319 BS24,Attorney General,,REP,Ken Paxton,1444,901,322,221
+Tom Green,319 BS24,Attorney General,,DEM,Justin Nelson,506,318,131,57
+Tom Green,319 BS24,Attorney General,,LIB,Michael Ray Harris,54,35,17,2
+Tom Green,319 BS24,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,319 BS24,Attorney General,,,Under Votes,37,19,11,7
+Tom Green,319 BS24,Comptroller of Public Accounts,,REP,Glenn Hegar,1467,932,315,220
+Tom Green,319 BS24,Comptroller of Public Accounts,,DEM,Joi Chevalier,438,264,122,52
+Tom Green,319 BS24,Comptroller of Public Accounts,,LIB,Ben Sanders,74,45,27,2
+Tom Green,319 BS24,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,319 BS24,Comptroller of Public Accounts,,,Under Votes,62,32,17,13
+Tom Green,319 BS24,Commissioner of the General Land Office,,REP,George P. Bush,1526,966,332,228
+Tom Green,319 BS24,Commissioner of the General Land Office,,DEM,Miguel Suazo,422,253,121,48
+Tom Green,319 BS24,Commissioner of the General Land Office,,LIB,Matt Pina,58,39,15,4
+Tom Green,319 BS24,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,319 BS24,Commissioner of the General Land Office,,,Under Votes,35,15,13,7
+Tom Green,319 BS24,Commissioner of Agriculture,,REP,Sid Miller,1465,925,321,219
+Tom Green,319 BS24,Commissioner of Agriculture,,DEM,Kim Olson,461,279,129,53
+Tom Green,319 BS24,Commissioner of Agriculture,,LIB,Richard Carpenter,51,34,14,3
+Tom Green,319 BS24,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,319 BS24,Commissioner of Agriculture,,,Under Votes,64,35,17,12
+Tom Green,319 BS24,Railroad Commissioner,,REP,Christi Craddick,1501,947,330,224
+Tom Green,319 BS24,Railroad Commissioner,,DEM,Roman McAllen,419,250,119,50
+Tom Green,319 BS24,Railroad Commissioner,,LIB,Mike Wright,67,43,20,4
+Tom Green,319 BS24,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,319 BS24,Railroad Commissioner,,,Under Votes,54,33,12,9
+Tom Green,319 BS24,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1495,946,328,221
+Tom Green,319 BS24,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,487,294,140,53
+Tom Green,319 BS24,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,319 BS24,"Justice, Supreme Court, Place 2",,,Under Votes,59,33,13,13
+Tom Green,319 BS24,"Justice, Supreme Court, Place 4",,REP,John Devine,1506,952,331,223
+Tom Green,319 BS24,"Justice, Supreme Court, Place 4",,,R. K. Sandill,476,287,137,52
+Tom Green,319 BS24,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,319 BS24,"Justice, Supreme Court, Place 4",,,Under Votes,59,34,13,12
+Tom Green,319 BS24,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1493,944,326,223
+Tom Green,319 BS24,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,487,297,142,48
+Tom Green,319 BS24,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,319 BS24,"Justice, Supreme Court, Place 6",,,Under Votes,61,32,13,16
+Tom Green,319 BS24,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1465,927,320,218
+Tom Green,319 BS24,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,464,284,129,51
+Tom Green,319 BS24,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,50,29,16,5
+Tom Green,319 BS24,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,319 BS24,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,62,33,16,13
+Tom Green,319 BS24,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1506,955,332,219
+Tom Green,319 BS24,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,465,283,130,52
+Tom Green,319 BS24,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,319 BS24,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,70,35,19,16
+Tom Green,319 BS24,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1571,992,350,229
+Tom Green,319 BS24,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,242,149,75,18
+Tom Green,319 BS24,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,1,1,0,0
+Tom Green,319 BS24,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,227,131,56,40
+Tom Green,319 BS24,State Representative,72,REP,Drew Darby,1694,1063,388,243
+Tom Green,319 BS24,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,319 BS24,State Representative,72,,Under Votes,347,210,93,44
+Tom Green,319 BS24,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,1521,961,341,219
+Tom Green,319 BS24,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,445,273,121,51
+Tom Green,319 BS24,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,319 BS24,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,75,39,19,17
+Tom Green,319 BS24,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,1499,949,333,217
+Tom Green,319 BS24,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,470,285,131,54
+Tom Green,319 BS24,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,319 BS24,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,72,39,17,16
+Tom Green,319 BS24,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,1499,946,332,221
+Tom Green,319 BS24,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,464,283,130,51
+Tom Green,319 BS24,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,319 BS24,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,78,44,19,15
+Tom Green,319 BS24,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",1492,943,330,219
+Tom Green,319 BS24,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,476,290,132,54
+Tom Green,319 BS24,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),0,0,0,0
+Tom Green,319 BS24,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,319 BS24,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,73,40,19,14
+Tom Green,319 BS24,San Angelo Independent School District Proposition A,,,FOR,886,543,222,121
+Tom Green,319 BS24,San Angelo Independent School District Proposition A,,,AGAINST,1016,653,232,131
+Tom Green,319 BS24,San Angelo Independent School District Proposition A,,,Over Votes,0,0,0,0
+Tom Green,319 BS24,San Angelo Independent School District Proposition A,,,Under Votes,139,77,27,35
+Tom Green,319 BS24,San Angelo Independent School District Proposition B,,,FOR,820,496,197,127
+Tom Green,319 BS24,San Angelo Independent School District Proposition B,,,AGAINST,1090,700,257,133
+Tom Green,319 BS24,San Angelo Independent School District Proposition B,,,Over Votes,0,0,0,0
+Tom Green,319 BS24,San Angelo Independent School District Proposition B,,,Under Votes,131,77,27,27
+Tom Green,319 BS24,Ballots Cast,,,,2041,1273,481,287
+Tom Green,327 BS25,STRAIGHT PARTY,,REP,,424,236,153,35
+Tom Green,327 BS25,STRAIGHT PARTY,,DEM,,250,120,102,28
+Tom Green,327 BS25,STRAIGHT PARTY,,LIB,,8,4,4,0
+Tom Green,327 BS25,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,327 BS25,STRAIGHT PARTY,,,Under Votes,441,257,146,38
+Tom Green,327 BS25,U.S. Senate,,REP,Ted Cruz,681,391,243,47
+Tom Green,327 BS25,U.S. Senate,,DEM,Beto O'Rourke,414,212,151,51
+Tom Green,327 BS25,U.S. Senate,,LIB,Neal M. Dikeman,14,5,8,1
+Tom Green,327 BS25,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,327 BS25,U.S. Senate,,,Under Votes,14,9,3,2
+Tom Green,327 BS25,U.S. House,11,REP,Mike Conaway,717,409,259,49
+Tom Green,327 BS25,U.S. House,11,DEM,Jennie Lou Leeder,380,194,136,50
+Tom Green,327 BS25,U.S. House,11,LIB,Rhett Rosenquest Smith,10,6,3,1
+Tom Green,327 BS25,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,327 BS25,U.S. House,11,,Under Votes,16,8,7,1
+Tom Green,327 BS25,Governor,,REP,Greg Abbott,704,404,252,48
+Tom Green,327 BS25,Governor,,DEM,Lupe Valdez,393,202,139,52
+Tom Green,327 BS25,Governor,,LIB,Mark Jay Tippetts,15,6,9,0
+Tom Green,327 BS25,Governor,,,Over Votes,0,0,0,0
+Tom Green,327 BS25,Governor,,,Under Votes,11,5,5,1
+Tom Green,327 BS25,Lieutenant Governor,,REP,Dan Patrick,665,382,234,49
+Tom Green,327 BS25,Lieutenant Governor,,DEM,Mike Collier,414,214,152,48
+Tom Green,327 BS25,Lieutenant Governor,,LIB,Kerry Douglas McKennon,25,12,12,1
+Tom Green,327 BS25,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,327 BS25,Lieutenant Governor,,,Under Votes,19,9,7,3
+Tom Green,327 BS25,Attorney General,,REP,Ken Paxton,660,375,238,47
+Tom Green,327 BS25,Attorney General,,DEM,Justin Nelson,415,217,148,50
+Tom Green,327 BS25,Attorney General,,LIB,Michael Ray Harris,25,12,12,1
+Tom Green,327 BS25,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,327 BS25,Attorney General,,,Under Votes,23,13,7,3
+Tom Green,327 BS25,Comptroller of Public Accounts,,REP,Glenn Hegar,666,379,237,50
+Tom Green,327 BS25,Comptroller of Public Accounts,,DEM,Joi Chevalier,380,198,135,47
+Tom Green,327 BS25,Comptroller of Public Accounts,,LIB,Ben Sanders,40,19,20,1
+Tom Green,327 BS25,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,327 BS25,Comptroller of Public Accounts,,,Under Votes,37,21,13,3
+Tom Green,327 BS25,Commissioner of the General Land Office,,REP,George P. Bush,672,386,239,47
+Tom Green,327 BS25,Commissioner of the General Land Office,,DEM,Miguel Suazo,387,201,137,49
+Tom Green,327 BS25,Commissioner of the General Land Office,,LIB,Matt Pina,40,22,17,1
+Tom Green,327 BS25,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,327 BS25,Commissioner of the General Land Office,,,Under Votes,24,8,12,4
+Tom Green,327 BS25,Commissioner of Agriculture,,REP,Sid Miller,665,379,236,50
+Tom Green,327 BS25,Commissioner of Agriculture,,DEM,Kim Olson,395,209,138,48
+Tom Green,327 BS25,Commissioner of Agriculture,,LIB,Richard Carpenter,28,12,15,1
+Tom Green,327 BS25,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,327 BS25,Commissioner of Agriculture,,,Under Votes,35,17,16,2
+Tom Green,327 BS25,Railroad Commissioner,,REP,Christi Craddick,670,388,233,49
+Tom Green,327 BS25,Railroad Commissioner,,DEM,Roman McAllen,391,199,145,47
+Tom Green,327 BS25,Railroad Commissioner,,LIB,Mike Wright,28,13,14,1
+Tom Green,327 BS25,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,327 BS25,Railroad Commissioner,,,Under Votes,34,17,13,4
+Tom Green,327 BS25,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,670,387,238,45
+Tom Green,327 BS25,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,416,211,153,52
+Tom Green,327 BS25,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,327 BS25,"Justice, Supreme Court, Place 2",,,Under Votes,37,19,14,4
+Tom Green,327 BS25,"Justice, Supreme Court, Place 4",,REP,John Devine,672,388,237,47
+Tom Green,327 BS25,"Justice, Supreme Court, Place 4",,,R. K. Sandill,412,210,153,49
+Tom Green,327 BS25,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,327 BS25,"Justice, Supreme Court, Place 4",,,Under Votes,39,19,15,5
+Tom Green,327 BS25,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,674,388,240,46
+Tom Green,327 BS25,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,412,212,152,48
+Tom Green,327 BS25,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,327 BS25,"Justice, Supreme Court, Place 6",,,Under Votes,37,17,13,7
+Tom Green,327 BS25,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,666,383,235,48
+Tom Green,327 BS25,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,399,205,146,48
+Tom Green,327 BS25,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,25,13,11,1
+Tom Green,327 BS25,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,327 BS25,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,33,16,13,4
+Tom Green,327 BS25,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,681,390,244,47
+Tom Green,327 BS25,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,406,210,146,50
+Tom Green,327 BS25,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,327 BS25,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,36,17,15,4
+Tom Green,327 BS25,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,721,406,263,52
+Tom Green,327 BS25,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,176,99,59,18
+Tom Green,327 BS25,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,327 BS25,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,226,112,83,31
+Tom Green,327 BS25,State Representative,72,REP,Drew Darby,809,452,293,64
+Tom Green,327 BS25,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,327 BS25,State Representative,72,,Under Votes,314,165,112,37
+Tom Green,327 BS25,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,679,390,240,49
+Tom Green,327 BS25,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,408,209,149,50
+Tom Green,327 BS25,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,327 BS25,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,36,18,16,2
+Tom Green,327 BS25,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,673,384,240,49
+Tom Green,327 BS25,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,414,216,149,49
+Tom Green,327 BS25,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,327 BS25,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,36,17,16,3
+Tom Green,327 BS25,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,674,389,238,47
+Tom Green,327 BS25,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,410,210,151,49
+Tom Green,327 BS25,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,327 BS25,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,39,18,16,5
+Tom Green,327 BS25,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",678,389,241,48
+Tom Green,327 BS25,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,405,208,148,49
+Tom Green,327 BS25,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),2,0,1,1
+Tom Green,327 BS25,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,327 BS25,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,38,20,15,3
+Tom Green,327 BS25,San Angelo Independent School District Proposition A,,,FOR,434,233,151,50
+Tom Green,327 BS25,San Angelo Independent School District Proposition A,,,AGAINST,602,337,226,39
+Tom Green,327 BS25,San Angelo Independent School District Proposition A,,,Over Votes,0,0,0,0
+Tom Green,327 BS25,San Angelo Independent School District Proposition A,,,Under Votes,87,47,28,12
+Tom Green,327 BS25,San Angelo Independent School District Proposition B,,,FOR,411,222,143,46
+Tom Green,327 BS25,San Angelo Independent School District Proposition B,,,AGAINST,628,347,236,45
+Tom Green,327 BS25,San Angelo Independent School District Proposition B,,,Over Votes,0,0,0,0
+Tom Green,327 BS25,San Angelo Independent School District Proposition B,,,Under Votes,84,48,26,10
+Tom Green,327 BS25,Ballots Cast,,,,1123,617,405,101
+Tom Green,348 BS26,STRAIGHT PARTY,,REP,,120,67,41,12
+Tom Green,348 BS26,STRAIGHT PARTY,,DEM,,44,31,12,1
+Tom Green,348 BS26,STRAIGHT PARTY,,LIB,,0,0,0,0
+Tom Green,348 BS26,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,348 BS26,STRAIGHT PARTY,,,Under Votes,86,53,25,8
+Tom Green,348 BS26,U.S. Senate,,REP,Ted Cruz,178,104,59,15
+Tom Green,348 BS26,U.S. Senate,,DEM,Beto O'Rourke,68,46,18,4
+Tom Green,348 BS26,U.S. Senate,,LIB,Neal M. Dikeman,2,1,0,1
+Tom Green,348 BS26,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,348 BS26,U.S. Senate,,,Under Votes,2,0,1,1
+Tom Green,348 BS26,U.S. House,11,REP,Mike Conaway,180,102,61,17
+Tom Green,348 BS26,U.S. House,11,DEM,Jennie Lou Leeder,61,43,16,2
+Tom Green,348 BS26,U.S. House,11,LIB,Rhett Rosenquest Smith,5,2,1,2
+Tom Green,348 BS26,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,348 BS26,U.S. House,11,,Under Votes,4,4,0,0
+Tom Green,348 BS26,Governor,,REP,Greg Abbott,183,106,61,16
+Tom Green,348 BS26,Governor,,DEM,Lupe Valdez,59,42,14,3
+Tom Green,348 BS26,Governor,,LIB,Mark Jay Tippetts,3,0,3,0
+Tom Green,348 BS26,Governor,,,Over Votes,0,0,0,0
+Tom Green,348 BS26,Governor,,,Under Votes,5,3,0,2
+Tom Green,348 BS26,Lieutenant Governor,,REP,Dan Patrick,174,100,58,16
+Tom Green,348 BS26,Lieutenant Governor,,DEM,Mike Collier,67,46,18,3
+Tom Green,348 BS26,Lieutenant Governor,,LIB,Kerry Douglas McKennon,5,3,2,0
+Tom Green,348 BS26,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,348 BS26,Lieutenant Governor,,,Under Votes,4,2,0,2
+Tom Green,348 BS26,Attorney General,,REP,Ken Paxton,174,98,60,16
+Tom Green,348 BS26,Attorney General,,DEM,Justin Nelson,65,48,15,2
+Tom Green,348 BS26,Attorney General,,LIB,Michael Ray Harris,7,4,3,0
+Tom Green,348 BS26,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,348 BS26,Attorney General,,,Under Votes,4,1,0,3
+Tom Green,348 BS26,Comptroller of Public Accounts,,REP,Glenn Hegar,178,103,59,16
+Tom Green,348 BS26,Comptroller of Public Accounts,,DEM,Joi Chevalier,57,39,16,2
+Tom Green,348 BS26,Comptroller of Public Accounts,,LIB,Ben Sanders,9,5,3,1
+Tom Green,348 BS26,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,348 BS26,Comptroller of Public Accounts,,,Under Votes,6,4,0,2
+Tom Green,348 BS26,Commissioner of the General Land Office,,REP,George P. Bush,167,97,56,14
+Tom Green,348 BS26,Commissioner of the General Land Office,,DEM,Miguel Suazo,62,42,16,4
+Tom Green,348 BS26,Commissioner of the General Land Office,,LIB,Matt Pina,15,8,6,1
+Tom Green,348 BS26,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,348 BS26,Commissioner of the General Land Office,,,Under Votes,6,4,0,2
+Tom Green,348 BS26,Commissioner of Agriculture,,REP,Sid Miller,179,103,61,15
+Tom Green,348 BS26,Commissioner of Agriculture,,DEM,Kim Olson,64,45,16,3
+Tom Green,348 BS26,Commissioner of Agriculture,,LIB,Richard Carpenter,3,1,1,1
+Tom Green,348 BS26,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,348 BS26,Commissioner of Agriculture,,,Under Votes,4,2,0,2
+Tom Green,348 BS26,Railroad Commissioner,,REP,Christi Craddick,181,103,62,16
+Tom Green,348 BS26,Railroad Commissioner,,DEM,Roman McAllen,58,41,14,3
+Tom Green,348 BS26,Railroad Commissioner,,LIB,Mike Wright,5,3,2,0
+Tom Green,348 BS26,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,348 BS26,Railroad Commissioner,,,Under Votes,6,4,0,2
+Tom Green,348 BS26,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,179,103,60,16
+Tom Green,348 BS26,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,66,45,18,3
+Tom Green,348 BS26,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,348 BS26,"Justice, Supreme Court, Place 2",,,Under Votes,5,3,0,2
+Tom Green,348 BS26,"Justice, Supreme Court, Place 4",,REP,John Devine,180,103,61,16
+Tom Green,348 BS26,"Justice, Supreme Court, Place 4",,,R. K. Sandill,65,45,17,3
+Tom Green,348 BS26,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,348 BS26,"Justice, Supreme Court, Place 4",,,Under Votes,5,3,0,2
+Tom Green,348 BS26,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,181,104,62,15
+Tom Green,348 BS26,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,64,44,16,4
+Tom Green,348 BS26,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,348 BS26,"Justice, Supreme Court, Place 6",,,Under Votes,5,3,0,2
+Tom Green,348 BS26,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,180,104,60,16
+Tom Green,348 BS26,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,60,43,15,2
+Tom Green,348 BS26,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,5,1,3,1
+Tom Green,348 BS26,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,348 BS26,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,5,3,0,2
+Tom Green,348 BS26,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,183,106,61,16
+Tom Green,348 BS26,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,63,43,17,3
+Tom Green,348 BS26,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,348 BS26,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,4,2,0,2
+Tom Green,348 BS26,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,187,108,62,17
+Tom Green,348 BS26,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,26,15,9,2
+Tom Green,348 BS26,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,348 BS26,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,37,28,7,2
+Tom Green,348 BS26,State Representative,72,REP,Drew Darby,194,113,65,16
+Tom Green,348 BS26,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,348 BS26,State Representative,72,,Under Votes,56,38,13,5
+Tom Green,348 BS26,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,183,105,61,17
+Tom Green,348 BS26,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,63,44,17,2
+Tom Green,348 BS26,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,348 BS26,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,4,2,0,2
+Tom Green,348 BS26,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,181,105,61,15
+Tom Green,348 BS26,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,66,45,17,4
+Tom Green,348 BS26,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,348 BS26,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,3,1,0,2
+Tom Green,348 BS26,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,179,103,60,16
+Tom Green,348 BS26,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,67,47,18,2
+Tom Green,348 BS26,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,348 BS26,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,4,1,0,3
+Tom Green,348 BS26,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",180,104,61,15
+Tom Green,348 BS26,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,66,45,17,4
+Tom Green,348 BS26,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),0,0,0,0
+Tom Green,348 BS26,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,348 BS26,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,4,2,0,2
+Tom Green,348 BS26,Ballots Cast,,,,250,151,78,21
+Tom Green,348 BS27,STRAIGHT PARTY,,REP,,78,48,27,3
+Tom Green,348 BS27,STRAIGHT PARTY,,DEM,,5,3,1,1
+Tom Green,348 BS27,STRAIGHT PARTY,,LIB,,0,0,0,0
+Tom Green,348 BS27,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,348 BS27,STRAIGHT PARTY,,,Under Votes,53,38,11,4
+Tom Green,348 BS27,U.S. Senate,,REP,Ted Cruz,116,77,34,5
+Tom Green,348 BS27,U.S. Senate,,DEM,Beto O'Rourke,18,10,5,3
+Tom Green,348 BS27,U.S. Senate,,LIB,Neal M. Dikeman,1,1,0,0
+Tom Green,348 BS27,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,348 BS27,U.S. Senate,,,Under Votes,1,1,0,0
+Tom Green,348 BS27,U.S. House,11,REP,Mike Conaway,117,77,35,5
+Tom Green,348 BS27,U.S. House,11,DEM,Jennie Lou Leeder,16,9,4,3
+Tom Green,348 BS27,U.S. House,11,LIB,Rhett Rosenquest Smith,2,2,0,0
+Tom Green,348 BS27,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,348 BS27,U.S. House,11,,Under Votes,1,1,0,0
+Tom Green,348 BS27,Governor,,REP,Greg Abbott,118,78,35,5
+Tom Green,348 BS27,Governor,,DEM,Lupe Valdez,16,9,4,3
+Tom Green,348 BS27,Governor,,LIB,Mark Jay Tippetts,0,0,0,0
+Tom Green,348 BS27,Governor,,,Over Votes,0,0,0,0
+Tom Green,348 BS27,Governor,,,Under Votes,2,2,0,0
+Tom Green,348 BS27,Lieutenant Governor,,REP,Dan Patrick,101,64,33,4
+Tom Green,348 BS27,Lieutenant Governor,,DEM,Mike Collier,28,18,6,4
+Tom Green,348 BS27,Lieutenant Governor,,LIB,Kerry Douglas McKennon,5,5,0,0
+Tom Green,348 BS27,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,348 BS27,Lieutenant Governor,,,Under Votes,2,2,0,0
+Tom Green,348 BS27,Attorney General,,REP,Ken Paxton,112,75,32,5
+Tom Green,348 BS27,Attorney General,,DEM,Justin Nelson,19,9,7,3
+Tom Green,348 BS27,Attorney General,,LIB,Michael Ray Harris,3,3,0,0
+Tom Green,348 BS27,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,348 BS27,Attorney General,,,Under Votes,2,2,0,0
+Tom Green,348 BS27,Comptroller of Public Accounts,,REP,Glenn Hegar,112,74,33,5
+Tom Green,348 BS27,Comptroller of Public Accounts,,DEM,Joi Chevalier,19,10,6,3
+Tom Green,348 BS27,Comptroller of Public Accounts,,LIB,Ben Sanders,2,2,0,0
+Tom Green,348 BS27,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,348 BS27,Comptroller of Public Accounts,,,Under Votes,3,3,0,0
+Tom Green,348 BS27,Commissioner of the General Land Office,,REP,George P. Bush,116,76,35,5
+Tom Green,348 BS27,Commissioner of the General Land Office,,DEM,Miguel Suazo,15,8,4,3
+Tom Green,348 BS27,Commissioner of the General Land Office,,LIB,Matt Pina,1,1,0,0
+Tom Green,348 BS27,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,348 BS27,Commissioner of the General Land Office,,,Under Votes,4,4,0,0
+Tom Green,348 BS27,Commissioner of Agriculture,,REP,Sid Miller,111,72,34,5
+Tom Green,348 BS27,Commissioner of Agriculture,,DEM,Kim Olson,20,12,5,3
+Tom Green,348 BS27,Commissioner of Agriculture,,LIB,Richard Carpenter,2,2,0,0
+Tom Green,348 BS27,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,348 BS27,Commissioner of Agriculture,,,Under Votes,3,3,0,0
+Tom Green,348 BS27,Railroad Commissioner,,REP,Christi Craddick,116,76,35,5
+Tom Green,348 BS27,Railroad Commissioner,,DEM,Roman McAllen,15,8,4,3
+Tom Green,348 BS27,Railroad Commissioner,,LIB,Mike Wright,2,2,0,0
+Tom Green,348 BS27,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,348 BS27,Railroad Commissioner,,,Under Votes,3,3,0,0
+Tom Green,348 BS27,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,114,75,34,5
+Tom Green,348 BS27,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,19,11,5,3
+Tom Green,348 BS27,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,348 BS27,"Justice, Supreme Court, Place 2",,,Under Votes,3,3,0,0
+Tom Green,348 BS27,"Justice, Supreme Court, Place 4",,REP,John Devine,114,75,34,5
+Tom Green,348 BS27,"Justice, Supreme Court, Place 4",,,R. K. Sandill,19,11,5,3
+Tom Green,348 BS27,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,348 BS27,"Justice, Supreme Court, Place 4",,,Under Votes,3,3,0,0
+Tom Green,348 BS27,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,114,76,33,5
+Tom Green,348 BS27,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,18,9,6,3
+Tom Green,348 BS27,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,348 BS27,"Justice, Supreme Court, Place 6",,,Under Votes,4,4,0,0
+Tom Green,348 BS27,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,114,75,34,5
+Tom Green,348 BS27,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,18,10,5,3
+Tom Green,348 BS27,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,0,0,0,0
+Tom Green,348 BS27,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,348 BS27,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,4,4,0,0
+Tom Green,348 BS27,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,114,75,34,5
+Tom Green,348 BS27,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,16,8,5,3
+Tom Green,348 BS27,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,348 BS27,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,6,6,0,0
+Tom Green,348 BS27,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,116,76,35,5
+Tom Green,348 BS27,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,8,4,3,1
+Tom Green,348 BS27,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,348 BS27,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,12,9,1,2
+Tom Green,348 BS27,State Representative,72,REP,Drew Darby,119,78,36,5
+Tom Green,348 BS27,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,348 BS27,State Representative,72,,Under Votes,17,11,3,3
+Tom Green,348 BS27,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,114,74,35,5
+Tom Green,348 BS27,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,16,9,4,3
+Tom Green,348 BS27,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,348 BS27,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,6,6,0,0
+Tom Green,348 BS27,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,112,74,33,5
+Tom Green,348 BS27,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,18,9,6,3
+Tom Green,348 BS27,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,348 BS27,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,6,6,0,0
+Tom Green,348 BS27,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,113,74,34,5
+Tom Green,348 BS27,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,17,9,5,3
+Tom Green,348 BS27,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,348 BS27,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,6,6,0,0
+Tom Green,348 BS27,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",112,73,34,5
+Tom Green,348 BS27,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,18,10,5,3
+Tom Green,348 BS27,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),0,0,0,0
+Tom Green,348 BS27,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,348 BS27,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,6,6,0,0
+Tom Green,348 BS27,San Angelo Independent School District Proposition A,,,FOR,44,29,12,3
+Tom Green,348 BS27,San Angelo Independent School District Proposition A,,,AGAINST,80,50,26,4
+Tom Green,348 BS27,San Angelo Independent School District Proposition A,,,Over Votes,0,0,0,0
+Tom Green,348 BS27,San Angelo Independent School District Proposition A,,,Under Votes,12,10,1,1
+Tom Green,348 BS27,San Angelo Independent School District Proposition B,,,FOR,33,18,11,4
+Tom Green,348 BS27,San Angelo Independent School District Proposition B,,,AGAINST,89,59,27,3
+Tom Green,348 BS27,San Angelo Independent School District Proposition B,,,Over Votes,0,0,0,0
+Tom Green,348 BS27,San Angelo Independent School District Proposition B,,,Under Votes,14,12,1,1
+Tom Green,348 BS27,Ballots Cast,,,,136,89,39,8
+Tom Green,351 BS28,STRAIGHT PARTY,,REP,,6,5,1,0
+Tom Green,351 BS28,STRAIGHT PARTY,,DEM,,1,1,0,0
+Tom Green,351 BS28,STRAIGHT PARTY,,LIB,,0,0,0,0
+Tom Green,351 BS28,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,351 BS28,STRAIGHT PARTY,,,Under Votes,12,6,2,4
+Tom Green,351 BS28,U.S. Senate,,REP,Ted Cruz,12,7,3,2
+Tom Green,351 BS28,U.S. Senate,,DEM,Beto O'Rourke,7,5,0,2
+Tom Green,351 BS28,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Tom Green,351 BS28,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,351 BS28,U.S. Senate,,,Under Votes,0,0,0,0
+Tom Green,351 BS28,U.S. House,11,REP,Mike Conaway,13,8,3,2
+Tom Green,351 BS28,U.S. House,11,DEM,Jennie Lou Leeder,4,3,0,1
+Tom Green,351 BS28,U.S. House,11,LIB,Rhett Rosenquest Smith,1,1,0,0
+Tom Green,351 BS28,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,351 BS28,U.S. House,11,,Under Votes,1,0,0,1
+Tom Green,351 BS28,Governor,,REP,Greg Abbott,11,7,3,1
+Tom Green,351 BS28,Governor,,DEM,Lupe Valdez,7,4,0,3
+Tom Green,351 BS28,Governor,,LIB,Mark Jay Tippetts,1,1,0,0
+Tom Green,351 BS28,Governor,,,Over Votes,0,0,0,0
+Tom Green,351 BS28,Governor,,,Under Votes,0,0,0,0
+Tom Green,351 BS28,Lieutenant Governor,,REP,Dan Patrick,10,6,3,1
+Tom Green,351 BS28,Lieutenant Governor,,DEM,Mike Collier,8,5,0,3
+Tom Green,351 BS28,Lieutenant Governor,,LIB,Kerry Douglas McKennon,1,1,0,0
+Tom Green,351 BS28,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,351 BS28,Lieutenant Governor,,,Under Votes,0,0,0,0
+Tom Green,351 BS28,Attorney General,,REP,Ken Paxton,9,6,3,0
+Tom Green,351 BS28,Attorney General,,DEM,Justin Nelson,8,5,0,3
+Tom Green,351 BS28,Attorney General,,LIB,Michael Ray Harris,1,1,0,0
+Tom Green,351 BS28,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,351 BS28,Attorney General,,,Under Votes,1,0,0,1
+Tom Green,351 BS28,Comptroller of Public Accounts,,REP,Glenn Hegar,13,8,3,2
+Tom Green,351 BS28,Comptroller of Public Accounts,,DEM,Joi Chevalier,4,3,0,1
+Tom Green,351 BS28,Comptroller of Public Accounts,,LIB,Ben Sanders,1,1,0,0
+Tom Green,351 BS28,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,351 BS28,Comptroller of Public Accounts,,,Under Votes,1,0,0,1
+Tom Green,351 BS28,Commissioner of the General Land Office,,REP,George P. Bush,8,6,2,0
+Tom Green,351 BS28,Commissioner of the General Land Office,,DEM,Miguel Suazo,8,5,0,3
+Tom Green,351 BS28,Commissioner of the General Land Office,,LIB,Matt Pina,2,1,1,0
+Tom Green,351 BS28,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,351 BS28,Commissioner of the General Land Office,,,Under Votes,1,0,0,1
+Tom Green,351 BS28,Commissioner of Agriculture,,REP,Sid Miller,11,6,3,2
+Tom Green,351 BS28,Commissioner of Agriculture,,DEM,Kim Olson,6,5,0,1
+Tom Green,351 BS28,Commissioner of Agriculture,,LIB,Richard Carpenter,1,1,0,0
+Tom Green,351 BS28,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,351 BS28,Commissioner of Agriculture,,,Under Votes,1,0,0,1
+Tom Green,351 BS28,Railroad Commissioner,,REP,Christi Craddick,13,8,3,2
+Tom Green,351 BS28,Railroad Commissioner,,DEM,Roman McAllen,4,3,0,1
+Tom Green,351 BS28,Railroad Commissioner,,LIB,Mike Wright,1,1,0,0
+Tom Green,351 BS28,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,351 BS28,Railroad Commissioner,,,Under Votes,1,0,0,1
+Tom Green,351 BS28,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,11,7,3,1
+Tom Green,351 BS28,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,6,5,0,1
+Tom Green,351 BS28,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,351 BS28,"Justice, Supreme Court, Place 2",,,Under Votes,2,0,0,2
+Tom Green,351 BS28,"Justice, Supreme Court, Place 4",,REP,John Devine,12,7,3,2
+Tom Green,351 BS28,"Justice, Supreme Court, Place 4",,,R. K. Sandill,6,5,0,1
+Tom Green,351 BS28,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,351 BS28,"Justice, Supreme Court, Place 4",,,Under Votes,1,0,0,1
+Tom Green,351 BS28,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,14,9,3,2
+Tom Green,351 BS28,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,4,3,0,1
+Tom Green,351 BS28,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,351 BS28,"Justice, Supreme Court, Place 6",,,Under Votes,1,0,0,1
+Tom Green,351 BS28,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,11,6,3,2
+Tom Green,351 BS28,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,6,5,0,1
+Tom Green,351 BS28,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,1,1,0,0
+Tom Green,351 BS28,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,351 BS28,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,1,0,0,1
+Tom Green,351 BS28,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,14,9,3,2
+Tom Green,351 BS28,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,4,3,0,1
+Tom Green,351 BS28,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,351 BS28,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,1,0,0,1
+Tom Green,351 BS28,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,12,8,2,2
+Tom Green,351 BS28,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,5,3,1,1
+Tom Green,351 BS28,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,351 BS28,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,2,1,0,1
+Tom Green,351 BS28,State Representative,72,REP,Drew Darby,16,10,3,3
+Tom Green,351 BS28,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,351 BS28,State Representative,72,,Under Votes,3,2,0,1
+Tom Green,351 BS28,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,14,9,3,2
+Tom Green,351 BS28,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,4,3,0,1
+Tom Green,351 BS28,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,351 BS28,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,1,0,0,1
+Tom Green,351 BS28,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,12,7,3,2
+Tom Green,351 BS28,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,6,5,0,1
+Tom Green,351 BS28,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,351 BS28,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,1,0,0,1
+Tom Green,351 BS28,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,14,9,3,2
+Tom Green,351 BS28,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,4,3,0,1
+Tom Green,351 BS28,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,351 BS28,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,1,0,0,1
+Tom Green,351 BS28,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",12,7,3,2
+Tom Green,351 BS28,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,6,5,0,1
+Tom Green,351 BS28,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),0,0,0,0
+Tom Green,351 BS28,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,351 BS28,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,1,0,0,1
+Tom Green,351 BS28,Ballots Cast,,,,19,12,3,4
+Tom Green,351 BS29,STRAIGHT PARTY,,REP,,122,93,23,6
+Tom Green,351 BS29,STRAIGHT PARTY,,DEM,,26,11,8,7
+Tom Green,351 BS29,STRAIGHT PARTY,,LIB,,0,0,0,0
+Tom Green,351 BS29,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,351 BS29,STRAIGHT PARTY,,,Under Votes,102,78,17,7
+Tom Green,351 BS29,U.S. Senate,,REP,Ted Cruz,198,153,38,7
+Tom Green,351 BS29,U.S. Senate,,DEM,Beto O'Rourke,52,29,10,13
+Tom Green,351 BS29,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Tom Green,351 BS29,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,351 BS29,U.S. Senate,,,Under Votes,0,0,0,0
+Tom Green,351 BS29,U.S. House,11,REP,Mike Conaway,203,158,38,7
+Tom Green,351 BS29,U.S. House,11,DEM,Jennie Lou Leeder,45,22,10,13
+Tom Green,351 BS29,U.S. House,11,LIB,Rhett Rosenquest Smith,1,1,0,0
+Tom Green,351 BS29,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,351 BS29,U.S. House,11,,Under Votes,1,1,0,0
+Tom Green,351 BS29,Governor,,REP,Greg Abbott,201,159,35,7
+Tom Green,351 BS29,Governor,,DEM,Lupe Valdez,47,21,13,13
+Tom Green,351 BS29,Governor,,LIB,Mark Jay Tippetts,2,2,0,0
+Tom Green,351 BS29,Governor,,,Over Votes,0,0,0,0
+Tom Green,351 BS29,Governor,,,Under Votes,0,0,0,0
+Tom Green,351 BS29,Lieutenant Governor,,REP,Dan Patrick,187,147,33,7
+Tom Green,351 BS29,Lieutenant Governor,,DEM,Mike Collier,59,32,14,13
+Tom Green,351 BS29,Lieutenant Governor,,LIB,Kerry Douglas McKennon,3,2,1,0
+Tom Green,351 BS29,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,351 BS29,Lieutenant Governor,,,Under Votes,1,1,0,0
+Tom Green,351 BS29,Attorney General,,REP,Ken Paxton,185,145,33,7
+Tom Green,351 BS29,Attorney General,,DEM,Justin Nelson,62,36,13,13
+Tom Green,351 BS29,Attorney General,,LIB,Michael Ray Harris,2,1,1,0
+Tom Green,351 BS29,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,351 BS29,Attorney General,,,Under Votes,1,0,1,0
+Tom Green,351 BS29,Comptroller of Public Accounts,,REP,Glenn Hegar,193,150,36,7
+Tom Green,351 BS29,Comptroller of Public Accounts,,DEM,Joi Chevalier,48,25,10,13
+Tom Green,351 BS29,Comptroller of Public Accounts,,LIB,Ben Sanders,6,5,1,0
+Tom Green,351 BS29,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,351 BS29,Comptroller of Public Accounts,,,Under Votes,3,2,1,0
+Tom Green,351 BS29,Commissioner of the General Land Office,,REP,George P. Bush,192,151,34,7
+Tom Green,351 BS29,Commissioner of the General Land Office,,DEM,Miguel Suazo,46,22,11,13
+Tom Green,351 BS29,Commissioner of the General Land Office,,LIB,Matt Pina,10,8,2,0
+Tom Green,351 BS29,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,351 BS29,Commissioner of the General Land Office,,,Under Votes,2,1,1,0
+Tom Green,351 BS29,Commissioner of Agriculture,,REP,Sid Miller,188,146,35,7
+Tom Green,351 BS29,Commissioner of Agriculture,,DEM,Kim Olson,56,33,11,12
+Tom Green,351 BS29,Commissioner of Agriculture,,LIB,Richard Carpenter,2,1,1,0
+Tom Green,351 BS29,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,351 BS29,Commissioner of Agriculture,,,Under Votes,4,2,1,1
+Tom Green,351 BS29,Railroad Commissioner,,REP,Christi Craddick,193,150,36,7
+Tom Green,351 BS29,Railroad Commissioner,,DEM,Roman McAllen,49,26,10,13
+Tom Green,351 BS29,Railroad Commissioner,,LIB,Mike Wright,5,4,1,0
+Tom Green,351 BS29,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,351 BS29,Railroad Commissioner,,,Under Votes,3,2,1,0
+Tom Green,351 BS29,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,197,154,36,7
+Tom Green,351 BS29,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,50,26,11,13
+Tom Green,351 BS29,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,351 BS29,"Justice, Supreme Court, Place 2",,,Under Votes,3,2,1,0
+Tom Green,351 BS29,"Justice, Supreme Court, Place 4",,REP,John Devine,198,155,36,7
+Tom Green,351 BS29,"Justice, Supreme Court, Place 4",,,R. K. Sandill,48,24,11,13
+Tom Green,351 BS29,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,351 BS29,"Justice, Supreme Court, Place 4",,,Under Votes,4,3,1,0
+Tom Green,351 BS29,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,199,156,36,7
+Tom Green,351 BS29,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,48,24,11,13
+Tom Green,351 BS29,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,351 BS29,"Justice, Supreme Court, Place 6",,,Under Votes,3,2,1,0
+Tom Green,351 BS29,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,192,149,36,7
+Tom Green,351 BS29,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,47,24,10,13
+Tom Green,351 BS29,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,7,6,1,0
+Tom Green,351 BS29,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,351 BS29,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,4,3,1,0
+Tom Green,351 BS29,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,201,155,39,7
+Tom Green,351 BS29,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,46,24,9,13
+Tom Green,351 BS29,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,351 BS29,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,3,3,0,0
+Tom Green,351 BS29,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,201,156,36,9
+Tom Green,351 BS29,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,21,12,5,4
+Tom Green,351 BS29,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,351 BS29,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,28,14,7,7
+Tom Green,351 BS29,State Representative,72,REP,Drew Darby,211,162,39,10
+Tom Green,351 BS29,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,351 BS29,State Representative,72,,Under Votes,39,20,9,10
+Tom Green,351 BS29,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,201,156,38,7
+Tom Green,351 BS29,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,46,24,9,13
+Tom Green,351 BS29,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,351 BS29,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,3,2,1,0
+Tom Green,351 BS29,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,199,155,37,7
+Tom Green,351 BS29,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,47,25,10,12
+Tom Green,351 BS29,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,351 BS29,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,4,2,1,1
+Tom Green,351 BS29,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,201,155,39,7
+Tom Green,351 BS29,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,47,25,9,13
+Tom Green,351 BS29,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,351 BS29,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,2,2,0,0
+Tom Green,351 BS29,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",199,155,37,7
+Tom Green,351 BS29,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,47,24,10,13
+Tom Green,351 BS29,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),0,0,0,0
+Tom Green,351 BS29,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,351 BS29,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,4,3,1,0
+Tom Green,351 BS29,San Angelo Independent School District Proposition A,,,FOR,92,61,19,12
+Tom Green,351 BS29,San Angelo Independent School District Proposition A,,,AGAINST,149,114,27,8
+Tom Green,351 BS29,San Angelo Independent School District Proposition A,,,Over Votes,0,0,0,0
+Tom Green,351 BS29,San Angelo Independent School District Proposition A,,,Under Votes,9,7,2,0
+Tom Green,351 BS29,San Angelo Independent School District Proposition B,,,FOR,77,48,17,12
+Tom Green,351 BS29,San Angelo Independent School District Proposition B,,,AGAINST,163,127,28,8
+Tom Green,351 BS29,San Angelo Independent School District Proposition B,,,Over Votes,0,0,0,0
+Tom Green,351 BS29,San Angelo Independent School District Proposition B,,,Under Votes,10,7,3,0
+Tom Green,351 BS29,Ballots Cast,,,,250,182,48,20
+Tom Green,358 BS30,STRAIGHT PARTY,,REP,,84,47,25,12
+Tom Green,358 BS30,STRAIGHT PARTY,,DEM,,10,5,2,3
+Tom Green,358 BS30,STRAIGHT PARTY,,LIB,,0,0,0,0
+Tom Green,358 BS30,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,358 BS30,STRAIGHT PARTY,,,Under Votes,51,28,13,10
+Tom Green,358 BS30,U.S. Senate,,REP,Ted Cruz,124,69,37,18
+Tom Green,358 BS30,U.S. Senate,,DEM,Beto O'Rourke,18,10,2,6
+Tom Green,358 BS30,U.S. Senate,,LIB,Neal M. Dikeman,2,1,0,1
+Tom Green,358 BS30,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,358 BS30,U.S. Senate,,,Under Votes,1,0,1,0
+Tom Green,358 BS30,U.S. House,11,REP,Mike Conaway,124,69,36,19
+Tom Green,358 BS30,U.S. House,11,DEM,Jennie Lou Leeder,16,8,2,6
+Tom Green,358 BS30,U.S. House,11,LIB,Rhett Rosenquest Smith,3,2,1,0
+Tom Green,358 BS30,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,358 BS30,U.S. House,11,,Under Votes,2,1,1,0
+Tom Green,358 BS30,Governor,,REP,Greg Abbott,125,68,37,20
+Tom Green,358 BS30,Governor,,DEM,Lupe Valdez,16,8,3,5
+Tom Green,358 BS30,Governor,,LIB,Mark Jay Tippetts,0,0,0,0
+Tom Green,358 BS30,Governor,,,Over Votes,0,0,0,0
+Tom Green,358 BS30,Governor,,,Under Votes,4,4,0,0
+Tom Green,358 BS30,Lieutenant Governor,,REP,Dan Patrick,119,66,35,18
+Tom Green,358 BS30,Lieutenant Governor,,DEM,Mike Collier,21,10,4,7
+Tom Green,358 BS30,Lieutenant Governor,,LIB,Kerry Douglas McKennon,2,1,1,0
+Tom Green,358 BS30,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,358 BS30,Lieutenant Governor,,,Under Votes,3,3,0,0
+Tom Green,358 BS30,Attorney General,,REP,Ken Paxton,118,65,35,18
+Tom Green,358 BS30,Attorney General,,DEM,Justin Nelson,20,10,4,6
+Tom Green,358 BS30,Attorney General,,LIB,Michael Ray Harris,3,2,0,1
+Tom Green,358 BS30,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,358 BS30,Attorney General,,,Under Votes,4,3,1,0
+Tom Green,358 BS30,Comptroller of Public Accounts,,REP,Glenn Hegar,117,64,35,18
+Tom Green,358 BS30,Comptroller of Public Accounts,,DEM,Joi Chevalier,15,7,2,6
+Tom Green,358 BS30,Comptroller of Public Accounts,,LIB,Ben Sanders,4,3,0,1
+Tom Green,358 BS30,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,358 BS30,Comptroller of Public Accounts,,,Under Votes,9,6,3,0
+Tom Green,358 BS30,Commissioner of the General Land Office,,REP,George P. Bush,117,62,36,19
+Tom Green,358 BS30,Commissioner of the General Land Office,,DEM,Miguel Suazo,18,9,3,6
+Tom Green,358 BS30,Commissioner of the General Land Office,,LIB,Matt Pina,5,4,1,0
+Tom Green,358 BS30,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,358 BS30,Commissioner of the General Land Office,,,Under Votes,5,5,0,0
+Tom Green,358 BS30,Commissioner of Agriculture,,REP,Sid Miller,119,65,36,18
+Tom Green,358 BS30,Commissioner of Agriculture,,DEM,Kim Olson,17,8,2,7
+Tom Green,358 BS30,Commissioner of Agriculture,,LIB,Richard Carpenter,2,2,0,0
+Tom Green,358 BS30,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,358 BS30,Commissioner of Agriculture,,,Under Votes,7,5,2,0
+Tom Green,358 BS30,Railroad Commissioner,,REP,Christi Craddick,117,65,35,17
+Tom Green,358 BS30,Railroad Commissioner,,DEM,Roman McAllen,18,9,3,6
+Tom Green,358 BS30,Railroad Commissioner,,LIB,Mike Wright,3,2,0,1
+Tom Green,358 BS30,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,358 BS30,Railroad Commissioner,,,Under Votes,7,4,2,1
+Tom Green,358 BS30,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,121,68,36,17
+Tom Green,358 BS30,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,17,8,2,7
+Tom Green,358 BS30,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,358 BS30,"Justice, Supreme Court, Place 2",,,Under Votes,7,4,2,1
+Tom Green,358 BS30,"Justice, Supreme Court, Place 4",,REP,John Devine,120,68,36,16
+Tom Green,358 BS30,"Justice, Supreme Court, Place 4",,,R. K. Sandill,18,8,3,7
+Tom Green,358 BS30,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,358 BS30,"Justice, Supreme Court, Place 4",,,Under Votes,7,4,1,2
+Tom Green,358 BS30,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,120,67,36,17
+Tom Green,358 BS30,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,17,8,2,7
+Tom Green,358 BS30,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,358 BS30,"Justice, Supreme Court, Place 6",,,Under Votes,8,5,2,1
+Tom Green,358 BS30,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,116,65,36,15
+Tom Green,358 BS30,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,16,8,3,5
+Tom Green,358 BS30,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,5,2,0,3
+Tom Green,358 BS30,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,358 BS30,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,8,5,1,2
+Tom Green,358 BS30,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,121,67,36,18
+Tom Green,358 BS30,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,18,9,3,6
+Tom Green,358 BS30,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,358 BS30,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,6,4,1,1
+Tom Green,358 BS30,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,118,65,36,17
+Tom Green,358 BS30,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,15,10,1,4
+Tom Green,358 BS30,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,358 BS30,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,12,5,3,4
+Tom Green,358 BS30,State Representative,72,REP,Drew Darby,127,70,36,21
+Tom Green,358 BS30,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,358 BS30,State Representative,72,,Under Votes,18,10,4,4
+Tom Green,358 BS30,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,122,67,36,19
+Tom Green,358 BS30,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,17,9,3,5
+Tom Green,358 BS30,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,358 BS30,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,6,4,1,1
+Tom Green,358 BS30,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,122,68,36,18
+Tom Green,358 BS30,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,17,8,3,6
+Tom Green,358 BS30,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,358 BS30,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,6,4,1,1
+Tom Green,358 BS30,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,121,66,36,19
+Tom Green,358 BS30,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,17,10,2,5
+Tom Green,358 BS30,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,358 BS30,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,7,4,2,1
+Tom Green,358 BS30,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",119,67,36,16
+Tom Green,358 BS30,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,17,9,3,5
+Tom Green,358 BS30,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),1,0,0,1
+Tom Green,358 BS30,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,358 BS30,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,8,4,1,3
+Tom Green,358 BS30,San Angelo Independent School District Proposition A,,,FOR,50,31,10,9
+Tom Green,358 BS30,San Angelo Independent School District Proposition A,,,AGAINST,80,41,26,13
+Tom Green,358 BS30,San Angelo Independent School District Proposition A,,,Over Votes,0,0,0,0
+Tom Green,358 BS30,San Angelo Independent School District Proposition A,,,Under Votes,15,8,4,3
+Tom Green,358 BS30,San Angelo Independent School District Proposition B,,,FOR,45,26,11,8
+Tom Green,358 BS30,San Angelo Independent School District Proposition B,,,AGAINST,84,46,25,13
+Tom Green,358 BS30,San Angelo Independent School District Proposition B,,,Over Votes,0,0,0,0
+Tom Green,358 BS30,San Angelo Independent School District Proposition B,,,Under Votes,16,8,4,4
+Tom Green,358 BS30,Ballots Cast,,,,145,80,40,25
+Tom Green,358 BS31,STRAIGHT PARTY,,REP,,853,401,394,58
+Tom Green,358 BS31,STRAIGHT PARTY,,DEM,,129,68,46,15
+Tom Green,358 BS31,STRAIGHT PARTY,,LIB,,4,2,2,0
+Tom Green,358 BS31,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,358 BS31,STRAIGHT PARTY,,,Under Votes,593,319,229,45
+Tom Green,358 BS31,U.S. Senate,,REP,Ted Cruz,1307,658,560,89
+Tom Green,358 BS31,U.S. Senate,,DEM,Beto O'Rourke,246,122,99,25
+Tom Green,358 BS31,U.S. Senate,,LIB,Neal M. Dikeman,8,3,5,0
+Tom Green,358 BS31,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,358 BS31,U.S. Senate,,,Under Votes,18,7,7,4
+Tom Green,358 BS31,U.S. House,11,REP,Mike Conaway,1333,661,580,92
+Tom Green,358 BS31,U.S. House,11,DEM,Jennie Lou Leeder,213,111,76,26
+Tom Green,358 BS31,U.S. House,11,LIB,Rhett Rosenquest Smith,17,9,8,0
+Tom Green,358 BS31,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,358 BS31,U.S. House,11,,Under Votes,16,9,7,0
+Tom Green,358 BS31,Governor,,REP,Greg Abbott,1330,664,574,92
+Tom Green,358 BS31,Governor,,DEM,Lupe Valdez,226,120,83,23
+Tom Green,358 BS31,Governor,,LIB,Mark Jay Tippetts,13,4,8,1
+Tom Green,358 BS31,Governor,,,Over Votes,0,0,0,0
+Tom Green,358 BS31,Governor,,,Under Votes,10,2,6,2
+Tom Green,358 BS31,Lieutenant Governor,,REP,Dan Patrick,1252,630,529,93
+Tom Green,358 BS31,Lieutenant Governor,,DEM,Mike Collier,278,141,114,23
+Tom Green,358 BS31,Lieutenant Governor,,LIB,Kerry Douglas McKennon,28,12,15,1
+Tom Green,358 BS31,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,358 BS31,Lieutenant Governor,,,Under Votes,21,7,13,1
+Tom Green,358 BS31,Attorney General,,REP,Ken Paxton,1283,638,553,92
+Tom Green,358 BS31,Attorney General,,DEM,Justin Nelson,254,130,100,24
+Tom Green,358 BS31,Attorney General,,LIB,Michael Ray Harris,26,16,9,1
+Tom Green,358 BS31,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,358 BS31,Attorney General,,,Under Votes,16,6,9,1
+Tom Green,358 BS31,Comptroller of Public Accounts,,REP,Glenn Hegar,1295,650,554,91
+Tom Green,358 BS31,Comptroller of Public Accounts,,DEM,Joi Chevalier,221,113,83,25
+Tom Green,358 BS31,Comptroller of Public Accounts,,LIB,Ben Sanders,39,17,21,1
+Tom Green,358 BS31,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,358 BS31,Comptroller of Public Accounts,,,Under Votes,24,10,13,1
+Tom Green,358 BS31,Commissioner of the General Land Office,,REP,George P. Bush,1268,625,555,88
+Tom Green,358 BS31,Commissioner of the General Land Office,,DEM,Miguel Suazo,222,116,80,26
+Tom Green,358 BS31,Commissioner of the General Land Office,,LIB,Matt Pina,62,35,25,2
+Tom Green,358 BS31,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,358 BS31,Commissioner of the General Land Office,,,Under Votes,27,14,11,2
+Tom Green,358 BS31,Commissioner of Agriculture,,REP,Sid Miller,1289,648,552,89
+Tom Green,358 BS31,Commissioner of Agriculture,,DEM,Kim Olson,240,119,94,27
+Tom Green,358 BS31,Commissioner of Agriculture,,LIB,Richard Carpenter,28,14,13,1
+Tom Green,358 BS31,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,358 BS31,Commissioner of Agriculture,,,Under Votes,22,9,12,1
+Tom Green,358 BS31,Railroad Commissioner,,REP,Christi Craddick,1294,647,559,88
+Tom Green,358 BS31,Railroad Commissioner,,DEM,Roman McAllen,216,113,77,26
+Tom Green,358 BS31,Railroad Commissioner,,LIB,Mike Wright,45,21,21,3
+Tom Green,358 BS31,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,358 BS31,Railroad Commissioner,,,Under Votes,24,9,14,1
+Tom Green,358 BS31,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1310,659,563,88
+Tom Green,358 BS31,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,242,120,94,28
+Tom Green,358 BS31,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,358 BS31,"Justice, Supreme Court, Place 2",,,Under Votes,27,11,14,2
+Tom Green,358 BS31,"Justice, Supreme Court, Place 4",,REP,John Devine,1316,660,566,90
+Tom Green,358 BS31,"Justice, Supreme Court, Place 4",,,R. K. Sandill,236,119,91,26
+Tom Green,358 BS31,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,358 BS31,"Justice, Supreme Court, Place 4",,,Under Votes,27,11,14,2
+Tom Green,358 BS31,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1318,660,567,91
+Tom Green,358 BS31,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,236,120,90,26
+Tom Green,358 BS31,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,358 BS31,"Justice, Supreme Court, Place 6",,,Under Votes,25,10,14,1
+Tom Green,358 BS31,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1290,649,551,90
+Tom Green,358 BS31,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,234,118,88,28
+Tom Green,358 BS31,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,27,9,18,0
+Tom Green,358 BS31,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,358 BS31,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,28,14,14,0
+Tom Green,358 BS31,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1322,657,573,92
+Tom Green,358 BS31,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,229,121,84,24
+Tom Green,358 BS31,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,358 BS31,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,28,12,14,2
+Tom Green,358 BS31,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1349,670,585,94
+Tom Green,358 BS31,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,93,51,34,8
+Tom Green,358 BS31,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,358 BS31,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,137,69,52,16
+Tom Green,358 BS31,State Representative,72,REP,Drew Darby,1381,686,601,94
+Tom Green,358 BS31,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,358 BS31,State Representative,72,,Under Votes,198,104,70,24
+Tom Green,358 BS31,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,1317,660,564,93
+Tom Green,358 BS31,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,231,115,91,25
+Tom Green,358 BS31,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,358 BS31,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,31,15,16,0
+Tom Green,358 BS31,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,1315,658,567,90
+Tom Green,358 BS31,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,231,116,89,26
+Tom Green,358 BS31,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,358 BS31,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,33,16,15,2
+Tom Green,358 BS31,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,1304,658,559,87
+Tom Green,358 BS31,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,241,117,96,28
+Tom Green,358 BS31,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,358 BS31,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,34,15,16,3
+Tom Green,358 BS31,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",1317,658,568,91
+Tom Green,358 BS31,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,231,118,87,26
+Tom Green,358 BS31,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),1,1,0,0
+Tom Green,358 BS31,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,358 BS31,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,30,13,16,1
+Tom Green,358 BS31,Ballots Cast,,,,1579,790,671,118
+Tom Green,358 BS32,STRAIGHT PARTY,,REP,,336,191,124,21
+Tom Green,358 BS32,STRAIGHT PARTY,,DEM,,34,16,10,8
+Tom Green,358 BS32,STRAIGHT PARTY,,LIB,,1,1,0,0
+Tom Green,358 BS32,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,358 BS32,STRAIGHT PARTY,,,Under Votes,297,168,103,26
+Tom Green,358 BS32,U.S. Senate,,REP,Ted Cruz,570,322,212,36
+Tom Green,358 BS32,U.S. Senate,,DEM,Beto O'Rourke,88,49,22,17
+Tom Green,358 BS32,U.S. Senate,,LIB,Neal M. Dikeman,6,2,2,2
+Tom Green,358 BS32,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,358 BS32,U.S. Senate,,,Under Votes,4,3,1,0
+Tom Green,358 BS32,U.S. House,11,REP,Mike Conaway,587,333,215,39
+Tom Green,358 BS32,U.S. House,11,DEM,Jennie Lou Leeder,64,36,15,13
+Tom Green,358 BS32,U.S. House,11,LIB,Rhett Rosenquest Smith,5,1,3,1
+Tom Green,358 BS32,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,358 BS32,U.S. House,11,,Under Votes,12,6,4,2
+Tom Green,358 BS32,Governor,,REP,Greg Abbott,579,331,212,36
+Tom Green,358 BS32,Governor,,DEM,Lupe Valdez,67,37,17,13
+Tom Green,358 BS32,Governor,,LIB,Mark Jay Tippetts,13,2,6,5
+Tom Green,358 BS32,Governor,,,Over Votes,0,0,0,0
+Tom Green,358 BS32,Governor,,,Under Votes,9,6,2,1
+Tom Green,358 BS32,Lieutenant Governor,,REP,Dan Patrick,516,298,183,35
+Tom Green,358 BS32,Lieutenant Governor,,DEM,Mike Collier,126,66,45,15
+Tom Green,358 BS32,Lieutenant Governor,,LIB,Kerry Douglas McKennon,16,6,6,4
+Tom Green,358 BS32,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,358 BS32,Lieutenant Governor,,,Under Votes,10,6,3,1
+Tom Green,358 BS32,Attorney General,,REP,Ken Paxton,550,316,201,33
+Tom Green,358 BS32,Attorney General,,DEM,Justin Nelson,94,47,30,17
+Tom Green,358 BS32,Attorney General,,LIB,Michael Ray Harris,12,5,4,3
+Tom Green,358 BS32,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,358 BS32,Attorney General,,,Under Votes,12,8,2,2
+Tom Green,358 BS32,Comptroller of Public Accounts,,REP,Glenn Hegar,563,323,208,32
+Tom Green,358 BS32,Comptroller of Public Accounts,,DEM,Joi Chevalier,73,40,19,14
+Tom Green,358 BS32,Comptroller of Public Accounts,,LIB,Ben Sanders,17,6,6,5
+Tom Green,358 BS32,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,358 BS32,Comptroller of Public Accounts,,,Under Votes,15,7,4,4
+Tom Green,358 BS32,Commissioner of the General Land Office,,REP,George P. Bush,565,323,207,35
+Tom Green,358 BS32,Commissioner of the General Land Office,,DEM,Miguel Suazo,72,42,16,14
+Tom Green,358 BS32,Commissioner of the General Land Office,,LIB,Matt Pina,19,6,10,3
+Tom Green,358 BS32,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,358 BS32,Commissioner of the General Land Office,,,Under Votes,12,5,4,3
+Tom Green,358 BS32,Commissioner of Agriculture,,REP,Sid Miller,561,326,204,31
+Tom Green,358 BS32,Commissioner of Agriculture,,DEM,Kim Olson,84,41,26,17
+Tom Green,358 BS32,Commissioner of Agriculture,,LIB,Richard Carpenter,9,1,4,4
+Tom Green,358 BS32,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,358 BS32,Commissioner of Agriculture,,,Under Votes,14,8,3,3
+Tom Green,358 BS32,Railroad Commissioner,,REP,Christi Craddick,565,324,209,32
+Tom Green,358 BS32,Railroad Commissioner,,DEM,Roman McAllen,72,38,18,16
+Tom Green,358 BS32,Railroad Commissioner,,LIB,Mike Wright,17,7,7,3
+Tom Green,358 BS32,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,358 BS32,Railroad Commissioner,,,Under Votes,14,7,3,4
+Tom Green,358 BS32,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,570,322,211,37
+Tom Green,358 BS32,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,81,44,20,17
+Tom Green,358 BS32,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,358 BS32,"Justice, Supreme Court, Place 2",,,Under Votes,17,10,6,1
+Tom Green,358 BS32,"Justice, Supreme Court, Place 4",,REP,John Devine,567,322,210,35
+Tom Green,358 BS32,"Justice, Supreme Court, Place 4",,,R. K. Sandill,82,43,21,18
+Tom Green,358 BS32,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,358 BS32,"Justice, Supreme Court, Place 4",,,Under Votes,19,11,6,2
+Tom Green,358 BS32,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,574,326,212,36
+Tom Green,358 BS32,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,77,41,19,17
+Tom Green,358 BS32,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,358 BS32,"Justice, Supreme Court, Place 6",,,Under Votes,17,9,6,2
+Tom Green,358 BS32,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,561,321,208,32
+Tom Green,358 BS32,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,77,40,19,18
+Tom Green,358 BS32,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,14,7,4,3
+Tom Green,358 BS32,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,358 BS32,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,16,8,6,2
+Tom Green,358 BS32,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,576,325,213,38
+Tom Green,358 BS32,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,72,41,16,15
+Tom Green,358 BS32,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,358 BS32,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,20,10,8,2
+Tom Green,358 BS32,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,576,330,210,36
+Tom Green,358 BS32,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,47,23,14,10
+Tom Green,358 BS32,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,358 BS32,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,45,23,13,9
+Tom Green,358 BS32,State Representative,72,REP,Drew Darby,600,340,219,41
+Tom Green,358 BS32,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,358 BS32,State Representative,72,,Under Votes,68,36,18,14
+Tom Green,358 BS32,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,570,322,210,38
+Tom Green,358 BS32,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,76,43,20,13
+Tom Green,358 BS32,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,358 BS32,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,22,11,7,4
+Tom Green,358 BS32,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,564,320,210,34
+Tom Green,358 BS32,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,83,46,20,17
+Tom Green,358 BS32,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,358 BS32,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,21,10,7,4
+Tom Green,358 BS32,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,572,323,213,36
+Tom Green,358 BS32,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,78,44,18,16
+Tom Green,358 BS32,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,358 BS32,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,18,9,6,3
+Tom Green,358 BS32,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",569,321,212,36
+Tom Green,358 BS32,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,76,43,18,15
+Tom Green,358 BS32,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),2,1,0,1
+Tom Green,358 BS32,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,358 BS32,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,21,11,7,3
+Tom Green,358 BS32,Water Valley Independent School District Board of Trustees Election,,,Angela Bloss,193,109,78,6
+Tom Green,358 BS32,Water Valley Independent School District Board of Trustees Election,,,Carl McCoy,76,40,30,6
+Tom Green,358 BS32,Water Valley Independent School District Board of Trustees Election,,,Wes Sutton,232,132,89,11
+Tom Green,358 BS32,Water Valley Independent School District Board of Trustees Election,,,Janna Sears Naylor,263,156,89,18
+Tom Green,358 BS32,Water Valley Independent School District Board of Trustees Election,,,Justin Herman,272,145,116,11
+Tom Green,358 BS32,Water Valley Independent School District Board of Trustees Election,,,Colby Lacy,222,125,88,9
+Tom Green,358 BS32,Water Valley Independent School District Board of Trustees Election,,,Over Votes,0,0,0,0
+Tom Green,358 BS32,Water Valley Independent School District Board of Trustees Election,,,Under Votes,746,421,221,104
+Tom Green,358 BS32,Ballots Cast,,,,668,376,237,55
+Tom Green,401 BS33,STRAIGHT PARTY,,REP,,35,19,12,4
+Tom Green,401 BS33,STRAIGHT PARTY,,DEM,,18,10,8,0
+Tom Green,401 BS33,STRAIGHT PARTY,,LIB,,1,1,0,0
+Tom Green,401 BS33,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,401 BS33,STRAIGHT PARTY,,,Under Votes,28,18,4,6
+Tom Green,401 BS33,U.S. Senate,,REP,Ted Cruz,51,28,15,8
+Tom Green,401 BS33,U.S. Senate,,DEM,Beto O'Rourke,30,19,9,2
+Tom Green,401 BS33,U.S. Senate,,LIB,Neal M. Dikeman,1,1,0,0
+Tom Green,401 BS33,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,401 BS33,U.S. Senate,,,Under Votes,0,0,0,0
+Tom Green,401 BS33,U.S. House,11,REP,Mike Conaway,53,29,15,9
+Tom Green,401 BS33,U.S. House,11,DEM,Jennie Lou Leeder,27,17,9,1
+Tom Green,401 BS33,U.S. House,11,LIB,Rhett Rosenquest Smith,1,1,0,0
+Tom Green,401 BS33,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,401 BS33,U.S. House,11,,Under Votes,1,1,0,0
+Tom Green,401 BS33,Governor,,REP,Greg Abbott,55,31,15,9
+Tom Green,401 BS33,Governor,,DEM,Lupe Valdez,27,17,9,1
+Tom Green,401 BS33,Governor,,LIB,Mark Jay Tippetts,0,0,0,0
+Tom Green,401 BS33,Governor,,,Over Votes,0,0,0,0
+Tom Green,401 BS33,Governor,,,Under Votes,0,0,0,0
+Tom Green,401 BS33,Lieutenant Governor,,REP,Dan Patrick,50,26,15,9
+Tom Green,401 BS33,Lieutenant Governor,,DEM,Mike Collier,29,19,9,1
+Tom Green,401 BS33,Lieutenant Governor,,LIB,Kerry Douglas McKennon,2,2,0,0
+Tom Green,401 BS33,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,401 BS33,Lieutenant Governor,,,Under Votes,1,1,0,0
+Tom Green,401 BS33,Attorney General,,REP,Ken Paxton,51,28,15,8
+Tom Green,401 BS33,Attorney General,,DEM,Justin Nelson,28,18,9,1
+Tom Green,401 BS33,Attorney General,,LIB,Michael Ray Harris,0,0,0,0
+Tom Green,401 BS33,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,401 BS33,Attorney General,,,Under Votes,3,2,0,1
+Tom Green,401 BS33,Comptroller of Public Accounts,,REP,Glenn Hegar,52,29,15,8
+Tom Green,401 BS33,Comptroller of Public Accounts,,DEM,Joi Chevalier,25,15,9,1
+Tom Green,401 BS33,Comptroller of Public Accounts,,LIB,Ben Sanders,3,3,0,0
+Tom Green,401 BS33,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,401 BS33,Comptroller of Public Accounts,,,Under Votes,2,1,0,1
+Tom Green,401 BS33,Commissioner of the General Land Office,,REP,George P. Bush,55,31,15,9
+Tom Green,401 BS33,Commissioner of the General Land Office,,DEM,Miguel Suazo,24,14,9,1
+Tom Green,401 BS33,Commissioner of the General Land Office,,LIB,Matt Pina,2,2,0,0
+Tom Green,401 BS33,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,401 BS33,Commissioner of the General Land Office,,,Under Votes,1,1,0,0
+Tom Green,401 BS33,Commissioner of Agriculture,,REP,Sid Miller,53,29,15,9
+Tom Green,401 BS33,Commissioner of Agriculture,,DEM,Kim Olson,27,17,9,1
+Tom Green,401 BS33,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0,0
+Tom Green,401 BS33,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,401 BS33,Commissioner of Agriculture,,,Under Votes,2,2,0,0
+Tom Green,401 BS33,Railroad Commissioner,,REP,Christi Craddick,54,31,15,8
+Tom Green,401 BS33,Railroad Commissioner,,DEM,Roman McAllen,25,15,9,1
+Tom Green,401 BS33,Railroad Commissioner,,LIB,Mike Wright,0,0,0,0
+Tom Green,401 BS33,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,401 BS33,Railroad Commissioner,,,Under Votes,3,2,0,1
+Tom Green,401 BS33,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,51,28,15,8
+Tom Green,401 BS33,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,27,17,9,1
+Tom Green,401 BS33,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,401 BS33,"Justice, Supreme Court, Place 2",,,Under Votes,4,3,0,1
+Tom Green,401 BS33,"Justice, Supreme Court, Place 4",,REP,John Devine,51,28,15,8
+Tom Green,401 BS33,"Justice, Supreme Court, Place 4",,,R. K. Sandill,28,18,9,1
+Tom Green,401 BS33,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,401 BS33,"Justice, Supreme Court, Place 4",,,Under Votes,3,2,0,1
+Tom Green,401 BS33,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,51,28,15,8
+Tom Green,401 BS33,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,28,18,9,1
+Tom Green,401 BS33,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,401 BS33,"Justice, Supreme Court, Place 6",,,Under Votes,3,2,0,1
+Tom Green,401 BS33,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,51,28,15,8
+Tom Green,401 BS33,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,28,17,9,2
+Tom Green,401 BS33,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,0,0,0,0
+Tom Green,401 BS33,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,401 BS33,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,3,3,0,0
+Tom Green,401 BS33,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,51,28,15,8
+Tom Green,401 BS33,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,28,18,9,1
+Tom Green,401 BS33,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,401 BS33,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,3,2,0,1
+Tom Green,401 BS33,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,56,33,15,8
+Tom Green,401 BS33,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,11,5,5,1
+Tom Green,401 BS33,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,401 BS33,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,15,10,4,1
+Tom Green,401 BS33,State Representative,72,REP,Drew Darby,60,36,16,8
+Tom Green,401 BS33,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,401 BS33,State Representative,72,,Under Votes,22,12,8,2
+Tom Green,401 BS33,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,52,29,15,8
+Tom Green,401 BS33,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,26,16,9,1
+Tom Green,401 BS33,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,401 BS33,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,4,3,0,1
+Tom Green,401 BS33,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,51,28,15,8
+Tom Green,401 BS33,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,27,17,9,1
+Tom Green,401 BS33,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,401 BS33,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,4,3,0,1
+Tom Green,401 BS33,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,52,29,15,8
+Tom Green,401 BS33,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,26,16,9,1
+Tom Green,401 BS33,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,401 BS33,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,4,3,0,1
+Tom Green,401 BS33,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",51,28,15,8
+Tom Green,401 BS33,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,27,17,9,1
+Tom Green,401 BS33,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),1,1,0,0
+Tom Green,401 BS33,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,401 BS33,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,3,2,0,1
+Tom Green,401 BS33,County Commissioner Pct.4,,REP,Bill Ford,55,34,14,7
+Tom Green,401 BS33,County Commissioner Pct.4,,,Gilbert Gallegos (W),6,4,1,1
+Tom Green,401 BS33,County Commissioner Pct.4,,,Over Votes,0,0,0,0
+Tom Green,401 BS33,County Commissioner Pct.4,,,Under Votes,21,10,9,2
+Tom Green,401 BS33,San Angelo Independent School District Proposition A,,,FOR,39,24,10,5
+Tom Green,401 BS33,San Angelo Independent School District Proposition A,,,AGAINST,35,20,13,2
+Tom Green,401 BS33,San Angelo Independent School District Proposition A,,,Over Votes,0,0,0,0
+Tom Green,401 BS33,San Angelo Independent School District Proposition A,,,Under Votes,8,4,1,3
+Tom Green,401 BS33,San Angelo Independent School District Proposition B,,,FOR,36,19,12,5
+Tom Green,401 BS33,San Angelo Independent School District Proposition B,,,AGAINST,36,23,11,2
+Tom Green,401 BS33,San Angelo Independent School District Proposition B,,,Over Votes,0,0,0,0
+Tom Green,401 BS33,San Angelo Independent School District Proposition B,,,Under Votes,10,6,1,3
+Tom Green,401 BS33,Ballots Cast,,,,82,48,24,10
+Tom Green,402 BS34,STRAIGHT PARTY,,REP,,580,342,192,46
+Tom Green,402 BS34,STRAIGHT PARTY,,DEM,,300,171,112,17
+Tom Green,402 BS34,STRAIGHT PARTY,,LIB,,8,5,3,0
+Tom Green,402 BS34,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,402 BS34,STRAIGHT PARTY,,,Under Votes,776,526,195,55
+Tom Green,402 BS34,U.S. Senate,,REP,Ted Cruz,1005,639,293,73
+Tom Green,402 BS34,U.S. Senate,,DEM,Beto O'Rourke,623,383,200,40
+Tom Green,402 BS34,U.S. Senate,,LIB,Neal M. Dikeman,12,5,6,1
+Tom Green,402 BS34,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,402 BS34,U.S. Senate,,,Under Votes,24,17,3,4
+Tom Green,402 BS34,U.S. House,11,REP,Mike Conaway,1099,698,325,76
+Tom Green,402 BS34,U.S. House,11,DEM,Jennie Lou Leeder,512,306,167,39
+Tom Green,402 BS34,U.S. House,11,LIB,Rhett Rosenquest Smith,24,18,5,1
+Tom Green,402 BS34,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,402 BS34,U.S. House,11,,Under Votes,29,22,5,2
+Tom Green,402 BS34,Governor,,REP,Greg Abbott,1086,691,317,78
+Tom Green,402 BS34,Governor,,DEM,Lupe Valdez,541,328,173,40
+Tom Green,402 BS34,Governor,,LIB,Mark Jay Tippetts,25,18,7,0
+Tom Green,402 BS34,Governor,,,Over Votes,0,0,0,0
+Tom Green,402 BS34,Governor,,,Under Votes,12,7,5,0
+Tom Green,402 BS34,Lieutenant Governor,,REP,Dan Patrick,976,613,289,74
+Tom Green,402 BS34,Lieutenant Governor,,DEM,Mike Collier,616,388,185,43
+Tom Green,402 BS34,Lieutenant Governor,,LIB,Kerry Douglas McKennon,42,25,16,1
+Tom Green,402 BS34,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,402 BS34,Lieutenant Governor,,,Under Votes,30,18,12,0
+Tom Green,402 BS34,Attorney General,,REP,Ken Paxton,977,623,285,69
+Tom Green,402 BS34,Attorney General,,DEM,Justin Nelson,607,375,186,46
+Tom Green,402 BS34,Attorney General,,LIB,Michael Ray Harris,50,29,21,0
+Tom Green,402 BS34,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,402 BS34,Attorney General,,,Under Votes,30,17,10,3
+Tom Green,402 BS34,Comptroller of Public Accounts,,REP,Glenn Hegar,1015,649,295,71
+Tom Green,402 BS34,Comptroller of Public Accounts,,DEM,Joi Chevalier,531,323,166,42
+Tom Green,402 BS34,Comptroller of Public Accounts,,LIB,Ben Sanders,64,36,27,1
+Tom Green,402 BS34,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,402 BS34,Comptroller of Public Accounts,,,Under Votes,54,36,14,4
+Tom Green,402 BS34,Commissioner of the General Land Office,,REP,George P. Bush,1047,667,304,76
+Tom Green,402 BS34,Commissioner of the General Land Office,,DEM,Miguel Suazo,499,302,159,38
+Tom Green,402 BS34,Commissioner of the General Land Office,,LIB,Matt Pina,75,47,27,1
+Tom Green,402 BS34,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,402 BS34,Commissioner of the General Land Office,,,Under Votes,43,28,12,3
+Tom Green,402 BS34,Commissioner of Agriculture,,REP,Sid Miller,985,625,291,69
+Tom Green,402 BS34,Commissioner of Agriculture,,DEM,Kim Olson,582,354,185,43
+Tom Green,402 BS34,Commissioner of Agriculture,,LIB,Richard Carpenter,43,28,14,1
+Tom Green,402 BS34,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,402 BS34,Commissioner of Agriculture,,,Under Votes,54,37,12,5
+Tom Green,402 BS34,Railroad Commissioner,,REP,Christi Craddick,1027,656,302,69
+Tom Green,402 BS34,Railroad Commissioner,,DEM,Roman McAllen,529,318,169,42
+Tom Green,402 BS34,Railroad Commissioner,,LIB,Mike Wright,59,41,17,1
+Tom Green,402 BS34,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,402 BS34,Railroad Commissioner,,,Under Votes,49,29,14,6
+Tom Green,402 BS34,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1022,649,303,70
+Tom Green,402 BS34,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,594,364,187,43
+Tom Green,402 BS34,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,402 BS34,"Justice, Supreme Court, Place 2",,,Under Votes,48,31,12,5
+Tom Green,402 BS34,"Justice, Supreme Court, Place 4",,REP,John Devine,1040,663,305,72
+Tom Green,402 BS34,"Justice, Supreme Court, Place 4",,,R. K. Sandill,572,349,185,38
+Tom Green,402 BS34,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,402 BS34,"Justice, Supreme Court, Place 4",,,Under Votes,52,32,12,8
+Tom Green,402 BS34,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1035,660,305,70
+Tom Green,402 BS34,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,580,353,185,42
+Tom Green,402 BS34,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,402 BS34,"Justice, Supreme Court, Place 6",,,Under Votes,49,31,12,6
+Tom Green,402 BS34,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1017,654,292,71
+Tom Green,402 BS34,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,564,344,179,41
+Tom Green,402 BS34,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,35,19,16,0
+Tom Green,402 BS34,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,402 BS34,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,48,27,15,6
+Tom Green,402 BS34,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1053,680,303,70
+Tom Green,402 BS34,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,556,328,186,42
+Tom Green,402 BS34,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,402 BS34,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,55,36,13,6
+Tom Green,402 BS34,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1133,711,345,77
+Tom Green,402 BS34,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,261,174,74,13
+Tom Green,402 BS34,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,402 BS34,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,270,159,83,28
+Tom Green,402 BS34,State Representative,72,REP,Drew Darby,1242,783,376,83
+Tom Green,402 BS34,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,402 BS34,State Representative,72,,Under Votes,422,261,126,35
+Tom Green,402 BS34,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,1053,667,313,73
+Tom Green,402 BS34,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,541,330,172,39
+Tom Green,402 BS34,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,402 BS34,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,70,47,17,6
+Tom Green,402 BS34,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,1027,655,304,68
+Tom Green,402 BS34,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,569,346,181,42
+Tom Green,402 BS34,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,402 BS34,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,68,43,17,8
+Tom Green,402 BS34,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,1025,655,302,68
+Tom Green,402 BS34,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,565,341,183,41
+Tom Green,402 BS34,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,402 BS34,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,74,48,17,9
+Tom Green,402 BS34,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",1018,646,303,69
+Tom Green,402 BS34,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,570,345,184,41
+Tom Green,402 BS34,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),2,1,0,1
+Tom Green,402 BS34,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,402 BS34,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,74,52,15,7
+Tom Green,402 BS34,County Commissioner Pct.4,,REP,Bill Ford,1143,708,361,74
+Tom Green,402 BS34,County Commissioner Pct.4,,,Gilbert Gallegos (W),121,82,18,21
+Tom Green,402 BS34,County Commissioner Pct.4,,,Over Votes,0,0,0,0
+Tom Green,402 BS34,County Commissioner Pct.4,,,Under Votes,400,254,123,23
+Tom Green,402 BS34,San Angelo Independent School District Proposition A,,,FOR,781,481,245,55
+Tom Green,402 BS34,San Angelo Independent School District Proposition A,,,AGAINST,736,467,217,52
+Tom Green,402 BS34,San Angelo Independent School District Proposition A,,,Over Votes,0,0,0,0
+Tom Green,402 BS34,San Angelo Independent School District Proposition A,,,Under Votes,147,96,40,11
+Tom Green,402 BS34,San Angelo Independent School District Proposition B,,,FOR,752,461,246,45
+Tom Green,402 BS34,San Angelo Independent School District Proposition B,,,AGAINST,769,491,217,61
+Tom Green,402 BS34,San Angelo Independent School District Proposition B,,,Over Votes,0,0,0,0
+Tom Green,402 BS34,San Angelo Independent School District Proposition B,,,Under Votes,143,92,39,12
+Tom Green,402 BS34,Ballots Cast,,,,1664,1044,502,118
+Tom Green,420 BS35,STRAIGHT PARTY,,REP,,140,105,32,3
+Tom Green,420 BS35,STRAIGHT PARTY,,DEM,,15,10,5,0
+Tom Green,420 BS35,STRAIGHT PARTY,,LIB,,0,0,0,0
+Tom Green,420 BS35,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,420 BS35,STRAIGHT PARTY,,,Under Votes,141,103,35,3
+Tom Green,420 BS35,U.S. Senate,,REP,Ted Cruz,242,182,54,6
+Tom Green,420 BS35,U.S. Senate,,DEM,Beto O'Rourke,51,33,18,0
+Tom Green,420 BS35,U.S. Senate,,LIB,Neal M. Dikeman,1,1,0,0
+Tom Green,420 BS35,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,420 BS35,U.S. Senate,,,Under Votes,2,2,0,0
+Tom Green,420 BS35,U.S. House,11,REP,Mike Conaway,247,188,53,6
+Tom Green,420 BS35,U.S. House,11,DEM,Jennie Lou Leeder,41,25,16,0
+Tom Green,420 BS35,U.S. House,11,LIB,Rhett Rosenquest Smith,5,2,3,0
+Tom Green,420 BS35,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,420 BS35,U.S. House,11,,Under Votes,3,3,0,0
+Tom Green,420 BS35,Governor,,REP,Greg Abbott,251,188,57,6
+Tom Green,420 BS35,Governor,,DEM,Lupe Valdez,39,24,15,0
+Tom Green,420 BS35,Governor,,LIB,Mark Jay Tippetts,4,4,0,0
+Tom Green,420 BS35,Governor,,,Over Votes,0,0,0,0
+Tom Green,420 BS35,Governor,,,Under Votes,2,2,0,0
+Tom Green,420 BS35,Lieutenant Governor,,REP,Dan Patrick,222,164,52,6
+Tom Green,420 BS35,Lieutenant Governor,,DEM,Mike Collier,58,41,17,0
+Tom Green,420 BS35,Lieutenant Governor,,LIB,Kerry Douglas McKennon,9,7,2,0
+Tom Green,420 BS35,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,420 BS35,Lieutenant Governor,,,Under Votes,7,6,1,0
+Tom Green,420 BS35,Attorney General,,REP,Ken Paxton,228,171,51,6
+Tom Green,420 BS35,Attorney General,,DEM,Justin Nelson,51,35,16,0
+Tom Green,420 BS35,Attorney General,,LIB,Michael Ray Harris,11,8,3,0
+Tom Green,420 BS35,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,420 BS35,Attorney General,,,Under Votes,6,4,2,0
+Tom Green,420 BS35,Comptroller of Public Accounts,,REP,Glenn Hegar,239,178,55,6
+Tom Green,420 BS35,Comptroller of Public Accounts,,DEM,Joi Chevalier,33,22,11,0
+Tom Green,420 BS35,Comptroller of Public Accounts,,LIB,Ben Sanders,12,9,3,0
+Tom Green,420 BS35,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,420 BS35,Comptroller of Public Accounts,,,Under Votes,12,9,3,0
+Tom Green,420 BS35,Commissioner of the General Land Office,,REP,George P. Bush,248,183,59,6
+Tom Green,420 BS35,Commissioner of the General Land Office,,DEM,Miguel Suazo,31,20,11,0
+Tom Green,420 BS35,Commissioner of the General Land Office,,LIB,Matt Pina,10,9,1,0
+Tom Green,420 BS35,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,420 BS35,Commissioner of the General Land Office,,,Under Votes,7,6,1,0
+Tom Green,420 BS35,Commissioner of Agriculture,,REP,Sid Miller,233,176,51,6
+Tom Green,420 BS35,Commissioner of Agriculture,,DEM,Kim Olson,46,30,16,0
+Tom Green,420 BS35,Commissioner of Agriculture,,LIB,Richard Carpenter,8,5,3,0
+Tom Green,420 BS35,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,420 BS35,Commissioner of Agriculture,,,Under Votes,9,7,2,0
+Tom Green,420 BS35,Railroad Commissioner,,REP,Christi Craddick,242,179,57,6
+Tom Green,420 BS35,Railroad Commissioner,,DEM,Roman McAllen,35,25,10,0
+Tom Green,420 BS35,Railroad Commissioner,,LIB,Mike Wright,10,7,3,0
+Tom Green,420 BS35,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,420 BS35,Railroad Commissioner,,,Under Votes,9,7,2,0
+Tom Green,420 BS35,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,239,180,53,6
+Tom Green,420 BS35,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,47,30,17,0
+Tom Green,420 BS35,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,420 BS35,"Justice, Supreme Court, Place 2",,,Under Votes,10,8,2,0
+Tom Green,420 BS35,"Justice, Supreme Court, Place 4",,REP,John Devine,244,185,53,6
+Tom Green,420 BS35,"Justice, Supreme Court, Place 4",,,R. K. Sandill,42,26,16,0
+Tom Green,420 BS35,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,420 BS35,"Justice, Supreme Court, Place 4",,,Under Votes,10,7,3,0
+Tom Green,420 BS35,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,239,181,53,5
+Tom Green,420 BS35,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,47,28,18,1
+Tom Green,420 BS35,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,420 BS35,"Justice, Supreme Court, Place 6",,,Under Votes,10,9,1,0
+Tom Green,420 BS35,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,235,176,53,6
+Tom Green,420 BS35,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,45,28,17,0
+Tom Green,420 BS35,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,6,5,1,0
+Tom Green,420 BS35,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,420 BS35,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,10,9,1,0
+Tom Green,420 BS35,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,238,179,53,6
+Tom Green,420 BS35,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,49,31,18,0
+Tom Green,420 BS35,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,420 BS35,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,9,8,1,0
+Tom Green,420 BS35,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,248,184,58,6
+Tom Green,420 BS35,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,28,18,10,0
+Tom Green,420 BS35,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,420 BS35,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,20,16,4,0
+Tom Green,420 BS35,State Representative,72,REP,Drew Darby,266,196,64,6
+Tom Green,420 BS35,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,420 BS35,State Representative,72,,Under Votes,30,22,8,0
+Tom Green,420 BS35,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,239,179,54,6
+Tom Green,420 BS35,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,45,28,17,0
+Tom Green,420 BS35,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,420 BS35,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,12,11,1,0
+Tom Green,420 BS35,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,234,176,52,6
+Tom Green,420 BS35,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,50,31,19,0
+Tom Green,420 BS35,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,420 BS35,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,12,11,1,0
+Tom Green,420 BS35,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,238,179,53,6
+Tom Green,420 BS35,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,47,29,18,0
+Tom Green,420 BS35,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,420 BS35,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,11,10,1,0
+Tom Green,420 BS35,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",232,175,52,5
+Tom Green,420 BS35,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,51,31,19,1
+Tom Green,420 BS35,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),1,1,0,0
+Tom Green,420 BS35,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,420 BS35,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,12,11,1,0
+Tom Green,420 BS35,County Commissioner Pct.4,,REP,Bill Ford,244,180,60,4
+Tom Green,420 BS35,County Commissioner Pct.4,,,Gilbert Gallegos (W),20,15,3,2
+Tom Green,420 BS35,County Commissioner Pct.4,,,Over Votes,1,1,0,0
+Tom Green,420 BS35,County Commissioner Pct.4,,,Under Votes,31,22,9,0
+Tom Green,420 BS35,San Angelo Independent School District Proposition A,,,FOR,120,88,29,3
+Tom Green,420 BS35,San Angelo Independent School District Proposition A,,,AGAINST,165,120,42,3
+Tom Green,420 BS35,San Angelo Independent School District Proposition A,,,Over Votes,0,0,0,0
+Tom Green,420 BS35,San Angelo Independent School District Proposition A,,,Under Votes,11,10,1,0
+Tom Green,420 BS35,San Angelo Independent School District Proposition B,,,FOR,112,83,28,1
+Tom Green,420 BS35,San Angelo Independent School District Proposition B,,,AGAINST,173,125,43,5
+Tom Green,420 BS35,San Angelo Independent School District Proposition B,,,Over Votes,0,0,0,0
+Tom Green,420 BS35,San Angelo Independent School District Proposition B,,,Under Votes,11,10,1,0
+Tom Green,420 BS35,Ballots Cast,,,,296,218,72,6
+Tom Green,421 BS36,STRAIGHT PARTY,,REP,,903,590,245,68
+Tom Green,421 BS36,STRAIGHT PARTY,,DEM,,206,121,58,27
+Tom Green,421 BS36,STRAIGHT PARTY,,LIB,,5,1,3,1
+Tom Green,421 BS36,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,421 BS36,STRAIGHT PARTY,,,Under Votes,920,644,197,79
+Tom Green,421 BS36,U.S. Senate,,REP,Ted Cruz,1510,1036,357,117
+Tom Green,421 BS36,U.S. Senate,,DEM,Beto O'Rourke,476,294,130,52
+Tom Green,421 BS36,U.S. Senate,,LIB,Neal M. Dikeman,18,8,9,1
+Tom Green,421 BS36,U.S. Senate,,,Over Votes,1,1,0,0
+Tom Green,421 BS36,U.S. Senate,,,Under Votes,29,17,7,5
+Tom Green,421 BS36,U.S. House,11,REP,Mike Conaway,1592,1080,390,122
+Tom Green,421 BS36,U.S. House,11,DEM,Jennie Lou Leeder,388,243,93,52
+Tom Green,421 BS36,U.S. House,11,LIB,Rhett Rosenquest Smith,20,12,8,0
+Tom Green,421 BS36,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,421 BS36,U.S. House,11,,Under Votes,34,21,12,1
+Tom Green,421 BS36,Governor,,REP,Greg Abbott,1569,1057,391,121
+Tom Green,421 BS36,Governor,,DEM,Lupe Valdez,415,266,96,53
+Tom Green,421 BS36,Governor,,LIB,Mark Jay Tippetts,27,20,7,0
+Tom Green,421 BS36,Governor,,,Over Votes,0,0,0,0
+Tom Green,421 BS36,Governor,,,Under Votes,23,13,9,1
+Tom Green,421 BS36,Lieutenant Governor,,REP,Dan Patrick,1410,957,338,115
+Tom Green,421 BS36,Lieutenant Governor,,DEM,Mike Collier,540,349,133,58
+Tom Green,421 BS36,Lieutenant Governor,,LIB,Kerry Douglas McKennon,45,26,19,0
+Tom Green,421 BS36,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,421 BS36,Lieutenant Governor,,,Under Votes,39,24,13,2
+Tom Green,421 BS36,Attorney General,,REP,Ken Paxton,1446,981,348,117
+Tom Green,421 BS36,Attorney General,,DEM,Justin Nelson,503,319,127,57
+Tom Green,421 BS36,Attorney General,,LIB,Michael Ray Harris,43,28,15,0
+Tom Green,421 BS36,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,421 BS36,Attorney General,,,Under Votes,42,28,13,1
+Tom Green,421 BS36,Comptroller of Public Accounts,,REP,Glenn Hegar,1510,1035,360,115
+Tom Green,421 BS36,Comptroller of Public Accounts,,DEM,Joi Chevalier,415,251,107,57
+Tom Green,421 BS36,Comptroller of Public Accounts,,LIB,Ben Sanders,45,29,16,0
+Tom Green,421 BS36,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,421 BS36,Comptroller of Public Accounts,,,Under Votes,64,41,20,3
+Tom Green,421 BS36,Commissioner of the General Land Office,,REP,George P. Bush,1494,1009,370,115
+Tom Green,421 BS36,Commissioner of the General Land Office,,DEM,Miguel Suazo,415,259,102,54
+Tom Green,421 BS36,Commissioner of the General Land Office,,LIB,Matt Pina,59,45,12,2
+Tom Green,421 BS36,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,421 BS36,Commissioner of the General Land Office,,,Under Votes,66,43,19,4
+Tom Green,421 BS36,Commissioner of Agriculture,,REP,Sid Miller,1475,1014,348,113
+Tom Green,421 BS36,Commissioner of Agriculture,,DEM,Kim Olson,458,283,117,58
+Tom Green,421 BS36,Commissioner of Agriculture,,LIB,Richard Carpenter,39,21,18,0
+Tom Green,421 BS36,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,421 BS36,Commissioner of Agriculture,,,Under Votes,62,38,20,4
+Tom Green,421 BS36,Railroad Commissioner,,REP,Christi Craddick,1497,1024,356,117
+Tom Green,421 BS36,Railroad Commissioner,,DEM,Roman McAllen,425,264,108,53
+Tom Green,421 BS36,Railroad Commissioner,,LIB,Mike Wright,48,29,18,1
+Tom Green,421 BS36,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,421 BS36,Railroad Commissioner,,,Under Votes,64,39,21,4
+Tom Green,421 BS36,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1524,1040,370,114
+Tom Green,421 BS36,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,447,277,115,55
+Tom Green,421 BS36,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,421 BS36,"Justice, Supreme Court, Place 2",,,Under Votes,63,39,18,6
+Tom Green,421 BS36,"Justice, Supreme Court, Place 4",,REP,John Devine,1526,1039,374,113
+Tom Green,421 BS36,"Justice, Supreme Court, Place 4",,,R. K. Sandill,438,273,111,54
+Tom Green,421 BS36,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,421 BS36,"Justice, Supreme Court, Place 4",,,Under Votes,70,44,18,8
+Tom Green,421 BS36,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1531,1043,372,116
+Tom Green,421 BS36,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,437,270,113,54
+Tom Green,421 BS36,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,421 BS36,"Justice, Supreme Court, Place 6",,,Under Votes,66,43,18,5
+Tom Green,421 BS36,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1507,1028,363,116
+Tom Green,421 BS36,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,422,259,110,53
+Tom Green,421 BS36,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,34,21,13,0
+Tom Green,421 BS36,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,421 BS36,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,71,48,17,6
+Tom Green,421 BS36,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1536,1045,378,113
+Tom Green,421 BS36,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,423,263,107,53
+Tom Green,421 BS36,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,421 BS36,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,75,48,18,9
+Tom Green,421 BS36,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1595,1090,385,120
+Tom Green,421 BS36,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,210,133,53,24
+Tom Green,421 BS36,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,421 BS36,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,229,133,65,31
+Tom Green,421 BS36,State Representative,72,REP,Drew Darby,1676,1129,416,131
+Tom Green,421 BS36,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,421 BS36,State Representative,72,,Under Votes,358,227,87,44
+Tom Green,421 BS36,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,1532,1044,373,115
+Tom Green,421 BS36,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,427,263,107,57
+Tom Green,421 BS36,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,421 BS36,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,75,49,23,3
+Tom Green,421 BS36,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,1531,1042,372,117
+Tom Green,421 BS36,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,429,264,111,54
+Tom Green,421 BS36,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,421 BS36,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,74,50,20,4
+Tom Green,421 BS36,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,1525,1034,374,117
+Tom Green,421 BS36,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,432,270,111,51
+Tom Green,421 BS36,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,1,1,0,0
+Tom Green,421 BS36,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,76,51,18,7
+Tom Green,421 BS36,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",1529,1036,374,119
+Tom Green,421 BS36,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,427,266,109,52
+Tom Green,421 BS36,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),4,3,1,0
+Tom Green,421 BS36,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,421 BS36,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,74,51,19,4
+Tom Green,421 BS36,County Commissioner Pct.4,,REP,Bill Ford,1545,1032,392,121
+Tom Green,421 BS36,County Commissioner Pct.4,,,Gilbert Gallegos (W),162,115,29,18
+Tom Green,421 BS36,County Commissioner Pct.4,,,Over Votes,0,0,0,0
+Tom Green,421 BS36,County Commissioner Pct.4,,,Under Votes,327,209,82,36
+Tom Green,421 BS36,San Angelo Independent School District Proposition A,,,FOR,775,517,180,78
+Tom Green,421 BS36,San Angelo Independent School District Proposition A,,,AGAINST,1116,767,277,72
+Tom Green,421 BS36,San Angelo Independent School District Proposition A,,,Over Votes,0,0,0,0
+Tom Green,421 BS36,San Angelo Independent School District Proposition A,,,Under Votes,143,72,46,25
+Tom Green,421 BS36,San Angelo Independent School District Proposition B,,,FOR,747,494,172,81
+Tom Green,421 BS36,San Angelo Independent School District Proposition B,,,AGAINST,1140,787,285,68
+Tom Green,421 BS36,San Angelo Independent School District Proposition B,,,Over Votes,0,0,0,0
+Tom Green,421 BS36,San Angelo Independent School District Proposition B,,,Under Votes,147,75,46,26
+Tom Green,421 BS36,Ballots Cast,,,,2034,1356,503,175
+Tom Green,422 BS37,STRAIGHT PARTY,,REP,,437,315,96,26
+Tom Green,422 BS37,STRAIGHT PARTY,,DEM,,49,28,14,7
+Tom Green,422 BS37,STRAIGHT PARTY,,LIB,,4,4,0,0
+Tom Green,422 BS37,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,422 BS37,STRAIGHT PARTY,,,Under Votes,394,307,65,22
+Tom Green,422 BS37,U.S. Senate,,REP,Ted Cruz,752,567,143,42
+Tom Green,422 BS37,U.S. Senate,,DEM,Beto O'Rourke,112,70,29,13
+Tom Green,422 BS37,U.S. Senate,,LIB,Neal M. Dikeman,9,8,1,0
+Tom Green,422 BS37,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,422 BS37,U.S. Senate,,,Under Votes,11,9,2,0
+Tom Green,422 BS37,U.S. House,11,REP,Mike Conaway,760,575,142,43
+Tom Green,422 BS37,U.S. House,11,DEM,Jennie Lou Leeder,98,62,24,12
+Tom Green,422 BS37,U.S. House,11,LIB,Rhett Rosenquest Smith,13,7,6,0
+Tom Green,422 BS37,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,422 BS37,U.S. House,11,,Under Votes,13,10,3,0
+Tom Green,422 BS37,Governor,,REP,Greg Abbott,749,566,142,41
+Tom Green,422 BS37,Governor,,DEM,Lupe Valdez,103,68,23,12
+Tom Green,422 BS37,Governor,,LIB,Mark Jay Tippetts,19,10,8,1
+Tom Green,422 BS37,Governor,,,Over Votes,0,0,0,0
+Tom Green,422 BS37,Governor,,,Under Votes,13,10,2,1
+Tom Green,422 BS37,Lieutenant Governor,,REP,Dan Patrick,708,531,135,42
+Tom Green,422 BS37,Lieutenant Governor,,DEM,Mike Collier,126,88,27,11
+Tom Green,422 BS37,Lieutenant Governor,,LIB,Kerry Douglas McKennon,32,21,10,1
+Tom Green,422 BS37,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,422 BS37,Lieutenant Governor,,,Under Votes,18,14,3,1
+Tom Green,422 BS37,Attorney General,,REP,Ken Paxton,720,542,136,42
+Tom Green,422 BS37,Attorney General,,DEM,Justin Nelson,120,82,26,12
+Tom Green,422 BS37,Attorney General,,LIB,Michael Ray Harris,30,20,10,0
+Tom Green,422 BS37,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,422 BS37,Attorney General,,,Under Votes,14,10,3,1
+Tom Green,422 BS37,Comptroller of Public Accounts,,REP,Glenn Hegar,732,549,141,42
+Tom Green,422 BS37,Comptroller of Public Accounts,,DEM,Joi Chevalier,101,66,22,13
+Tom Green,422 BS37,Comptroller of Public Accounts,,LIB,Ben Sanders,25,17,8,0
+Tom Green,422 BS37,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,422 BS37,Comptroller of Public Accounts,,,Under Votes,26,22,4,0
+Tom Green,422 BS37,Commissioner of the General Land Office,,REP,George P. Bush,719,537,140,42
+Tom Green,422 BS37,Commissioner of the General Land Office,,DEM,Miguel Suazo,99,65,22,12
+Tom Green,422 BS37,Commissioner of the General Land Office,,LIB,Matt Pina,45,36,9,0
+Tom Green,422 BS37,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,422 BS37,Commissioner of the General Land Office,,,Under Votes,21,16,4,1
+Tom Green,422 BS37,Commissioner of Agriculture,,REP,Sid Miller,732,552,139,41
+Tom Green,422 BS37,Commissioner of Agriculture,,DEM,Kim Olson,108,73,22,13
+Tom Green,422 BS37,Commissioner of Agriculture,,LIB,Richard Carpenter,22,13,9,0
+Tom Green,422 BS37,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,422 BS37,Commissioner of Agriculture,,,Under Votes,22,16,5,1
+Tom Green,422 BS37,Railroad Commissioner,,REP,Christi Craddick,733,552,139,42
+Tom Green,422 BS37,Railroad Commissioner,,DEM,Roman McAllen,101,64,25,12
+Tom Green,422 BS37,Railroad Commissioner,,LIB,Mike Wright,29,22,6,1
+Tom Green,422 BS37,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,422 BS37,Railroad Commissioner,,,Under Votes,21,16,5,0
+Tom Green,422 BS37,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,737,557,140,40
+Tom Green,422 BS37,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,113,72,30,11
+Tom Green,422 BS37,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,422 BS37,"Justice, Supreme Court, Place 2",,,Under Votes,34,25,5,4
+Tom Green,422 BS37,"Justice, Supreme Court, Place 4",,REP,John Devine,745,563,141,41
+Tom Green,422 BS37,"Justice, Supreme Court, Place 4",,,R. K. Sandill,108,65,30,13
+Tom Green,422 BS37,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,422 BS37,"Justice, Supreme Court, Place 4",,,Under Votes,31,26,4,1
+Tom Green,422 BS37,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,742,559,142,41
+Tom Green,422 BS37,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,111,68,30,13
+Tom Green,422 BS37,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,422 BS37,"Justice, Supreme Court, Place 6",,,Under Votes,31,27,3,1
+Tom Green,422 BS37,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,728,549,139,40
+Tom Green,422 BS37,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,108,69,26,13
+Tom Green,422 BS37,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,20,14,6,0
+Tom Green,422 BS37,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,422 BS37,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,28,22,4,2
+Tom Green,422 BS37,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,740,558,141,41
+Tom Green,422 BS37,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,111,69,30,12
+Tom Green,422 BS37,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,422 BS37,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,33,27,4,2
+Tom Green,422 BS37,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,745,560,145,40
+Tom Green,422 BS37,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,61,45,11,5
+Tom Green,422 BS37,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,422 BS37,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,78,49,19,10
+Tom Green,422 BS37,State Representative,72,REP,Drew Darby,778,588,147,43
+Tom Green,422 BS37,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,422 BS37,State Representative,72,,Under Votes,106,66,28,12
+Tom Green,422 BS37,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,737,553,143,41
+Tom Green,422 BS37,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,114,74,27,13
+Tom Green,422 BS37,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,422 BS37,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,33,27,5,1
+Tom Green,422 BS37,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,735,554,140,41
+Tom Green,422 BS37,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,117,74,30,13
+Tom Green,422 BS37,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,422 BS37,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,32,26,5,1
+Tom Green,422 BS37,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,735,555,138,42
+Tom Green,422 BS37,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,113,71,31,11
+Tom Green,422 BS37,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,422 BS37,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,36,28,6,2
+Tom Green,422 BS37,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",740,559,140,41
+Tom Green,422 BS37,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,113,71,29,13
+Tom Green,422 BS37,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),0,0,0,0
+Tom Green,422 BS37,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,422 BS37,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,31,24,6,1
+Tom Green,422 BS37,County Commissioner Pct.4,,REP,Bill Ford,680,507,131,42
+Tom Green,422 BS37,County Commissioner Pct.4,,,Gilbert Gallegos (W),120,93,23,4
+Tom Green,422 BS37,County Commissioner Pct.4,,,Over Votes,0,0,0,0
+Tom Green,422 BS37,County Commissioner Pct.4,,,Under Votes,84,54,21,9
+Tom Green,422 BS37,Christoval Independent School District Proposition A,,,FOR,359,268,76,15
+Tom Green,422 BS37,Christoval Independent School District Proposition A,,,AGAINST,477,354,89,34
+Tom Green,422 BS37,Christoval Independent School District Proposition A,,,Over Votes,0,0,0,0
+Tom Green,422 BS37,Christoval Independent School District Proposition A,,,Under Votes,48,32,10,6
+Tom Green,422 BS37,Ballots Cast,,,,884,654,175,55
+Tom Green,423 BS38,STRAIGHT PARTY,,REP,,24,13,11,0
+Tom Green,423 BS38,STRAIGHT PARTY,,DEM,,1,0,1,0
+Tom Green,423 BS38,STRAIGHT PARTY,,LIB,,0,0,0,0
+Tom Green,423 BS38,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,423 BS38,STRAIGHT PARTY,,,Under Votes,10,4,6,0
+Tom Green,423 BS38,U.S. Senate,,REP,Ted Cruz,33,16,17,0
+Tom Green,423 BS38,U.S. Senate,,DEM,Beto O'Rourke,2,1,1,0
+Tom Green,423 BS38,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Tom Green,423 BS38,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,423 BS38,U.S. Senate,,,Under Votes,0,0,0,0
+Tom Green,423 BS38,U.S. House,11,REP,Mike Conaway,33,16,17,0
+Tom Green,423 BS38,U.S. House,11,DEM,Jennie Lou Leeder,1,0,1,0
+Tom Green,423 BS38,U.S. House,11,LIB,Rhett Rosenquest Smith,0,0,0,0
+Tom Green,423 BS38,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,423 BS38,U.S. House,11,,Under Votes,1,1,0,0
+Tom Green,423 BS38,Governor,,REP,Greg Abbott,34,17,17,0
+Tom Green,423 BS38,Governor,,DEM,Lupe Valdez,1,0,1,0
+Tom Green,423 BS38,Governor,,LIB,Mark Jay Tippetts,0,0,0,0
+Tom Green,423 BS38,Governor,,,Over Votes,0,0,0,0
+Tom Green,423 BS38,Governor,,,Under Votes,0,0,0,0
+Tom Green,423 BS38,Lieutenant Governor,,REP,Dan Patrick,31,15,16,0
+Tom Green,423 BS38,Lieutenant Governor,,DEM,Mike Collier,2,0,2,0
+Tom Green,423 BS38,Lieutenant Governor,,LIB,Kerry Douglas McKennon,1,1,0,0
+Tom Green,423 BS38,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,423 BS38,Lieutenant Governor,,,Under Votes,1,1,0,0
+Tom Green,423 BS38,Attorney General,,REP,Ken Paxton,33,16,17,0
+Tom Green,423 BS38,Attorney General,,DEM,Justin Nelson,1,0,1,0
+Tom Green,423 BS38,Attorney General,,LIB,Michael Ray Harris,0,0,0,0
+Tom Green,423 BS38,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,423 BS38,Attorney General,,,Under Votes,1,1,0,0
+Tom Green,423 BS38,Comptroller of Public Accounts,,REP,Glenn Hegar,31,15,16,0
+Tom Green,423 BS38,Comptroller of Public Accounts,,DEM,Joi Chevalier,1,0,1,0
+Tom Green,423 BS38,Comptroller of Public Accounts,,LIB,Ben Sanders,1,1,0,0
+Tom Green,423 BS38,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,423 BS38,Comptroller of Public Accounts,,,Under Votes,2,1,1,0
+Tom Green,423 BS38,Commissioner of the General Land Office,,REP,George P. Bush,30,15,15,0
+Tom Green,423 BS38,Commissioner of the General Land Office,,DEM,Miguel Suazo,1,0,1,0
+Tom Green,423 BS38,Commissioner of the General Land Office,,LIB,Matt Pina,2,1,1,0
+Tom Green,423 BS38,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,423 BS38,Commissioner of the General Land Office,,,Under Votes,2,1,1,0
+Tom Green,423 BS38,Commissioner of Agriculture,,REP,Sid Miller,32,16,16,0
+Tom Green,423 BS38,Commissioner of Agriculture,,DEM,Kim Olson,1,0,1,0
+Tom Green,423 BS38,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0,0
+Tom Green,423 BS38,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,423 BS38,Commissioner of Agriculture,,,Under Votes,2,1,1,0
+Tom Green,423 BS38,Railroad Commissioner,,REP,Christi Craddick,31,16,15,0
+Tom Green,423 BS38,Railroad Commissioner,,DEM,Roman McAllen,1,0,1,0
+Tom Green,423 BS38,Railroad Commissioner,,LIB,Mike Wright,1,0,1,0
+Tom Green,423 BS38,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,423 BS38,Railroad Commissioner,,,Under Votes,2,1,1,0
+Tom Green,423 BS38,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,31,16,15,0
+Tom Green,423 BS38,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,1,0,1,0
+Tom Green,423 BS38,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,423 BS38,"Justice, Supreme Court, Place 2",,,Under Votes,3,1,2,0
+Tom Green,423 BS38,"Justice, Supreme Court, Place 4",,REP,John Devine,31,16,15,0
+Tom Green,423 BS38,"Justice, Supreme Court, Place 4",,,R. K. Sandill,1,0,1,0
+Tom Green,423 BS38,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,423 BS38,"Justice, Supreme Court, Place 4",,,Under Votes,3,1,2,0
+Tom Green,423 BS38,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,31,16,15,0
+Tom Green,423 BS38,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,1,0,1,0
+Tom Green,423 BS38,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,423 BS38,"Justice, Supreme Court, Place 6",,,Under Votes,3,1,2,0
+Tom Green,423 BS38,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,30,16,14,0
+Tom Green,423 BS38,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,1,0,1,0
+Tom Green,423 BS38,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,1,0,1,0
+Tom Green,423 BS38,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,423 BS38,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,3,1,2,0
+Tom Green,423 BS38,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,31,16,15,0
+Tom Green,423 BS38,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,1,0,1,0
+Tom Green,423 BS38,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,423 BS38,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,3,1,2,0
+Tom Green,423 BS38,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,27,15,12,0
+Tom Green,423 BS38,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,4,0,4,0
+Tom Green,423 BS38,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,423 BS38,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,4,2,2,0
+Tom Green,423 BS38,State Representative,72,REP,Drew Darby,31,16,15,0
+Tom Green,423 BS38,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,423 BS38,State Representative,72,,Under Votes,4,1,3,0
+Tom Green,423 BS38,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,29,15,14,0
+Tom Green,423 BS38,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,2,0,2,0
+Tom Green,423 BS38,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,423 BS38,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,4,2,2,0
+Tom Green,423 BS38,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,30,15,15,0
+Tom Green,423 BS38,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,1,0,1,0
+Tom Green,423 BS38,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,423 BS38,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,4,2,2,0
+Tom Green,423 BS38,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,29,15,14,0
+Tom Green,423 BS38,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,2,0,2,0
+Tom Green,423 BS38,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,423 BS38,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,4,2,2,0
+Tom Green,423 BS38,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",30,15,15,0
+Tom Green,423 BS38,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,1,0,1,0
+Tom Green,423 BS38,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),0,0,0,0
+Tom Green,423 BS38,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,423 BS38,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,4,2,2,0
+Tom Green,423 BS38,County Commissioner Pct.4,,REP,Bill Ford,29,15,14,0
+Tom Green,423 BS38,County Commissioner Pct.4,,,Gilbert Gallegos (W),1,0,1,0
+Tom Green,423 BS38,County Commissioner Pct.4,,,Over Votes,0,0,0,0
+Tom Green,423 BS38,County Commissioner Pct.4,,,Under Votes,5,2,3,0
+Tom Green,423 BS38,Ballots Cast,,,,35,17,18,0
+Tom Green,423 BS39,STRAIGHT PARTY,,REP,,120,77,27,16
+Tom Green,423 BS39,STRAIGHT PARTY,,DEM,,4,2,2,0
+Tom Green,423 BS39,STRAIGHT PARTY,,LIB,,1,1,0,0
+Tom Green,423 BS39,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,423 BS39,STRAIGHT PARTY,,,Under Votes,73,48,16,9
+Tom Green,423 BS39,U.S. Senate,,REP,Ted Cruz,184,119,42,23
+Tom Green,423 BS39,U.S. Senate,,DEM,Beto O'Rourke,10,6,2,2
+Tom Green,423 BS39,U.S. Senate,,LIB,Neal M. Dikeman,1,1,0,0
+Tom Green,423 BS39,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,423 BS39,U.S. Senate,,,Under Votes,3,2,1,0
+Tom Green,423 BS39,U.S. House,11,REP,Mike Conaway,183,117,43,23
+Tom Green,423 BS39,U.S. House,11,DEM,Jennie Lou Leeder,10,6,2,2
+Tom Green,423 BS39,U.S. House,11,LIB,Rhett Rosenquest Smith,2,2,0,0
+Tom Green,423 BS39,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,423 BS39,U.S. House,11,,Under Votes,3,3,0,0
+Tom Green,423 BS39,Governor,,REP,Greg Abbott,186,120,43,23
+Tom Green,423 BS39,Governor,,DEM,Lupe Valdez,8,5,2,1
+Tom Green,423 BS39,Governor,,LIB,Mark Jay Tippetts,2,2,0,0
+Tom Green,423 BS39,Governor,,,Over Votes,0,0,0,0
+Tom Green,423 BS39,Governor,,,Under Votes,2,1,0,1
+Tom Green,423 BS39,Lieutenant Governor,,REP,Dan Patrick,180,115,42,23
+Tom Green,423 BS39,Lieutenant Governor,,DEM,Mike Collier,14,9,3,2
+Tom Green,423 BS39,Lieutenant Governor,,LIB,Kerry Douglas McKennon,3,3,0,0
+Tom Green,423 BS39,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,423 BS39,Lieutenant Governor,,,Under Votes,1,1,0,0
+Tom Green,423 BS39,Attorney General,,REP,Ken Paxton,183,118,42,23
+Tom Green,423 BS39,Attorney General,,DEM,Justin Nelson,11,7,2,2
+Tom Green,423 BS39,Attorney General,,LIB,Michael Ray Harris,4,3,1,0
+Tom Green,423 BS39,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,423 BS39,Attorney General,,,Under Votes,0,0,0,0
+Tom Green,423 BS39,Comptroller of Public Accounts,,REP,Glenn Hegar,185,120,41,24
+Tom Green,423 BS39,Comptroller of Public Accounts,,DEM,Joi Chevalier,7,4,2,1
+Tom Green,423 BS39,Comptroller of Public Accounts,,LIB,Ben Sanders,5,3,2,0
+Tom Green,423 BS39,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,423 BS39,Comptroller of Public Accounts,,,Under Votes,1,1,0,0
+Tom Green,423 BS39,Commissioner of the General Land Office,,REP,George P. Bush,174,113,39,22
+Tom Green,423 BS39,Commissioner of the General Land Office,,DEM,Miguel Suazo,10,5,3,2
+Tom Green,423 BS39,Commissioner of the General Land Office,,LIB,Matt Pina,8,6,2,0
+Tom Green,423 BS39,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,423 BS39,Commissioner of the General Land Office,,,Under Votes,6,4,1,1
+Tom Green,423 BS39,Commissioner of Agriculture,,REP,Sid Miller,182,117,42,23
+Tom Green,423 BS39,Commissioner of Agriculture,,DEM,Kim Olson,10,6,2,2
+Tom Green,423 BS39,Commissioner of Agriculture,,LIB,Richard Carpenter,5,4,1,0
+Tom Green,423 BS39,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,423 BS39,Commissioner of Agriculture,,,Under Votes,1,1,0,0
+Tom Green,423 BS39,Railroad Commissioner,,REP,Christi Craddick,186,120,42,24
+Tom Green,423 BS39,Railroad Commissioner,,DEM,Roman McAllen,8,5,2,1
+Tom Green,423 BS39,Railroad Commissioner,,LIB,Mike Wright,3,2,1,0
+Tom Green,423 BS39,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,423 BS39,Railroad Commissioner,,,Under Votes,1,1,0,0
+Tom Green,423 BS39,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,186,120,43,23
+Tom Green,423 BS39,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,11,7,2,2
+Tom Green,423 BS39,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,423 BS39,"Justice, Supreme Court, Place 2",,,Under Votes,1,1,0,0
+Tom Green,423 BS39,"Justice, Supreme Court, Place 4",,REP,John Devine,186,120,43,23
+Tom Green,423 BS39,"Justice, Supreme Court, Place 4",,,R. K. Sandill,11,7,2,2
+Tom Green,423 BS39,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,423 BS39,"Justice, Supreme Court, Place 4",,,Under Votes,1,1,0,0
+Tom Green,423 BS39,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,185,120,43,22
+Tom Green,423 BS39,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,11,7,2,2
+Tom Green,423 BS39,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,423 BS39,"Justice, Supreme Court, Place 6",,,Under Votes,2,1,0,1
+Tom Green,423 BS39,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,183,119,42,22
+Tom Green,423 BS39,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,10,5,3,2
+Tom Green,423 BS39,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,2,2,0,0
+Tom Green,423 BS39,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,423 BS39,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,3,2,0,1
+Tom Green,423 BS39,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,185,120,43,22
+Tom Green,423 BS39,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,10,6,2,2
+Tom Green,423 BS39,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,423 BS39,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,3,2,0,1
+Tom Green,423 BS39,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,184,118,43,23
+Tom Green,423 BS39,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,6,6,0,0
+Tom Green,423 BS39,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,423 BS39,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,8,4,2,2
+Tom Green,423 BS39,State Representative,72,REP,Drew Darby,179,114,41,24
+Tom Green,423 BS39,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,423 BS39,State Representative,72,,Under Votes,19,14,4,1
+Tom Green,423 BS39,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,183,117,42,24
+Tom Green,423 BS39,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,9,5,3,1
+Tom Green,423 BS39,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,423 BS39,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,6,6,0,0
+Tom Green,423 BS39,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,182,116,43,23
+Tom Green,423 BS39,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,10,6,2,2
+Tom Green,423 BS39,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,423 BS39,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,6,6,0,0
+Tom Green,423 BS39,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,182,116,43,23
+Tom Green,423 BS39,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,10,6,2,2
+Tom Green,423 BS39,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,423 BS39,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,6,6,0,0
+Tom Green,423 BS39,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",181,115,43,23
+Tom Green,423 BS39,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,10,6,2,2
+Tom Green,423 BS39,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),0,0,0,0
+Tom Green,423 BS39,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,423 BS39,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,7,7,0,0
+Tom Green,423 BS39,County Commissioner Pct.4,,REP,Bill Ford,174,111,40,23
+Tom Green,423 BS39,County Commissioner Pct.4,,,Gilbert Gallegos (W),12,8,4,0
+Tom Green,423 BS39,County Commissioner Pct.4,,,Over Votes,0,0,0,0
+Tom Green,423 BS39,County Commissioner Pct.4,,,Under Votes,12,9,1,2
+Tom Green,423 BS39,San Angelo Independent School District Proposition A,,,FOR,55,39,10,6
+Tom Green,423 BS39,San Angelo Independent School District Proposition A,,,AGAINST,117,72,28,17
+Tom Green,423 BS39,San Angelo Independent School District Proposition A,,,Over Votes,0,0,0,0
+Tom Green,423 BS39,San Angelo Independent School District Proposition A,,,Under Votes,26,17,7,2
+Tom Green,423 BS39,San Angelo Independent School District Proposition B,,,FOR,51,38,7,6
+Tom Green,423 BS39,San Angelo Independent School District Proposition B,,,AGAINST,121,73,31,17
+Tom Green,423 BS39,San Angelo Independent School District Proposition B,,,Over Votes,0,0,0,0
+Tom Green,423 BS39,San Angelo Independent School District Proposition B,,,Under Votes,26,17,7,2
+Tom Green,423 BS39,Ballots Cast,,,,198,128,45,25
+Tom Green,423 BS40,STRAIGHT PARTY,,REP,,223,164,44,15
+Tom Green,423 BS40,STRAIGHT PARTY,,DEM,,23,14,6,3
+Tom Green,423 BS40,STRAIGHT PARTY,,LIB,,1,1,0,0
+Tom Green,423 BS40,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,423 BS40,STRAIGHT PARTY,,,Under Votes,183,143,27,13
+Tom Green,423 BS40,U.S. Senate,,REP,Ted Cruz,366,279,64,23
+Tom Green,423 BS40,U.S. Senate,,DEM,Beto O'Rourke,59,41,11,7
+Tom Green,423 BS40,U.S. Senate,,LIB,Neal M. Dikeman,2,1,1,0
+Tom Green,423 BS40,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,423 BS40,U.S. Senate,,,Under Votes,3,1,1,1
+Tom Green,423 BS40,U.S. House,11,REP,Mike Conaway,375,285,65,25
+Tom Green,423 BS40,U.S. House,11,DEM,Jennie Lou Leeder,46,31,9,6
+Tom Green,423 BS40,U.S. House,11,LIB,Rhett Rosenquest Smith,6,4,2,0
+Tom Green,423 BS40,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,423 BS40,U.S. House,11,,Under Votes,3,2,1,0
+Tom Green,423 BS40,Governor,,REP,Greg Abbott,377,288,65,24
+Tom Green,423 BS40,Governor,,DEM,Lupe Valdez,45,28,10,7
+Tom Green,423 BS40,Governor,,LIB,Mark Jay Tippetts,5,4,1,0
+Tom Green,423 BS40,Governor,,,Over Votes,0,0,0,0
+Tom Green,423 BS40,Governor,,,Under Votes,3,2,1,0
+Tom Green,423 BS40,Lieutenant Governor,,REP,Dan Patrick,351,265,62,24
+Tom Green,423 BS40,Lieutenant Governor,,DEM,Mike Collier,62,42,13,7
+Tom Green,423 BS40,Lieutenant Governor,,LIB,Kerry Douglas McKennon,9,8,1,0
+Tom Green,423 BS40,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,423 BS40,Lieutenant Governor,,,Under Votes,8,7,1,0
+Tom Green,423 BS40,Attorney General,,REP,Ken Paxton,352,263,65,24
+Tom Green,423 BS40,Attorney General,,DEM,Justin Nelson,62,44,11,7
+Tom Green,423 BS40,Attorney General,,LIB,Michael Ray Harris,6,6,0,0
+Tom Green,423 BS40,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,423 BS40,Attorney General,,,Under Votes,10,9,1,0
+Tom Green,423 BS40,Comptroller of Public Accounts,,REP,Glenn Hegar,352,263,66,23
+Tom Green,423 BS40,Comptroller of Public Accounts,,DEM,Joi Chevalier,53,37,8,8
+Tom Green,423 BS40,Comptroller of Public Accounts,,LIB,Ben Sanders,9,8,1,0
+Tom Green,423 BS40,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,423 BS40,Comptroller of Public Accounts,,,Under Votes,16,14,2,0
+Tom Green,423 BS40,Commissioner of the General Land Office,,REP,George P. Bush,360,266,69,25
+Tom Green,423 BS40,Commissioner of the General Land Office,,DEM,Miguel Suazo,45,32,7,6
+Tom Green,423 BS40,Commissioner of the General Land Office,,LIB,Matt Pina,16,16,0,0
+Tom Green,423 BS40,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,423 BS40,Commissioner of the General Land Office,,,Under Votes,9,8,1,0
+Tom Green,423 BS40,Commissioner of Agriculture,,REP,Sid Miller,355,264,66,25
+Tom Green,423 BS40,Commissioner of Agriculture,,DEM,Kim Olson,52,39,7,6
+Tom Green,423 BS40,Commissioner of Agriculture,,LIB,Richard Carpenter,10,7,3,0
+Tom Green,423 BS40,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,423 BS40,Commissioner of Agriculture,,,Under Votes,13,12,1,0
+Tom Green,423 BS40,Railroad Commissioner,,REP,Christi Craddick,363,272,66,25
+Tom Green,423 BS40,Railroad Commissioner,,DEM,Roman McAllen,46,32,8,6
+Tom Green,423 BS40,Railroad Commissioner,,LIB,Mike Wright,8,6,2,0
+Tom Green,423 BS40,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,423 BS40,Railroad Commissioner,,,Under Votes,13,12,1,0
+Tom Green,423 BS40,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,362,274,64,24
+Tom Green,423 BS40,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,52,35,11,6
+Tom Green,423 BS40,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,423 BS40,"Justice, Supreme Court, Place 2",,,Under Votes,16,13,2,1
+Tom Green,423 BS40,"Justice, Supreme Court, Place 4",,REP,John Devine,363,276,63,24
+Tom Green,423 BS40,"Justice, Supreme Court, Place 4",,,R. K. Sandill,53,35,12,6
+Tom Green,423 BS40,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,423 BS40,"Justice, Supreme Court, Place 4",,,Under Votes,14,11,2,1
+Tom Green,423 BS40,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,365,276,65,24
+Tom Green,423 BS40,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,51,35,10,6
+Tom Green,423 BS40,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,423 BS40,"Justice, Supreme Court, Place 6",,,Under Votes,14,11,2,1
+Tom Green,423 BS40,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,358,270,64,24
+Tom Green,423 BS40,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,53,37,10,6
+Tom Green,423 BS40,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,6,5,1,0
+Tom Green,423 BS40,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,423 BS40,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,13,10,2,1
+Tom Green,423 BS40,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,365,277,64,24
+Tom Green,423 BS40,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,50,33,11,6
+Tom Green,423 BS40,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,423 BS40,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,15,12,2,1
+Tom Green,423 BS40,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,369,280,64,25
+Tom Green,423 BS40,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,31,22,6,3
+Tom Green,423 BS40,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,423 BS40,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,30,20,7,3
+Tom Green,423 BS40,State Representative,72,REP,Drew Darby,382,286,68,28
+Tom Green,423 BS40,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,423 BS40,State Representative,72,,Under Votes,48,36,9,3
+Tom Green,423 BS40,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,368,278,64,26
+Tom Green,423 BS40,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,48,32,11,5
+Tom Green,423 BS40,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,423 BS40,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,14,12,2,0
+Tom Green,423 BS40,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,363,275,64,24
+Tom Green,423 BS40,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,52,34,11,7
+Tom Green,423 BS40,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,423 BS40,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,15,13,2,0
+Tom Green,423 BS40,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,362,273,65,24
+Tom Green,423 BS40,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,54,37,10,7
+Tom Green,423 BS40,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,423 BS40,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,14,12,2,0
+Tom Green,423 BS40,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",364,276,65,23
+Tom Green,423 BS40,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,51,34,10,7
+Tom Green,423 BS40,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),0,0,0,0
+Tom Green,423 BS40,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,423 BS40,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,15,12,2,1
+Tom Green,423 BS40,County Commissioner Pct.4,,REP,Bill Ford,340,253,63,24
+Tom Green,423 BS40,County Commissioner Pct.4,,,Gilbert Gallegos (W),45,34,5,6
+Tom Green,423 BS40,County Commissioner Pct.4,,,Over Votes,0,0,0,0
+Tom Green,423 BS40,County Commissioner Pct.4,,,Under Votes,45,35,9,1
+Tom Green,423 BS40,Christoval Independent School District Proposition A,,,FOR,167,125,33,9
+Tom Green,423 BS40,Christoval Independent School District Proposition A,,,AGAINST,230,179,34,17
+Tom Green,423 BS40,Christoval Independent School District Proposition A,,,Over Votes,0,0,0,0
+Tom Green,423 BS40,Christoval Independent School District Proposition A,,,Under Votes,33,18,10,5
+Tom Green,423 BS40,Ballots Cast,,,,430,322,77,31
+Tom Green,424 BS41,STRAIGHT PARTY,,REP,,492,328,124,40
+Tom Green,424 BS41,STRAIGHT PARTY,,DEM,,169,116,47,6
+Tom Green,424 BS41,STRAIGHT PARTY,,LIB,,8,3,5,0
+Tom Green,424 BS41,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,424 BS41,STRAIGHT PARTY,,,Under Votes,553,367,136,50
+Tom Green,424 BS41,U.S. Senate,,REP,Ted Cruz,828,551,205,72
+Tom Green,424 BS41,U.S. Senate,,DEM,Beto O'Rourke,373,248,101,24
+Tom Green,424 BS41,U.S. Senate,,LIB,Neal M. Dikeman,9,4,5,0
+Tom Green,424 BS41,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,424 BS41,U.S. Senate,,,Under Votes,12,11,1,0
+Tom Green,424 BS41,U.S. House,11,REP,Mike Conaway,882,580,229,73
+Tom Green,424 BS41,U.S. House,11,DEM,Jennie Lou Leeder,299,210,68,21
+Tom Green,424 BS41,U.S. House,11,LIB,Rhett Rosenquest Smith,23,12,9,2
+Tom Green,424 BS41,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,424 BS41,U.S. House,11,,Under Votes,18,12,6,0
+Tom Green,424 BS41,Governor,,REP,Greg Abbott,879,583,222,74
+Tom Green,424 BS41,Governor,,DEM,Lupe Valdez,315,219,76,20
+Tom Green,424 BS41,Governor,,LIB,Mark Jay Tippetts,16,9,6,1
+Tom Green,424 BS41,Governor,,,Over Votes,0,0,0,0
+Tom Green,424 BS41,Governor,,,Under Votes,12,3,8,1
+Tom Green,424 BS41,Lieutenant Governor,,REP,Dan Patrick,781,523,189,69
+Tom Green,424 BS41,Lieutenant Governor,,DEM,Mike Collier,385,260,102,23
+Tom Green,424 BS41,Lieutenant Governor,,LIB,Kerry Douglas McKennon,30,17,10,3
+Tom Green,424 BS41,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,424 BS41,Lieutenant Governor,,,Under Votes,26,14,11,1
+Tom Green,424 BS41,Attorney General,,REP,Ken Paxton,804,535,202,67
+Tom Green,424 BS41,Attorney General,,DEM,Justin Nelson,360,252,84,24
+Tom Green,424 BS41,Attorney General,,LIB,Michael Ray Harris,32,14,15,3
+Tom Green,424 BS41,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,424 BS41,Attorney General,,,Under Votes,26,13,11,2
+Tom Green,424 BS41,Comptroller of Public Accounts,,REP,Glenn Hegar,838,557,211,70
+Tom Green,424 BS41,Comptroller of Public Accounts,,DEM,Joi Chevalier,319,222,75,22
+Tom Green,424 BS41,Comptroller of Public Accounts,,LIB,Ben Sanders,39,20,16,3
+Tom Green,424 BS41,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,424 BS41,Comptroller of Public Accounts,,,Under Votes,26,15,10,1
+Tom Green,424 BS41,Commissioner of the General Land Office,,REP,George P. Bush,839,556,213,70
+Tom Green,424 BS41,Commissioner of the General Land Office,,DEM,Miguel Suazo,308,211,75,22
+Tom Green,424 BS41,Commissioner of the General Land Office,,LIB,Matt Pina,46,30,14,2
+Tom Green,424 BS41,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,424 BS41,Commissioner of the General Land Office,,,Under Votes,29,17,10,2
+Tom Green,424 BS41,Commissioner of Agriculture,,REP,Sid Miller,819,552,197,70
+Tom Green,424 BS41,Commissioner of Agriculture,,DEM,Kim Olson,340,230,88,22
+Tom Green,424 BS41,Commissioner of Agriculture,,LIB,Richard Carpenter,34,17,15,2
+Tom Green,424 BS41,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,424 BS41,Commissioner of Agriculture,,,Under Votes,29,15,12,2
+Tom Green,424 BS41,Railroad Commissioner,,REP,Christi Craddick,848,566,211,71
+Tom Green,424 BS41,Railroad Commissioner,,DEM,Roman McAllen,316,218,76,22
+Tom Green,424 BS41,Railroad Commissioner,,LIB,Mike Wright,33,16,15,2
+Tom Green,424 BS41,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,424 BS41,Railroad Commissioner,,,Under Votes,25,14,10,1
+Tom Green,424 BS41,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,845,562,213,70
+Tom Green,424 BS41,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,342,232,86,24
+Tom Green,424 BS41,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,424 BS41,"Justice, Supreme Court, Place 2",,,Under Votes,35,20,13,2
+Tom Green,424 BS41,"Justice, Supreme Court, Place 4",,REP,John Devine,850,563,216,71
+Tom Green,424 BS41,"Justice, Supreme Court, Place 4",,,R. K. Sandill,333,230,82,21
+Tom Green,424 BS41,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,424 BS41,"Justice, Supreme Court, Place 4",,,Under Votes,39,21,14,4
+Tom Green,424 BS41,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,847,564,211,72
+Tom Green,424 BS41,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,339,229,88,22
+Tom Green,424 BS41,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,424 BS41,"Justice, Supreme Court, Place 6",,,Under Votes,36,21,13,2
+Tom Green,424 BS41,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,831,559,201,71
+Tom Green,424 BS41,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,327,222,84,21
+Tom Green,424 BS41,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,30,13,15,2
+Tom Green,424 BS41,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,424 BS41,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,34,20,12,2
+Tom Green,424 BS41,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,846,562,212,72
+Tom Green,424 BS41,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,334,226,87,21
+Tom Green,424 BS41,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,424 BS41,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,42,26,13,3
+Tom Green,424 BS41,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,892,599,222,71
+Tom Green,424 BS41,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,163,101,46,16
+Tom Green,424 BS41,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,424 BS41,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,167,114,44,9
+Tom Green,424 BS41,State Representative,72,REP,Drew Darby,979,635,262,82
+Tom Green,424 BS41,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,424 BS41,State Representative,72,,Under Votes,243,179,50,14
+Tom Green,424 BS41,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,851,566,213,72
+Tom Green,424 BS41,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,325,218,86,21
+Tom Green,424 BS41,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,424 BS41,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,46,30,13,3
+Tom Green,424 BS41,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,840,560,212,68
+Tom Green,424 BS41,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,329,222,86,21
+Tom Green,424 BS41,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,424 BS41,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,53,32,14,7
+Tom Green,424 BS41,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,843,561,213,69
+Tom Green,424 BS41,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,329,222,84,23
+Tom Green,424 BS41,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,424 BS41,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,50,31,15,4
+Tom Green,424 BS41,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",838,559,210,69
+Tom Green,424 BS41,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,331,218,88,25
+Tom Green,424 BS41,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),3,2,1,0
+Tom Green,424 BS41,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,424 BS41,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,50,35,13,2
+Tom Green,424 BS41,County Commissioner Pct.4,,REP,Bill Ford,887,579,241,67
+Tom Green,424 BS41,County Commissioner Pct.4,,,Gilbert Gallegos (W),98,63,19,16
+Tom Green,424 BS41,County Commissioner Pct.4,,,Over Votes,0,0,0,0
+Tom Green,424 BS41,County Commissioner Pct.4,,,Under Votes,237,172,52,13
+Tom Green,424 BS41,San Angelo Independent School District Proposition A,,,FOR,524,353,136,35
+Tom Green,424 BS41,San Angelo Independent School District Proposition A,,,AGAINST,613,408,151,54
+Tom Green,424 BS41,San Angelo Independent School District Proposition A,,,Over Votes,1,1,0,0
+Tom Green,424 BS41,San Angelo Independent School District Proposition A,,,Under Votes,84,52,25,7
+Tom Green,424 BS41,San Angelo Independent School District Proposition B,,,FOR,488,328,125,35
+Tom Green,424 BS41,San Angelo Independent School District Proposition B,,,AGAINST,648,432,165,51
+Tom Green,424 BS41,San Angelo Independent School District Proposition B,,,Over Votes,0,0,0,0
+Tom Green,424 BS41,San Angelo Independent School District Proposition B,,,Under Votes,86,54,22,10
+Tom Green,424 BS41,Ballots Cast,,,,1222,814,312,96
+Tom Green,434 BS42,STRAIGHT PARTY,,REP,,164,91,61,12
+Tom Green,434 BS42,STRAIGHT PARTY,,DEM,,112,62,40,10
+Tom Green,434 BS42,STRAIGHT PARTY,,LIB,,7,4,3,0
+Tom Green,434 BS42,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,434 BS42,STRAIGHT PARTY,,,Under Votes,232,142,71,19
+Tom Green,434 BS42,U.S. Senate,,REP,Ted Cruz,264,161,84,19
+Tom Green,434 BS42,U.S. Senate,,DEM,Beto O'Rourke,229,128,81,20
+Tom Green,434 BS42,U.S. Senate,,LIB,Neal M. Dikeman,9,4,5,0
+Tom Green,434 BS42,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,434 BS42,U.S. Senate,,,Under Votes,13,6,5,2
+Tom Green,434 BS42,U.S. House,11,REP,Mike Conaway,293,171,102,20
+Tom Green,434 BS42,U.S. House,11,DEM,Jennie Lou Leeder,196,115,62,19
+Tom Green,434 BS42,U.S. House,11,LIB,Rhett Rosenquest Smith,12,6,5,1
+Tom Green,434 BS42,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,434 BS42,U.S. House,11,,Under Votes,14,7,6,1
+Tom Green,434 BS42,Governor,,REP,Greg Abbott,301,177,104,20
+Tom Green,434 BS42,Governor,,DEM,Lupe Valdez,191,111,61,19
+Tom Green,434 BS42,Governor,,LIB,Mark Jay Tippetts,10,6,3,1
+Tom Green,434 BS42,Governor,,,Over Votes,0,0,0,0
+Tom Green,434 BS42,Governor,,,Under Votes,13,5,7,1
+Tom Green,434 BS42,Lieutenant Governor,,REP,Dan Patrick,255,153,85,17
+Tom Green,434 BS42,Lieutenant Governor,,DEM,Mike Collier,225,128,75,22
+Tom Green,434 BS42,Lieutenant Governor,,LIB,Kerry Douglas McKennon,17,10,7,0
+Tom Green,434 BS42,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,434 BS42,Lieutenant Governor,,,Under Votes,18,8,8,2
+Tom Green,434 BS42,Attorney General,,REP,Ken Paxton,256,150,88,18
+Tom Green,434 BS42,Attorney General,,DEM,Justin Nelson,217,125,71,21
+Tom Green,434 BS42,Attorney General,,LIB,Michael Ray Harris,20,12,8,0
+Tom Green,434 BS42,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,434 BS42,Attorney General,,,Under Votes,22,12,8,2
+Tom Green,434 BS42,Comptroller of Public Accounts,,REP,Glenn Hegar,259,153,87,19
+Tom Green,434 BS42,Comptroller of Public Accounts,,DEM,Joi Chevalier,202,115,68,19
+Tom Green,434 BS42,Comptroller of Public Accounts,,LIB,Ben Sanders,28,18,10,0
+Tom Green,434 BS42,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,434 BS42,Comptroller of Public Accounts,,,Under Votes,26,13,10,3
+Tom Green,434 BS42,Commissioner of the General Land Office,,REP,George P. Bush,278,162,93,23
+Tom Green,434 BS42,Commissioner of the General Land Office,,DEM,Miguel Suazo,194,111,65,18
+Tom Green,434 BS42,Commissioner of the General Land Office,,LIB,Matt Pina,24,14,10,0
+Tom Green,434 BS42,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,434 BS42,Commissioner of the General Land Office,,,Under Votes,19,12,7,0
+Tom Green,434 BS42,Commissioner of Agriculture,,REP,Sid Miller,256,152,85,19
+Tom Green,434 BS42,Commissioner of Agriculture,,DEM,Kim Olson,212,120,71,21
+Tom Green,434 BS42,Commissioner of Agriculture,,LIB,Richard Carpenter,20,11,9,0
+Tom Green,434 BS42,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,434 BS42,Commissioner of Agriculture,,,Under Votes,27,16,10,1
+Tom Green,434 BS42,Railroad Commissioner,,REP,Christi Craddick,267,158,91,18
+Tom Green,434 BS42,Railroad Commissioner,,DEM,Roman McAllen,195,115,63,17
+Tom Green,434 BS42,Railroad Commissioner,,LIB,Mike Wright,24,12,11,1
+Tom Green,434 BS42,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,434 BS42,Railroad Commissioner,,,Under Votes,29,14,10,5
+Tom Green,434 BS42,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,267,151,98,18
+Tom Green,434 BS42,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,222,134,67,21
+Tom Green,434 BS42,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,434 BS42,"Justice, Supreme Court, Place 2",,,Under Votes,26,14,10,2
+Tom Green,434 BS42,"Justice, Supreme Court, Place 4",,REP,John Devine,268,158,93,17
+Tom Green,434 BS42,"Justice, Supreme Court, Place 4",,,R. K. Sandill,215,122,72,21
+Tom Green,434 BS42,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,434 BS42,"Justice, Supreme Court, Place 4",,,Under Votes,32,19,10,3
+Tom Green,434 BS42,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,269,159,92,18
+Tom Green,434 BS42,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,218,126,73,19
+Tom Green,434 BS42,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,434 BS42,"Justice, Supreme Court, Place 6",,,Under Votes,28,14,10,4
+Tom Green,434 BS42,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,252,150,85,17
+Tom Green,434 BS42,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,209,123,67,19
+Tom Green,434 BS42,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,26,11,13,2
+Tom Green,434 BS42,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,434 BS42,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,28,15,10,3
+Tom Green,434 BS42,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,265,160,87,18
+Tom Green,434 BS42,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,220,122,78,20
+Tom Green,434 BS42,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,434 BS42,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,30,17,10,3
+Tom Green,434 BS42,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,294,169,107,18
+Tom Green,434 BS42,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,109,72,24,13
+Tom Green,434 BS42,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,434 BS42,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,112,58,44,10
+Tom Green,434 BS42,State Representative,72,REP,Drew Darby,348,200,119,29
+Tom Green,434 BS42,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,434 BS42,State Representative,72,,Under Votes,167,99,56,12
+Tom Green,434 BS42,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,271,160,92,19
+Tom Green,434 BS42,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,217,122,73,22
+Tom Green,434 BS42,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,434 BS42,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,27,17,10,0
+Tom Green,434 BS42,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,264,155,92,17
+Tom Green,434 BS42,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,219,125,73,21
+Tom Green,434 BS42,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,434 BS42,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,32,19,10,3
+Tom Green,434 BS42,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,268,159,92,17
+Tom Green,434 BS42,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,217,123,73,21
+Tom Green,434 BS42,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,434 BS42,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,30,17,10,3
+Tom Green,434 BS42,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",265,155,93,17
+Tom Green,434 BS42,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,213,123,70,20
+Tom Green,434 BS42,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),2,1,0,1
+Tom Green,434 BS42,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,434 BS42,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,35,20,12,3
+Tom Green,434 BS42,County Commissioner Pct.4,,REP,Bill Ford,311,174,118,19
+Tom Green,434 BS42,County Commissioner Pct.4,,,Gilbert Gallegos (W),37,19,6,12
+Tom Green,434 BS42,County Commissioner Pct.4,,,Over Votes,0,0,0,0
+Tom Green,434 BS42,County Commissioner Pct.4,,,Under Votes,167,106,51,10
+Tom Green,434 BS42,San Angelo Independent School District Proposition A,,,FOR,184,105,62,17
+Tom Green,434 BS42,San Angelo Independent School District Proposition A,,,AGAINST,275,174,83,18
+Tom Green,434 BS42,San Angelo Independent School District Proposition A,,,Over Votes,0,0,0,0
+Tom Green,434 BS42,San Angelo Independent School District Proposition A,,,Under Votes,56,20,30,6
+Tom Green,434 BS42,San Angelo Independent School District Proposition B,,,FOR,177,98,60,19
+Tom Green,434 BS42,San Angelo Independent School District Proposition B,,,AGAINST,286,183,86,17
+Tom Green,434 BS42,San Angelo Independent School District Proposition B,,,Over Votes,0,0,0,0
+Tom Green,434 BS42,San Angelo Independent School District Proposition B,,,Under Votes,52,18,29,5
+Tom Green,434 BS42,Ballots Cast,,,,515,299,175,41
+Tom Green,435 BS43,STRAIGHT PARTY,,REP,,188,104,74,10
+Tom Green,435 BS43,STRAIGHT PARTY,,DEM,,90,46,40,4
+Tom Green,435 BS43,STRAIGHT PARTY,,LIB,,2,0,2,0
+Tom Green,435 BS43,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,435 BS43,STRAIGHT PARTY,,,Under Votes,237,153,73,11
+Tom Green,435 BS43,U.S. Senate,,REP,Ted Cruz,328,203,112,13
+Tom Green,435 BS43,U.S. Senate,,DEM,Beto O'Rourke,181,95,74,12
+Tom Green,435 BS43,U.S. Senate,,LIB,Neal M. Dikeman,2,1,1,0
+Tom Green,435 BS43,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,435 BS43,U.S. Senate,,,Under Votes,6,4,2,0
+Tom Green,435 BS43,U.S. House,11,REP,Mike Conaway,362,215,132,15
+Tom Green,435 BS43,U.S. House,11,DEM,Jennie Lou Leeder,135,74,51,10
+Tom Green,435 BS43,U.S. House,11,LIB,Rhett Rosenquest Smith,11,9,2,0
+Tom Green,435 BS43,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,435 BS43,U.S. House,11,,Under Votes,9,5,4,0
+Tom Green,435 BS43,Governor,,REP,Greg Abbott,352,213,125,14
+Tom Green,435 BS43,Governor,,DEM,Lupe Valdez,151,80,60,11
+Tom Green,435 BS43,Governor,,LIB,Mark Jay Tippetts,10,8,2,0
+Tom Green,435 BS43,Governor,,,Over Votes,0,0,0,0
+Tom Green,435 BS43,Governor,,,Under Votes,4,2,2,0
+Tom Green,435 BS43,Lieutenant Governor,,REP,Dan Patrick,316,191,112,13
+Tom Green,435 BS43,Lieutenant Governor,,DEM,Mike Collier,171,93,66,12
+Tom Green,435 BS43,Lieutenant Governor,,LIB,Kerry Douglas McKennon,17,11,6,0
+Tom Green,435 BS43,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,435 BS43,Lieutenant Governor,,,Under Votes,13,8,5,0
+Tom Green,435 BS43,Attorney General,,REP,Ken Paxton,316,191,113,12
+Tom Green,435 BS43,Attorney General,,DEM,Justin Nelson,176,97,66,13
+Tom Green,435 BS43,Attorney General,,LIB,Michael Ray Harris,16,11,5,0
+Tom Green,435 BS43,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,435 BS43,Attorney General,,,Under Votes,9,4,5,0
+Tom Green,435 BS43,Comptroller of Public Accounts,,REP,Glenn Hegar,320,196,112,12
+Tom Green,435 BS43,Comptroller of Public Accounts,,DEM,Joi Chevalier,147,77,58,12
+Tom Green,435 BS43,Comptroller of Public Accounts,,LIB,Ben Sanders,29,15,13,1
+Tom Green,435 BS43,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,435 BS43,Comptroller of Public Accounts,,,Under Votes,21,15,6,0
+Tom Green,435 BS43,Commissioner of the General Land Office,,REP,George P. Bush,335,200,121,14
+Tom Green,435 BS43,Commissioner of the General Land Office,,DEM,Miguel Suazo,140,76,53,11
+Tom Green,435 BS43,Commissioner of the General Land Office,,LIB,Matt Pina,24,16,8,0
+Tom Green,435 BS43,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,435 BS43,Commissioner of the General Land Office,,,Under Votes,18,11,7,0
+Tom Green,435 BS43,Commissioner of Agriculture,,REP,Sid Miller,323,201,111,11
+Tom Green,435 BS43,Commissioner of Agriculture,,DEM,Kim Olson,165,89,63,13
+Tom Green,435 BS43,Commissioner of Agriculture,,LIB,Richard Carpenter,15,6,8,1
+Tom Green,435 BS43,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,435 BS43,Commissioner of Agriculture,,,Under Votes,14,7,7,0
+Tom Green,435 BS43,Railroad Commissioner,,REP,Christi Craddick,330,204,113,13
+Tom Green,435 BS43,Railroad Commissioner,,DEM,Roman McAllen,147,76,59,12
+Tom Green,435 BS43,Railroad Commissioner,,LIB,Mike Wright,24,15,9,0
+Tom Green,435 BS43,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,435 BS43,Railroad Commissioner,,,Under Votes,16,8,8,0
+Tom Green,435 BS43,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,336,208,116,12
+Tom Green,435 BS43,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,161,84,66,11
+Tom Green,435 BS43,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,435 BS43,"Justice, Supreme Court, Place 2",,,Under Votes,20,11,7,2
+Tom Green,435 BS43,"Justice, Supreme Court, Place 4",,REP,John Devine,340,210,118,12
+Tom Green,435 BS43,"Justice, Supreme Court, Place 4",,,R. K. Sandill,158,82,64,12
+Tom Green,435 BS43,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,435 BS43,"Justice, Supreme Court, Place 4",,,Under Votes,19,11,7,1
+Tom Green,435 BS43,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,331,203,116,12
+Tom Green,435 BS43,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,168,89,67,12
+Tom Green,435 BS43,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,435 BS43,"Justice, Supreme Court, Place 6",,,Under Votes,18,11,6,1
+Tom Green,435 BS43,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,325,202,111,12
+Tom Green,435 BS43,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,158,81,65,12
+Tom Green,435 BS43,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,17,10,7,0
+Tom Green,435 BS43,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,435 BS43,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,17,10,6,1
+Tom Green,435 BS43,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,336,205,118,13
+Tom Green,435 BS43,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,160,84,65,11
+Tom Green,435 BS43,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,435 BS43,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,21,14,6,1
+Tom Green,435 BS43,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,358,216,129,13
+Tom Green,435 BS43,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,79,45,30,4
+Tom Green,435 BS43,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,435 BS43,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,80,42,30,8
+Tom Green,435 BS43,State Representative,72,REP,Drew Darby,409,243,149,17
+Tom Green,435 BS43,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,435 BS43,State Representative,72,,Under Votes,108,60,40,8
+Tom Green,435 BS43,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,337,205,119,13
+Tom Green,435 BS43,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,157,82,64,11
+Tom Green,435 BS43,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,435 BS43,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,23,16,6,1
+Tom Green,435 BS43,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,330,200,117,13
+Tom Green,435 BS43,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,164,87,66,11
+Tom Green,435 BS43,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,435 BS43,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,23,16,6,1
+Tom Green,435 BS43,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,330,203,115,12
+Tom Green,435 BS43,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,164,85,67,12
+Tom Green,435 BS43,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,435 BS43,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,23,15,7,1
+Tom Green,435 BS43,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",332,202,118,12
+Tom Green,435 BS43,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,159,86,63,10
+Tom Green,435 BS43,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),2,0,0,2
+Tom Green,435 BS43,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,435 BS43,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,24,15,8,1
+Tom Green,435 BS43,County Commissioner Pct.4,,REP,Bill Ford,367,217,136,14
+Tom Green,435 BS43,County Commissioner Pct.4,,,Gilbert Gallegos (W),33,23,6,4
+Tom Green,435 BS43,County Commissioner Pct.4,,,Over Votes,0,0,0,0
+Tom Green,435 BS43,County Commissioner Pct.4,,,Under Votes,117,63,47,7
+Tom Green,435 BS43,San Angelo Independent School District Proposition A,,,FOR,191,110,68,13
+Tom Green,435 BS43,San Angelo Independent School District Proposition A,,,AGAINST,289,172,106,11
+Tom Green,435 BS43,San Angelo Independent School District Proposition A,,,Over Votes,0,0,0,0
+Tom Green,435 BS43,San Angelo Independent School District Proposition A,,,Under Votes,37,21,15,1
+Tom Green,435 BS43,San Angelo Independent School District Proposition B,,,FOR,186,100,72,14
+Tom Green,435 BS43,San Angelo Independent School District Proposition B,,,AGAINST,291,180,102,9
+Tom Green,435 BS43,San Angelo Independent School District Proposition B,,,Over Votes,0,0,0,0
+Tom Green,435 BS43,San Angelo Independent School District Proposition B,,,Under Votes,40,23,15,2
+Tom Green,435 BS43,Ballots Cast,,,,517,303,189,25
+Tom Green,436 BS44,STRAIGHT PARTY,,REP,,829,514,250,65
+Tom Green,436 BS44,STRAIGHT PARTY,,DEM,,278,167,92,19
+Tom Green,436 BS44,STRAIGHT PARTY,,LIB,,13,5,8,0
+Tom Green,436 BS44,STRAIGHT PARTY,,,Over Votes,0,0,0,0
+Tom Green,436 BS44,STRAIGHT PARTY,,,Under Votes,1098,771,259,68
+Tom Green,436 BS44,U.S. Senate,,REP,Ted Cruz,1419,938,390,91
+Tom Green,436 BS44,U.S. Senate,,DEM,Beto O'Rourke,748,496,198,54
+Tom Green,436 BS44,U.S. Senate,,LIB,Neal M. Dikeman,29,16,10,3
+Tom Green,436 BS44,U.S. Senate,,,Over Votes,0,0,0,0
+Tom Green,436 BS44,U.S. Senate,,,Under Votes,22,7,11,4
+Tom Green,436 BS44,U.S. House,11,REP,Mike Conaway,1545,1016,431,98
+Tom Green,436 BS44,U.S. House,11,DEM,Jennie Lou Leeder,598,396,153,49
+Tom Green,436 BS44,U.S. House,11,LIB,Rhett Rosenquest Smith,47,31,13,3
+Tom Green,436 BS44,U.S. House,11,,Over Votes,0,0,0,0
+Tom Green,436 BS44,U.S. House,11,,Under Votes,28,14,12,2
+Tom Green,436 BS44,Governor,,REP,Greg Abbott,1532,1008,423,101
+Tom Green,436 BS44,Governor,,DEM,Lupe Valdez,614,409,157,48
+Tom Green,436 BS44,Governor,,LIB,Mark Jay Tippetts,45,26,18,1
+Tom Green,436 BS44,Governor,,,Over Votes,0,0,0,0
+Tom Green,436 BS44,Governor,,,Under Votes,27,14,11,2
+Tom Green,436 BS44,Lieutenant Governor,,REP,Dan Patrick,1380,901,381,98
+Tom Green,436 BS44,Lieutenant Governor,,DEM,Mike Collier,729,495,184,50
+Tom Green,436 BS44,Lieutenant Governor,,LIB,Kerry Douglas McKennon,62,38,23,1
+Tom Green,436 BS44,Lieutenant Governor,,,Over Votes,0,0,0,0
+Tom Green,436 BS44,Lieutenant Governor,,,Under Votes,47,23,21,3
+Tom Green,436 BS44,Attorney General,,REP,Ken Paxton,1374,904,377,93
+Tom Green,436 BS44,Attorney General,,DEM,Justin Nelson,714,475,189,50
+Tom Green,436 BS44,Attorney General,,LIB,Michael Ray Harris,81,49,27,5
+Tom Green,436 BS44,Attorney General,,,Over Votes,0,0,0,0
+Tom Green,436 BS44,Attorney General,,,Under Votes,49,29,16,4
+Tom Green,436 BS44,Comptroller of Public Accounts,,REP,Glenn Hegar,1447,970,381,96
+Tom Green,436 BS44,Comptroller of Public Accounts,,DEM,Joi Chevalier,600,388,164,48
+Tom Green,436 BS44,Comptroller of Public Accounts,,LIB,Ben Sanders,91,55,34,2
+Tom Green,436 BS44,Comptroller of Public Accounts,,,Over Votes,0,0,0,0
+Tom Green,436 BS44,Comptroller of Public Accounts,,,Under Votes,80,44,30,6
+Tom Green,436 BS44,Commissioner of the General Land Office,,REP,George P. Bush,1484,983,404,97
+Tom Green,436 BS44,Commissioner of the General Land Office,,DEM,Miguel Suazo,576,373,157,46
+Tom Green,436 BS44,Commissioner of the General Land Office,,LIB,Matt Pina,92,65,24,3
+Tom Green,436 BS44,Commissioner of the General Land Office,,,Over Votes,0,0,0,0
+Tom Green,436 BS44,Commissioner of the General Land Office,,,Under Votes,66,36,24,6
+Tom Green,436 BS44,Commissioner of Agriculture,,REP,Sid Miller,1402,934,373,95
+Tom Green,436 BS44,Commissioner of Agriculture,,DEM,Kim Olson,657,425,181,51
+Tom Green,436 BS44,Commissioner of Agriculture,,LIB,Richard Carpenter,75,49,25,1
+Tom Green,436 BS44,Commissioner of Agriculture,,,Over Votes,0,0,0,0
+Tom Green,436 BS44,Commissioner of Agriculture,,,Under Votes,84,49,30,5
+Tom Green,436 BS44,Railroad Commissioner,,REP,Christi Craddick,1461,973,389,99
+Tom Green,436 BS44,Railroad Commissioner,,DEM,Roman McAllen,588,388,155,45
+Tom Green,436 BS44,Railroad Commissioner,,LIB,Mike Wright,95,58,34,3
+Tom Green,436 BS44,Railroad Commissioner,,,Over Votes,0,0,0,0
+Tom Green,436 BS44,Railroad Commissioner,,,Under Votes,74,38,31,5
+Tom Green,436 BS44,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1472,981,396,95
+Tom Green,436 BS44,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,671,438,183,50
+Tom Green,436 BS44,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0,0
+Tom Green,436 BS44,"Justice, Supreme Court, Place 2",,,Under Votes,75,38,30,7
+Tom Green,436 BS44,"Justice, Supreme Court, Place 4",,REP,John Devine,1474,985,396,93
+Tom Green,436 BS44,"Justice, Supreme Court, Place 4",,,R. K. Sandill,661,432,177,52
+Tom Green,436 BS44,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0,0
+Tom Green,436 BS44,"Justice, Supreme Court, Place 4",,,Under Votes,83,40,36,7
+Tom Green,436 BS44,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1474,986,390,98
+Tom Green,436 BS44,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,666,429,189,48
+Tom Green,436 BS44,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0,0
+Tom Green,436 BS44,"Justice, Supreme Court, Place 6",,,Under Votes,78,42,30,6
+Tom Green,436 BS44,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1428,950,383,95
+Tom Green,436 BS44,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,638,417,173,48
+Tom Green,436 BS44,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,74,47,24,3
+Tom Green,436 BS44,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0,0
+Tom Green,436 BS44,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,78,43,29,6
+Tom Green,436 BS44,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1490,991,402,97
+Tom Green,436 BS44,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,640,416,174,50
+Tom Green,436 BS44,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0,0
+Tom Green,436 BS44,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,88,50,33,5
+Tom Green,436 BS44,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1559,1037,423,99
+Tom Green,436 BS44,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,336,222,92,22
+Tom Green,436 BS44,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0,0
+Tom Green,436 BS44,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,323,198,94,31
+Tom Green,436 BS44,State Representative,72,REP,Drew Darby,1736,1150,475,111
+Tom Green,436 BS44,State Representative,72,,Over Votes,0,0,0,0
+Tom Green,436 BS44,State Representative,72,,Under Votes,482,307,134,41
+Tom Green,436 BS44,"Justice, 3rd Court of Appeals District, Place 2",,REP,Cindy Olson Bourland,1517,1008,408,101
+Tom Green,436 BS44,"Justice, 3rd Court of Appeals District, Place 2",,DEM,Edward Smith,616,404,170,42
+Tom Green,436 BS44,"Justice, 3rd Court of Appeals District, Place 2",,,Over Votes,0,0,0,0
+Tom Green,436 BS44,"Justice, 3rd Court of Appeals District, Place 2",,,Under Votes,85,45,31,9
+Tom Green,436 BS44,"Justice, 3rd Court of Appeals District, Place 3",,REP,Scott Field,1474,982,400,92
+Tom Green,436 BS44,"Justice, 3rd Court of Appeals District, Place 3",,DEM,Chari Kelly,650,425,175,50
+Tom Green,436 BS44,"Justice, 3rd Court of Appeals District, Place 3",,,Over Votes,0,0,0,0
+Tom Green,436 BS44,"Justice, 3rd Court of Appeals District, Place 3",,,Under Votes,94,50,34,10
+Tom Green,436 BS44,"Justice, 3rd Court of Appeals District, Place 5",,REP,David Puryear,1477,986,393,98
+Tom Green,436 BS44,"Justice, 3rd Court of Appeals District, Place 5",,DEM,Thomas J. Baker,648,419,184,45
+Tom Green,436 BS44,"Justice, 3rd Court of Appeals District, Place 5",,,Over Votes,0,0,0,0
+Tom Green,436 BS44,"Justice, 3rd Court of Appeals District, Place 5",,,Under Votes,93,52,32,9
+Tom Green,436 BS44,"Justice, 3rd Court of Appeals District, Place 6",,REP,"Michael ""Mike"" Toth",1462,972,396,94
+Tom Green,436 BS44,"Justice, 3rd Court of Appeals District, Place 6",,DEM,Gisela D. Triana,656,431,177,48
+Tom Green,436 BS44,"Justice, 3rd Court of Appeals District, Place 6",,,Kewrry O Brien (W),4,4,0,0
+Tom Green,436 BS44,"Justice, 3rd Court of Appeals District, Place 6",,,Over Votes,0,0,0,0
+Tom Green,436 BS44,"Justice, 3rd Court of Appeals District, Place 6",,,Under Votes,96,50,36,10
+Tom Green,436 BS44,County Commissioner Pct.4,,REP,Bill Ford,1528,1003,434,91
+Tom Green,436 BS44,County Commissioner Pct.4,,,Gilbert Gallegos (W),238,173,38,27
+Tom Green,436 BS44,County Commissioner Pct.4,,,Over Votes,0,0,0,0
+Tom Green,436 BS44,County Commissioner Pct.4,,,Under Votes,452,281,137,34
+Tom Green,436 BS44,San Angelo Independent School District Proposition A,,,FOR,973,666,249,58
+Tom Green,436 BS44,San Angelo Independent School District Proposition A,,,AGAINST,1100,717,307,76
+Tom Green,436 BS44,San Angelo Independent School District Proposition A,,,Over Votes,0,0,0,0
+Tom Green,436 BS44,San Angelo Independent School District Proposition A,,,Under Votes,145,74,53,18
+Tom Green,436 BS44,San Angelo Independent School District Proposition B,,,FOR,950,622,270,58
+Tom Green,436 BS44,San Angelo Independent School District Proposition B,,,AGAINST,1121,755,291,75
+Tom Green,436 BS44,San Angelo Independent School District Proposition B,,,Over Votes,0,0,0,0
+Tom Green,436 BS44,San Angelo Independent School District Proposition B,,,Under Votes,147,80,48,19
+Tom Green,436 BS44,Ballots Cast,,,,2218,1457,609,152


### PR DESCRIPTION
This county used Hart (non-Verity) software. `pdf.py` was used to parse.