### PR TITLE
Add precinct-level results for the 2018 general election in Guadalupe County

### DIFF
--- a/2018/20181106__tx__general__guadalupe__precinct.csv
+++ b/2018/20181106__tx__general__guadalupe__precinct.csv
@@ -1,0 +1,5986 @@
+county,precinct,office,district,party,candidate,votes,early_voting,election_day,absentee
+Guadalupe,101,Registered Voters,,,,630,,,
+Guadalupe,101,Ballots Cast,,,,369,244,97,28
+Guadalupe,102,Registered Voters,,,,1113,,,
+Guadalupe,102,Ballots Cast,,,,598,422,122,54
+Guadalupe,103,Registered Voters,,,,742,,,
+Guadalupe,103,Ballots Cast,,,,459,324,105,30
+Guadalupe,104,Registered Voters,,,,1062,,,
+Guadalupe,104,Ballots Cast,,,,520,350,131,39
+Guadalupe,105,Registered Voters,,,,2916,,,
+Guadalupe,105,Ballots Cast,,,,1514,906,504,104
+Guadalupe,106,Registered Voters,,,,3032,,,
+Guadalupe,106,Ballots Cast,,,,1905,1367,377,161
+Guadalupe,107,Registered Voters,,,,1132,,,
+Guadalupe,107,Ballots Cast,,,,708,388,287,33
+Guadalupe,108,Registered Voters,,,,694,,,
+Guadalupe,108,Ballots Cast,,,,431,168,218,45
+Guadalupe,109,Registered Voters,,,,554,,,
+Guadalupe,109,Ballots Cast,,,,312,152,148,12
+Guadalupe,110,Registered Voters,,,,233,,,
+Guadalupe,110,Ballots Cast,,,,151,117,26,8
+Guadalupe,111,Registered Voters,,,,157,,,
+Guadalupe,111,Ballots Cast,,,,64,34,16,14
+Guadalupe,112,Registered Voters,,,,447,,,
+Guadalupe,112,Ballots Cast,,,,226,85,140,1
+Guadalupe,113,Registered Voters,,,,1189,,,
+Guadalupe,113,Ballots Cast,,,,584,404,152,28
+Guadalupe,114,Registered Voters,,,,879,,,
+Guadalupe,114,Ballots Cast,,,,451,316,109,26
+Guadalupe,115,Registered Voters,,,,287,,,
+Guadalupe,115,Ballots Cast,,,,176,126,46,4
+Guadalupe,116,Registered Voters,,,,2421,,,
+Guadalupe,116,Ballots Cast,,,,1341,846,406,89
+Guadalupe,117,Registered Voters,,,,4080,,,
+Guadalupe,117,Ballots Cast,,,,2538,1829,582,127
+Guadalupe,118,Registered Voters,,,,69,,,
+Guadalupe,118,Ballots Cast,,,,43,29,13,1
+Guadalupe,119,Registered Voters,,,,1809,,,
+Guadalupe,119,Ballots Cast,,,,1100,826,216,58
+Guadalupe,120,Registered Voters,,,,1158,,,
+Guadalupe,120,Ballots Cast,,,,720,493,164,63
+Guadalupe,121,Registered Voters,,,,114,,,
+Guadalupe,121,Ballots Cast,,,,94,79,11,4
+Guadalupe,122,Registered Voters,,,,37,,,
+Guadalupe,122,Ballots Cast,,,,27,17,1,9
+Guadalupe,123,Registered Voters,,,,2,,,
+Guadalupe,123,Ballots Cast,,,,1,0,0,1
+Guadalupe,124,Registered Voters,,,,3,,,
+Guadalupe,124,Ballots Cast,,,,2,2,0,0
+Guadalupe,125,Registered Voters,,,,176,,,
+Guadalupe,125,Ballots Cast,,,,109,79,18,12
+Guadalupe,126,Registered Voters,,,,33,,,
+Guadalupe,126,Ballots Cast,,,,14,6,7,1
+Guadalupe,127,Registered Voters,,,,20,,,
+Guadalupe,127,Ballots Cast,,,,15,4,10,1
+Guadalupe,201,Registered Voters,,,,616,,,
+Guadalupe,201,Ballots Cast,,,,212,139,55,18
+Guadalupe,202,Registered Voters,,,,1208,,,
+Guadalupe,202,Ballots Cast,,,,463,255,163,45
+Guadalupe,203,Registered Voters,,,,630,,,
+Guadalupe,203,Ballots Cast,,,,180,85,81,14
+Guadalupe,204,Registered Voters,,,,1661,,,
+Guadalupe,204,Ballots Cast,,,,628,351,247,30
+Guadalupe,205,Registered Voters,,,,1224,,,
+Guadalupe,205,Ballots Cast,,,,667,386,258,23
+Guadalupe,206,Registered Voters,,,,2673,,,
+Guadalupe,206,Ballots Cast,,,,971,335,590,46
+Guadalupe,207,Registered Voters,,,,1183,,,
+Guadalupe,207,Ballots Cast,,,,408,262,118,28
+Guadalupe,208,Registered Voters,,,,3268,,,
+Guadalupe,208,Ballots Cast,,,,1892,1364,422,106
+Guadalupe,209,Registered Voters,,,,1113,,,
+Guadalupe,209,Ballots Cast,,,,322,161,137,24
+Guadalupe,210,Registered Voters,,,,832,,,
+Guadalupe,210,Ballots Cast,,,,483,313,134,36
+Guadalupe,211,Registered Voters,,,,106,,,
+Guadalupe,211,Ballots Cast,,,,80,64,11,5
+Guadalupe,212,Registered Voters,,,,176,,,
+Guadalupe,212,Ballots Cast,,,,86,61,21,4
+Guadalupe,213,Registered Voters,,,,2314,,,
+Guadalupe,213,Ballots Cast,,,,1235,838,349,48
+Guadalupe,214,Registered Voters,,,,639,,,
+Guadalupe,214,Ballots Cast,,,,371,255,98,18
+Guadalupe,215,Registered Voters,,,,849,,,
+Guadalupe,215,Ballots Cast,,,,542,365,137,40
+Guadalupe,216,Registered Voters,,,,63,,,
+Guadalupe,216,Ballots Cast,,,,37,22,11,4
+Guadalupe,217,Registered Voters,,,,180,,,
+Guadalupe,217,Ballots Cast,,,,65,22,40,3
+Guadalupe,218,Registered Voters,,,,79,,,
+Guadalupe,218,Ballots Cast,,,,38,32,5,1
+Guadalupe,219,Registered Voters,,,,98,,,
+Guadalupe,219,Ballots Cast,,,,51,41,9,1
+Guadalupe,220,Registered Voters,,,,92,,,
+Guadalupe,220,Ballots Cast,,,,43,31,10,2
+Guadalupe,221,Registered Voters,,,,34,,,
+Guadalupe,221,Ballots Cast,,,,16,9,4,3
+Guadalupe,222,Registered Voters,,,,8,,,
+Guadalupe,222,Ballots Cast,,,,0,0,0,0
+Guadalupe,223,Registered Voters,,,,276,,,
+Guadalupe,223,Ballots Cast,,,,159,110,38,11
+Guadalupe,224,Registered Voters,,,,184,,,
+Guadalupe,224,Ballots Cast,,,,60,27,26,7
+Guadalupe,225,Registered Voters,,,,22,,,
+Guadalupe,225,Ballots Cast,,,,11,8,3,0
+Guadalupe,226,Registered Voters,,,,366,,,
+Guadalupe,226,Ballots Cast,,,,160,99,55,6
+Guadalupe,301,Registered Voters,,,,3258,,,
+Guadalupe,301,Ballots Cast,,,,1744,1131,535,78
+Guadalupe,302,Registered Voters,,,,4734,,,
+Guadalupe,302,Ballots Cast,,,,2324,1549,671,104
+Guadalupe,303,Registered Voters,,,,1401,,,
+Guadalupe,303,Ballots Cast,,,,808,604,153,51
+Guadalupe,304,Registered Voters,,,,3962,,,
+Guadalupe,304,Ballots Cast,,,,2336,1775,432,129
+Guadalupe,305,Registered Voters,,,,4199,,,
+Guadalupe,305,Ballots Cast,,,,2410,1681,594,135
+Guadalupe,306,Registered Voters,,,,4004,,,
+Guadalupe,306,Ballots Cast,,,,2411,1890,397,124
+Guadalupe,307,Registered Voters,,,,4552,,,
+Guadalupe,307,Ballots Cast,,,,2539,1957,477,105
+Guadalupe,308,Registered Voters,,,,2192,,,
+Guadalupe,308,Ballots Cast,,,,1282,956,236,90
+Guadalupe,401,Registered Voters,,,,1632,,,
+Guadalupe,401,Ballots Cast,,,,874,498,322,54
+Guadalupe,402,Registered Voters,,,,2000,,,
+Guadalupe,402,Ballots Cast,,,,915,597,233,85
+Guadalupe,403,Registered Voters,,,,2970,,,
+Guadalupe,403,Ballots Cast,,,,1320,858,326,136
+Guadalupe,404,Registered Voters,,,,3169,,,
+Guadalupe,404,Ballots Cast,,,,1667,1006,533,128
+Guadalupe,405,Registered Voters,,,,2056,,,
+Guadalupe,405,Ballots Cast,,,,1115,663,407,45
+Guadalupe,406,Registered Voters,,,,1870,,,
+Guadalupe,406,Ballots Cast,,,,1220,903,261,56
+Guadalupe,407,Registered Voters,,,,1906,,,
+Guadalupe,407,Ballots Cast,,,,1084,755,266,63
+Guadalupe,408,Registered Voters,,,,3977,,,
+Guadalupe,408,Ballots Cast,,,,2352,1530,642,180
+Guadalupe,409,Registered Voters,,,,4643,,,
+Guadalupe,409,Ballots Cast,,,,2638,1902,627,109
+Guadalupe,410,Registered Voters,,,,154,,,
+Guadalupe,410,Ballots Cast,,,,83,65,18,0
+Guadalupe,411,Registered Voters,,,,3572,,,
+Guadalupe,411,Ballots Cast,,,,1998,1459,439,100
+Guadalupe,101,Straight Party,,,Under Votes,143,87,42,14
+Guadalupe,101,Straight Party,,REP,,181,130,39,12
+Guadalupe,101,Straight Party,,DEM,,43,27,14,2
+Guadalupe,101,Straight Party,,LIB,,2,0,2,0
+Guadalupe,102,Straight Party,,,Under Votes,222,161,42,19
+Guadalupe,102,Straight Party,,REP,,280,211,44,25
+Guadalupe,102,Straight Party,,DEM,,93,49,34,10
+Guadalupe,102,Straight Party,,LIB,,3,1,2,0
+Guadalupe,103,Straight Party,,,Under Votes,148,100,37,11
+Guadalupe,103,Straight Party,,REP,,235,178,45,12
+Guadalupe,103,Straight Party,,DEM,,75,45,23,7
+Guadalupe,103,Straight Party,,LIB,,1,1,0,0
+Guadalupe,104,Straight Party,,,Under Votes,222,155,48,19
+Guadalupe,104,Straight Party,,REP,,172,119,40,13
+Guadalupe,104,Straight Party,,DEM,,119,70,42,7
+Guadalupe,104,Straight Party,,LIB,,7,6,1,0
+Guadalupe,105,Straight Party,,,Under Votes,451,284,137,30
+Guadalupe,105,Straight Party,,REP,,845,509,284,52
+Guadalupe,105,Straight Party,,DEM,,211,112,77,22
+Guadalupe,105,Straight Party,,LIB,,7,1,6,0
+Guadalupe,106,Straight Party,,,Under Votes,751,545,138,68
+Guadalupe,106,Straight Party,,REP,,850,622,154,74
+Guadalupe,106,Straight Party,,DEM,,298,199,81,18
+Guadalupe,106,Straight Party,,LIB,,6,1,4,1
+Guadalupe,107,Straight Party,,,Under Votes,232,111,110,11
+Guadalupe,107,Straight Party,,REP,,399,230,150,19
+Guadalupe,107,Straight Party,,DEM,,76,47,26,3
+Guadalupe,107,Straight Party,,LIB,,1,0,1,0
+Guadalupe,108,Straight Party,,,Under Votes,149,55,78,16
+Guadalupe,108,Straight Party,,REP,,186,68,99,19
+Guadalupe,108,Straight Party,,DEM,,95,45,40,10
+Guadalupe,108,Straight Party,,LIB,,1,0,1,0
+Guadalupe,109,Straight Party,,,Under Votes,102,56,44,2
+Guadalupe,109,Straight Party,,REP,,182,85,89,8
+Guadalupe,109,Straight Party,,DEM,,25,9,14,2
+Guadalupe,109,Straight Party,,LIB,,3,2,1,0
+Guadalupe,110,Straight Party,,,Under Votes,59,48,9,2
+Guadalupe,110,Straight Party,,REP,,51,39,10,2
+Guadalupe,110,Straight Party,,DEM,,41,30,7,4
+Guadalupe,110,Straight Party,,LIB,,0,0,0,0
+Guadalupe,111,Straight Party,,,Under Votes,21,12,5,4
+Guadalupe,111,Straight Party,,REP,,21,12,5,4
+Guadalupe,111,Straight Party,,DEM,,22,10,6,6
+Guadalupe,111,Straight Party,,LIB,,0,0,0,0
+Guadalupe,112,Straight Party,,,Under Votes,61,23,37,1
+Guadalupe,112,Straight Party,,REP,,51,21,30,0
+Guadalupe,112,Straight Party,,DEM,,112,40,72,0
+Guadalupe,112,Straight Party,,LIB,,2,1,1,0
+Guadalupe,113,Straight Party,,,Under Votes,198,140,50,8
+Guadalupe,113,Straight Party,,REP,,275,198,63,14
+Guadalupe,113,Straight Party,,DEM,,107,63,38,6
+Guadalupe,113,Straight Party,,LIB,,4,3,1,0
+Guadalupe,114,Straight Party,,,Under Votes,145,110,23,12
+Guadalupe,114,Straight Party,,REP,,193,133,50,10
+Guadalupe,114,Straight Party,,DEM,,110,70,36,4
+Guadalupe,114,Straight Party,,LIB,,3,3,0,0
+Guadalupe,115,Straight Party,,,Under Votes,65,46,16,3
+Guadalupe,115,Straight Party,,REP,,98,70,27,1
+Guadalupe,115,Straight Party,,DEM,,13,10,3,0
+Guadalupe,115,Straight Party,,LIB,,0,0,0,0
+Guadalupe,116,Straight Party,,,Under Votes,420,263,130,27
+Guadalupe,116,Straight Party,,REP,,709,478,183,48
+Guadalupe,116,Straight Party,,DEM,,206,103,89,14
+Guadalupe,116,Straight Party,,LIB,,6,2,4,0
+Guadalupe,117,Straight Party,,,Under Votes,831,600,176,55
+Guadalupe,117,Straight Party,,REP,,1277,943,289,45
+Guadalupe,117,Straight Party,,DEM,,416,276,113,27
+Guadalupe,117,Straight Party,,LIB,,14,10,4,0
+Guadalupe,118,Straight Party,,,Under Votes,21,15,6,0
+Guadalupe,118,Straight Party,,REP,,12,8,4,0
+Guadalupe,118,Straight Party,,DEM,,10,6,3,1
+Guadalupe,118,Straight Party,,LIB,,0,0,0,0
+Guadalupe,119,Straight Party,,,Under Votes,389,305,63,21
+Guadalupe,119,Straight Party,,REP,,562,421,114,27
+Guadalupe,119,Straight Party,,DEM,,144,98,36,10
+Guadalupe,119,Straight Party,,LIB,,5,2,3,0
+Guadalupe,120,Straight Party,,,Under Votes,273,190,68,15
+Guadalupe,120,Straight Party,,REP,,352,248,69,35
+Guadalupe,120,Straight Party,,DEM,,91,53,25,13
+Guadalupe,120,Straight Party,,LIB,,4,2,2,0
+Guadalupe,121,Straight Party,,,Under Votes,48,41,7,0
+Guadalupe,121,Straight Party,,REP,,33,27,4,2
+Guadalupe,121,Straight Party,,DEM,,13,11,0,2
+Guadalupe,121,Straight Party,,LIB,,0,0,0,0
+Guadalupe,122,Straight Party,,,Under Votes,12,8,0,4
+Guadalupe,122,Straight Party,,REP,,11,8,1,2
+Guadalupe,122,Straight Party,,DEM,,4,1,0,3
+Guadalupe,122,Straight Party,,LIB,,0,0,0,0
+Guadalupe,123,Straight Party,,,Under Votes,1,0,0,1
+Guadalupe,123,Straight Party,,REP,,0,0,0,0
+Guadalupe,123,Straight Party,,DEM,,0,0,0,0
+Guadalupe,123,Straight Party,,LIB,,0,0,0,0
+Guadalupe,124,Straight Party,,,Under Votes,2,2,0,0
+Guadalupe,124,Straight Party,,REP,,0,0,0,0
+Guadalupe,124,Straight Party,,DEM,,0,0,0,0
+Guadalupe,124,Straight Party,,LIB,,0,0,0,0
+Guadalupe,125,Straight Party,,,Under Votes,36,26,7,3
+Guadalupe,125,Straight Party,,REP,,60,44,7,9
+Guadalupe,125,Straight Party,,DEM,,13,9,4,0
+Guadalupe,125,Straight Party,,LIB,,0,0,0,0
+Guadalupe,126,Straight Party,,,Under Votes,2,0,2,0
+Guadalupe,126,Straight Party,,REP,,10,4,5,1
+Guadalupe,126,Straight Party,,DEM,,2,2,0,0
+Guadalupe,126,Straight Party,,LIB,,0,0,0,0
+Guadalupe,127,Straight Party,,,Under Votes,8,2,5,1
+Guadalupe,127,Straight Party,,REP,,5,2,3,0
+Guadalupe,127,Straight Party,,DEM,,2,0,2,0
+Guadalupe,127,Straight Party,,LIB,,0,0,0,0
+Guadalupe,201,Straight Party,,,Under Votes,77,49,18,10
+Guadalupe,201,Straight Party,,REP,,75,51,20,4
+Guadalupe,201,Straight Party,,DEM,,58,37,17,4
+Guadalupe,201,Straight Party,,LIB,,2,2,0,0
+Guadalupe,202,Straight Party,,,Under Votes,141,76,52,13
+Guadalupe,202,Straight Party,,REP,,85,56,25,4
+Guadalupe,202,Straight Party,,DEM,,234,121,85,28
+Guadalupe,202,Straight Party,,LIB,,3,2,1,0
+Guadalupe,203,Straight Party,,,Under Votes,52,28,22,2
+Guadalupe,203,Straight Party,,REP,,29,16,10,3
+Guadalupe,203,Straight Party,,DEM,,99,41,49,9
+Guadalupe,203,Straight Party,,LIB,,0,0,0,0
+Guadalupe,204,Straight Party,,,Under Votes,192,107,76,9
+Guadalupe,204,Straight Party,,REP,,160,96,61,3
+Guadalupe,204,Straight Party,,DEM,,270,146,106,18
+Guadalupe,204,Straight Party,,LIB,,6,2,4,0
+Guadalupe,205,Straight Party,,,Under Votes,252,145,99,8
+Guadalupe,205,Straight Party,,REP,,299,180,109,10
+Guadalupe,205,Straight Party,,DEM,,113,61,47,5
+Guadalupe,205,Straight Party,,LIB,,3,0,3,0
+Guadalupe,206,Straight Party,,,Under Votes,315,136,167,12
+Guadalupe,206,Straight Party,,REP,,234,82,139,13
+Guadalupe,206,Straight Party,,DEM,,416,114,281,21
+Guadalupe,206,Straight Party,,LIB,,6,3,3,0
+Guadalupe,207,Straight Party,,,Under Votes,121,84,26,11
+Guadalupe,207,Straight Party,,REP,,113,81,26,6
+Guadalupe,207,Straight Party,,DEM,,171,96,64,11
+Guadalupe,207,Straight Party,,LIB,,3,1,2,0
+Guadalupe,208,Straight Party,,,Under Votes,649,476,129,44
+Guadalupe,208,Straight Party,,REP,,989,713,222,54
+Guadalupe,208,Straight Party,,DEM,,247,172,67,8
+Guadalupe,208,Straight Party,,LIB,,7,3,4,0
+Guadalupe,209,Straight Party,,,Under Votes,78,43,32,3
+Guadalupe,209,Straight Party,,REP,,63,34,26,3
+Guadalupe,209,Straight Party,,DEM,,181,84,79,18
+Guadalupe,209,Straight Party,,LIB,,0,0,0,0
+Guadalupe,210,Straight Party,,,Under Votes,220,141,59,20
+Guadalupe,210,Straight Party,,REP,,156,102,46,8
+Guadalupe,210,Straight Party,,DEM,,107,70,29,8
+Guadalupe,210,Straight Party,,LIB,,0,0,0,0
+Guadalupe,211,Straight Party,,,Under Votes,27,22,4,1
+Guadalupe,211,Straight Party,,REP,,26,20,5,1
+Guadalupe,211,Straight Party,,DEM,,27,22,2,3
+Guadalupe,211,Straight Party,,LIB,,0,0,0,0
+Guadalupe,212,Straight Party,,,Under Votes,39,29,8,2
+Guadalupe,212,Straight Party,,REP,,19,18,1,0
+Guadalupe,212,Straight Party,,DEM,,27,13,12,2
+Guadalupe,212,Straight Party,,LIB,,1,1,0,0
+Guadalupe,213,Straight Party,,,Under Votes,408,280,108,20
+Guadalupe,213,Straight Party,,REP,,595,413,163,19
+Guadalupe,213,Straight Party,,DEM,,217,135,73,9
+Guadalupe,213,Straight Party,,LIB,,15,10,5,0
+Guadalupe,214,Straight Party,,,Under Votes,151,101,42,8
+Guadalupe,214,Straight Party,,REP,,170,126,39,5
+Guadalupe,214,Straight Party,,DEM,,50,28,17,5
+Guadalupe,214,Straight Party,,LIB,,0,0,0,0
+Guadalupe,215,Straight Party,,,Under Votes,189,130,46,13
+Guadalupe,215,Straight Party,,REP,,263,174,69,20
+Guadalupe,215,Straight Party,,DEM,,88,60,21,7
+Guadalupe,215,Straight Party,,LIB,,2,1,1,0
+Guadalupe,216,Straight Party,,,Under Votes,15,8,6,1
+Guadalupe,216,Straight Party,,REP,,20,12,5,3
+Guadalupe,216,Straight Party,,DEM,,2,2,0,0
+Guadalupe,216,Straight Party,,LIB,,0,0,0,0
+Guadalupe,217,Straight Party,,,Under Votes,21,8,12,1
+Guadalupe,217,Straight Party,,REP,,19,7,10,2
+Guadalupe,217,Straight Party,,DEM,,25,7,18,0
+Guadalupe,217,Straight Party,,LIB,,0,0,0,0
+Guadalupe,218,Straight Party,,,Under Votes,14,12,1,1
+Guadalupe,218,Straight Party,,REP,,7,6,1,0
+Guadalupe,218,Straight Party,,DEM,,17,14,3,0
+Guadalupe,218,Straight Party,,LIB,,0,0,0,0
+Guadalupe,219,Straight Party,,,Under Votes,31,27,3,1
+Guadalupe,219,Straight Party,,REP,,10,6,4,0
+Guadalupe,219,Straight Party,,DEM,,10,8,2,0
+Guadalupe,219,Straight Party,,LIB,,0,0,0,0
+Guadalupe,220,Straight Party,,,Under Votes,21,12,8,1
+Guadalupe,220,Straight Party,,REP,,9,8,1,0
+Guadalupe,220,Straight Party,,DEM,,13,11,1,1
+Guadalupe,220,Straight Party,,LIB,,0,0,0,0
+Guadalupe,221,Straight Party,,,Under Votes,8,5,2,1
+Guadalupe,221,Straight Party,,REP,,4,3,1,0
+Guadalupe,221,Straight Party,,DEM,,4,1,1,2
+Guadalupe,221,Straight Party,,LIB,,0,0,0,0
+Guadalupe,222,Straight Party,,,Under Votes,0,0,0,0
+Guadalupe,222,Straight Party,,REP,,0,0,0,0
+Guadalupe,222,Straight Party,,DEM,,0,0,0,0
+Guadalupe,222,Straight Party,,LIB,,0,0,0,0
+Guadalupe,223,Straight Party,,,Under Votes,65,47,13,5
+Guadalupe,223,Straight Party,,REP,,49,28,17,4
+Guadalupe,223,Straight Party,,DEM,,44,35,7,2
+Guadalupe,223,Straight Party,,LIB,,1,0,1,0
+Guadalupe,224,Straight Party,,,Under Votes,18,8,7,3
+Guadalupe,224,Straight Party,,REP,,6,2,4,0
+Guadalupe,224,Straight Party,,DEM,,36,17,15,4
+Guadalupe,224,Straight Party,,LIB,,0,0,0,0
+Guadalupe,225,Straight Party,,,Under Votes,6,4,2,0
+Guadalupe,225,Straight Party,,REP,,0,0,0,0
+Guadalupe,225,Straight Party,,DEM,,5,4,1,0
+Guadalupe,225,Straight Party,,LIB,,0,0,0,0
+Guadalupe,226,Straight Party,,,Under Votes,60,38,18,4
+Guadalupe,226,Straight Party,,REP,,58,42,16,0
+Guadalupe,226,Straight Party,,DEM,,42,19,21,2
+Guadalupe,226,Straight Party,,LIB,,0,0,0,0
+Guadalupe,301,Straight Party,,,Under Votes,578,361,185,32
+Guadalupe,301,Straight Party,,REP,,693,443,215,35
+Guadalupe,301,Straight Party,,DEM,,466,323,133,10
+Guadalupe,301,Straight Party,,LIB,,7,4,2,1
+Guadalupe,302,Straight Party,,,Under Votes,771,502,232,37
+Guadalupe,302,Straight Party,,REP,,861,592,231,38
+Guadalupe,302,Straight Party,,DEM,,676,445,203,28
+Guadalupe,302,Straight Party,,LIB,,16,10,5,1
+Guadalupe,303,Straight Party,,,Under Votes,279,207,53,19
+Guadalupe,303,Straight Party,,REP,,364,281,61,22
+Guadalupe,303,Straight Party,,DEM,,161,114,37,10
+Guadalupe,303,Straight Party,,LIB,,4,2,2,0
+Guadalupe,304,Straight Party,,,Under Votes,804,614,141,49
+Guadalupe,304,Straight Party,,REP,,973,745,184,44
+Guadalupe,304,Straight Party,,DEM,,552,411,105,36
+Guadalupe,304,Straight Party,,LIB,,7,5,2,0
+Guadalupe,305,Straight Party,,,Under Votes,812,556,211,45
+Guadalupe,305,Straight Party,,REP,,938,670,222,46
+Guadalupe,305,Straight Party,,DEM,,650,451,155,44
+Guadalupe,305,Straight Party,,LIB,,10,4,6,0
+Guadalupe,306,Straight Party,,,Under Votes,809,638,129,42
+Guadalupe,306,Straight Party,,REP,,1033,809,176,48
+Guadalupe,306,Straight Party,,DEM,,562,441,88,33
+Guadalupe,306,Straight Party,,LIB,,7,2,4,1
+Guadalupe,307,Straight Party,,,Under Votes,867,673,161,33
+Guadalupe,307,Straight Party,,REP,,1005,782,177,46
+Guadalupe,307,Straight Party,,DEM,,653,497,131,25
+Guadalupe,307,Straight Party,,LIB,,14,5,8,1
+Guadalupe,308,Straight Party,,,Under Votes,458,346,77,35
+Guadalupe,308,Straight Party,,REP,,572,445,95,32
+Guadalupe,308,Straight Party,,DEM,,248,161,64,23
+Guadalupe,308,Straight Party,,LIB,,4,4,0,0
+Guadalupe,401,Straight Party,,,Under Votes,319,186,109,24
+Guadalupe,401,Straight Party,,REP,,430,238,168,24
+Guadalupe,401,Straight Party,,DEM,,116,67,43,6
+Guadalupe,401,Straight Party,,LIB,,9,7,2,0
+Guadalupe,402,Straight Party,,,Under Votes,295,210,61,24
+Guadalupe,402,Straight Party,,REP,,383,258,90,35
+Guadalupe,402,Straight Party,,DEM,,229,128,76,25
+Guadalupe,402,Straight Party,,LIB,,8,1,6,1
+Guadalupe,403,Straight Party,,,Under Votes,395,251,104,40
+Guadalupe,403,Straight Party,,REP,,559,392,126,41
+Guadalupe,403,Straight Party,,DEM,,356,211,90,55
+Guadalupe,403,Straight Party,,LIB,,10,4,6,0
+Guadalupe,404,Straight Party,,,Under Votes,562,334,182,46
+Guadalupe,404,Straight Party,,REP,,672,405,214,53
+Guadalupe,404,Straight Party,,DEM,,424,265,130,29
+Guadalupe,404,Straight Party,,LIB,,9,2,7,0
+Guadalupe,405,Straight Party,,,Under Votes,365,217,141,7
+Guadalupe,405,Straight Party,,REP,,628,371,227,30
+Guadalupe,405,Straight Party,,DEM,,118,73,37,8
+Guadalupe,405,Straight Party,,LIB,,4,2,2,0
+Guadalupe,406,Straight Party,,,Under Votes,451,333,92,26
+Guadalupe,406,Straight Party,,REP,,680,512,145,23
+Guadalupe,406,Straight Party,,DEM,,87,57,23,7
+Guadalupe,406,Straight Party,,LIB,,2,1,1,0
+Guadalupe,407,Straight Party,,,Under Votes,324,233,68,23
+Guadalupe,407,Straight Party,,REP,,628,450,154,24
+Guadalupe,407,Straight Party,,DEM,,124,71,40,13
+Guadalupe,407,Straight Party,,LIB,,8,1,4,3
+Guadalupe,408,Straight Party,,,Under Votes,754,473,215,66
+Guadalupe,408,Straight Party,,REP,,1131,761,279,91
+Guadalupe,408,Straight Party,,DEM,,455,290,142,23
+Guadalupe,408,Straight Party,,LIB,,12,6,6,0
+Guadalupe,409,Straight Party,,,Under Votes,860,636,187,37
+Guadalupe,409,Straight Party,,REP,,855,605,217,33
+Guadalupe,409,Straight Party,,DEM,,915,655,221,39
+Guadalupe,409,Straight Party,,LIB,,8,6,2,0
+Guadalupe,410,Straight Party,,,Under Votes,29,23,6,0
+Guadalupe,410,Straight Party,,REP,,39,33,6,0
+Guadalupe,410,Straight Party,,DEM,,13,9,4,0
+Guadalupe,410,Straight Party,,LIB,,2,0,2,0
+Guadalupe,411,Straight Party,,,Under Votes,701,506,161,34
+Guadalupe,411,Straight Party,,REP,,810,578,192,40
+Guadalupe,411,Straight Party,,DEM,,479,371,82,26
+Guadalupe,411,Straight Party,,LIB,,8,4,4,0
+Guadalupe,101,U.S. Senate,,,Under Votes,0,0,0,0
+Guadalupe,101,U.S. Senate,,REP,Ted Cruz,262,176,68,18
+Guadalupe,101,U.S. Senate,,DEM,Beto O'Rourke,103,68,25,10
+Guadalupe,101,U.S. Senate,,LIB,Neal M. Dikeman,4,0,4,0
+Guadalupe,102,U.S. Senate,,,Under Votes,2,0,2,0
+Guadalupe,102,U.S. Senate,,REP,Ted Cruz,410,308,65,37
+Guadalupe,102,U.S. Senate,,DEM,Beto O'Rourke,181,111,53,17
+Guadalupe,102,U.S. Senate,,LIB,Neal M. Dikeman,5,3,2,0
+Guadalupe,103,U.S. Senate,,,Under Votes,2,1,1,0
+Guadalupe,103,U.S. Senate,,REP,Ted Cruz,328,246,62,20
+Guadalupe,103,U.S. Senate,,DEM,Beto O'Rourke,126,75,41,10
+Guadalupe,103,U.S. Senate,,LIB,Neal M. Dikeman,3,2,1,0
+Guadalupe,104,U.S. Senate,,,Under Votes,9,6,3,0
+Guadalupe,104,U.S. Senate,,REP,Ted Cruz,268,197,53,18
+Guadalupe,104,U.S. Senate,,DEM,Beto O'Rourke,238,142,75,21
+Guadalupe,104,U.S. Senate,,LIB,Neal M. Dikeman,5,5,0,0
+Guadalupe,105,U.S. Senate,,,Under Votes,8,5,3,0
+Guadalupe,105,U.S. Senate,,REP,Ted Cruz,1163,706,384,73
+Guadalupe,105,U.S. Senate,,DEM,Beto O'Rourke,324,186,108,30
+Guadalupe,105,U.S. Senate,,LIB,Neal M. Dikeman,19,9,9,1
+Guadalupe,106,U.S. Senate,,,Under Votes,6,5,0,1
+Guadalupe,106,U.S. Senate,,REP,Ted Cruz,1294,944,233,117
+Guadalupe,106,U.S. Senate,,DEM,Beto O'Rourke,586,405,139,42
+Guadalupe,106,U.S. Senate,,LIB,Neal M. Dikeman,19,13,5,1
+Guadalupe,107,U.S. Senate,,,Under Votes,2,0,2,0
+Guadalupe,107,U.S. Senate,,REP,Ted Cruz,555,304,222,29
+Guadalupe,107,U.S. Senate,,DEM,Beto O'Rourke,140,81,55,4
+Guadalupe,107,U.S. Senate,,LIB,Neal M. Dikeman,11,3,8,0
+Guadalupe,108,U.S. Senate,,,Under Votes,1,0,1,0
+Guadalupe,108,U.S. Senate,,REP,Ted Cruz,265,101,136,28
+Guadalupe,108,U.S. Senate,,DEM,Beto O'Rourke,160,67,76,17
+Guadalupe,108,U.S. Senate,,LIB,Neal M. Dikeman,5,0,5,0
+Guadalupe,109,U.S. Senate,,,Under Votes,6,4,2,0
+Guadalupe,109,U.S. Senate,,REP,Ted Cruz,250,120,121,9
+Guadalupe,109,U.S. Senate,,DEM,Beto O'Rourke,55,27,25,3
+Guadalupe,109,U.S. Senate,,LIB,Neal M. Dikeman,1,1,0,0
+Guadalupe,110,U.S. Senate,,,Under Votes,1,1,0,0
+Guadalupe,110,U.S. Senate,,REP,Ted Cruz,87,70,14,3
+Guadalupe,110,U.S. Senate,,DEM,Beto O'Rourke,61,45,11,5
+Guadalupe,110,U.S. Senate,,LIB,Neal M. Dikeman,2,1,1,0
+Guadalupe,111,U.S. Senate,,,Under Votes,0,0,0,0
+Guadalupe,111,U.S. Senate,,REP,Ted Cruz,30,19,6,5
+Guadalupe,111,U.S. Senate,,DEM,Beto O'Rourke,33,15,10,8
+Guadalupe,111,U.S. Senate,,LIB,Neal M. Dikeman,1,0,0,1
+Guadalupe,112,U.S. Senate,,,Under Votes,0,0,0,0
+Guadalupe,112,U.S. Senate,,REP,Ted Cruz,59,22,36,1
+Guadalupe,112,U.S. Senate,,DEM,Beto O'Rourke,165,61,104,0
+Guadalupe,112,U.S. Senate,,LIB,Neal M. Dikeman,2,2,0,0
+Guadalupe,113,U.S. Senate,,,Under Votes,5,4,1,0
+Guadalupe,113,U.S. Senate,,REP,Ted Cruz,382,275,89,18
+Guadalupe,113,U.S. Senate,,DEM,Beto O'Rourke,188,120,58,10
+Guadalupe,113,U.S. Senate,,LIB,Neal M. Dikeman,9,5,4,0
+Guadalupe,114,U.S. Senate,,,Under Votes,3,2,1,0
+Guadalupe,114,U.S. Senate,,REP,Ted Cruz,276,201,60,15
+Guadalupe,114,U.S. Senate,,DEM,Beto O'Rourke,163,107,47,9
+Guadalupe,114,U.S. Senate,,LIB,Neal M. Dikeman,9,6,1,2
+Guadalupe,115,U.S. Senate,,,Under Votes,0,0,0,0
+Guadalupe,115,U.S. Senate,,REP,Ted Cruz,149,107,41,1
+Guadalupe,115,U.S. Senate,,DEM,Beto O'Rourke,27,19,5,3
+Guadalupe,115,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Guadalupe,116,U.S. Senate,,,Under Votes,11,6,5,0
+Guadalupe,116,U.S. Senate,,REP,Ted Cruz,981,666,252,63
+Guadalupe,116,U.S. Senate,,DEM,Beto O'Rourke,339,170,144,25
+Guadalupe,116,U.S. Senate,,LIB,Neal M. Dikeman,10,4,5,1
+Guadalupe,117,U.S. Senate,,,Under Votes,2,2,0,0
+Guadalupe,117,U.S. Senate,,REP,Ted Cruz,1746,1289,379,78
+Guadalupe,117,U.S. Senate,,DEM,Beto O'Rourke,770,524,198,48
+Guadalupe,117,U.S. Senate,,LIB,Neal M. Dikeman,20,14,5,1
+Guadalupe,118,U.S. Senate,,,Under Votes,0,0,0,0
+Guadalupe,118,U.S. Senate,,REP,Ted Cruz,22,16,6,0
+Guadalupe,118,U.S. Senate,,DEM,Beto O'Rourke,21,13,7,1
+Guadalupe,118,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Guadalupe,119,U.S. Senate,,,Under Votes,4,3,1,0
+Guadalupe,119,U.S. Senate,,REP,Ted Cruz,822,630,150,42
+Guadalupe,119,U.S. Senate,,DEM,Beto O'Rourke,261,185,60,16
+Guadalupe,119,U.S. Senate,,LIB,Neal M. Dikeman,13,8,5,0
+Guadalupe,120,U.S. Senate,,,Under Votes,2,1,1,0
+Guadalupe,120,U.S. Senate,,REP,Ted Cruz,545,380,121,44
+Guadalupe,120,U.S. Senate,,DEM,Beto O'Rourke,168,110,39,19
+Guadalupe,120,U.S. Senate,,LIB,Neal M. Dikeman,5,2,3,0
+Guadalupe,121,U.S. Senate,,,Under Votes,3,1,2,0
+Guadalupe,121,U.S. Senate,,REP,Ted Cruz,62,53,7,2
+Guadalupe,121,U.S. Senate,,DEM,Beto O'Rourke,27,23,2,2
+Guadalupe,121,U.S. Senate,,LIB,Neal M. Dikeman,2,2,0,0
+Guadalupe,122,U.S. Senate,,,Under Votes,0,0,0,0
+Guadalupe,122,U.S. Senate,,REP,Ted Cruz,20,16,1,3
+Guadalupe,122,U.S. Senate,,DEM,Beto O'Rourke,7,1,0,6
+Guadalupe,122,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Guadalupe,123,U.S. Senate,,,Under Votes,0,0,0,0
+Guadalupe,123,U.S. Senate,,REP,Ted Cruz,0,0,0,0
+Guadalupe,123,U.S. Senate,,DEM,Beto O'Rourke,1,0,0,1
+Guadalupe,123,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Guadalupe,124,U.S. Senate,,,Under Votes,0,0,0,0
+Guadalupe,124,U.S. Senate,,REP,Ted Cruz,2,2,0,0
+Guadalupe,124,U.S. Senate,,DEM,Beto O'Rourke,0,0,0,0
+Guadalupe,124,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Guadalupe,125,U.S. Senate,,,Under Votes,0,0,0,0
+Guadalupe,125,U.S. Senate,,REP,Ted Cruz,90,67,12,11
+Guadalupe,125,U.S. Senate,,DEM,Beto O'Rourke,19,12,6,1
+Guadalupe,125,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Guadalupe,126,U.S. Senate,,,Under Votes,0,0,0,0
+Guadalupe,126,U.S. Senate,,REP,Ted Cruz,11,3,7,1
+Guadalupe,126,U.S. Senate,,DEM,Beto O'Rourke,2,2,0,0
+Guadalupe,126,U.S. Senate,,LIB,Neal M. Dikeman,1,1,0,0
+Guadalupe,127,U.S. Senate,,,Under Votes,0,0,0,0
+Guadalupe,127,U.S. Senate,,REP,Ted Cruz,11,4,6,1
+Guadalupe,127,U.S. Senate,,DEM,Beto O'Rourke,4,0,4,0
+Guadalupe,127,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Guadalupe,201,U.S. Senate,,,Under Votes,0,0,0,0
+Guadalupe,201,U.S. Senate,,REP,Ted Cruz,119,82,28,9
+Guadalupe,201,U.S. Senate,,DEM,Beto O'Rourke,92,57,27,8
+Guadalupe,201,U.S. Senate,,LIB,Neal M. Dikeman,1,0,0,1
+Guadalupe,202,U.S. Senate,,,Under Votes,3,0,2,1
+Guadalupe,202,U.S. Senate,,REP,Ted Cruz,134,84,41,9
+Guadalupe,202,U.S. Senate,,DEM,Beto O'Rourke,323,171,117,35
+Guadalupe,202,U.S. Senate,,LIB,Neal M. Dikeman,3,0,3,0
+Guadalupe,203,U.S. Senate,,,Under Votes,3,2,1,0
+Guadalupe,203,U.S. Senate,,REP,Ted Cruz,45,28,13,4
+Guadalupe,203,U.S. Senate,,DEM,Beto O'Rourke,131,55,66,10
+Guadalupe,203,U.S. Senate,,LIB,Neal M. Dikeman,1,0,1,0
+Guadalupe,204,U.S. Senate,,,Under Votes,7,3,3,1
+Guadalupe,204,U.S. Senate,,REP,Ted Cruz,251,145,99,7
+Guadalupe,204,U.S. Senate,,DEM,Beto O'Rourke,364,199,144,21
+Guadalupe,204,U.S. Senate,,LIB,Neal M. Dikeman,6,4,1,1
+Guadalupe,205,U.S. Senate,,,Under Votes,4,2,2,0
+Guadalupe,205,U.S. Senate,,REP,Ted Cruz,485,282,186,17
+Guadalupe,205,U.S. Senate,,DEM,Beto O'Rourke,172,99,67,6
+Guadalupe,205,U.S. Senate,,LIB,Neal M. Dikeman,6,3,3,0
+Guadalupe,206,U.S. Senate,,,Under Votes,5,0,3,2
+Guadalupe,206,U.S. Senate,,REP,Ted Cruz,356,137,202,17
+Guadalupe,206,U.S. Senate,,DEM,Beto O'Rourke,603,194,382,27
+Guadalupe,206,U.S. Senate,,LIB,Neal M. Dikeman,7,4,3,0
+Guadalupe,207,U.S. Senate,,,Under Votes,5,3,1,1
+Guadalupe,207,U.S. Senate,,REP,Ted Cruz,147,102,35,10
+Guadalupe,207,U.S. Senate,,DEM,Beto O'Rourke,251,155,79,17
+Guadalupe,207,U.S. Senate,,LIB,Neal M. Dikeman,5,2,3,0
+Guadalupe,208,U.S. Senate,,,Under Votes,6,5,1,0
+Guadalupe,208,U.S. Senate,,REP,Ted Cruz,1414,1039,300,75
+Guadalupe,208,U.S. Senate,,DEM,Beto O'Rourke,448,310,111,27
+Guadalupe,208,U.S. Senate,,LIB,Neal M. Dikeman,24,10,10,4
+Guadalupe,209,U.S. Senate,,,Under Votes,3,3,0,0
+Guadalupe,209,U.S. Senate,,REP,Ted Cruz,89,48,35,6
+Guadalupe,209,U.S. Senate,,DEM,Beto O'Rourke,229,109,102,18
+Guadalupe,209,U.S. Senate,,LIB,Neal M. Dikeman,1,1,0,0
+Guadalupe,210,U.S. Senate,,,Under Votes,3,1,2,0
+Guadalupe,210,U.S. Senate,,REP,Ted Cruz,256,165,74,17
+Guadalupe,210,U.S. Senate,,DEM,Beto O'Rourke,218,142,57,19
+Guadalupe,210,U.S. Senate,,LIB,Neal M. Dikeman,6,5,1,0
+Guadalupe,211,U.S. Senate,,,Under Votes,0,0,0,0
+Guadalupe,211,U.S. Senate,,REP,Ted Cruz,38,30,7,1
+Guadalupe,211,U.S. Senate,,DEM,Beto O'Rourke,40,32,4,4
+Guadalupe,211,U.S. Senate,,LIB,Neal M. Dikeman,2,2,0,0
+Guadalupe,212,U.S. Senate,,,Under Votes,2,1,0,1
+Guadalupe,212,U.S. Senate,,REP,Ted Cruz,34,30,4,0
+Guadalupe,212,U.S. Senate,,DEM,Beto O'Rourke,50,30,17,3
+Guadalupe,212,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Guadalupe,213,U.S. Senate,,,Under Votes,4,2,1,1
+Guadalupe,213,U.S. Senate,,REP,Ted Cruz,818,565,225,28
+Guadalupe,213,U.S. Senate,,DEM,Beto O'Rourke,389,259,113,17
+Guadalupe,213,U.S. Senate,,LIB,Neal M. Dikeman,24,12,10,2
+Guadalupe,214,U.S. Senate,,,Under Votes,0,0,0,0
+Guadalupe,214,U.S. Senate,,REP,Ted Cruz,274,195,70,9
+Guadalupe,214,U.S. Senate,,DEM,Beto O'Rourke,93,57,27,9
+Guadalupe,214,U.S. Senate,,LIB,Neal M. Dikeman,4,3,1,0
+Guadalupe,215,U.S. Senate,,,Under Votes,1,1,0,0
+Guadalupe,215,U.S. Senate,,REP,Ted Cruz,378,252,98,28
+Guadalupe,215,U.S. Senate,,DEM,Beto O'Rourke,158,109,38,11
+Guadalupe,215,U.S. Senate,,LIB,Neal M. Dikeman,5,3,1,1
+Guadalupe,216,U.S. Senate,,,Under Votes,0,0,0,0
+Guadalupe,216,U.S. Senate,,REP,Ted Cruz,29,17,8,4
+Guadalupe,216,U.S. Senate,,DEM,Beto O'Rourke,8,5,3,0
+Guadalupe,216,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Guadalupe,217,U.S. Senate,,,Under Votes,0,0,0,0
+Guadalupe,217,U.S. Senate,,REP,Ted Cruz,29,12,14,3
+Guadalupe,217,U.S. Senate,,DEM,Beto O'Rourke,36,10,26,0
+Guadalupe,217,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Guadalupe,218,U.S. Senate,,,Under Votes,0,0,0,0
+Guadalupe,218,U.S. Senate,,REP,Ted Cruz,15,13,1,1
+Guadalupe,218,U.S. Senate,,DEM,Beto O'Rourke,23,19,4,0
+Guadalupe,218,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Guadalupe,219,U.S. Senate,,,Under Votes,1,1,0,0
+Guadalupe,219,U.S. Senate,,REP,Ted Cruz,25,20,5,0
+Guadalupe,219,U.S. Senate,,DEM,Beto O'Rourke,25,20,4,1
+Guadalupe,219,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Guadalupe,220,U.S. Senate,,,Under Votes,0,0,0,0
+Guadalupe,220,U.S. Senate,,REP,Ted Cruz,19,14,5,0
+Guadalupe,220,U.S. Senate,,DEM,Beto O'Rourke,24,17,5,2
+Guadalupe,220,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Guadalupe,221,U.S. Senate,,,Under Votes,0,0,0,0
+Guadalupe,221,U.S. Senate,,REP,Ted Cruz,11,8,3,0
+Guadalupe,221,U.S. Senate,,DEM,Beto O'Rourke,5,1,1,3
+Guadalupe,221,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Guadalupe,222,U.S. Senate,,,Under Votes,0,0,0,0
+Guadalupe,222,U.S. Senate,,REP,Ted Cruz,0,0,0,0
+Guadalupe,222,U.S. Senate,,DEM,Beto O'Rourke,0,0,0,0
+Guadalupe,222,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Guadalupe,223,U.S. Senate,,,Under Votes,1,1,0,0
+Guadalupe,223,U.S. Senate,,REP,Ted Cruz,75,44,26,5
+Guadalupe,223,U.S. Senate,,DEM,Beto O'Rourke,81,64,11,6
+Guadalupe,223,U.S. Senate,,LIB,Neal M. Dikeman,2,1,1,0
+Guadalupe,224,U.S. Senate,,,Under Votes,0,0,0,0
+Guadalupe,224,U.S. Senate,,REP,Ted Cruz,10,3,7,0
+Guadalupe,224,U.S. Senate,,DEM,Beto O'Rourke,50,24,19,7
+Guadalupe,224,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Guadalupe,225,U.S. Senate,,,Under Votes,0,0,0,0
+Guadalupe,225,U.S. Senate,,REP,Ted Cruz,1,0,1,0
+Guadalupe,225,U.S. Senate,,DEM,Beto O'Rourke,10,8,2,0
+Guadalupe,225,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Guadalupe,226,U.S. Senate,,,Under Votes,1,0,1,0
+Guadalupe,226,U.S. Senate,,REP,Ted Cruz,103,69,31,3
+Guadalupe,226,U.S. Senate,,DEM,Beto O'Rourke,56,30,23,3
+Guadalupe,226,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Guadalupe,301,U.S. Senate,,,Under Votes,3,1,2,0
+Guadalupe,301,U.S. Senate,,REP,Ted Cruz,1002,630,319,53
+Guadalupe,301,U.S. Senate,,DEM,Beto O'Rourke,723,490,208,25
+Guadalupe,301,U.S. Senate,,LIB,Neal M. Dikeman,16,10,6,0
+Guadalupe,302,U.S. Senate,,,Under Votes,6,5,0,1
+Guadalupe,302,U.S. Senate,,REP,Ted Cruz,1227,855,320,52
+Guadalupe,302,U.S. Senate,,DEM,Beto O'Rourke,1068,678,339,51
+Guadalupe,302,U.S. Senate,,LIB,Neal M. Dikeman,23,11,12,0
+Guadalupe,303,U.S. Senate,,,Under Votes,1,0,1,0
+Guadalupe,303,U.S. Senate,,REP,Ted Cruz,519,402,89,28
+Guadalupe,303,U.S. Senate,,DEM,Beto O'Rourke,278,198,59,21
+Guadalupe,303,U.S. Senate,,LIB,Neal M. Dikeman,10,4,4,2
+Guadalupe,304,U.S. Senate,,,Under Votes,7,4,2,1
+Guadalupe,304,U.S. Senate,,REP,Ted Cruz,1385,1073,245,67
+Guadalupe,304,U.S. Senate,,DEM,Beto O'Rourke,926,686,179,61
+Guadalupe,304,U.S. Senate,,LIB,Neal M. Dikeman,18,12,6,0
+Guadalupe,305,U.S. Senate,,,Under Votes,7,6,1,0
+Guadalupe,305,U.S. Senate,,REP,Ted Cruz,1316,931,325,60
+Guadalupe,305,U.S. Senate,,DEM,Beto O'Rourke,1061,730,256,75
+Guadalupe,305,U.S. Senate,,LIB,Neal M. Dikeman,26,14,12,0
+Guadalupe,306,U.S. Senate,,,Under Votes,4,2,2,0
+Guadalupe,306,U.S. Senate,,REP,Ted Cruz,1436,1137,234,65
+Guadalupe,306,U.S. Senate,,DEM,Beto O'Rourke,951,741,151,59
+Guadalupe,306,U.S. Senate,,LIB,Neal M. Dikeman,20,10,10,0
+Guadalupe,307,U.S. Senate,,,Under Votes,2,0,1,1
+Guadalupe,307,U.S. Senate,,REP,Ted Cruz,1397,1091,250,56
+Guadalupe,307,U.S. Senate,,DEM,Beto O'Rourke,1111,849,216,46
+Guadalupe,307,U.S. Senate,,LIB,Neal M. Dikeman,29,17,10,2
+Guadalupe,308,U.S. Senate,,,Under Votes,2,2,0,0
+Guadalupe,308,U.S. Senate,,REP,Ted Cruz,808,632,126,50
+Guadalupe,308,U.S. Senate,,DEM,Beto O'Rourke,462,314,109,39
+Guadalupe,308,U.S. Senate,,LIB,Neal M. Dikeman,10,8,1,1
+Guadalupe,401,U.S. Senate,,,Under Votes,3,0,3,0
+Guadalupe,401,U.S. Senate,,REP,Ted Cruz,653,374,237,42
+Guadalupe,401,U.S. Senate,,DEM,Beto O'Rourke,206,118,76,12
+Guadalupe,401,U.S. Senate,,LIB,Neal M. Dikeman,12,6,6,0
+Guadalupe,402,U.S. Senate,,,Under Votes,4,3,0,1
+Guadalupe,402,U.S. Senate,,REP,Ted Cruz,521,364,115,42
+Guadalupe,402,U.S. Senate,,DEM,Beto O'Rourke,378,223,113,42
+Guadalupe,402,U.S. Senate,,LIB,Neal M. Dikeman,12,7,5,0
+Guadalupe,403,U.S. Senate,,,Under Votes,9,6,3,0
+Guadalupe,403,U.S. Senate,,REP,Ted Cruz,755,517,174,64
+Guadalupe,403,U.S. Senate,,DEM,Beto O'Rourke,542,329,141,72
+Guadalupe,403,U.S. Senate,,LIB,Neal M. Dikeman,14,6,8,0
+Guadalupe,404,U.S. Senate,,,Under Votes,2,1,1,0
+Guadalupe,404,U.S. Senate,,REP,Ted Cruz,934,561,298,75
+Guadalupe,404,U.S. Senate,,DEM,Beto O'Rourke,714,438,226,50
+Guadalupe,404,U.S. Senate,,LIB,Neal M. Dikeman,17,6,8,3
+Guadalupe,405,U.S. Senate,,,Under Votes,6,5,1,0
+Guadalupe,405,U.S. Senate,,REP,Ted Cruz,889,527,329,33
+Guadalupe,405,U.S. Senate,,DEM,Beto O'Rourke,212,127,74,11
+Guadalupe,405,U.S. Senate,,LIB,Neal M. Dikeman,8,4,3,1
+Guadalupe,406,U.S. Senate,,,Under Votes,4,3,1,0
+Guadalupe,406,U.S. Senate,,REP,Ted Cruz,1022,768,212,42
+Guadalupe,406,U.S. Senate,,DEM,Beto O'Rourke,182,125,45,12
+Guadalupe,406,U.S. Senate,,LIB,Neal M. Dikeman,12,7,3,2
+Guadalupe,407,U.S. Senate,,,Under Votes,3,2,1,0
+Guadalupe,407,U.S. Senate,,REP,Ted Cruz,867,625,201,41
+Guadalupe,407,U.S. Senate,,DEM,Beto O'Rourke,204,124,60,20
+Guadalupe,407,U.S. Senate,,LIB,Neal M. Dikeman,10,4,4,2
+Guadalupe,408,U.S. Senate,,,Under Votes,8,4,3,1
+Guadalupe,408,U.S. Senate,,REP,Ted Cruz,1544,1012,401,131
+Guadalupe,408,U.S. Senate,,DEM,Beto O'Rourke,774,503,225,46
+Guadalupe,408,U.S. Senate,,LIB,Neal M. Dikeman,26,11,13,2
+Guadalupe,409,U.S. Senate,,,Under Votes,8,6,2,0
+Guadalupe,409,U.S. Senate,,REP,Ted Cruz,1191,860,284,47
+Guadalupe,409,U.S. Senate,,DEM,Beto O'Rourke,1415,1021,333,61
+Guadalupe,409,U.S. Senate,,LIB,Neal M. Dikeman,24,15,8,1
+Guadalupe,410,U.S. Senate,,,Under Votes,0,0,0,0
+Guadalupe,410,U.S. Senate,,REP,Ted Cruz,56,46,10,0
+Guadalupe,410,U.S. Senate,,DEM,Beto O'Rourke,25,19,6,0
+Guadalupe,410,U.S. Senate,,LIB,Neal M. Dikeman,2,0,2,0
+Guadalupe,411,U.S. Senate,,,Under Votes,6,4,2,0
+Guadalupe,411,U.S. Senate,,REP,Ted Cruz,1171,843,271,57
+Guadalupe,411,U.S. Senate,,DEM,Beto O'Rourke,799,599,157,43
+Guadalupe,411,U.S. Senate,,LIB,Neal M. Dikeman,22,13,9,0
+Guadalupe,101,U.S. House,15,,Under Votes,4,3,1,0
+Guadalupe,101,U.S. House,15,REP,Tim Westley,265,175,72,18
+Guadalupe,101,U.S. House,15,DEM,Vicente Gonzalez,91,60,21,10
+Guadalupe,101,U.S. House,15,LIB,Anthony Cristo,9,6,3,0
+Guadalupe,102,U.S. House,15,,Under Votes,10,6,2,2
+Guadalupe,102,U.S. House,15,REP,Tim Westley,401,306,61,34
+Guadalupe,102,U.S. House,15,DEM,Vicente Gonzalez,172,102,53,17
+Guadalupe,102,U.S. House,15,LIB,Anthony Cristo,15,8,6,1
+Guadalupe,103,U.S. House,15,,Under Votes,10,7,1,2
+Guadalupe,103,U.S. House,15,REP,Tim Westley,321,238,66,17
+Guadalupe,103,U.S. House,15,DEM,Vicente Gonzalez,123,78,34,11
+Guadalupe,103,U.S. House,15,LIB,Anthony Cristo,5,1,4,0
+Guadalupe,104,U.S. House,15,,Under Votes,20,13,5,2
+Guadalupe,104,U.S. House,15,REP,Tim Westley,266,193,55,18
+Guadalupe,104,U.S. House,15,DEM,Vicente Gonzalez,223,135,69,19
+Guadalupe,104,U.S. House,15,LIB,Anthony Cristo,11,9,2,0
+Guadalupe,105,U.S. House,15,,Under Votes,26,16,6,4
+Guadalupe,105,U.S. House,15,REP,Tim Westley,1140,692,381,67
+Guadalupe,105,U.S. House,15,DEM,Vicente Gonzalez,317,186,100,31
+Guadalupe,105,U.S. House,15,LIB,Anthony Cristo,31,12,17,2
+Guadalupe,106,U.S. House,15,,Under Votes,48,19,10,19
+Guadalupe,106,U.S. House,15,REP,Tim Westley,1276,946,234,96
+Guadalupe,106,U.S. House,15,DEM,Vicente Gonzalez,556,389,123,44
+Guadalupe,106,U.S. House,15,LIB,Anthony Cristo,25,13,10,2
+Guadalupe,107,U.S. House,15,,Under Votes,15,5,6,4
+Guadalupe,107,U.S. House,15,REP,Tim Westley,555,309,223,23
+Guadalupe,107,U.S. House,15,DEM,Vicente Gonzalez,125,70,51,4
+Guadalupe,107,U.S. House,15,LIB,Anthony Cristo,13,4,7,2
+Guadalupe,108,U.S. House,15,,Under Votes,7,0,2,5
+Guadalupe,108,U.S. House,15,REP,Tim Westley,263,100,140,23
+Guadalupe,108,U.S. House,15,DEM,Vicente Gonzalez,155,67,73,15
+Guadalupe,108,U.S. House,15,LIB,Anthony Cristo,6,1,3,2
+Guadalupe,109,U.S. House,15,,Under Votes,6,3,3,0
+Guadalupe,109,U.S. House,15,REP,Tim Westley,250,123,119,8
+Guadalupe,109,U.S. House,15,DEM,Vicente Gonzalez,51,23,25,3
+Guadalupe,109,U.S. House,15,LIB,Anthony Cristo,5,3,1,1
+Guadalupe,110,U.S. House,15,,Under Votes,6,2,3,1
+Guadalupe,110,U.S. House,15,REP,Tim Westley,81,67,12,2
+Guadalupe,110,U.S. House,15,DEM,Vicente Gonzalez,61,45,11,5
+Guadalupe,110,U.S. House,15,LIB,Anthony Cristo,3,3,0,0
+Guadalupe,111,U.S. House,15,,Under Votes,3,1,1,1
+Guadalupe,111,U.S. House,15,REP,Tim Westley,30,19,6,5
+Guadalupe,111,U.S. House,15,DEM,Vicente Gonzalez,28,12,9,7
+Guadalupe,111,U.S. House,15,LIB,Anthony Cristo,3,2,0,1
+Guadalupe,112,U.S. House,15,,Under Votes,17,7,9,1
+Guadalupe,112,U.S. House,15,REP,Tim Westley,63,25,38,0
+Guadalupe,112,U.S. House,15,DEM,Vicente Gonzalez,139,52,87,0
+Guadalupe,112,U.S. House,15,LIB,Anthony Cristo,7,1,6,0
+Guadalupe,113,U.S. House,15,,Under Votes,12,7,2,3
+Guadalupe,113,U.S. House,15,REP,Tim Westley,383,277,89,17
+Guadalupe,113,U.S. House,15,DEM,Vicente Gonzalez,171,109,54,8
+Guadalupe,113,U.S. House,15,LIB,Anthony Cristo,18,11,7,0
+Guadalupe,114,U.S. House,15,,Under Votes,8,2,2,4
+Guadalupe,114,U.S. House,15,REP,Tim Westley,281,205,60,16
+Guadalupe,114,U.S. House,15,DEM,Vicente Gonzalez,153,104,43,6
+Guadalupe,114,U.S. House,15,LIB,Anthony Cristo,9,5,4,0
+Guadalupe,115,U.S. House,15,,Under Votes,6,2,3,1
+Guadalupe,115,U.S. House,15,REP,Tim Westley,145,106,38,1
+Guadalupe,115,U.S. House,15,DEM,Vicente Gonzalez,23,17,4,2
+Guadalupe,115,U.S. House,15,LIB,Anthony Cristo,2,1,1,0
+Guadalupe,116,U.S. House,15,,Under Votes,27,11,11,5
+Guadalupe,116,U.S. House,15,REP,Tim Westley,970,660,250,60
+Guadalupe,116,U.S. House,15,DEM,Vicente Gonzalez,322,164,136,22
+Guadalupe,116,U.S. House,15,LIB,Anthony Cristo,22,11,9,2
+Guadalupe,117,U.S. House,15,,Under Votes,41,13,9,19
+Guadalupe,117,U.S. House,15,REP,Tim Westley,1748,1304,378,66
+Guadalupe,117,U.S. House,15,DEM,Vicente Gonzalez,692,478,174,40
+Guadalupe,117,U.S. House,15,LIB,Anthony Cristo,57,34,21,2
+Guadalupe,118,U.S. House,15,,Under Votes,0,0,0,0
+Guadalupe,118,U.S. House,15,REP,Tim Westley,23,17,6,0
+Guadalupe,118,U.S. House,15,DEM,Vicente Gonzalez,19,11,7,1
+Guadalupe,118,U.S. House,15,LIB,Anthony Cristo,1,1,0,0
+Guadalupe,119,U.S. House,15,,Under Votes,18,9,4,5
+Guadalupe,119,U.S. House,15,REP,Tim Westley,806,618,151,37
+Guadalupe,119,U.S. House,15,DEM,Vicente Gonzalez,250,183,53,14
+Guadalupe,119,U.S. House,15,LIB,Anthony Cristo,26,16,8,2
+Guadalupe,120,U.S. House,15,,Under Votes,17,12,4,1
+Guadalupe,120,U.S. House,15,REP,Tim Westley,531,369,119,43
+Guadalupe,120,U.S. House,15,DEM,Vicente Gonzalez,159,105,37,17
+Guadalupe,120,U.S. House,15,LIB,Anthony Cristo,13,7,4,2
+Guadalupe,121,U.S. House,15,,Under Votes,9,6,3,0
+Guadalupe,121,U.S. House,15,REP,Tim Westley,61,52,7,2
+Guadalupe,121,U.S. House,15,DEM,Vicente Gonzalez,23,20,1,2
+Guadalupe,121,U.S. House,15,LIB,Anthony Cristo,1,1,0,0
+Guadalupe,122,U.S. House,15,,Under Votes,1,0,0,1
+Guadalupe,122,U.S. House,15,REP,Tim Westley,19,16,1,2
+Guadalupe,122,U.S. House,15,DEM,Vicente Gonzalez,7,1,0,6
+Guadalupe,122,U.S. House,15,LIB,Anthony Cristo,0,0,0,0
+Guadalupe,123,U.S. House,15,,Under Votes,1,0,0,1
+Guadalupe,123,U.S. House,15,REP,Tim Westley,0,0,0,0
+Guadalupe,123,U.S. House,15,DEM,Vicente Gonzalez,0,0,0,0
+Guadalupe,123,U.S. House,15,LIB,Anthony Cristo,0,0,0,0
+Guadalupe,124,U.S. House,15,,Under Votes,1,1,0,0
+Guadalupe,124,U.S. House,15,REP,Tim Westley,1,1,0,0
+Guadalupe,124,U.S. House,15,DEM,Vicente Gonzalez,0,0,0,0
+Guadalupe,124,U.S. House,15,LIB,Anthony Cristo,0,0,0,0
+Guadalupe,125,U.S. House,15,,Under Votes,2,1,0,1
+Guadalupe,125,U.S. House,15,REP,Tim Westley,87,65,12,10
+Guadalupe,125,U.S. House,15,DEM,Vicente Gonzalez,20,13,6,1
+Guadalupe,125,U.S. House,15,LIB,Anthony Cristo,0,0,0,0
+Guadalupe,126,U.S. House,15,,Under Votes,0,0,0,0
+Guadalupe,126,U.S. House,15,REP,Tim Westley,12,4,7,1
+Guadalupe,126,U.S. House,15,DEM,Vicente Gonzalez,2,2,0,0
+Guadalupe,126,U.S. House,15,LIB,Anthony Cristo,0,0,0,0
+Guadalupe,127,U.S. House,15,,Under Votes,0,0,0,0
+Guadalupe,127,U.S. House,15,REP,Tim Westley,9,3,5,1
+Guadalupe,127,U.S. House,15,DEM,Vicente Gonzalez,4,0,4,0
+Guadalupe,127,U.S. House,15,LIB,Anthony Cristo,2,1,1,0
+Guadalupe,201,U.S. House,15,,Under Votes,7,1,2,4
+Guadalupe,201,U.S. House,15,REP,Tim Westley,117,82,28,7
+Guadalupe,201,U.S. House,15,DEM,Vicente Gonzalez,86,54,25,7
+Guadalupe,201,U.S. House,15,LIB,Anthony Cristo,2,2,0,0
+Guadalupe,202,U.S. House,15,,Under Votes,17,5,6,6
+Guadalupe,202,U.S. House,15,REP,Tim Westley,121,81,35,5
+Guadalupe,202,U.S. House,15,DEM,Vicente Gonzalez,314,164,116,34
+Guadalupe,202,U.S. House,15,LIB,Anthony Cristo,11,5,6,0
+Guadalupe,203,U.S. House,15,,Under Votes,6,3,3,0
+Guadalupe,203,U.S. House,15,REP,Tim Westley,42,24,14,4
+Guadalupe,203,U.S. House,15,DEM,Vicente Gonzalez,131,57,64,10
+Guadalupe,203,U.S. House,15,LIB,Anthony Cristo,1,1,0,0
+Guadalupe,204,U.S. House,15,,Under Votes,17,5,9,3
+Guadalupe,204,U.S. House,15,REP,Tim Westley,241,142,94,5
+Guadalupe,204,U.S. House,15,DEM,Vicente Gonzalez,361,200,140,21
+Guadalupe,204,U.S. House,15,LIB,Anthony Cristo,9,4,4,1
+Guadalupe,205,U.S. House,15,,Under Votes,20,8,10,2
+Guadalupe,205,U.S. House,15,REP,Tim Westley,469,276,178,15
+Guadalupe,205,U.S. House,15,DEM,Vicente Gonzalez,169,97,66,6
+Guadalupe,205,U.S. House,15,LIB,Anthony Cristo,9,5,4,0
+Guadalupe,206,U.S. House,15,,Under Votes,20,7,12,1
+Guadalupe,206,U.S. House,15,REP,Tim Westley,345,136,192,17
+Guadalupe,206,U.S. House,15,DEM,Vicente Gonzalez,587,185,374,28
+Guadalupe,206,U.S. House,15,LIB,Anthony Cristo,19,7,12,0
+Guadalupe,207,U.S. House,15,,Under Votes,12,7,5,0
+Guadalupe,207,U.S. House,15,REP,Tim Westley,143,101,33,9
+Guadalupe,207,U.S. House,15,DEM,Vicente Gonzalez,243,150,75,18
+Guadalupe,207,U.S. House,15,LIB,Anthony Cristo,10,4,5,1
+Guadalupe,208,U.S. House,15,,Under Votes,40,22,6,12
+Guadalupe,208,U.S. House,15,REP,Tim Westley,1417,1042,307,68
+Guadalupe,208,U.S. House,15,DEM,Vicente Gonzalez,399,278,98,23
+Guadalupe,208,U.S. House,15,LIB,Anthony Cristo,36,22,11,3
+Guadalupe,209,U.S. House,15,,Under Votes,10,5,4,1
+Guadalupe,209,U.S. House,15,REP,Tim Westley,75,39,32,4
+Guadalupe,209,U.S. House,15,DEM,Vicente Gonzalez,233,116,100,17
+Guadalupe,209,U.S. House,15,LIB,Anthony Cristo,4,1,1,2
+Guadalupe,210,U.S. House,15,,Under Votes,18,6,7,5
+Guadalupe,210,U.S. House,15,REP,Tim Westley,249,163,75,11
+Guadalupe,210,U.S. House,15,DEM,Vicente Gonzalez,209,140,50,19
+Guadalupe,210,U.S. House,15,LIB,Anthony Cristo,7,4,2,1
+Guadalupe,211,U.S. House,15,,Under Votes,0,0,0,0
+Guadalupe,211,U.S. House,15,REP,Tim Westley,42,33,8,1
+Guadalupe,211,U.S. House,15,DEM,Vicente Gonzalez,37,30,3,4
+Guadalupe,211,U.S. House,15,LIB,Anthony Cristo,1,1,0,0
+Guadalupe,212,U.S. House,15,,Under Votes,4,2,1,1
+Guadalupe,212,U.S. House,15,REP,Tim Westley,33,29,4,0
+Guadalupe,212,U.S. House,15,DEM,Vicente Gonzalez,48,29,16,3
+Guadalupe,212,U.S. House,15,LIB,Anthony Cristo,1,1,0,0
+Guadalupe,213,U.S. House,15,,Under Votes,29,11,8,10
+Guadalupe,213,U.S. House,15,REP,Tim Westley,815,568,225,22
+Guadalupe,213,U.S. House,15,DEM,Vicente Gonzalez,357,237,105,15
+Guadalupe,213,U.S. House,15,LIB,Anthony Cristo,34,22,11,1
+Guadalupe,214,U.S. House,15,,Under Votes,7,2,0,5
+Guadalupe,214,U.S. House,15,REP,Tim Westley,268,194,69,5
+Guadalupe,214,U.S. House,15,DEM,Vicente Gonzalez,91,56,28,7
+Guadalupe,214,U.S. House,15,LIB,Anthony Cristo,5,3,1,1
+Guadalupe,215,U.S. House,15,,Under Votes,17,8,3,6
+Guadalupe,215,U.S. House,15,REP,Tim Westley,364,247,94,23
+Guadalupe,215,U.S. House,15,DEM,Vicente Gonzalez,150,103,36,11
+Guadalupe,215,U.S. House,15,LIB,Anthony Cristo,11,7,4,0
+Guadalupe,216,U.S. House,15,,Under Votes,0,0,0,0
+Guadalupe,216,U.S. House,15,REP,Tim Westley,29,17,8,4
+Guadalupe,216,U.S. House,15,DEM,Vicente Gonzalez,8,5,3,0
+Guadalupe,216,U.S. House,15,LIB,Anthony Cristo,0,0,0,0
+Guadalupe,217,U.S. House,15,,Under Votes,1,0,1,0
+Guadalupe,217,U.S. House,15,REP,Tim Westley,27,11,13,3
+Guadalupe,217,U.S. House,15,DEM,Vicente Gonzalez,36,10,26,0
+Guadalupe,217,U.S. House,15,LIB,Anthony Cristo,1,1,0,0
+Guadalupe,218,U.S. House,15,,Under Votes,1,0,0,1
+Guadalupe,218,U.S. House,15,REP,Tim Westley,11,10,1,0
+Guadalupe,218,U.S. House,15,DEM,Vicente Gonzalez,26,22,4,0
+Guadalupe,218,U.S. House,15,LIB,Anthony Cristo,0,0,0,0
+Guadalupe,219,U.S. House,15,,Under Votes,3,2,0,1
+Guadalupe,219,U.S. House,15,REP,Tim Westley,25,19,6,0
+Guadalupe,219,U.S. House,15,DEM,Vicente Gonzalez,23,20,3,0
+Guadalupe,219,U.S. House,15,LIB,Anthony Cristo,0,0,0,0
+Guadalupe,220,U.S. House,15,,Under Votes,2,0,2,0
+Guadalupe,220,U.S. House,15,REP,Tim Westley,18,14,4,0
+Guadalupe,220,U.S. House,15,DEM,Vicente Gonzalez,23,17,4,2
+Guadalupe,220,U.S. House,15,LIB,Anthony Cristo,0,0,0,0
+Guadalupe,221,U.S. House,15,,Under Votes,1,0,0,1
+Guadalupe,221,U.S. House,15,REP,Tim Westley,9,8,1,0
+Guadalupe,221,U.S. House,15,DEM,Vicente Gonzalez,6,1,3,2
+Guadalupe,221,U.S. House,15,LIB,Anthony Cristo,0,0,0,0
+Guadalupe,222,U.S. House,15,,Under Votes,0,0,0,0
+Guadalupe,222,U.S. House,15,REP,Tim Westley,0,0,0,0
+Guadalupe,222,U.S. House,15,DEM,Vicente Gonzalez,0,0,0,0
+Guadalupe,222,U.S. House,15,LIB,Anthony Cristo,0,0,0,0
+Guadalupe,223,U.S. House,15,,Under Votes,6,5,0,1
+Guadalupe,223,U.S. House,15,REP,Tim Westley,72,40,27,5
+Guadalupe,223,U.S. House,15,DEM,Vicente Gonzalez,76,62,9,5
+Guadalupe,223,U.S. House,15,LIB,Anthony Cristo,5,3,2,0
+Guadalupe,224,U.S. House,15,,Under Votes,2,0,0,2
+Guadalupe,224,U.S. House,15,REP,Tim Westley,8,2,6,0
+Guadalupe,224,U.S. House,15,DEM,Vicente Gonzalez,49,25,19,5
+Guadalupe,224,U.S. House,15,LIB,Anthony Cristo,1,0,1,0
+Guadalupe,225,U.S. House,15,,Under Votes,1,1,0,0
+Guadalupe,225,U.S. House,15,REP,Tim Westley,0,0,0,0
+Guadalupe,225,U.S. House,15,DEM,Vicente Gonzalez,10,7,3,0
+Guadalupe,225,U.S. House,15,LIB,Anthony Cristo,0,0,0,0
+Guadalupe,226,U.S. House,15,,Under Votes,2,2,0,0
+Guadalupe,226,U.S. House,15,REP,Tim Westley,101,67,32,2
+Guadalupe,226,U.S. House,15,DEM,Vicente Gonzalez,54,28,22,4
+Guadalupe,226,U.S. House,15,LIB,Anthony Cristo,3,2,1,0
+Guadalupe,301,U.S. House,15,,Under Votes,26,9,8,9
+Guadalupe,301,U.S. House,15,REP,Tim Westley,1011,641,319,51
+Guadalupe,301,U.S. House,15,DEM,Vicente Gonzalez,675,462,195,18
+Guadalupe,301,U.S. House,15,LIB,Anthony Cristo,32,19,13,0
+Guadalupe,302,U.S. House,15,,Under Votes,35,18,11,6
+Guadalupe,302,U.S. House,15,REP,Tim Westley,1223,852,325,46
+Guadalupe,302,U.S. House,15,DEM,Vicente Gonzalez,999,641,307,51
+Guadalupe,302,U.S. House,15,LIB,Anthony Cristo,67,38,28,1
+Guadalupe,303,U.S. House,15,,Under Votes,10,5,2,3
+Guadalupe,303,U.S. House,15,REP,Tim Westley,514,394,91,29
+Guadalupe,303,U.S. House,15,DEM,Vicente Gonzalez,269,195,56,18
+Guadalupe,303,U.S. House,15,LIB,Anthony Cristo,15,10,4,1
+Guadalupe,306,U.S. House,15,,Under Votes,22,15,3,4
+Guadalupe,306,U.S. House,15,REP,Tim Westley,1453,1153,238,62
+Guadalupe,306,U.S. House,15,DEM,Vicente Gonzalez,888,695,137,56
+Guadalupe,306,U.S. House,15,LIB,Anthony Cristo,48,27,19,2
+Guadalupe,307,U.S. House,15,,Under Votes,31,17,5,9
+Guadalupe,307,U.S. House,15,REP,Tim Westley,1420,1109,256,55
+Guadalupe,307,U.S. House,15,DEM,Vicente Gonzalez,1023,788,196,39
+Guadalupe,307,U.S. House,15,LIB,Anthony Cristo,65,43,20,2
+Guadalupe,401,U.S. House,15,,Under Votes,18,4,7,7
+Guadalupe,401,U.S. House,15,REP,Tim Westley,638,366,235,37
+Guadalupe,401,U.S. House,15,DEM,Vicente Gonzalez,194,115,69,10
+Guadalupe,401,U.S. House,15,LIB,Anthony Cristo,24,13,11,0
+Guadalupe,403,U.S. House,15,,Under Votes,29,11,10,8
+Guadalupe,403,U.S. House,15,REP,Tim Westley,758,526,171,61
+Guadalupe,403,U.S. House,15,DEM,Vicente Gonzalez,498,300,131,67
+Guadalupe,403,U.S. House,15,LIB,Anthony Cristo,35,21,14,0
+Guadalupe,405,U.S. House,15,,Under Votes,19,12,5,2
+Guadalupe,405,U.S. House,15,REP,Tim Westley,878,519,328,31
+Guadalupe,405,U.S. House,15,DEM,Vicente Gonzalez,208,128,68,12
+Guadalupe,405,U.S. House,15,LIB,Anthony Cristo,10,4,6,0
+Guadalupe,406,U.S. House,15,,Under Votes,28,18,3,7
+Guadalupe,406,U.S. House,15,REP,Tim Westley,995,752,210,33
+Guadalupe,406,U.S. House,15,DEM,Vicente Gonzalez,179,121,43,15
+Guadalupe,406,U.S. House,15,LIB,Anthony Cristo,18,12,5,1
+Guadalupe,407,U.S. House,15,,Under Votes,23,10,6,7
+Guadalupe,407,U.S. House,15,REP,Tim Westley,854,618,202,34
+Guadalupe,407,U.S. House,15,DEM,Vicente Gonzalez,195,121,54,20
+Guadalupe,407,U.S. House,15,LIB,Anthony Cristo,12,6,4,2
+Guadalupe,408,U.S. House,15,,Under Votes,64,17,19,28
+Guadalupe,408,U.S. House,15,REP,Tim Westley,1535,1019,402,114
+Guadalupe,408,U.S. House,15,DEM,Vicente Gonzalez,715,472,205,38
+Guadalupe,408,U.S. House,15,LIB,Anthony Cristo,38,22,16,0
+Guadalupe,409,U.S. House,15,,Under Votes,45,13,16,16
+Guadalupe,409,U.S. House,15,REP,Tim Westley,1193,865,287,41
+Guadalupe,409,U.S. House,15,DEM,Vicente Gonzalez,1337,980,307,50
+Guadalupe,409,U.S. House,15,LIB,Anthony Cristo,63,44,17,2
+Guadalupe,410,U.S. House,15,,Under Votes,0,0,0,0
+Guadalupe,410,U.S. House,15,REP,Tim Westley,57,46,11,0
+Guadalupe,410,U.S. House,15,DEM,Vicente Gonzalez,23,18,5,0
+Guadalupe,410,U.S. House,15,LIB,Anthony Cristo,3,1,2,0
+Guadalupe,304,U.S. House,35,,Under Votes,31,11,12,8
+Guadalupe,304,U.S. House,35,REP,David Smalling,1361,1053,248,60
+Guadalupe,304,U.S. House,35,DEM,Lloyd Doggett,895,673,165,57
+Guadalupe,304,U.S. House,35,LIB,Clark Patterson,49,38,7,4
+Guadalupe,305,U.S. House,35,,Under Votes,43,20,12,11
+Guadalupe,305,U.S. House,35,REP,David Smalling,1291,911,327,53
+Guadalupe,305,U.S. House,35,DEM,Lloyd Doggett,1022,715,238,69
+Guadalupe,305,U.S. House,35,LIB,Clark Patterson,54,35,17,2
+Guadalupe,308,U.S. House,35,,Under Votes,19,7,2,10
+Guadalupe,308,U.S. House,35,REP,David Smalling,778,608,130,40
+Guadalupe,308,U.S. House,35,DEM,Lloyd Doggett,458,321,98,39
+Guadalupe,308,U.S. House,35,LIB,Clark Patterson,27,20,6,1
+Guadalupe,402,U.S. House,35,,Under Votes,15,9,1,5
+Guadalupe,402,U.S. House,35,REP,David Smalling,489,341,112,36
+Guadalupe,402,U.S. House,35,DEM,Lloyd Doggett,377,230,105,42
+Guadalupe,402,U.S. House,35,LIB,Clark Patterson,34,17,15,2
+Guadalupe,404,U.S. House,35,,Under Votes,40,13,13,14
+Guadalupe,404,U.S. House,35,REP,David Smalling,889,543,281,65
+Guadalupe,404,U.S. House,35,DEM,Lloyd Doggett,688,428,213,47
+Guadalupe,404,U.S. House,35,LIB,Clark Patterson,50,22,26,2
+Guadalupe,411,U.S. House,35,,Under Votes,32,14,5,13
+Guadalupe,411,U.S. House,35,REP,David Smalling,1143,822,272,49
+Guadalupe,411,U.S. House,35,DEM,Lloyd Doggett,776,590,149,37
+Guadalupe,411,U.S. House,35,LIB,Clark Patterson,47,33,13,1
+Guadalupe,101,Governor,,,Under Votes,3,0,0,3
+Guadalupe,101,Governor,,REP,Greg Abbott,276,182,76,18
+Guadalupe,101,Governor,,DEM,Lupe Valdez,80,56,17,7
+Guadalupe,101,Governor,,LIB,Mark Jay Tippetts,10,6,4,0
+Guadalupe,102,Governor,,,Under Votes,3,2,1,0
+Guadalupe,102,Governor,,REP,Greg Abbott,437,323,77,37
+Guadalupe,102,Governor,,DEM,Lupe Valdez,149,91,42,16
+Guadalupe,102,Governor,,LIB,Mark Jay Tippetts,9,6,2,1
+Guadalupe,103,Governor,,,Under Votes,5,3,1,1
+Guadalupe,103,Governor,,REP,Greg Abbott,349,254,73,22
+Guadalupe,103,Governor,,DEM,Lupe Valdez,98,64,27,7
+Guadalupe,103,Governor,,LIB,Mark Jay Tippetts,7,3,4,0
+Guadalupe,104,Governor,,,Under Votes,5,4,1,0
+Guadalupe,104,Governor,,REP,Greg Abbott,308,226,64,18
+Guadalupe,104,Governor,,DEM,Lupe Valdez,197,111,65,21
+Guadalupe,104,Governor,,LIB,Mark Jay Tippetts,10,9,1,0
+Guadalupe,105,Governor,,,Under Votes,7,5,1,1
+Guadalupe,105,Governor,,REP,Greg Abbott,1195,723,396,76
+Guadalupe,105,Governor,,DEM,Lupe Valdez,291,166,99,26
+Guadalupe,105,Governor,,LIB,Mark Jay Tippetts,21,12,8,1
+Guadalupe,106,Governor,,,Under Votes,10,5,3,2
+Guadalupe,106,Governor,,REP,Greg Abbott,1392,1009,260,123
+Guadalupe,106,Governor,,DEM,Lupe Valdez,477,335,108,34
+Guadalupe,106,Governor,,LIB,Mark Jay Tippetts,26,18,6,2
+Guadalupe,107,Governor,,,Under Votes,2,0,2,0
+Guadalupe,107,Governor,,REP,Greg Abbott,587,321,236,30
+Guadalupe,107,Governor,,DEM,Lupe Valdez,110,64,43,3
+Guadalupe,107,Governor,,LIB,Mark Jay Tippetts,9,3,6,0
+Guadalupe,108,Governor,,,Under Votes,2,1,1,0
+Guadalupe,108,Governor,,REP,Greg Abbott,282,102,151,29
+Guadalupe,108,Governor,,DEM,Lupe Valdez,143,63,64,16
+Guadalupe,108,Governor,,LIB,Mark Jay Tippetts,4,2,2,0
+Guadalupe,109,Governor,,,Under Votes,0,0,0,0
+Guadalupe,109,Governor,,REP,Greg Abbott,260,126,125,9
+Guadalupe,109,Governor,,DEM,Lupe Valdez,47,22,22,3
+Guadalupe,109,Governor,,LIB,Mark Jay Tippetts,5,4,1,0
+Guadalupe,110,Governor,,,Under Votes,1,0,1,0
+Guadalupe,110,Governor,,REP,Greg Abbott,90,72,15,3
+Guadalupe,110,Governor,,DEM,Lupe Valdez,58,43,10,5
+Guadalupe,110,Governor,,LIB,Mark Jay Tippetts,2,2,0,0
+Guadalupe,111,Governor,,,Under Votes,1,0,0,1
+Guadalupe,111,Governor,,REP,Greg Abbott,35,22,8,5
+Guadalupe,111,Governor,,DEM,Lupe Valdez,26,11,8,7
+Guadalupe,111,Governor,,LIB,Mark Jay Tippetts,2,1,0,1
+Guadalupe,112,Governor,,,Under Votes,11,4,7,0
+Guadalupe,112,Governor,,REP,Greg Abbott,80,29,50,1
+Guadalupe,112,Governor,,DEM,Lupe Valdez,131,50,81,0
+Guadalupe,112,Governor,,LIB,Mark Jay Tippetts,4,2,2,0
+Guadalupe,113,Governor,,,Under Votes,6,5,1,0
+Guadalupe,113,Governor,,REP,Greg Abbott,410,288,102,20
+Guadalupe,113,Governor,,DEM,Lupe Valdez,158,105,45,8
+Guadalupe,113,Governor,,LIB,Mark Jay Tippetts,10,6,4,0
+Guadalupe,114,Governor,,,Under Votes,3,1,1,1
+Guadalupe,114,Governor,,REP,Greg Abbott,308,221,69,18
+Guadalupe,114,Governor,,DEM,Lupe Valdez,135,90,38,7
+Guadalupe,114,Governor,,LIB,Mark Jay Tippetts,5,4,1,0
+Guadalupe,115,Governor,,,Under Votes,1,0,0,1
+Guadalupe,115,Governor,,REP,Greg Abbott,151,108,42,1
+Guadalupe,115,Governor,,DEM,Lupe Valdez,21,16,3,2
+Guadalupe,115,Governor,,LIB,Mark Jay Tippetts,3,2,1,0
+Guadalupe,116,Governor,,,Under Votes,9,5,4,0
+Guadalupe,116,Governor,,REP,Greg Abbott,1028,678,284,66
+Guadalupe,116,Governor,,DEM,Lupe Valdez,288,154,113,21
+Guadalupe,116,Governor,,LIB,Mark Jay Tippetts,16,9,5,2
+Guadalupe,117,Governor,,,Under Votes,10,7,3,0
+Guadalupe,117,Governor,,REP,Greg Abbott,1836,1346,408,82
+Guadalupe,117,Governor,,DEM,Lupe Valdez,649,449,155,45
+Guadalupe,117,Governor,,LIB,Mark Jay Tippetts,43,27,16,0
+Guadalupe,118,Governor,,,Under Votes,0,0,0,0
+Guadalupe,118,Governor,,REP,Greg Abbott,24,18,6,0
+Guadalupe,118,Governor,,DEM,Lupe Valdez,18,10,7,1
+Guadalupe,118,Governor,,LIB,Mark Jay Tippetts,1,1,0,0
+Guadalupe,119,Governor,,,Under Votes,6,3,2,1
+Guadalupe,119,Governor,,REP,Greg Abbott,867,654,170,43
+Guadalupe,119,Governor,,DEM,Lupe Valdez,214,159,42,13
+Guadalupe,119,Governor,,LIB,Mark Jay Tippetts,13,10,2,1
+Guadalupe,120,Governor,,,Under Votes,4,2,2,0
+Guadalupe,120,Governor,,REP,Greg Abbott,574,398,127,49
+Guadalupe,120,Governor,,DEM,Lupe Valdez,133,88,32,13
+Guadalupe,120,Governor,,LIB,Mark Jay Tippetts,9,5,3,1
+Guadalupe,121,Governor,,,Under Votes,3,1,2,0
+Guadalupe,121,Governor,,REP,Greg Abbott,65,55,8,2
+Guadalupe,121,Governor,,DEM,Lupe Valdez,23,20,1,2
+Guadalupe,121,Governor,,LIB,Mark Jay Tippetts,3,3,0,0
+Guadalupe,122,Governor,,,Under Votes,0,0,0,0
+Guadalupe,122,Governor,,REP,Greg Abbott,20,16,1,3
+Guadalupe,122,Governor,,DEM,Lupe Valdez,7,1,0,6
+Guadalupe,122,Governor,,LIB,Mark Jay Tippetts,0,0,0,0
+Guadalupe,123,Governor,,,Under Votes,0,0,0,0
+Guadalupe,123,Governor,,REP,Greg Abbott,0,0,0,0
+Guadalupe,123,Governor,,DEM,Lupe Valdez,1,0,0,1
+Guadalupe,123,Governor,,LIB,Mark Jay Tippetts,0,0,0,0
+Guadalupe,124,Governor,,,Under Votes,0,0,0,0
+Guadalupe,124,Governor,,REP,Greg Abbott,2,2,0,0
+Guadalupe,124,Governor,,DEM,Lupe Valdez,0,0,0,0
+Guadalupe,124,Governor,,LIB,Mark Jay Tippetts,0,0,0,0
+Guadalupe,125,Governor,,,Under Votes,0,0,0,0
+Guadalupe,125,Governor,,REP,Greg Abbott,94,70,13,11
+Guadalupe,125,Governor,,DEM,Lupe Valdez,15,9,5,1
+Guadalupe,125,Governor,,LIB,Mark Jay Tippetts,0,0,0,0
+Guadalupe,126,Governor,,,Under Votes,0,0,0,0
+Guadalupe,126,Governor,,REP,Greg Abbott,12,4,7,1
+Guadalupe,126,Governor,,DEM,Lupe Valdez,2,2,0,0
+Guadalupe,126,Governor,,LIB,Mark Jay Tippetts,0,0,0,0
+Guadalupe,127,Governor,,,Under Votes,0,0,0,0
+Guadalupe,127,Governor,,REP,Greg Abbott,11,4,6,1
+Guadalupe,127,Governor,,DEM,Lupe Valdez,4,0,4,0
+Guadalupe,127,Governor,,LIB,Mark Jay Tippetts,0,0,0,0
+Guadalupe,201,Governor,,,Under Votes,2,0,2,0
+Guadalupe,201,Governor,,REP,Greg Abbott,125,84,32,9
+Guadalupe,201,Governor,,DEM,Lupe Valdez,83,55,21,7
+Guadalupe,201,Governor,,LIB,Mark Jay Tippetts,2,0,0,2
+Guadalupe,202,Governor,,,Under Votes,12,5,6,1
+Guadalupe,202,Governor,,REP,Greg Abbott,144,88,46,10
+Guadalupe,202,Governor,,DEM,Lupe Valdez,297,158,105,34
+Guadalupe,202,Governor,,LIB,Mark Jay Tippetts,10,4,6,0
+Guadalupe,203,Governor,,,Under Votes,6,3,3,0
+Guadalupe,203,Governor,,REP,Greg Abbott,56,31,21,4
+Guadalupe,203,Governor,,DEM,Lupe Valdez,118,51,57,10
+Guadalupe,203,Governor,,LIB,Mark Jay Tippetts,0,0,0,0
+Guadalupe,204,Governor,,,Under Votes,9,3,6,0
+Guadalupe,204,Governor,,REP,Greg Abbott,284,160,115,9
+Guadalupe,204,Governor,,DEM,Lupe Valdez,328,183,125,20
+Guadalupe,204,Governor,,LIB,Mark Jay Tippetts,7,5,1,1
+Guadalupe,205,Governor,,,Under Votes,6,3,3,0
+Guadalupe,205,Governor,,REP,Greg Abbott,497,288,192,17
+Guadalupe,205,Governor,,DEM,Lupe Valdez,158,93,59,6
+Guadalupe,205,Governor,,LIB,Mark Jay Tippetts,6,2,4,0
+Guadalupe,206,Governor,,,Under Votes,11,4,7,0
+Guadalupe,206,Governor,,REP,Greg Abbott,391,150,224,17
+Guadalupe,206,Governor,,DEM,Lupe Valdez,553,174,350,29
+Guadalupe,206,Governor,,LIB,Mark Jay Tippetts,16,7,9,0
+Guadalupe,207,Governor,,,Under Votes,9,6,2,1
+Guadalupe,207,Governor,,REP,Greg Abbott,161,110,40,11
+Guadalupe,207,Governor,,DEM,Lupe Valdez,232,143,73,16
+Guadalupe,207,Governor,,LIB,Mark Jay Tippetts,6,3,3,0
+Guadalupe,208,Governor,,,Under Votes,14,13,1,0
+Guadalupe,208,Governor,,REP,Greg Abbott,1477,1074,322,81
+Guadalupe,208,Governor,,DEM,Lupe Valdez,365,253,91,21
+Guadalupe,208,Governor,,LIB,Mark Jay Tippetts,36,24,8,4
+Guadalupe,209,Governor,,,Under Votes,7,4,3,0
+Guadalupe,209,Governor,,REP,Greg Abbott,101,51,44,6
+Guadalupe,209,Governor,,DEM,Lupe Valdez,213,105,90,18
+Guadalupe,209,Governor,,LIB,Mark Jay Tippetts,1,1,0,0
+Guadalupe,210,Governor,,,Under Votes,4,4,0,0
+Guadalupe,210,Governor,,REP,Greg Abbott,280,175,86,19
+Guadalupe,210,Governor,,DEM,Lupe Valdez,189,124,48,17
+Guadalupe,210,Governor,,LIB,Mark Jay Tippetts,10,10,0,0
+Guadalupe,211,Governor,,,Under Votes,0,0,0,0
+Guadalupe,211,Governor,,REP,Greg Abbott,42,32,8,2
+Guadalupe,211,Governor,,DEM,Lupe Valdez,36,30,3,3
+Guadalupe,211,Governor,,LIB,Mark Jay Tippetts,2,2,0,0
+Guadalupe,212,Governor,,,Under Votes,2,1,0,1
+Guadalupe,212,Governor,,REP,Greg Abbott,43,33,10,0
+Guadalupe,212,Governor,,DEM,Lupe Valdez,39,25,11,3
+Guadalupe,212,Governor,,LIB,Mark Jay Tippetts,2,2,0,0
+Guadalupe,213,Governor,,,Under Votes,9,5,4,0
+Guadalupe,213,Governor,,REP,Greg Abbott,863,597,237,29
+Guadalupe,213,Governor,,DEM,Lupe Valdez,334,220,96,18
+Guadalupe,213,Governor,,LIB,Mark Jay Tippetts,29,16,12,1
+Guadalupe,214,Governor,,,Under Votes,0,0,0,0
+Guadalupe,214,Governor,,REP,Greg Abbott,285,204,72,9
+Guadalupe,214,Governor,,DEM,Lupe Valdez,84,50,25,9
+Guadalupe,214,Governor,,LIB,Mark Jay Tippetts,2,1,1,0
+Guadalupe,215,Governor,,,Under Votes,3,1,1,1
+Guadalupe,215,Governor,,REP,Greg Abbott,407,273,104,30
+Guadalupe,215,Governor,,DEM,Lupe Valdez,127,88,31,8
+Guadalupe,215,Governor,,LIB,Mark Jay Tippetts,5,3,1,1
+Guadalupe,216,Governor,,,Under Votes,0,0,0,0
+Guadalupe,216,Governor,,REP,Greg Abbott,29,17,8,4
+Guadalupe,216,Governor,,DEM,Lupe Valdez,7,4,3,0
+Guadalupe,216,Governor,,LIB,Mark Jay Tippetts,1,1,0,0
+Guadalupe,217,Governor,,,Under Votes,0,0,0,0
+Guadalupe,217,Governor,,REP,Greg Abbott,32,13,16,3
+Guadalupe,217,Governor,,DEM,Lupe Valdez,33,9,24,0
+Guadalupe,217,Governor,,LIB,Mark Jay Tippetts,0,0,0,0
+Guadalupe,218,Governor,,,Under Votes,1,1,0,0
+Guadalupe,218,Governor,,REP,Greg Abbott,16,14,1,1
+Guadalupe,218,Governor,,DEM,Lupe Valdez,21,17,4,0
+Guadalupe,218,Governor,,LIB,Mark Jay Tippetts,0,0,0,0
+Guadalupe,219,Governor,,,Under Votes,0,0,0,0
+Guadalupe,219,Governor,,REP,Greg Abbott,28,22,6,0
+Guadalupe,219,Governor,,DEM,Lupe Valdez,22,18,3,1
+Guadalupe,219,Governor,,LIB,Mark Jay Tippetts,1,1,0,0
+Guadalupe,220,Governor,,,Under Votes,0,0,0,0
+Guadalupe,220,Governor,,REP,Greg Abbott,25,18,6,1
+Guadalupe,220,Governor,,DEM,Lupe Valdez,17,12,4,1
+Guadalupe,220,Governor,,LIB,Mark Jay Tippetts,1,1,0,0
+Guadalupe,221,Governor,,,Under Votes,0,0,0,0
+Guadalupe,221,Governor,,REP,Greg Abbott,12,8,4,0
+Guadalupe,221,Governor,,DEM,Lupe Valdez,4,1,0,3
+Guadalupe,221,Governor,,LIB,Mark Jay Tippetts,0,0,0,0
+Guadalupe,222,Governor,,,Under Votes,0,0,0,0
+Guadalupe,222,Governor,,REP,Greg Abbott,0,0,0,0
+Guadalupe,222,Governor,,DEM,Lupe Valdez,0,0,0,0
+Guadalupe,222,Governor,,LIB,Mark Jay Tippetts,0,0,0,0
+Guadalupe,223,Governor,,,Under Votes,0,0,0,0
+Guadalupe,223,Governor,,REP,Greg Abbott,79,46,28,5
+Guadalupe,223,Governor,,DEM,Lupe Valdez,77,62,9,6
+Guadalupe,223,Governor,,LIB,Mark Jay Tippetts,3,2,1,0
+Guadalupe,224,Governor,,,Under Votes,0,0,0,0
+Guadalupe,224,Governor,,REP,Greg Abbott,13,4,9,0
+Guadalupe,224,Governor,,DEM,Lupe Valdez,47,23,17,7
+Guadalupe,224,Governor,,LIB,Mark Jay Tippetts,0,0,0,0
+Guadalupe,225,Governor,,,Under Votes,0,0,0,0
+Guadalupe,225,Governor,,REP,Greg Abbott,1,0,1,0
+Guadalupe,225,Governor,,DEM,Lupe Valdez,10,8,2,0
+Guadalupe,225,Governor,,LIB,Mark Jay Tippetts,0,0,0,0
+Guadalupe,226,Governor,,,Under Votes,2,1,0,1
+Guadalupe,226,Governor,,REP,Greg Abbott,104,69,33,2
+Guadalupe,226,Governor,,DEM,Lupe Valdez,52,27,22,3
+Guadalupe,226,Governor,,LIB,Mark Jay Tippetts,2,2,0,0
+Guadalupe,301,Governor,,,Under Votes,9,4,4,1
+Guadalupe,301,Governor,,REP,Greg Abbott,1069,664,348,57
+Guadalupe,301,Governor,,DEM,Lupe Valdez,636,448,168,20
+Guadalupe,301,Governor,,LIB,Mark Jay Tippetts,30,15,15,0
+Guadalupe,302,Governor,,,Under Votes,17,11,4,2
+Guadalupe,302,Governor,,REP,Greg Abbott,1343,908,380,55
+Guadalupe,302,Governor,,DEM,Lupe Valdez,913,600,266,47
+Guadalupe,302,Governor,,LIB,Mark Jay Tippetts,51,30,21,0
+Guadalupe,303,Governor,,,Under Votes,3,1,2,0
+Guadalupe,303,Governor,,REP,Greg Abbott,555,422,102,31
+Guadalupe,303,Governor,,DEM,Lupe Valdez,239,173,46,20
+Guadalupe,303,Governor,,LIB,Mark Jay Tippetts,11,8,3,0
+Guadalupe,304,Governor,,,Under Votes,15,7,6,2
+Guadalupe,304,Governor,,REP,Greg Abbott,1491,1139,282,70
+Guadalupe,304,Governor,,DEM,Lupe Valdez,798,604,138,56
+Guadalupe,304,Governor,,LIB,Mark Jay Tippetts,32,25,6,1
+Guadalupe,305,Governor,,,Under Votes,22,8,8,6
+Guadalupe,305,Governor,,REP,Greg Abbott,1424,1004,360,60
+Guadalupe,305,Governor,,DEM,Lupe Valdez,924,643,213,68
+Guadalupe,305,Governor,,LIB,Mark Jay Tippetts,40,26,13,1
+Guadalupe,306,Governor,,,Under Votes,8,6,2,0
+Guadalupe,306,Governor,,REP,Greg Abbott,1545,1213,259,73
+Guadalupe,306,Governor,,DEM,Lupe Valdez,827,650,128,49
+Guadalupe,306,Governor,,LIB,Mark Jay Tippetts,31,21,8,2
+Guadalupe,307,Governor,,,Under Votes,8,5,3,0
+Guadalupe,307,Governor,,REP,Greg Abbott,1533,1179,292,62
+Guadalupe,307,Governor,,DEM,Lupe Valdez,955,745,168,42
+Guadalupe,307,Governor,,LIB,Mark Jay Tippetts,43,28,14,1
+Guadalupe,308,Governor,,,Under Votes,6,3,1,2
+Guadalupe,308,Governor,,REP,Greg Abbott,873,670,151,52
+Guadalupe,308,Governor,,DEM,Lupe Valdez,378,261,81,36
+Guadalupe,308,Governor,,LIB,Mark Jay Tippetts,25,22,3,0
+Guadalupe,401,Governor,,,Under Votes,4,1,3,0
+Guadalupe,401,Governor,,REP,Greg Abbott,686,388,255,43
+Guadalupe,401,Governor,,DEM,Lupe Valdez,166,98,58,10
+Guadalupe,401,Governor,,LIB,Mark Jay Tippetts,18,11,6,1
+Guadalupe,402,Governor,,,Under Votes,10,5,1,4
+Guadalupe,402,Governor,,REP,Greg Abbott,565,393,126,46
+Guadalupe,402,Governor,,DEM,Lupe Valdez,322,190,99,33
+Guadalupe,402,Governor,,LIB,Mark Jay Tippetts,18,9,7,2
+Guadalupe,403,Governor,,,Under Votes,13,9,4,0
+Guadalupe,403,Governor,,REP,Greg Abbott,829,563,201,65
+Guadalupe,403,Governor,,DEM,Lupe Valdez,455,275,112,68
+Guadalupe,403,Governor,,LIB,Mark Jay Tippetts,23,11,9,3
+Guadalupe,404,Governor,,,Under Votes,10,9,1,0
+Guadalupe,404,Governor,,REP,Greg Abbott,1015,600,337,78
+Guadalupe,404,Governor,,DEM,Lupe Valdez,615,384,182,49
+Guadalupe,404,Governor,,LIB,Mark Jay Tippetts,27,13,13,1
+Guadalupe,405,Governor,,,Under Votes,8,7,1,0
+Guadalupe,405,Governor,,REP,Greg Abbott,918,542,342,34
+Guadalupe,405,Governor,,DEM,Lupe Valdez,177,110,57,10
+Guadalupe,405,Governor,,LIB,Mark Jay Tippetts,12,4,7,1
+Guadalupe,406,Governor,,,Under Votes,3,1,1,1
+Guadalupe,406,Governor,,REP,Greg Abbott,1043,782,218,43
+Guadalupe,406,Governor,,DEM,Lupe Valdez,156,106,39,11
+Guadalupe,406,Governor,,LIB,Mark Jay Tippetts,18,14,3,1
+Guadalupe,407,Governor,,,Under Votes,10,6,4,0
+Guadalupe,407,Governor,,REP,Greg Abbott,885,632,212,41
+Guadalupe,407,Governor,,DEM,Lupe Valdez,176,111,46,19
+Guadalupe,407,Governor,,LIB,Mark Jay Tippetts,13,6,4,3
+Guadalupe,408,Governor,,,Under Votes,14,5,8,1
+Guadalupe,408,Governor,,REP,Greg Abbott,1648,1076,437,135
+Guadalupe,408,Governor,,DEM,Lupe Valdez,658,434,184,40
+Guadalupe,408,Governor,,LIB,Mark Jay Tippetts,32,15,13,4
+Guadalupe,409,Governor,,,Under Votes,9,5,3,1
+Guadalupe,409,Governor,,REP,Greg Abbott,1343,960,331,52
+Guadalupe,409,Governor,,DEM,Lupe Valdez,1250,911,283,56
+Guadalupe,409,Governor,,LIB,Mark Jay Tippetts,36,26,10,0
+Guadalupe,410,Governor,,,Under Votes,1,1,0,0
+Guadalupe,410,Governor,,REP,Greg Abbott,58,47,11,0
+Guadalupe,410,Governor,,DEM,Lupe Valdez,20,16,4,0
+Guadalupe,410,Governor,,LIB,Mark Jay Tippetts,4,1,3,0
+Guadalupe,411,Governor,,,Under Votes,10,7,1,2
+Guadalupe,411,Governor,,REP,Greg Abbott,1273,907,304,62
+Guadalupe,411,Governor,,DEM,Lupe Valdez,679,517,126,36
+Guadalupe,411,Governor,,LIB,Mark Jay Tippetts,36,28,8,0
+Guadalupe,101,Lieutenant Governor,,,Under Votes,5,2,0,3
+Guadalupe,101,Lieutenant Governor,,REP,Dan Patrick,256,168,71,17
+Guadalupe,101,Lieutenant Governor,,DEM,Mike Collier,95,65,22,8
+Guadalupe,101,Lieutenant Governor,,LIB,Kerry McKennon,13,9,4,0
+Guadalupe,102,Lieutenant Governor,,,Under Votes,7,3,4,0
+Guadalupe,102,Lieutenant Governor,,REP,Dan Patrick,404,303,64,37
+Guadalupe,102,Lieutenant Governor,,DEM,Mike Collier,176,111,49,16
+Guadalupe,102,Lieutenant Governor,,LIB,Kerry McKennon,11,5,5,1
+Guadalupe,103,Lieutenant Governor,,,Under Votes,5,3,2,0
+Guadalupe,103,Lieutenant Governor,,REP,Dan Patrick,328,242,65,21
+Guadalupe,103,Lieutenant Governor,,DEM,Mike Collier,120,78,33,9
+Guadalupe,103,Lieutenant Governor,,LIB,Kerry McKennon,6,1,5,0
+Guadalupe,104,Lieutenant Governor,,,Under Votes,13,11,2,0
+Guadalupe,104,Lieutenant Governor,,REP,Dan Patrick,292,217,57,18
+Guadalupe,104,Lieutenant Governor,,DEM,Mike Collier,198,115,63,20
+Guadalupe,104,Lieutenant Governor,,LIB,Kerry McKennon,17,7,9,1
+Guadalupe,105,Lieutenant Governor,,,Under Votes,16,10,5,1
+Guadalupe,105,Lieutenant Governor,,REP,Dan Patrick,1158,708,379,71
+Guadalupe,105,Lieutenant Governor,,DEM,Mike Collier,309,175,106,28
+Guadalupe,105,Lieutenant Governor,,LIB,Kerry McKennon,31,13,14,4
+Guadalupe,106,Lieutenant Governor,,,Under Votes,16,12,4,0
+Guadalupe,106,Lieutenant Governor,,REP,Dan Patrick,1292,944,235,113
+Guadalupe,106,Lieutenant Governor,,DEM,Mike Collier,561,385,129,47
+Guadalupe,106,Lieutenant Governor,,LIB,Kerry McKennon,36,26,9,1
+Guadalupe,107,Lieutenant Governor,,,Under Votes,5,2,3,0
+Guadalupe,107,Lieutenant Governor,,REP,Dan Patrick,559,307,223,29
+Guadalupe,107,Lieutenant Governor,,DEM,Mike Collier,130,75,51,4
+Guadalupe,107,Lieutenant Governor,,LIB,Kerry McKennon,14,4,10,0
+Guadalupe,108,Lieutenant Governor,,,Under Votes,2,0,2,0
+Guadalupe,108,Lieutenant Governor,,REP,Dan Patrick,270,102,140,28
+Guadalupe,108,Lieutenant Governor,,DEM,Mike Collier,153,64,72,17
+Guadalupe,108,Lieutenant Governor,,LIB,Kerry McKennon,6,2,4,0
+Guadalupe,109,Lieutenant Governor,,,Under Votes,2,0,2,0
+Guadalupe,109,Lieutenant Governor,,REP,Dan Patrick,253,121,123,9
+Guadalupe,109,Lieutenant Governor,,DEM,Mike Collier,54,28,23,3
+Guadalupe,109,Lieutenant Governor,,LIB,Kerry McKennon,3,3,0,0
+Guadalupe,110,Lieutenant Governor,,,Under Votes,2,1,1,0
+Guadalupe,110,Lieutenant Governor,,REP,Dan Patrick,85,67,15,3
+Guadalupe,110,Lieutenant Governor,,DEM,Mike Collier,59,44,10,5
+Guadalupe,110,Lieutenant Governor,,LIB,Kerry McKennon,5,5,0,0
+Guadalupe,111,Lieutenant Governor,,,Under Votes,3,1,1,1
+Guadalupe,111,Lieutenant Governor,,REP,Dan Patrick,32,20,7,5
+Guadalupe,111,Lieutenant Governor,,DEM,Mike Collier,28,13,8,7
+Guadalupe,111,Lieutenant Governor,,LIB,Kerry McKennon,1,0,0,1
+Guadalupe,112,Lieutenant Governor,,,Under Votes,13,4,9,0
+Guadalupe,112,Lieutenant Governor,,REP,Dan Patrick,74,29,44,1
+Guadalupe,112,Lieutenant Governor,,DEM,Mike Collier,134,51,83,0
+Guadalupe,112,Lieutenant Governor,,LIB,Kerry McKennon,5,1,4,0
+Guadalupe,113,Lieutenant Governor,,,Under Votes,7,6,1,0
+Guadalupe,113,Lieutenant Governor,,REP,Dan Patrick,387,278,91,18
+Guadalupe,113,Lieutenant Governor,,DEM,Mike Collier,175,113,52,10
+Guadalupe,113,Lieutenant Governor,,LIB,Kerry McKennon,15,7,8,0
+Guadalupe,114,Lieutenant Governor,,,Under Votes,5,2,2,1
+Guadalupe,114,Lieutenant Governor,,REP,Dan Patrick,287,206,63,18
+Guadalupe,114,Lieutenant Governor,,DEM,Mike Collier,149,99,43,7
+Guadalupe,114,Lieutenant Governor,,LIB,Kerry McKennon,10,9,1,0
+Guadalupe,115,Lieutenant Governor,,,Under Votes,2,1,1,0
+Guadalupe,115,Lieutenant Governor,,REP,Dan Patrick,140,101,38,1
+Guadalupe,115,Lieutenant Governor,,DEM,Mike Collier,30,21,6,3
+Guadalupe,115,Lieutenant Governor,,LIB,Kerry McKennon,4,3,1,0
+Guadalupe,116,Lieutenant Governor,,,Under Votes,15,5,9,1
+Guadalupe,116,Lieutenant Governor,,REP,Dan Patrick,978,652,264,62
+Guadalupe,116,Lieutenant Governor,,DEM,Mike Collier,313,169,120,24
+Guadalupe,116,Lieutenant Governor,,LIB,Kerry McKennon,35,20,13,2
+Guadalupe,117,Lieutenant Governor,,,Under Votes,22,13,9,0
+Guadalupe,117,Lieutenant Governor,,REP,Dan Patrick,1740,1275,386,79
+Guadalupe,117,Lieutenant Governor,,DEM,Mike Collier,713,500,165,48
+Guadalupe,117,Lieutenant Governor,,LIB,Kerry McKennon,63,41,22,0
+Guadalupe,118,Lieutenant Governor,,,Under Votes,0,0,0,0
+Guadalupe,118,Lieutenant Governor,,REP,Dan Patrick,22,16,6,0
+Guadalupe,118,Lieutenant Governor,,DEM,Mike Collier,21,13,7,1
+Guadalupe,118,Lieutenant Governor,,LIB,Kerry McKennon,0,0,0,0
+Guadalupe,119,Lieutenant Governor,,,Under Votes,10,6,3,1
+Guadalupe,119,Lieutenant Governor,,REP,Dan Patrick,816,624,150,42
+Guadalupe,119,Lieutenant Governor,,DEM,Mike Collier,253,182,57,14
+Guadalupe,119,Lieutenant Governor,,LIB,Kerry McKennon,21,14,6,1
+Guadalupe,120,Lieutenant Governor,,,Under Votes,7,4,3,0
+Guadalupe,120,Lieutenant Governor,,REP,Dan Patrick,541,374,120,47
+Guadalupe,120,Lieutenant Governor,,DEM,Mike Collier,152,102,35,15
+Guadalupe,120,Lieutenant Governor,,LIB,Kerry McKennon,20,13,6,1
+Guadalupe,121,Lieutenant Governor,,,Under Votes,5,4,1,0
+Guadalupe,121,Lieutenant Governor,,REP,Dan Patrick,59,49,8,2
+Guadalupe,121,Lieutenant Governor,,DEM,Mike Collier,28,24,2,2
+Guadalupe,121,Lieutenant Governor,,LIB,Kerry McKennon,2,2,0,0
+Guadalupe,122,Lieutenant Governor,,,Under Votes,0,0,0,0
+Guadalupe,122,Lieutenant Governor,,REP,Dan Patrick,16,12,1,3
+Guadalupe,122,Lieutenant Governor,,DEM,Mike Collier,10,4,0,6
+Guadalupe,122,Lieutenant Governor,,LIB,Kerry McKennon,1,1,0,0
+Guadalupe,123,Lieutenant Governor,,,Under Votes,0,0,0,0
+Guadalupe,123,Lieutenant Governor,,REP,Dan Patrick,0,0,0,0
+Guadalupe,123,Lieutenant Governor,,DEM,Mike Collier,1,0,0,1
+Guadalupe,123,Lieutenant Governor,,LIB,Kerry McKennon,0,0,0,0
+Guadalupe,124,Lieutenant Governor,,,Under Votes,0,0,0,0
+Guadalupe,124,Lieutenant Governor,,REP,Dan Patrick,1,1,0,0
+Guadalupe,124,Lieutenant Governor,,DEM,Mike Collier,1,1,0,0
+Guadalupe,124,Lieutenant Governor,,LIB,Kerry McKennon,0,0,0,0
+Guadalupe,125,Lieutenant Governor,,,Under Votes,1,1,0,0
+Guadalupe,125,Lieutenant Governor,,REP,Dan Patrick,91,68,12,11
+Guadalupe,125,Lieutenant Governor,,DEM,Mike Collier,17,10,6,1
+Guadalupe,125,Lieutenant Governor,,LIB,Kerry McKennon,0,0,0,0
+Guadalupe,126,Lieutenant Governor,,,Under Votes,0,0,0,0
+Guadalupe,126,Lieutenant Governor,,REP,Dan Patrick,12,4,7,1
+Guadalupe,126,Lieutenant Governor,,DEM,Mike Collier,2,2,0,0
+Guadalupe,126,Lieutenant Governor,,LIB,Kerry McKennon,0,0,0,0
+Guadalupe,127,Lieutenant Governor,,,Under Votes,0,0,0,0
+Guadalupe,127,Lieutenant Governor,,REP,Dan Patrick,9,3,5,1
+Guadalupe,127,Lieutenant Governor,,DEM,Mike Collier,4,0,4,0
+Guadalupe,127,Lieutenant Governor,,LIB,Kerry McKennon,2,1,1,0
+Guadalupe,201,Lieutenant Governor,,,Under Votes,4,2,2,0
+Guadalupe,201,Lieutenant Governor,,REP,Dan Patrick,118,78,31,9
+Guadalupe,201,Lieutenant Governor,,DEM,Mike Collier,85,55,22,8
+Guadalupe,201,Lieutenant Governor,,LIB,Kerry McKennon,5,4,0,1
+Guadalupe,202,Lieutenant Governor,,,Under Votes,17,4,11,2
+Guadalupe,202,Lieutenant Governor,,REP,Dan Patrick,133,84,41,8
+Guadalupe,202,Lieutenant Governor,,DEM,Mike Collier,301,160,106,35
+Guadalupe,202,Lieutenant Governor,,LIB,Kerry McKennon,12,7,5,0
+Guadalupe,203,Lieutenant Governor,,,Under Votes,9,5,4,0
+Guadalupe,203,Lieutenant Governor,,REP,Dan Patrick,47,26,17,4
+Guadalupe,203,Lieutenant Governor,,DEM,Mike Collier,121,51,60,10
+Guadalupe,203,Lieutenant Governor,,LIB,Kerry McKennon,3,3,0,0
+Guadalupe,204,Lieutenant Governor,,,Under Votes,10,4,6,0
+Guadalupe,204,Lieutenant Governor,,REP,Dan Patrick,262,148,106,8
+Guadalupe,204,Lieutenant Governor,,DEM,Mike Collier,344,195,127,22
+Guadalupe,204,Lieutenant Governor,,LIB,Kerry McKennon,12,4,8,0
+Guadalupe,205,Lieutenant Governor,,,Under Votes,10,4,6,0
+Guadalupe,205,Lieutenant Governor,,REP,Dan Patrick,461,274,171,16
+Guadalupe,205,Lieutenant Governor,,DEM,Mike Collier,175,103,65,7
+Guadalupe,205,Lieutenant Governor,,LIB,Kerry McKennon,21,5,16,0
+Guadalupe,206,Lieutenant Governor,,,Under Votes,16,6,10,0
+Guadalupe,206,Lieutenant Governor,,REP,Dan Patrick,354,140,199,15
+Guadalupe,206,Lieutenant Governor,,DEM,Mike Collier,573,175,367,31
+Guadalupe,206,Lieutenant Governor,,LIB,Kerry McKennon,28,14,14,0
+Guadalupe,207,Lieutenant Governor,,,Under Votes,13,8,3,2
+Guadalupe,207,Lieutenant Governor,,REP,Dan Patrick,149,102,37,10
+Guadalupe,207,Lieutenant Governor,,DEM,Mike Collier,234,143,75,16
+Guadalupe,207,Lieutenant Governor,,LIB,Kerry McKennon,12,9,3,0
+Guadalupe,208,Lieutenant Governor,,,Under Votes,22,19,3,0
+Guadalupe,208,Lieutenant Governor,,REP,Dan Patrick,1420,1033,308,79
+Guadalupe,208,Lieutenant Governor,,DEM,Mike Collier,410,285,99,26
+Guadalupe,208,Lieutenant Governor,,LIB,Kerry McKennon,40,27,12,1
+Guadalupe,209,Lieutenant Governor,,,Under Votes,11,6,5,0
+Guadalupe,209,Lieutenant Governor,,REP,Dan Patrick,89,46,38,5
+Guadalupe,209,Lieutenant Governor,,DEM,Mike Collier,216,107,90,19
+Guadalupe,209,Lieutenant Governor,,LIB,Kerry McKennon,6,2,4,0
+Guadalupe,210,Lieutenant Governor,,,Under Votes,8,5,3,0
+Guadalupe,210,Lieutenant Governor,,REP,Dan Patrick,251,161,73,17
+Guadalupe,210,Lieutenant Governor,,DEM,Mike Collier,208,136,54,18
+Guadalupe,210,Lieutenant Governor,,LIB,Kerry McKennon,16,11,4,1
+Guadalupe,211,Lieutenant Governor,,,Under Votes,0,0,0,0
+Guadalupe,211,Lieutenant Governor,,REP,Dan Patrick,41,32,8,1
+Guadalupe,211,Lieutenant Governor,,DEM,Mike Collier,36,29,3,4
+Guadalupe,211,Lieutenant Governor,,LIB,Kerry McKennon,3,3,0,0
+Guadalupe,212,Lieutenant Governor,,,Under Votes,2,1,0,1
+Guadalupe,212,Lieutenant Governor,,REP,Dan Patrick,36,30,6,0
+Guadalupe,212,Lieutenant Governor,,DEM,Mike Collier,46,28,15,3
+Guadalupe,212,Lieutenant Governor,,LIB,Kerry McKennon,2,2,0,0
+Guadalupe,213,Lieutenant Governor,,,Under Votes,12,6,5,1
+Guadalupe,213,Lieutenant Governor,,REP,Dan Patrick,830,575,224,31
+Guadalupe,213,Lieutenant Governor,,DEM,Mike Collier,360,238,107,15
+Guadalupe,213,Lieutenant Governor,,LIB,Kerry McKennon,33,19,13,1
+Guadalupe,214,Lieutenant Governor,,,Under Votes,5,5,0,0
+Guadalupe,214,Lieutenant Governor,,REP,Dan Patrick,269,190,70,9
+Guadalupe,214,Lieutenant Governor,,DEM,Mike Collier,86,53,24,9
+Guadalupe,214,Lieutenant Governor,,LIB,Kerry McKennon,11,7,4,0
+Guadalupe,215,Lieutenant Governor,,,Under Votes,6,4,2,0
+Guadalupe,215,Lieutenant Governor,,REP,Dan Patrick,372,251,92,29
+Guadalupe,215,Lieutenant Governor,,DEM,Mike Collier,152,104,37,11
+Guadalupe,215,Lieutenant Governor,,LIB,Kerry McKennon,12,6,6,0
+Guadalupe,216,Lieutenant Governor,,,Under Votes,0,0,0,0
+Guadalupe,216,Lieutenant Governor,,REP,Dan Patrick,28,17,8,3
+Guadalupe,216,Lieutenant Governor,,DEM,Mike Collier,7,5,2,0
+Guadalupe,216,Lieutenant Governor,,LIB,Kerry McKennon,2,0,1,1
+Guadalupe,217,Lieutenant Governor,,,Under Votes,1,0,1,0
+Guadalupe,217,Lieutenant Governor,,REP,Dan Patrick,28,12,13,3
+Guadalupe,217,Lieutenant Governor,,DEM,Mike Collier,36,10,26,0
+Guadalupe,217,Lieutenant Governor,,LIB,Kerry McKennon,0,0,0,0
+Guadalupe,218,Lieutenant Governor,,,Under Votes,1,1,0,0
+Guadalupe,218,Lieutenant Governor,,REP,Dan Patrick,15,13,1,1
+Guadalupe,218,Lieutenant Governor,,DEM,Mike Collier,21,17,4,0
+Guadalupe,218,Lieutenant Governor,,LIB,Kerry McKennon,1,1,0,0
+Guadalupe,219,Lieutenant Governor,,,Under Votes,1,1,0,0
+Guadalupe,219,Lieutenant Governor,,REP,Dan Patrick,27,22,5,0
+Guadalupe,219,Lieutenant Governor,,DEM,Mike Collier,22,18,3,1
+Guadalupe,219,Lieutenant Governor,,LIB,Kerry McKennon,1,0,1,0
+Guadalupe,220,Lieutenant Governor,,,Under Votes,1,0,0,1
+Guadalupe,220,Lieutenant Governor,,REP,Dan Patrick,19,13,6,0
+Guadalupe,220,Lieutenant Governor,,DEM,Mike Collier,23,18,4,1
+Guadalupe,220,Lieutenant Governor,,LIB,Kerry McKennon,0,0,0,0
+Guadalupe,221,Lieutenant Governor,,,Under Votes,0,0,0,0
+Guadalupe,221,Lieutenant Governor,,REP,Dan Patrick,10,7,3,0
+Guadalupe,221,Lieutenant Governor,,DEM,Mike Collier,6,2,1,3
+Guadalupe,221,Lieutenant Governor,,LIB,Kerry McKennon,0,0,0,0
+Guadalupe,222,Lieutenant Governor,,,Under Votes,0,0,0,0
+Guadalupe,222,Lieutenant Governor,,REP,Dan Patrick,0,0,0,0
+Guadalupe,222,Lieutenant Governor,,DEM,Mike Collier,0,0,0,0
+Guadalupe,222,Lieutenant Governor,,LIB,Kerry McKennon,0,0,0,0
+Guadalupe,223,Lieutenant Governor,,,Under Votes,2,2,0,0
+Guadalupe,223,Lieutenant Governor,,REP,Dan Patrick,76,43,28,5
+Guadalupe,223,Lieutenant Governor,,DEM,Mike Collier,75,61,8,6
+Guadalupe,223,Lieutenant Governor,,LIB,Kerry McKennon,6,4,2,0
+Guadalupe,224,Lieutenant Governor,,,Under Votes,0,0,0,0
+Guadalupe,224,Lieutenant Governor,,REP,Dan Patrick,10,3,7,0
+Guadalupe,224,Lieutenant Governor,,DEM,Mike Collier,50,24,19,7
+Guadalupe,224,Lieutenant Governor,,LIB,Kerry McKennon,0,0,0,0
+Guadalupe,225,Lieutenant Governor,,,Under Votes,1,1,0,0
+Guadalupe,225,Lieutenant Governor,,REP,Dan Patrick,2,0,2,0
+Guadalupe,225,Lieutenant Governor,,DEM,Mike Collier,8,7,1,0
+Guadalupe,225,Lieutenant Governor,,LIB,Kerry McKennon,0,0,0,0
+Guadalupe,226,Lieutenant Governor,,,Under Votes,3,2,0,1
+Guadalupe,226,Lieutenant Governor,,REP,Dan Patrick,99,65,32,2
+Guadalupe,226,Lieutenant Governor,,DEM,Mike Collier,55,29,23,3
+Guadalupe,226,Lieutenant Governor,,LIB,Kerry McKennon,3,3,0,0
+Guadalupe,301,Lieutenant Governor,,,Under Votes,22,14,7,1
+Guadalupe,301,Lieutenant Governor,,REP,Dan Patrick,1022,637,331,54
+Guadalupe,301,Lieutenant Governor,,DEM,Mike Collier,667,459,185,23
+Guadalupe,301,Lieutenant Governor,,LIB,Kerry McKennon,33,21,12,0
+Guadalupe,302,Lieutenant Governor,,,Under Votes,27,17,7,3
+Guadalupe,302,Lieutenant Governor,,REP,Dan Patrick,1254,855,349,50
+Guadalupe,302,Lieutenant Governor,,DEM,Mike Collier,977,636,291,50
+Guadalupe,302,Lieutenant Governor,,LIB,Kerry McKennon,66,41,24,1
+Guadalupe,303,Lieutenant Governor,,,Under Votes,5,3,2,0
+Guadalupe,303,Lieutenant Governor,,REP,Dan Patrick,527,400,97,30
+Guadalupe,303,Lieutenant Governor,,DEM,Mike Collier,259,187,52,20
+Guadalupe,303,Lieutenant Governor,,LIB,Kerry McKennon,17,14,2,1
+Guadalupe,304,Lieutenant Governor,,,Under Votes,21,9,9,3
+Guadalupe,304,Lieutenant Governor,,REP,Dan Patrick,1403,1082,254,67
+Guadalupe,304,Lieutenant Governor,,DEM,Mike Collier,854,649,150,55
+Guadalupe,304,Lieutenant Governor,,LIB,Kerry McKennon,58,35,19,4
+Guadalupe,305,Lieutenant Governor,,,Under Votes,30,14,10,6
+Guadalupe,305,Lieutenant Governor,,REP,Dan Patrick,1341,939,344,58
+Guadalupe,305,Lieutenant Governor,,DEM,Mike Collier,993,700,223,70
+Guadalupe,305,Lieutenant Governor,,LIB,Kerry McKennon,46,28,17,1
+Guadalupe,306,Lieutenant Governor,,,Under Votes,17,13,4,0
+Guadalupe,306,Lieutenant Governor,,REP,Dan Patrick,1453,1149,240,64
+Guadalupe,306,Lieutenant Governor,,DEM,Mike Collier,891,692,141,58
+Guadalupe,306,Lieutenant Governor,,LIB,Kerry McKennon,50,36,12,2
+Guadalupe,307,Lieutenant Governor,,,Under Votes,21,15,5,1
+Guadalupe,307,Lieutenant Governor,,REP,Dan Patrick,1434,1118,256,60
+Guadalupe,307,Lieutenant Governor,,DEM,Mike Collier,1021,784,195,42
+Guadalupe,307,Lieutenant Governor,,LIB,Kerry McKennon,63,40,21,2
+Guadalupe,308,Lieutenant Governor,,,Under Votes,13,7,4,2
+Guadalupe,308,Lieutenant Governor,,REP,Dan Patrick,823,638,136,49
+Guadalupe,308,Lieutenant Governor,,DEM,Mike Collier,407,280,90,37
+Guadalupe,308,Lieutenant Governor,,LIB,Kerry McKennon,39,31,6,2
+Guadalupe,401,Lieutenant Governor,,,Under Votes,8,1,6,1
+Guadalupe,401,Lieutenant Governor,,REP,Dan Patrick,656,370,243,43
+Guadalupe,401,Lieutenant Governor,,DEM,Mike Collier,185,111,65,9
+Guadalupe,401,Lieutenant Governor,,LIB,Kerry McKennon,25,16,8,1
+Guadalupe,402,Lieutenant Governor,,,Under Votes,13,8,1,4
+Guadalupe,402,Lieutenant Governor,,REP,Dan Patrick,531,367,120,44
+Guadalupe,402,Lieutenant Governor,,DEM,Mike Collier,342,208,99,35
+Guadalupe,402,Lieutenant Governor,,LIB,Kerry McKennon,29,14,13,2
+Guadalupe,403,Lieutenant Governor,,,Under Votes,17,12,4,1
+Guadalupe,403,Lieutenant Governor,,REP,Dan Patrick,772,528,184,60
+Guadalupe,403,Lieutenant Governor,,DEM,Mike Collier,491,299,119,73
+Guadalupe,403,Lieutenant Governor,,LIB,Kerry McKennon,40,19,19,2
+Guadalupe,404,Lieutenant Governor,,,Under Votes,19,13,6,0
+Guadalupe,404,Lieutenant Governor,,REP,Dan Patrick,946,567,300,79
+Guadalupe,404,Lieutenant Governor,,DEM,Mike Collier,659,405,205,49
+Guadalupe,404,Lieutenant Governor,,LIB,Kerry McKennon,43,21,22,0
+Guadalupe,405,Lieutenant Governor,,,Under Votes,10,8,2,0
+Guadalupe,405,Lieutenant Governor,,REP,Dan Patrick,888,532,323,33
+Guadalupe,405,Lieutenant Governor,,DEM,Mike Collier,195,117,67,11
+Guadalupe,405,Lieutenant Governor,,LIB,Kerry McKennon,22,6,15,1
+Guadalupe,406,Lieutenant Governor,,,Under Votes,13,9,3,1
+Guadalupe,406,Lieutenant Governor,,REP,Dan Patrick,994,749,204,41
+Guadalupe,406,Lieutenant Governor,,DEM,Mike Collier,192,132,47,13
+Guadalupe,406,Lieutenant Governor,,LIB,Kerry McKennon,21,13,7,1
+Guadalupe,407,Lieutenant Governor,,,Under Votes,9,6,3,0
+Guadalupe,407,Lieutenant Governor,,REP,Dan Patrick,868,625,203,40
+Guadalupe,407,Lieutenant Governor,,DEM,Mike Collier,191,118,54,19
+Guadalupe,407,Lieutenant Governor,,LIB,Kerry McKennon,16,6,6,4
+Guadalupe,408,Lieutenant Governor,,,Under Votes,26,10,14,2
+Guadalupe,408,Lieutenant Governor,,REP,Dan Patrick,1555,1022,400,133
+Guadalupe,408,Lieutenant Governor,,DEM,Mike Collier,720,470,209,41
+Guadalupe,408,Lieutenant Governor,,LIB,Kerry McKennon,51,28,19,4
+Guadalupe,409,Lieutenant Governor,,,Under Votes,22,13,8,1
+Guadalupe,409,Lieutenant Governor,,REP,Dan Patrick,1254,899,307,48
+Guadalupe,409,Lieutenant Governor,,DEM,Mike Collier,1309,952,298,59
+Guadalupe,409,Lieutenant Governor,,LIB,Kerry McKennon,53,38,14,1
+Guadalupe,410,Lieutenant Governor,,,Under Votes,2,2,0,0
+Guadalupe,410,Lieutenant Governor,,REP,Dan Patrick,55,45,10,0
+Guadalupe,410,Lieutenant Governor,,DEM,Mike Collier,24,18,6,0
+Guadalupe,410,Lieutenant Governor,,LIB,Kerry McKennon,2,0,2,0
+Guadalupe,411,Lieutenant Governor,,,Under Votes,23,12,8,3
+Guadalupe,411,Lieutenant Governor,,REP,Dan Patrick,1167,836,277,54
+Guadalupe,411,Lieutenant Governor,,DEM,Mike Collier,757,573,142,42
+Guadalupe,411,Lieutenant Governor,,LIB,Kerry McKennon,51,38,12,1
+Guadalupe,101,Attorney General,,,Under Votes,7,3,1,3
+Guadalupe,101,Attorney General,,REP,Ken Paxton,250,169,65,16
+Guadalupe,101,Attorney General,,DEM,Justin Nelson,95,63,23,9
+Guadalupe,101,Attorney General,,LIB,Michael Ray Harris,17,9,8,0
+Guadalupe,102,Attorney General,,,Under Votes,10,5,5,0
+Guadalupe,102,Attorney General,,REP,Ken Paxton,397,297,66,34
+Guadalupe,102,Attorney General,,DEM,Justin Nelson,172,107,47,18
+Guadalupe,102,Attorney General,,LIB,Michael Ray Harris,19,13,4,2
+Guadalupe,103,Attorney General,,,Under Votes,6,4,2,0
+Guadalupe,103,Attorney General,,REP,Ken Paxton,316,234,62,20
+Guadalupe,103,Attorney General,,DEM,Justin Nelson,128,83,36,9
+Guadalupe,103,Attorney General,,LIB,Michael Ray Harris,9,3,5,1
+Guadalupe,104,Attorney General,,,Under Votes,15,13,2,0
+Guadalupe,104,Attorney General,,REP,Ken Paxton,264,191,57,16
+Guadalupe,104,Attorney General,,DEM,Justin Nelson,218,136,62,20
+Guadalupe,104,Attorney General,,LIB,Michael Ray Harris,23,10,10,3
+Guadalupe,105,Attorney General,,,Under Votes,19,14,4,1
+Guadalupe,105,Attorney General,,REP,Ken Paxton,1130,687,373,70
+Guadalupe,105,Attorney General,,DEM,Justin Nelson,332,188,113,31
+Guadalupe,105,Attorney General,,LIB,Michael Ray Harris,33,17,14,2
+Guadalupe,106,Attorney General,,,Under Votes,22,16,6,0
+Guadalupe,106,Attorney General,,REP,Ken Paxton,1258,916,232,110
+Guadalupe,106,Attorney General,,DEM,Justin Nelson,582,409,127,46
+Guadalupe,106,Attorney General,,LIB,Michael Ray Harris,43,26,12,5
+Guadalupe,107,Attorney General,,,Under Votes,5,2,3,0
+Guadalupe,107,Attorney General,,REP,Ken Paxton,547,301,220,26
+Guadalupe,107,Attorney General,,DEM,Justin Nelson,131,77,50,4
+Guadalupe,107,Attorney General,,LIB,Michael Ray Harris,25,8,14,3
+Guadalupe,108,Attorney General,,,Under Votes,3,1,2,0
+Guadalupe,108,Attorney General,,REP,Ken Paxton,261,97,136,28
+Guadalupe,108,Attorney General,,DEM,Justin Nelson,155,66,74,15
+Guadalupe,108,Attorney General,,LIB,Michael Ray Harris,12,4,6,2
+Guadalupe,109,Attorney General,,,Under Votes,3,0,3,0
+Guadalupe,109,Attorney General,,REP,Ken Paxton,243,118,118,7
+Guadalupe,109,Attorney General,,DEM,Justin Nelson,59,30,25,4
+Guadalupe,109,Attorney General,,LIB,Michael Ray Harris,7,4,2,1
+Guadalupe,110,Attorney General,,,Under Votes,4,1,2,1
+Guadalupe,110,Attorney General,,REP,Ken Paxton,85,69,14,2
+Guadalupe,110,Attorney General,,DEM,Justin Nelson,61,46,10,5
+Guadalupe,110,Attorney General,,LIB,Michael Ray Harris,1,1,0,0
+Guadalupe,111,Attorney General,,,Under Votes,3,1,1,1
+Guadalupe,111,Attorney General,,REP,Ken Paxton,31,19,7,5
+Guadalupe,111,Attorney General,,DEM,Justin Nelson,28,13,8,7
+Guadalupe,111,Attorney General,,LIB,Michael Ray Harris,2,1,0,1
+Guadalupe,112,Attorney General,,,Under Votes,16,6,10,0
+Guadalupe,112,Attorney General,,REP,Ken Paxton,66,27,38,1
+Guadalupe,112,Attorney General,,DEM,Justin Nelson,139,51,88,0
+Guadalupe,112,Attorney General,,LIB,Michael Ray Harris,5,1,4,0
+Guadalupe,113,Attorney General,,,Under Votes,6,4,2,0
+Guadalupe,113,Attorney General,,REP,Ken Paxton,385,274,93,18
+Guadalupe,113,Attorney General,,DEM,Justin Nelson,178,116,53,9
+Guadalupe,113,Attorney General,,LIB,Michael Ray Harris,15,10,4,1
+Guadalupe,114,Attorney General,,,Under Votes,4,2,1,1
+Guadalupe,114,Attorney General,,REP,Ken Paxton,275,198,60,17
+Guadalupe,114,Attorney General,,DEM,Justin Nelson,156,105,44,7
+Guadalupe,114,Attorney General,,LIB,Michael Ray Harris,16,11,4,1
+Guadalupe,115,Attorney General,,,Under Votes,4,2,2,0
+Guadalupe,115,Attorney General,,REP,Ken Paxton,141,101,39,1
+Guadalupe,115,Attorney General,,DEM,Justin Nelson,28,20,5,3
+Guadalupe,115,Attorney General,,LIB,Michael Ray Harris,3,3,0,0
+Guadalupe,116,Attorney General,,,Under Votes,18,8,8,2
+Guadalupe,116,Attorney General,,REP,Ken Paxton,961,645,257,59
+Guadalupe,116,Attorney General,,DEM,Justin Nelson,334,179,130,25
+Guadalupe,116,Attorney General,,LIB,Michael Ray Harris,28,14,11,3
+Guadalupe,117,Attorney General,,,Under Votes,33,22,11,0
+Guadalupe,117,Attorney General,,REP,Ken Paxton,1702,1253,370,79
+Guadalupe,117,Attorney General,,DEM,Justin Nelson,730,504,178,48
+Guadalupe,117,Attorney General,,LIB,Michael Ray Harris,73,50,23,0
+Guadalupe,118,Attorney General,,,Under Votes,0,0,0,0
+Guadalupe,118,Attorney General,,REP,Ken Paxton,22,17,5,0
+Guadalupe,118,Attorney General,,DEM,Justin Nelson,20,12,7,1
+Guadalupe,118,Attorney General,,LIB,Michael Ray Harris,1,0,1,0
+Guadalupe,119,Attorney General,,,Under Votes,17,14,2,1
+Guadalupe,119,Attorney General,,REP,Ken Paxton,800,608,152,40
+Guadalupe,119,Attorney General,,DEM,Justin Nelson,254,187,53,14
+Guadalupe,119,Attorney General,,LIB,Michael Ray Harris,29,17,9,3
+Guadalupe,120,Attorney General,,,Under Votes,9,4,5,0
+Guadalupe,120,Attorney General,,REP,Ken Paxton,529,370,118,41
+Guadalupe,120,Attorney General,,DEM,Justin Nelson,161,105,38,18
+Guadalupe,120,Attorney General,,LIB,Michael Ray Harris,21,14,3,4
+Guadalupe,121,Attorney General,,,Under Votes,6,3,3,0
+Guadalupe,121,Attorney General,,REP,Ken Paxton,55,47,6,2
+Guadalupe,121,Attorney General,,DEM,Justin Nelson,28,24,2,2
+Guadalupe,121,Attorney General,,LIB,Michael Ray Harris,5,5,0,0
+Guadalupe,122,Attorney General,,,Under Votes,0,0,0,0
+Guadalupe,122,Attorney General,,REP,Ken Paxton,18,14,1,3
+Guadalupe,122,Attorney General,,DEM,Justin Nelson,7,2,0,5
+Guadalupe,122,Attorney General,,LIB,Michael Ray Harris,2,1,0,1
+Guadalupe,123,Attorney General,,,Under Votes,0,0,0,0
+Guadalupe,123,Attorney General,,REP,Ken Paxton,0,0,0,0
+Guadalupe,123,Attorney General,,DEM,Justin Nelson,1,0,0,1
+Guadalupe,123,Attorney General,,LIB,Michael Ray Harris,0,0,0,0
+Guadalupe,124,Attorney General,,,Under Votes,0,0,0,0
+Guadalupe,124,Attorney General,,REP,Ken Paxton,1,1,0,0
+Guadalupe,124,Attorney General,,DEM,Justin Nelson,1,1,0,0
+Guadalupe,124,Attorney General,,LIB,Michael Ray Harris,0,0,0,0
+Guadalupe,125,Attorney General,,,Under Votes,1,1,0,0
+Guadalupe,125,Attorney General,,REP,Ken Paxton,89,66,12,11
+Guadalupe,125,Attorney General,,DEM,Justin Nelson,19,12,6,1
+Guadalupe,125,Attorney General,,LIB,Michael Ray Harris,0,0,0,0
+Guadalupe,126,Attorney General,,,Under Votes,0,0,0,0
+Guadalupe,126,Attorney General,,REP,Ken Paxton,12,4,7,1
+Guadalupe,126,Attorney General,,DEM,Justin Nelson,2,2,0,0
+Guadalupe,126,Attorney General,,LIB,Michael Ray Harris,0,0,0,0
+Guadalupe,127,Attorney General,,,Under Votes,0,0,0,0
+Guadalupe,127,Attorney General,,REP,Ken Paxton,7,2,4,1
+Guadalupe,127,Attorney General,,DEM,Justin Nelson,5,0,5,0
+Guadalupe,127,Attorney General,,LIB,Michael Ray Harris,3,2,1,0
+Guadalupe,201,Attorney General,,,Under Votes,5,2,2,1
+Guadalupe,201,Attorney General,,REP,Ken Paxton,114,75,31,8
+Guadalupe,201,Attorney General,,DEM,Justin Nelson,86,57,20,9
+Guadalupe,201,Attorney General,,LIB,Michael Ray Harris,7,5,2,0
+Guadalupe,202,Attorney General,,,Under Votes,18,6,9,3
+Guadalupe,202,Attorney General,,REP,Ken Paxton,124,75,42,7
+Guadalupe,202,Attorney General,,DEM,Justin Nelson,304,163,109,32
+Guadalupe,202,Attorney General,,LIB,Michael Ray Harris,17,11,3,3
+Guadalupe,203,Attorney General,,,Under Votes,9,5,4,0
+Guadalupe,203,Attorney General,,REP,Ken Paxton,44,26,14,4
+Guadalupe,203,Attorney General,,DEM,Justin Nelson,122,52,60,10
+Guadalupe,203,Attorney General,,LIB,Michael Ray Harris,5,2,3,0
+Guadalupe,204,Attorney General,,,Under Votes,16,5,11,0
+Guadalupe,204,Attorney General,,REP,Ken Paxton,242,141,94,7
+Guadalupe,204,Attorney General,,DEM,Justin Nelson,359,203,135,21
+Guadalupe,204,Attorney General,,LIB,Michael Ray Harris,11,2,7,2
+Guadalupe,205,Attorney General,,,Under Votes,11,5,6,0
+Guadalupe,205,Attorney General,,REP,Ken Paxton,469,275,179,15
+Guadalupe,205,Attorney General,,DEM,Justin Nelson,173,102,64,7
+Guadalupe,205,Attorney General,,LIB,Michael Ray Harris,14,4,9,1
+Guadalupe,206,Attorney General,,,Under Votes,16,6,10,0
+Guadalupe,206,Attorney General,,REP,Ken Paxton,336,131,189,16
+Guadalupe,206,Attorney General,,DEM,Justin Nelson,584,184,372,28
+Guadalupe,206,Attorney General,,LIB,Michael Ray Harris,35,14,19,2
+Guadalupe,207,Attorney General,,,Under Votes,11,5,4,2
+Guadalupe,207,Attorney General,,REP,Ken Paxton,151,103,38,10
+Guadalupe,207,Attorney General,,DEM,Justin Nelson,231,144,71,16
+Guadalupe,207,Attorney General,,LIB,Michael Ray Harris,15,10,5,0
+Guadalupe,208,Attorney General,,,Under Votes,28,25,3,0
+Guadalupe,208,Attorney General,,REP,Ken Paxton,1391,1012,307,72
+Guadalupe,208,Attorney General,,DEM,Justin Nelson,425,303,95,27
+Guadalupe,208,Attorney General,,LIB,Michael Ray Harris,48,24,17,7
+Guadalupe,209,Attorney General,,,Under Votes,12,4,8,0
+Guadalupe,209,Attorney General,,REP,Ken Paxton,88,48,34,6
+Guadalupe,209,Attorney General,,DEM,Justin Nelson,213,104,91,18
+Guadalupe,209,Attorney General,,LIB,Michael Ray Harris,9,5,4,0
+Guadalupe,210,Attorney General,,,Under Votes,8,4,4,0
+Guadalupe,210,Attorney General,,REP,Ken Paxton,246,156,74,16
+Guadalupe,210,Attorney General,,DEM,Justin Nelson,210,137,55,18
+Guadalupe,210,Attorney General,,LIB,Michael Ray Harris,19,16,1,2
+Guadalupe,211,Attorney General,,,Under Votes,0,0,0,0
+Guadalupe,211,Attorney General,,REP,Ken Paxton,37,29,7,1
+Guadalupe,211,Attorney General,,DEM,Justin Nelson,36,29,3,4
+Guadalupe,211,Attorney General,,LIB,Michael Ray Harris,7,6,1,0
+Guadalupe,212,Attorney General,,,Under Votes,3,1,1,1
+Guadalupe,212,Attorney General,,REP,Ken Paxton,35,30,5,0
+Guadalupe,212,Attorney General,,DEM,Justin Nelson,47,29,15,3
+Guadalupe,212,Attorney General,,LIB,Michael Ray Harris,1,1,0,0
+Guadalupe,213,Attorney General,,,Under Votes,16,9,6,1
+Guadalupe,213,Attorney General,,REP,Ken Paxton,809,563,221,25
+Guadalupe,213,Attorney General,,DEM,Justin Nelson,366,240,107,19
+Guadalupe,213,Attorney General,,LIB,Michael Ray Harris,44,26,15,3
+Guadalupe,214,Attorney General,,,Under Votes,2,1,0,1
+Guadalupe,214,Attorney General,,REP,Ken Paxton,264,188,67,9
+Guadalupe,214,Attorney General,,DEM,Justin Nelson,93,57,28,8
+Guadalupe,214,Attorney General,,LIB,Michael Ray Harris,12,9,3,0
+Guadalupe,215,Attorney General,,,Under Votes,12,9,3,0
+Guadalupe,215,Attorney General,,REP,Ken Paxton,364,243,93,28
+Guadalupe,215,Attorney General,,DEM,Justin Nelson,152,104,38,10
+Guadalupe,215,Attorney General,,LIB,Michael Ray Harris,14,9,3,2
+Guadalupe,216,Attorney General,,,Under Votes,0,0,0,0
+Guadalupe,216,Attorney General,,REP,Ken Paxton,28,17,8,3
+Guadalupe,216,Attorney General,,DEM,Justin Nelson,8,5,3,0
+Guadalupe,216,Attorney General,,LIB,Michael Ray Harris,1,0,0,1
+Guadalupe,217,Attorney General,,,Under Votes,1,0,1,0
+Guadalupe,217,Attorney General,,REP,Ken Paxton,26,10,13,3
+Guadalupe,217,Attorney General,,DEM,Justin Nelson,38,12,26,0
+Guadalupe,217,Attorney General,,LIB,Michael Ray Harris,0,0,0,0
+Guadalupe,218,Attorney General,,,Under Votes,1,1,0,0
+Guadalupe,218,Attorney General,,REP,Ken Paxton,16,14,1,1
+Guadalupe,218,Attorney General,,DEM,Justin Nelson,21,17,4,0
+Guadalupe,218,Attorney General,,LIB,Michael Ray Harris,0,0,0,0
+Guadalupe,219,Attorney General,,,Under Votes,2,2,0,0
+Guadalupe,219,Attorney General,,REP,Ken Paxton,24,19,5,0
+Guadalupe,219,Attorney General,,DEM,Justin Nelson,23,19,4,0
+Guadalupe,219,Attorney General,,LIB,Michael Ray Harris,2,1,0,1
+Guadalupe,220,Attorney General,,,Under Votes,1,0,1,0
+Guadalupe,220,Attorney General,,REP,Ken Paxton,19,13,5,1
+Guadalupe,220,Attorney General,,DEM,Justin Nelson,22,17,4,1
+Guadalupe,220,Attorney General,,LIB,Michael Ray Harris,1,1,0,0
+Guadalupe,221,Attorney General,,,Under Votes,0,0,0,0
+Guadalupe,221,Attorney General,,REP,Ken Paxton,11,8,3,0
+Guadalupe,221,Attorney General,,DEM,Justin Nelson,5,1,1,3
+Guadalupe,221,Attorney General,,LIB,Michael Ray Harris,0,0,0,0
+Guadalupe,222,Attorney General,,,Under Votes,0,0,0,0
+Guadalupe,222,Attorney General,,REP,Ken Paxton,0,0,0,0
+Guadalupe,222,Attorney General,,DEM,Justin Nelson,0,0,0,0
+Guadalupe,222,Attorney General,,LIB,Michael Ray Harris,0,0,0,0
+Guadalupe,223,Attorney General,,,Under Votes,2,2,0,0
+Guadalupe,223,Attorney General,,REP,Ken Paxton,75,43,27,5
+Guadalupe,223,Attorney General,,DEM,Justin Nelson,78,62,10,6
+Guadalupe,223,Attorney General,,LIB,Michael Ray Harris,4,3,1,0
+Guadalupe,224,Attorney General,,,Under Votes,0,0,0,0
+Guadalupe,224,Attorney General,,REP,Ken Paxton,10,4,6,0
+Guadalupe,224,Attorney General,,DEM,Justin Nelson,46,23,18,5
+Guadalupe,224,Attorney General,,LIB,Michael Ray Harris,4,0,2,2
+Guadalupe,225,Attorney General,,,Under Votes,1,1,0,0
+Guadalupe,225,Attorney General,,REP,Ken Paxton,0,0,0,0
+Guadalupe,225,Attorney General,,DEM,Justin Nelson,8,7,1,0
+Guadalupe,225,Attorney General,,LIB,Michael Ray Harris,2,0,2,0
+Guadalupe,226,Attorney General,,,Under Votes,3,2,0,1
+Guadalupe,226,Attorney General,,REP,Ken Paxton,95,63,30,2
+Guadalupe,226,Attorney General,,DEM,Justin Nelson,56,30,23,3
+Guadalupe,226,Attorney General,,LIB,Michael Ray Harris,6,4,2,0
+Guadalupe,301,Attorney General,,,Under Votes,22,11,10,1
+Guadalupe,301,Attorney General,,REP,Ken Paxton,987,624,309,54
+Guadalupe,301,Attorney General,,DEM,Justin Nelson,691,474,195,22
+Guadalupe,301,Attorney General,,LIB,Michael Ray Harris,44,22,21,1
+Guadalupe,302,Attorney General,,,Under Votes,30,19,8,3
+Guadalupe,302,Attorney General,,REP,Ken Paxton,1202,820,332,50
+Guadalupe,302,Attorney General,,DEM,Justin Nelson,1011,656,305,50
+Guadalupe,302,Attorney General,,LIB,Michael Ray Harris,81,54,26,1
+Guadalupe,303,Attorney General,,,Under Votes,7,5,2,0
+Guadalupe,303,Attorney General,,REP,Ken Paxton,505,390,86,29
+Guadalupe,303,Attorney General,,DEM,Justin Nelson,279,197,60,22
+Guadalupe,303,Attorney General,,LIB,Michael Ray Harris,17,12,5,0
+Guadalupe,304,Attorney General,,,Under Votes,23,11,9,3
+Guadalupe,304,Attorney General,,REP,Ken Paxton,1360,1053,242,65
+Guadalupe,304,Attorney General,,DEM,Justin Nelson,887,667,162,58
+Guadalupe,304,Attorney General,,LIB,Michael Ray Harris,66,44,19,3
+Guadalupe,305,Attorney General,,,Under Votes,31,16,9,6
+Guadalupe,305,Attorney General,,REP,Ken Paxton,1295,912,329,54
+Guadalupe,305,Attorney General,,DEM,Justin Nelson,1009,709,230,70
+Guadalupe,305,Attorney General,,LIB,Michael Ray Harris,75,44,26,5
+Guadalupe,306,Attorney General,,,Under Votes,23,21,2,0
+Guadalupe,306,Attorney General,,REP,Ken Paxton,1404,1102,242,60
+Guadalupe,306,Attorney General,,DEM,Justin Nelson,913,714,138,61
+Guadalupe,306,Attorney General,,LIB,Michael Ray Harris,71,53,15,3
+Guadalupe,307,Attorney General,,,Under Votes,33,20,11,2
+Guadalupe,307,Attorney General,,REP,Ken Paxton,1389,1082,248,59
+Guadalupe,307,Attorney General,,DEM,Justin Nelson,1043,804,197,42
+Guadalupe,307,Attorney General,,LIB,Michael Ray Harris,74,51,21,2
+Guadalupe,308,Attorney General,,,Under Votes,14,9,3,2
+Guadalupe,308,Attorney General,,REP,Ken Paxton,797,620,130,47
+Guadalupe,308,Attorney General,,DEM,Justin Nelson,436,299,97,40
+Guadalupe,308,Attorney General,,LIB,Michael Ray Harris,35,28,6,1
+Guadalupe,401,Attorney General,,,Under Votes,9,3,6,0
+Guadalupe,401,Attorney General,,REP,Ken Paxton,632,358,232,42
+Guadalupe,401,Attorney General,,DEM,Justin Nelson,208,123,73,12
+Guadalupe,401,Attorney General,,LIB,Michael Ray Harris,25,14,11,0
+Guadalupe,402,Attorney General,,,Under Votes,17,13,1,3
+Guadalupe,402,Attorney General,,REP,Ken Paxton,506,346,119,41
+Guadalupe,402,Attorney General,,DEM,Justin Nelson,362,221,101,40
+Guadalupe,402,Attorney General,,LIB,Michael Ray Harris,30,17,12,1
+Guadalupe,403,Attorney General,,,Under Votes,14,9,4,1
+Guadalupe,403,Attorney General,,REP,Ken Paxton,751,515,177,59
+Guadalupe,403,Attorney General,,DEM,Justin Nelson,515,312,129,74
+Guadalupe,403,Attorney General,,LIB,Michael Ray Harris,40,22,16,2
+Guadalupe,404,Attorney General,,,Under Votes,23,12,10,1
+Guadalupe,404,Attorney General,,REP,Ken Paxton,906,542,292,72
+Guadalupe,404,Attorney General,,DEM,Justin Nelson,688,425,209,54
+Guadalupe,404,Attorney General,,LIB,Michael Ray Harris,50,27,22,1
+Guadalupe,405,Attorney General,,,Under Votes,16,12,4,0
+Guadalupe,405,Attorney General,,REP,Ken Paxton,873,516,325,32
+Guadalupe,405,Attorney General,,DEM,Justin Nelson,213,130,72,11
+Guadalupe,405,Attorney General,,LIB,Michael Ray Harris,13,5,6,2
+Guadalupe,406,Attorney General,,,Under Votes,18,14,3,1
+Guadalupe,406,Attorney General,,REP,Ken Paxton,1000,752,207,41
+Guadalupe,406,Attorney General,,DEM,Justin Nelson,184,126,45,13
+Guadalupe,406,Attorney General,,LIB,Michael Ray Harris,18,11,6,1
+Guadalupe,407,Attorney General,,,Under Votes,11,7,4,0
+Guadalupe,407,Attorney General,,REP,Ken Paxton,839,601,198,40
+Guadalupe,407,Attorney General,,DEM,Justin Nelson,211,133,58,20
+Guadalupe,407,Attorney General,,LIB,Michael Ray Harris,23,14,6,3
+Guadalupe,408,Attorney General,,,Under Votes,27,13,11,3
+Guadalupe,408,Attorney General,,REP,Ken Paxton,1519,997,392,130
+Guadalupe,408,Attorney General,,DEM,Justin Nelson,733,474,216,43
+Guadalupe,408,Attorney General,,LIB,Michael Ray Harris,73,46,23,4
+Guadalupe,409,Attorney General,,,Under Votes,27,12,14,1
+Guadalupe,409,Attorney General,,REP,Ken Paxton,1165,837,285,43
+Guadalupe,409,Attorney General,,DEM,Justin Nelson,1366,1000,308,58
+Guadalupe,409,Attorney General,,LIB,Michael Ray Harris,80,53,20,7
+Guadalupe,410,Attorney General,,,Under Votes,1,1,0,0
+Guadalupe,410,Attorney General,,REP,Ken Paxton,56,45,11,0
+Guadalupe,410,Attorney General,,DEM,Justin Nelson,23,18,5,0
+Guadalupe,410,Attorney General,,LIB,Michael Ray Harris,3,1,2,0
+Guadalupe,411,Attorney General,,,Under Votes,27,15,9,3
+Guadalupe,411,Attorney General,,REP,Ken Paxton,1137,814,271,52
+Guadalupe,411,Attorney General,,DEM,Justin Nelson,766,585,138,43
+Guadalupe,411,Attorney General,,LIB,Michael Ray Harris,68,45,21,2
+Guadalupe,101,Comptroller of Public Accounts,,,Under Votes,8,4,1,3
+Guadalupe,101,Comptroller of Public Accounts,,REP,Glenn Hegar,259,175,67,17
+Guadalupe,101,Comptroller of Public Accounts,,DEM,Joi Chevalier,86,56,24,6
+Guadalupe,101,Comptroller of Public Accounts,,LIB,Ben Sanders,16,9,5,2
+Guadalupe,102,Comptroller of Public Accounts,,,Under Votes,15,7,6,2
+Guadalupe,102,Comptroller of Public Accounts,,REP,Glenn Hegar,408,306,66,36
+Guadalupe,102,Comptroller of Public Accounts,,DEM,Joi Chevalier,153,95,44,14
+Guadalupe,102,Comptroller of Public Accounts,,LIB,Ben Sanders,22,14,6,2
+Guadalupe,103,Comptroller of Public Accounts,,,Under Votes,7,5,2,0
+Guadalupe,103,Comptroller of Public Accounts,,REP,Glenn Hegar,329,245,64,20
+Guadalupe,103,Comptroller of Public Accounts,,DEM,Joi Chevalier,109,70,30,9
+Guadalupe,103,Comptroller of Public Accounts,,LIB,Ben Sanders,14,4,9,1
+Guadalupe,104,Comptroller of Public Accounts,,,Under Votes,17,13,4,0
+Guadalupe,104,Comptroller of Public Accounts,,REP,Glenn Hegar,286,208,60,18
+Guadalupe,104,Comptroller of Public Accounts,,DEM,Joi Chevalier,192,114,59,19
+Guadalupe,104,Comptroller of Public Accounts,,LIB,Ben Sanders,25,15,8,2
+Guadalupe,105,Comptroller of Public Accounts,,,Under Votes,25,18,5,2
+Guadalupe,105,Comptroller of Public Accounts,,REP,Glenn Hegar,1147,694,382,71
+Guadalupe,105,Comptroller of Public Accounts,,DEM,Joi Chevalier,297,174,95,28
+Guadalupe,105,Comptroller of Public Accounts,,LIB,Ben Sanders,45,20,22,3
+Guadalupe,106,Comptroller of Public Accounts,,,Under Votes,27,18,9,0
+Guadalupe,106,Comptroller of Public Accounts,,REP,Glenn Hegar,1325,968,240,117
+Guadalupe,106,Comptroller of Public Accounts,,DEM,Joi Chevalier,505,348,117,40
+Guadalupe,106,Comptroller of Public Accounts,,LIB,Ben Sanders,48,33,11,4
+Guadalupe,107,Comptroller of Public Accounts,,,Under Votes,13,6,7,0
+Guadalupe,107,Comptroller of Public Accounts,,REP,Glenn Hegar,558,307,221,30
+Guadalupe,107,Comptroller of Public Accounts,,DEM,Joi Chevalier,115,67,45,3
+Guadalupe,107,Comptroller of Public Accounts,,LIB,Ben Sanders,22,8,14,0
+Guadalupe,108,Comptroller of Public Accounts,,,Under Votes,4,0,4,0
+Guadalupe,108,Comptroller of Public Accounts,,REP,Glenn Hegar,271,101,140,30
+Guadalupe,108,Comptroller of Public Accounts,,DEM,Joi Chevalier,146,65,66,15
+Guadalupe,108,Comptroller of Public Accounts,,LIB,Ben Sanders,10,2,8,0
+Guadalupe,109,Comptroller of Public Accounts,,,Under Votes,5,2,3,0
+Guadalupe,109,Comptroller of Public Accounts,,REP,Glenn Hegar,251,126,116,9
+Guadalupe,109,Comptroller of Public Accounts,,DEM,Joi Chevalier,46,19,24,3
+Guadalupe,109,Comptroller of Public Accounts,,LIB,Ben Sanders,10,5,5,0
+Guadalupe,110,Comptroller of Public Accounts,,,Under Votes,6,2,3,1
+Guadalupe,110,Comptroller of Public Accounts,,REP,Glenn Hegar,86,71,13,2
+Guadalupe,110,Comptroller of Public Accounts,,DEM,Joi Chevalier,55,40,10,5
+Guadalupe,110,Comptroller of Public Accounts,,LIB,Ben Sanders,4,4,0,0
+Guadalupe,111,Comptroller of Public Accounts,,,Under Votes,4,1,2,1
+Guadalupe,111,Comptroller of Public Accounts,,REP,Glenn Hegar,33,22,6,5
+Guadalupe,111,Comptroller of Public Accounts,,DEM,Joi Chevalier,26,11,8,7
+Guadalupe,111,Comptroller of Public Accounts,,LIB,Ben Sanders,1,0,0,1
+Guadalupe,112,Comptroller of Public Accounts,,,Under Votes,17,6,10,1
+Guadalupe,112,Comptroller of Public Accounts,,REP,Glenn Hegar,67,25,42,0
+Guadalupe,112,Comptroller of Public Accounts,,DEM,Joi Chevalier,129,49,80,0
+Guadalupe,112,Comptroller of Public Accounts,,LIB,Ben Sanders,13,5,8,0
+Guadalupe,113,Comptroller of Public Accounts,,,Under Votes,8,6,2,0
+Guadalupe,113,Comptroller of Public Accounts,,REP,Glenn Hegar,379,274,86,19
+Guadalupe,113,Comptroller of Public Accounts,,DEM,Joi Chevalier,166,106,51,9
+Guadalupe,113,Comptroller of Public Accounts,,LIB,Ben Sanders,31,18,13,0
+Guadalupe,114,Comptroller of Public Accounts,,,Under Votes,7,4,1,2
+Guadalupe,114,Comptroller of Public Accounts,,REP,Glenn Hegar,283,204,60,19
+Guadalupe,114,Comptroller of Public Accounts,,DEM,Joi Chevalier,143,95,43,5
+Guadalupe,114,Comptroller of Public Accounts,,LIB,Ben Sanders,18,13,5,0
+Guadalupe,115,Comptroller of Public Accounts,,,Under Votes,8,4,3,1
+Guadalupe,115,Comptroller of Public Accounts,,REP,Glenn Hegar,146,107,38,1
+Guadalupe,115,Comptroller of Public Accounts,,DEM,Joi Chevalier,21,15,4,2
+Guadalupe,115,Comptroller of Public Accounts,,LIB,Ben Sanders,1,0,1,0
+Guadalupe,116,Comptroller of Public Accounts,,,Under Votes,28,12,14,2
+Guadalupe,116,Comptroller of Public Accounts,,REP,Glenn Hegar,992,668,260,64
+Guadalupe,116,Comptroller of Public Accounts,,DEM,Joi Chevalier,292,153,118,21
+Guadalupe,116,Comptroller of Public Accounts,,LIB,Ben Sanders,29,13,14,2
+Guadalupe,117,Comptroller of Public Accounts,,,Under Votes,41,27,12,2
+Guadalupe,117,Comptroller of Public Accounts,,REP,Glenn Hegar,1772,1312,380,80
+Guadalupe,117,Comptroller of Public Accounts,,DEM,Joi Chevalier,643,438,161,44
+Guadalupe,117,Comptroller of Public Accounts,,LIB,Ben Sanders,82,52,29,1
+Guadalupe,118,Comptroller of Public Accounts,,,Under Votes,0,0,0,0
+Guadalupe,118,Comptroller of Public Accounts,,REP,Glenn Hegar,25,20,5,0
+Guadalupe,118,Comptroller of Public Accounts,,DEM,Joi Chevalier,17,9,7,1
+Guadalupe,118,Comptroller of Public Accounts,,LIB,Ben Sanders,1,0,1,0
+Guadalupe,119,Comptroller of Public Accounts,,,Under Votes,23,16,6,1
+Guadalupe,119,Comptroller of Public Accounts,,REP,Glenn Hegar,824,633,149,42
+Guadalupe,119,Comptroller of Public Accounts,,DEM,Joi Chevalier,218,158,47,13
+Guadalupe,119,Comptroller of Public Accounts,,LIB,Ben Sanders,35,19,14,2
+Guadalupe,120,Comptroller of Public Accounts,,,Under Votes,14,9,5,0
+Guadalupe,120,Comptroller of Public Accounts,,REP,Glenn Hegar,552,384,121,47
+Guadalupe,120,Comptroller of Public Accounts,,DEM,Joi Chevalier,129,84,31,14
+Guadalupe,120,Comptroller of Public Accounts,,LIB,Ben Sanders,25,16,7,2
+Guadalupe,121,Comptroller of Public Accounts,,,Under Votes,10,5,5,0
+Guadalupe,121,Comptroller of Public Accounts,,REP,Glenn Hegar,60,52,6,2
+Guadalupe,121,Comptroller of Public Accounts,,DEM,Joi Chevalier,22,20,0,2
+Guadalupe,121,Comptroller of Public Accounts,,LIB,Ben Sanders,2,2,0,0
+Guadalupe,122,Comptroller of Public Accounts,,,Under Votes,1,0,0,1
+Guadalupe,122,Comptroller of Public Accounts,,REP,Glenn Hegar,21,16,1,4
+Guadalupe,122,Comptroller of Public Accounts,,DEM,Joi Chevalier,5,1,0,4
+Guadalupe,122,Comptroller of Public Accounts,,LIB,Ben Sanders,0,0,0,0
+Guadalupe,123,Comptroller of Public Accounts,,,Under Votes,0,0,0,0
+Guadalupe,123,Comptroller of Public Accounts,,REP,Glenn Hegar,0,0,0,0
+Guadalupe,123,Comptroller of Public Accounts,,DEM,Joi Chevalier,1,0,0,1
+Guadalupe,123,Comptroller of Public Accounts,,LIB,Ben Sanders,0,0,0,0
+Guadalupe,124,Comptroller of Public Accounts,,,Under Votes,1,1,0,0
+Guadalupe,124,Comptroller of Public Accounts,,REP,Glenn Hegar,1,1,0,0
+Guadalupe,124,Comptroller of Public Accounts,,DEM,Joi Chevalier,0,0,0,0
+Guadalupe,124,Comptroller of Public Accounts,,LIB,Ben Sanders,0,0,0,0
+Guadalupe,125,Comptroller of Public Accounts,,,Under Votes,1,1,0,0
+Guadalupe,125,Comptroller of Public Accounts,,REP,Glenn Hegar,89,66,12,11
+Guadalupe,125,Comptroller of Public Accounts,,DEM,Joi Chevalier,19,12,6,1
+Guadalupe,125,Comptroller of Public Accounts,,LIB,Ben Sanders,0,0,0,0
+Guadalupe,126,Comptroller of Public Accounts,,,Under Votes,0,0,0,0
+Guadalupe,126,Comptroller of Public Accounts,,REP,Glenn Hegar,12,4,7,1
+Guadalupe,126,Comptroller of Public Accounts,,DEM,Joi Chevalier,2,2,0,0
+Guadalupe,126,Comptroller of Public Accounts,,LIB,Ben Sanders,0,0,0,0
+Guadalupe,127,Comptroller of Public Accounts,,,Under Votes,0,0,0,0
+Guadalupe,127,Comptroller of Public Accounts,,REP,Glenn Hegar,10,4,5,1
+Guadalupe,127,Comptroller of Public Accounts,,DEM,Joi Chevalier,4,0,4,0
+Guadalupe,127,Comptroller of Public Accounts,,LIB,Ben Sanders,1,0,1,0
+Guadalupe,201,Comptroller of Public Accounts,,,Under Votes,5,2,2,1
+Guadalupe,201,Comptroller of Public Accounts,,REP,Glenn Hegar,117,79,31,7
+Guadalupe,201,Comptroller of Public Accounts,,DEM,Joi Chevalier,85,55,21,9
+Guadalupe,201,Comptroller of Public Accounts,,LIB,Ben Sanders,5,3,1,1
+Guadalupe,202,Comptroller of Public Accounts,,,Under Votes,18,4,11,3
+Guadalupe,202,Comptroller of Public Accounts,,REP,Glenn Hegar,127,81,38,8
+Guadalupe,202,Comptroller of Public Accounts,,DEM,Joi Chevalier,293,154,105,34
+Guadalupe,202,Comptroller of Public Accounts,,LIB,Ben Sanders,25,16,9,0
+Guadalupe,203,Comptroller of Public Accounts,,,Under Votes,9,4,5,0
+Guadalupe,203,Comptroller of Public Accounts,,REP,Glenn Hegar,44,26,14,4
+Guadalupe,203,Comptroller of Public Accounts,,DEM,Joi Chevalier,124,54,60,10
+Guadalupe,203,Comptroller of Public Accounts,,LIB,Ben Sanders,3,1,2,0
+Guadalupe,204,Comptroller of Public Accounts,,,Under Votes,18,5,12,1
+Guadalupe,204,Comptroller of Public Accounts,,REP,Glenn Hegar,247,147,93,7
+Guadalupe,204,Comptroller of Public Accounts,,DEM,Joi Chevalier,334,192,123,19
+Guadalupe,204,Comptroller of Public Accounts,,LIB,Ben Sanders,29,7,19,3
+Guadalupe,205,Comptroller of Public Accounts,,,Under Votes,21,10,11,0
+Guadalupe,205,Comptroller of Public Accounts,,REP,Glenn Hegar,473,282,175,16
+Guadalupe,205,Comptroller of Public Accounts,,DEM,Joi Chevalier,151,88,57,6
+Guadalupe,205,Comptroller of Public Accounts,,LIB,Ben Sanders,22,6,15,1
+Guadalupe,206,Comptroller of Public Accounts,,,Under Votes,22,6,15,1
+Guadalupe,206,Comptroller of Public Accounts,,REP,Glenn Hegar,357,143,197,17
+Guadalupe,206,Comptroller of Public Accounts,,DEM,Joi Chevalier,551,170,353,28
+Guadalupe,206,Comptroller of Public Accounts,,LIB,Ben Sanders,41,16,25,0
+Guadalupe,207,Comptroller of Public Accounts,,,Under Votes,14,8,5,1
+Guadalupe,207,Comptroller of Public Accounts,,REP,Glenn Hegar,144,100,35,9
+Guadalupe,207,Comptroller of Public Accounts,,DEM,Joi Chevalier,230,142,72,16
+Guadalupe,207,Comptroller of Public Accounts,,LIB,Ben Sanders,20,12,6,2
+Guadalupe,208,Comptroller of Public Accounts,,,Under Votes,31,26,4,1
+Guadalupe,208,Comptroller of Public Accounts,,REP,Glenn Hegar,1441,1046,312,83
+Guadalupe,208,Comptroller of Public Accounts,,DEM,Joi Chevalier,367,259,87,21
+Guadalupe,208,Comptroller of Public Accounts,,LIB,Ben Sanders,53,33,19,1
+Guadalupe,209,Comptroller of Public Accounts,,,Under Votes,11,5,6,0
+Guadalupe,209,Comptroller of Public Accounts,,REP,Glenn Hegar,81,44,32,5
+Guadalupe,209,Comptroller of Public Accounts,,DEM,Joi Chevalier,219,107,94,18
+Guadalupe,209,Comptroller of Public Accounts,,LIB,Ben Sanders,11,5,5,1
+Guadalupe,210,Comptroller of Public Accounts,,,Under Votes,17,7,10,0
+Guadalupe,210,Comptroller of Public Accounts,,REP,Glenn Hegar,254,162,75,17
+Guadalupe,210,Comptroller of Public Accounts,,DEM,Joi Chevalier,186,123,45,18
+Guadalupe,210,Comptroller of Public Accounts,,LIB,Ben Sanders,26,21,4,1
+Guadalupe,211,Comptroller of Public Accounts,,,Under Votes,0,0,0,0
+Guadalupe,211,Comptroller of Public Accounts,,REP,Glenn Hegar,41,32,8,1
+Guadalupe,211,Comptroller of Public Accounts,,DEM,Joi Chevalier,35,28,3,4
+Guadalupe,211,Comptroller of Public Accounts,,LIB,Ben Sanders,4,4,0,0
+Guadalupe,212,Comptroller of Public Accounts,,,Under Votes,2,1,0,1
+Guadalupe,212,Comptroller of Public Accounts,,REP,Glenn Hegar,36,31,5,0
+Guadalupe,212,Comptroller of Public Accounts,,DEM,Joi Chevalier,44,26,15,3
+Guadalupe,212,Comptroller of Public Accounts,,LIB,Ben Sanders,4,3,1,0
+Guadalupe,213,Comptroller of Public Accounts,,,Under Votes,19,11,6,2
+Guadalupe,213,Comptroller of Public Accounts,,REP,Glenn Hegar,837,583,228,26
+Guadalupe,213,Comptroller of Public Accounts,,DEM,Joi Chevalier,324,215,93,16
+Guadalupe,213,Comptroller of Public Accounts,,LIB,Ben Sanders,55,29,22,4
+Guadalupe,214,Comptroller of Public Accounts,,,Under Votes,3,2,0,1
+Guadalupe,214,Comptroller of Public Accounts,,REP,Glenn Hegar,274,195,69,10
+Guadalupe,214,Comptroller of Public Accounts,,DEM,Joi Chevalier,81,50,25,6
+Guadalupe,214,Comptroller of Public Accounts,,LIB,Ben Sanders,13,8,4,1
+Guadalupe,215,Comptroller of Public Accounts,,,Under Votes,15,12,2,1
+Guadalupe,215,Comptroller of Public Accounts,,REP,Glenn Hegar,375,250,97,28
+Guadalupe,215,Comptroller of Public Accounts,,DEM,Joi Chevalier,139,95,33,11
+Guadalupe,215,Comptroller of Public Accounts,,LIB,Ben Sanders,13,8,5,0
+Guadalupe,216,Comptroller of Public Accounts,,,Under Votes,0,0,0,0
+Guadalupe,216,Comptroller of Public Accounts,,REP,Glenn Hegar,30,17,9,4
+Guadalupe,216,Comptroller of Public Accounts,,DEM,Joi Chevalier,6,4,2,0
+Guadalupe,216,Comptroller of Public Accounts,,LIB,Ben Sanders,1,1,0,0
+Guadalupe,217,Comptroller of Public Accounts,,,Under Votes,0,0,0,0
+Guadalupe,217,Comptroller of Public Accounts,,REP,Glenn Hegar,28,12,13,3
+Guadalupe,217,Comptroller of Public Accounts,,DEM,Joi Chevalier,35,9,26,0
+Guadalupe,217,Comptroller of Public Accounts,,LIB,Ben Sanders,2,1,1,0
+Guadalupe,218,Comptroller of Public Accounts,,,Under Votes,1,1,0,0
+Guadalupe,218,Comptroller of Public Accounts,,REP,Glenn Hegar,15,13,1,1
+Guadalupe,218,Comptroller of Public Accounts,,DEM,Joi Chevalier,21,17,4,0
+Guadalupe,218,Comptroller of Public Accounts,,LIB,Ben Sanders,1,1,0,0
+Guadalupe,219,Comptroller of Public Accounts,,,Under Votes,2,2,0,0
+Guadalupe,219,Comptroller of Public Accounts,,REP,Glenn Hegar,26,21,5,0
+Guadalupe,219,Comptroller of Public Accounts,,DEM,Joi Chevalier,20,16,4,0
+Guadalupe,219,Comptroller of Public Accounts,,LIB,Ben Sanders,3,2,0,1
+Guadalupe,220,Comptroller of Public Accounts,,,Under Votes,3,1,2,0
+Guadalupe,220,Comptroller of Public Accounts,,REP,Glenn Hegar,19,15,4,0
+Guadalupe,220,Comptroller of Public Accounts,,DEM,Joi Chevalier,20,14,4,2
+Guadalupe,220,Comptroller of Public Accounts,,LIB,Ben Sanders,1,1,0,0
+Guadalupe,221,Comptroller of Public Accounts,,,Under Votes,0,0,0,0
+Guadalupe,221,Comptroller of Public Accounts,,REP,Glenn Hegar,11,8,3,0
+Guadalupe,221,Comptroller of Public Accounts,,DEM,Joi Chevalier,5,1,1,3
+Guadalupe,221,Comptroller of Public Accounts,,LIB,Ben Sanders,0,0,0,0
+Guadalupe,222,Comptroller of Public Accounts,,,Under Votes,0,0,0,0
+Guadalupe,222,Comptroller of Public Accounts,,REP,Glenn Hegar,0,0,0,0
+Guadalupe,222,Comptroller of Public Accounts,,DEM,Joi Chevalier,0,0,0,0
+Guadalupe,222,Comptroller of Public Accounts,,LIB,Ben Sanders,0,0,0,0
+Guadalupe,223,Comptroller of Public Accounts,,,Under Votes,2,2,0,0
+Guadalupe,223,Comptroller of Public Accounts,,REP,Glenn Hegar,76,45,26,5
+Guadalupe,223,Comptroller of Public Accounts,,DEM,Joi Chevalier,72,57,9,6
+Guadalupe,223,Comptroller of Public Accounts,,LIB,Ben Sanders,9,6,3,0
+Guadalupe,224,Comptroller of Public Accounts,,,Under Votes,0,0,0,0
+Guadalupe,224,Comptroller of Public Accounts,,REP,Glenn Hegar,10,3,7,0
+Guadalupe,224,Comptroller of Public Accounts,,DEM,Joi Chevalier,49,24,18,7
+Guadalupe,224,Comptroller of Public Accounts,,LIB,Ben Sanders,1,0,1,0
+Guadalupe,225,Comptroller of Public Accounts,,,Under Votes,1,1,0,0
+Guadalupe,225,Comptroller of Public Accounts,,REP,Glenn Hegar,0,0,0,0
+Guadalupe,225,Comptroller of Public Accounts,,DEM,Joi Chevalier,9,7,2,0
+Guadalupe,225,Comptroller of Public Accounts,,LIB,Ben Sanders,1,0,1,0
+Guadalupe,226,Comptroller of Public Accounts,,,Under Votes,4,3,0,1
+Guadalupe,226,Comptroller of Public Accounts,,REP,Glenn Hegar,100,66,32,2
+Guadalupe,226,Comptroller of Public Accounts,,DEM,Joi Chevalier,53,27,23,3
+Guadalupe,226,Comptroller of Public Accounts,,LIB,Ben Sanders,3,3,0,0
+Guadalupe,301,Comptroller of Public Accounts,,,Under Votes,27,13,13,1
+Guadalupe,301,Comptroller of Public Accounts,,REP,Glenn Hegar,1003,634,313,56
+Guadalupe,301,Comptroller of Public Accounts,,DEM,Joi Chevalier,665,457,187,21
+Guadalupe,301,Comptroller of Public Accounts,,LIB,Ben Sanders,49,27,22,0
+Guadalupe,302,Comptroller of Public Accounts,,,Under Votes,46,29,14,3
+Guadalupe,302,Comptroller of Public Accounts,,REP,Glenn Hegar,1225,843,332,50
+Guadalupe,302,Comptroller of Public Accounts,,DEM,Joi Chevalier,946,618,279,49
+Guadalupe,302,Comptroller of Public Accounts,,LIB,Ben Sanders,107,59,46,2
+Guadalupe,303,Comptroller of Public Accounts,,,Under Votes,12,8,3,1
+Guadalupe,303,Comptroller of Public Accounts,,REP,Glenn Hegar,521,398,94,29
+Guadalupe,303,Comptroller of Public Accounts,,DEM,Joi Chevalier,245,178,49,18
+Guadalupe,303,Comptroller of Public Accounts,,LIB,Ben Sanders,30,20,7,3
+Guadalupe,304,Comptroller of Public Accounts,,,Under Votes,32,13,13,6
+Guadalupe,304,Comptroller of Public Accounts,,REP,Glenn Hegar,1420,1096,258,66
+Guadalupe,304,Comptroller of Public Accounts,,DEM,Joi Chevalier,806,612,140,54
+Guadalupe,304,Comptroller of Public Accounts,,LIB,Ben Sanders,78,54,21,3
+Guadalupe,305,Comptroller of Public Accounts,,,Under Votes,54,31,16,7
+Guadalupe,305,Comptroller of Public Accounts,,REP,Glenn Hegar,1351,957,338,56
+Guadalupe,305,Comptroller of Public Accounts,,DEM,Joi Chevalier,916,641,206,69
+Guadalupe,305,Comptroller of Public Accounts,,LIB,Ben Sanders,89,52,34,3
+Guadalupe,306,Comptroller of Public Accounts,,,Under Votes,26,19,5,2
+Guadalupe,306,Comptroller of Public Accounts,,REP,Glenn Hegar,1478,1165,247,66
+Guadalupe,306,Comptroller of Public Accounts,,DEM,Joi Chevalier,853,671,128,54
+Guadalupe,306,Comptroller of Public Accounts,,LIB,Ben Sanders,54,35,17,2
+Guadalupe,307,Comptroller of Public Accounts,,,Under Votes,44,30,10,4
+Guadalupe,307,Comptroller of Public Accounts,,REP,Glenn Hegar,1431,1125,247,59
+Guadalupe,307,Comptroller of Public Accounts,,DEM,Joi Chevalier,957,735,183,39
+Guadalupe,307,Comptroller of Public Accounts,,LIB,Ben Sanders,107,67,37,3
+Guadalupe,308,Comptroller of Public Accounts,,,Under Votes,28,19,4,5
+Guadalupe,308,Comptroller of Public Accounts,,REP,Glenn Hegar,819,635,134,50
+Guadalupe,308,Comptroller of Public Accounts,,DEM,Joi Chevalier,382,265,83,34
+Guadalupe,308,Comptroller of Public Accounts,,LIB,Ben Sanders,53,37,15,1
+Guadalupe,401,Comptroller of Public Accounts,,,Under Votes,11,3,8,0
+Guadalupe,401,Comptroller of Public Accounts,,REP,Glenn Hegar,651,371,238,42
+Guadalupe,401,Comptroller of Public Accounts,,DEM,Joi Chevalier,175,104,59,12
+Guadalupe,401,Comptroller of Public Accounts,,LIB,Ben Sanders,37,20,17,0
+Guadalupe,402,Comptroller of Public Accounts,,,Under Votes,17,12,2,3
+Guadalupe,402,Comptroller of Public Accounts,,REP,Glenn Hegar,523,366,114,43
+Guadalupe,402,Comptroller of Public Accounts,,DEM,Joi Chevalier,333,200,98,35
+Guadalupe,402,Comptroller of Public Accounts,,LIB,Ben Sanders,42,19,19,4
+Guadalupe,403,Comptroller of Public Accounts,,,Under Votes,25,16,7,2
+Guadalupe,403,Comptroller of Public Accounts,,REP,Glenn Hegar,753,518,173,62
+Guadalupe,403,Comptroller of Public Accounts,,DEM,Joi Chevalier,472,285,117,70
+Guadalupe,403,Comptroller of Public Accounts,,LIB,Ben Sanders,70,39,29,2
+Guadalupe,404,Comptroller of Public Accounts,,,Under Votes,36,16,16,4
+Guadalupe,404,Comptroller of Public Accounts,,REP,Glenn Hegar,956,576,302,78
+Guadalupe,404,Comptroller of Public Accounts,,DEM,Joi Chevalier,610,380,184,46
+Guadalupe,404,Comptroller of Public Accounts,,LIB,Ben Sanders,65,34,31,0
+Guadalupe,405,Comptroller of Public Accounts,,,Under Votes,22,15,7,0
+Guadalupe,405,Comptroller of Public Accounts,,REP,Glenn Hegar,882,527,322,33
+Guadalupe,405,Comptroller of Public Accounts,,DEM,Joi Chevalier,184,111,62,11
+Guadalupe,405,Comptroller of Public Accounts,,LIB,Ben Sanders,27,10,16,1
+Guadalupe,406,Comptroller of Public Accounts,,,Under Votes,25,16,7,2
+Guadalupe,406,Comptroller of Public Accounts,,REP,Glenn Hegar,1003,754,209,40
+Guadalupe,406,Comptroller of Public Accounts,,DEM,Joi Chevalier,163,109,40,14
+Guadalupe,406,Comptroller of Public Accounts,,LIB,Ben Sanders,29,24,5,0
+Guadalupe,407,Comptroller of Public Accounts,,,Under Votes,20,13,7,0
+Guadalupe,407,Comptroller of Public Accounts,,REP,Glenn Hegar,842,608,195,39
+Guadalupe,407,Comptroller of Public Accounts,,DEM,Joi Chevalier,188,114,55,19
+Guadalupe,407,Comptroller of Public Accounts,,LIB,Ben Sanders,34,20,9,5
+Guadalupe,408,Comptroller of Public Accounts,,,Under Votes,42,19,19,4
+Guadalupe,408,Comptroller of Public Accounts,,REP,Glenn Hegar,1566,1028,407,131
+Guadalupe,408,Comptroller of Public Accounts,,DEM,Joi Chevalier,669,446,186,37
+Guadalupe,408,Comptroller of Public Accounts,,LIB,Ben Sanders,75,37,30,8
+Guadalupe,409,Comptroller of Public Accounts,,,Under Votes,44,20,22,2
+Guadalupe,409,Comptroller of Public Accounts,,REP,Glenn Hegar,1198,858,294,46
+Guadalupe,409,Comptroller of Public Accounts,,DEM,Joi Chevalier,1287,948,282,57
+Guadalupe,409,Comptroller of Public Accounts,,LIB,Ben Sanders,109,76,29,4
+Guadalupe,410,Comptroller of Public Accounts,,,Under Votes,1,1,0,0
+Guadalupe,410,Comptroller of Public Accounts,,REP,Glenn Hegar,55,45,10,0
+Guadalupe,410,Comptroller of Public Accounts,,DEM,Joi Chevalier,22,18,4,0
+Guadalupe,410,Comptroller of Public Accounts,,LIB,Ben Sanders,5,1,4,0
+Guadalupe,411,Comptroller of Public Accounts,,,Under Votes,43,26,12,5
+Guadalupe,411,Comptroller of Public Accounts,,REP,Glenn Hegar,1186,859,273,54
+Guadalupe,411,Comptroller of Public Accounts,,DEM,Joi Chevalier,695,528,126,41
+Guadalupe,411,Comptroller of Public Accounts,,LIB,Ben Sanders,74,46,28,0
+Guadalupe,101,Commissioner of the General Land Office,,,Under Votes,8,3,1,4
+Guadalupe,101,Commissioner of the General Land Office,,REP,George P. Bush,268,175,71,22
+Guadalupe,101,Commissioner of the General Land Office,,DEM,Miguel Suazo,76,53,21,2
+Guadalupe,101,Commissioner of the General Land Office,,LIB,Matt Pina,17,13,4,0
+Guadalupe,102,Commissioner of the General Land Office,,,Under Votes,5,3,2,0
+Guadalupe,102,Commissioner of the General Land Office,,REP,George P. Bush,424,320,69,35
+Guadalupe,102,Commissioner of the General Land Office,,DEM,Miguel Suazo,145,83,44,18
+Guadalupe,102,Commissioner of the General Land Office,,LIB,Matt Pina,24,16,7,1
+Guadalupe,103,Commissioner of the General Land Office,,,Under Votes,5,3,2,0
+Guadalupe,103,Commissioner of the General Land Office,,REP,George P. Bush,334,246,69,19
+Guadalupe,103,Commissioner of the General Land Office,,DEM,Miguel Suazo,105,69,27,9
+Guadalupe,103,Commissioner of the General Land Office,,LIB,Matt Pina,15,6,7,2
+Guadalupe,104,Commissioner of the General Land Office,,,Under Votes,16,12,4,0
+Guadalupe,104,Commissioner of the General Land Office,,REP,George P. Bush,294,209,66,19
+Guadalupe,104,Commissioner of the General Land Office,,DEM,Miguel Suazo,187,112,56,19
+Guadalupe,104,Commissioner of the General Land Office,,LIB,Matt Pina,23,17,5,1
+Guadalupe,105,Commissioner of the General Land Office,,,Under Votes,26,14,11,1
+Guadalupe,105,Commissioner of the General Land Office,,REP,George P. Bush,1139,691,370,78
+Guadalupe,105,Commissioner of the General Land Office,,DEM,Miguel Suazo,290,171,95,24
+Guadalupe,105,Commissioner of the General Land Office,,LIB,Matt Pina,59,30,28,1
+Guadalupe,106,Commissioner of the General Land Office,,,Under Votes,22,14,7,1
+Guadalupe,106,Commissioner of the General Land Office,,REP,George P. Bush,1320,963,242,115
+Guadalupe,106,Commissioner of the General Land Office,,DEM,Miguel Suazo,497,340,114,43
+Guadalupe,106,Commissioner of the General Land Office,,LIB,Matt Pina,66,50,14,2
+Guadalupe,107,Commissioner of the General Land Office,,,Under Votes,10,3,6,1
+Guadalupe,107,Commissioner of the General Land Office,,REP,George P. Bush,552,305,220,27
+Guadalupe,107,Commissioner of the General Land Office,,DEM,Miguel Suazo,118,70,45,3
+Guadalupe,107,Commissioner of the General Land Office,,LIB,Matt Pina,28,10,16,2
+Guadalupe,108,Commissioner of the General Land Office,,,Under Votes,5,1,4,0
+Guadalupe,108,Commissioner of the General Land Office,,REP,George P. Bush,259,95,136,28
+Guadalupe,108,Commissioner of the General Land Office,,DEM,Miguel Suazo,148,67,65,16
+Guadalupe,108,Commissioner of the General Land Office,,LIB,Matt Pina,19,5,13,1
+Guadalupe,109,Commissioner of the General Land Office,,,Under Votes,4,2,2,0
+Guadalupe,109,Commissioner of the General Land Office,,REP,George P. Bush,248,123,116,9
+Guadalupe,109,Commissioner of the General Land Office,,DEM,Miguel Suazo,47,20,24,3
+Guadalupe,109,Commissioner of the General Land Office,,LIB,Matt Pina,13,7,6,0
+Guadalupe,110,Commissioner of the General Land Office,,,Under Votes,5,3,1,1
+Guadalupe,110,Commissioner of the General Land Office,,REP,George P. Bush,84,67,15,2
+Guadalupe,110,Commissioner of the General Land Office,,DEM,Miguel Suazo,56,41,10,5
+Guadalupe,110,Commissioner of the General Land Office,,LIB,Matt Pina,6,6,0,0
+Guadalupe,111,Commissioner of the General Land Office,,,Under Votes,2,0,1,1
+Guadalupe,111,Commissioner of the General Land Office,,REP,George P. Bush,35,22,7,6
+Guadalupe,111,Commissioner of the General Land Office,,DEM,Miguel Suazo,27,12,8,7
+Guadalupe,111,Commissioner of the General Land Office,,LIB,Matt Pina,0,0,0,0
+Guadalupe,112,Commissioner of the General Land Office,,,Under Votes,15,6,9,0
+Guadalupe,112,Commissioner of the General Land Office,,REP,George P. Bush,67,26,40,1
+Guadalupe,112,Commissioner of the General Land Office,,DEM,Miguel Suazo,138,52,86,0
+Guadalupe,112,Commissioner of the General Land Office,,LIB,Matt Pina,6,1,5,0
+Guadalupe,113,Commissioner of the General Land Office,,,Under Votes,9,7,2,0
+Guadalupe,113,Commissioner of the General Land Office,,REP,George P. Bush,377,263,95,19
+Guadalupe,113,Commissioner of the General Land Office,,DEM,Miguel Suazo,159,104,46,9
+Guadalupe,113,Commissioner of the General Land Office,,LIB,Matt Pina,39,30,9,0
+Guadalupe,114,Commissioner of the General Land Office,,,Under Votes,5,3,1,1
+Guadalupe,114,Commissioner of the General Land Office,,REP,George P. Bush,279,203,62,14
+Guadalupe,114,Commissioner of the General Land Office,,DEM,Miguel Suazo,145,93,44,8
+Guadalupe,114,Commissioner of the General Land Office,,LIB,Matt Pina,22,17,2,3
+Guadalupe,115,Commissioner of the General Land Office,,,Under Votes,3,1,1,1
+Guadalupe,115,Commissioner of the General Land Office,,REP,George P. Bush,142,102,39,1
+Guadalupe,115,Commissioner of the General Land Office,,DEM,Miguel Suazo,25,18,5,2
+Guadalupe,115,Commissioner of the General Land Office,,LIB,Matt Pina,6,5,1,0
+Guadalupe,116,Commissioner of the General Land Office,,,Under Votes,19,7,11,1
+Guadalupe,116,Commissioner of the General Land Office,,REP,George P. Bush,995,657,269,69
+Guadalupe,116,Commissioner of the General Land Office,,DEM,Miguel Suazo,282,153,111,18
+Guadalupe,116,Commissioner of the General Land Office,,LIB,Matt Pina,45,29,15,1
+Guadalupe,117,Commissioner of the General Land Office,,,Under Votes,33,18,13,2
+Guadalupe,117,Commissioner of the General Land Office,,REP,George P. Bush,1766,1304,380,82
+Guadalupe,117,Commissioner of the General Land Office,,DEM,Miguel Suazo,633,431,160,42
+Guadalupe,117,Commissioner of the General Land Office,,LIB,Matt Pina,106,76,29,1
+Guadalupe,118,Commissioner of the General Land Office,,,Under Votes,0,0,0,0
+Guadalupe,118,Commissioner of the General Land Office,,REP,George P. Bush,24,18,6,0
+Guadalupe,118,Commissioner of the General Land Office,,DEM,Miguel Suazo,19,11,7,1
+Guadalupe,118,Commissioner of the General Land Office,,LIB,Matt Pina,0,0,0,0
+Guadalupe,119,Commissioner of the General Land Office,,,Under Votes,18,14,3,1
+Guadalupe,119,Commissioner of the General Land Office,,REP,George P. Bush,817,613,159,45
+Guadalupe,119,Commissioner of the General Land Office,,DEM,Miguel Suazo,221,163,46,12
+Guadalupe,119,Commissioner of the General Land Office,,LIB,Matt Pina,44,36,8,0
+Guadalupe,120,Commissioner of the General Land Office,,,Under Votes,10,5,5,0
+Guadalupe,120,Commissioner of the General Land Office,,REP,George P. Bush,559,392,122,45
+Guadalupe,120,Commissioner of the General Land Office,,DEM,Miguel Suazo,131,85,30,16
+Guadalupe,120,Commissioner of the General Land Office,,LIB,Matt Pina,20,11,7,2
+Guadalupe,121,Commissioner of the General Land Office,,,Under Votes,7,3,4,0
+Guadalupe,121,Commissioner of the General Land Office,,REP,George P. Bush,57,49,6,2
+Guadalupe,121,Commissioner of the General Land Office,,DEM,Miguel Suazo,24,21,1,2
+Guadalupe,121,Commissioner of the General Land Office,,LIB,Matt Pina,6,6,0,0
+Guadalupe,122,Commissioner of the General Land Office,,,Under Votes,0,0,0,0
+Guadalupe,122,Commissioner of the General Land Office,,REP,George P. Bush,21,16,1,4
+Guadalupe,122,Commissioner of the General Land Office,,DEM,Miguel Suazo,5,1,0,4
+Guadalupe,122,Commissioner of the General Land Office,,LIB,Matt Pina,1,0,0,1
+Guadalupe,123,Commissioner of the General Land Office,,,Under Votes,0,0,0,0
+Guadalupe,123,Commissioner of the General Land Office,,REP,George P. Bush,0,0,0,0
+Guadalupe,123,Commissioner of the General Land Office,,DEM,Miguel Suazo,1,0,0,1
+Guadalupe,123,Commissioner of the General Land Office,,LIB,Matt Pina,0,0,0,0
+Guadalupe,124,Commissioner of the General Land Office,,,Under Votes,0,0,0,0
+Guadalupe,124,Commissioner of the General Land Office,,REP,George P. Bush,2,2,0,0
+Guadalupe,124,Commissioner of the General Land Office,,DEM,Miguel Suazo,0,0,0,0
+Guadalupe,124,Commissioner of the General Land Office,,LIB,Matt Pina,0,0,0,0
+Guadalupe,125,Commissioner of the General Land Office,,,Under Votes,0,0,0,0
+Guadalupe,125,Commissioner of the General Land Office,,REP,George P. Bush,90,67,12,11
+Guadalupe,125,Commissioner of the General Land Office,,DEM,Miguel Suazo,18,12,5,1
+Guadalupe,125,Commissioner of the General Land Office,,LIB,Matt Pina,1,0,1,0
+Guadalupe,126,Commissioner of the General Land Office,,,Under Votes,0,0,0,0
+Guadalupe,126,Commissioner of the General Land Office,,REP,George P. Bush,12,4,7,1
+Guadalupe,126,Commissioner of the General Land Office,,DEM,Miguel Suazo,2,2,0,0
+Guadalupe,126,Commissioner of the General Land Office,,LIB,Matt Pina,0,0,0,0
+Guadalupe,127,Commissioner of the General Land Office,,,Under Votes,0,0,0,0
+Guadalupe,127,Commissioner of the General Land Office,,REP,George P. Bush,8,3,4,1
+Guadalupe,127,Commissioner of the General Land Office,,DEM,Miguel Suazo,5,0,5,0
+Guadalupe,127,Commissioner of the General Land Office,,LIB,Matt Pina,2,1,1,0
+Guadalupe,201,Commissioner of the General Land Office,,,Under Votes,4,2,1,1
+Guadalupe,201,Commissioner of the General Land Office,,REP,George P. Bush,126,87,30,9
+Guadalupe,201,Commissioner of the General Land Office,,DEM,Miguel Suazo,75,45,23,7
+Guadalupe,201,Commissioner of the General Land Office,,LIB,Matt Pina,7,5,1,1
+Guadalupe,202,Commissioner of the General Land Office,,,Under Votes,20,5,11,4
+Guadalupe,202,Commissioner of the General Land Office,,REP,George P. Bush,136,88,43,5
+Guadalupe,202,Commissioner of the General Land Office,,DEM,Miguel Suazo,287,151,101,35
+Guadalupe,202,Commissioner of the General Land Office,,LIB,Matt Pina,20,11,8,1
+Guadalupe,203,Commissioner of the General Land Office,,,Under Votes,6,3,3,0
+Guadalupe,203,Commissioner of the General Land Office,,REP,George P. Bush,49,28,17,4
+Guadalupe,203,Commissioner of the General Land Office,,DEM,Miguel Suazo,123,54,59,10
+Guadalupe,203,Commissioner of the General Land Office,,LIB,Matt Pina,2,0,2,0
+Guadalupe,204,Commissioner of the General Land Office,,,Under Votes,13,5,8,0
+Guadalupe,204,Commissioner of the General Land Office,,REP,George P. Bush,263,156,100,7
+Guadalupe,204,Commissioner of the General Land Office,,DEM,Miguel Suazo,334,185,128,21
+Guadalupe,204,Commissioner of the General Land Office,,LIB,Matt Pina,18,5,11,2
+Guadalupe,205,Commissioner of the General Land Office,,,Under Votes,16,7,9,0
+Guadalupe,205,Commissioner of the General Land Office,,REP,George P. Bush,478,284,177,17
+Guadalupe,205,Commissioner of the General Land Office,,DEM,Miguel Suazo,151,87,58,6
+Guadalupe,205,Commissioner of the General Land Office,,LIB,Matt Pina,22,8,14,0
+Guadalupe,206,Commissioner of the General Land Office,,,Under Votes,21,8,13,0
+Guadalupe,206,Commissioner of the General Land Office,,REP,George P. Bush,356,135,205,16
+Guadalupe,206,Commissioner of the General Land Office,,DEM,Miguel Suazo,563,178,356,29
+Guadalupe,206,Commissioner of the General Land Office,,LIB,Matt Pina,31,14,16,1
+Guadalupe,207,Commissioner of the General Land Office,,,Under Votes,11,7,3,1
+Guadalupe,207,Commissioner of the General Land Office,,REP,George P. Bush,160,110,40,10
+Guadalupe,207,Commissioner of the General Land Office,,DEM,Miguel Suazo,223,137,70,16
+Guadalupe,207,Commissioner of the General Land Office,,LIB,Matt Pina,14,8,5,1
+Guadalupe,208,Commissioner of the General Land Office,,,Under Votes,26,24,2,0
+Guadalupe,208,Commissioner of the General Land Office,,REP,George P. Bush,1417,1026,302,89
+Guadalupe,208,Commissioner of the General Land Office,,DEM,Miguel Suazo,376,262,98,16
+Guadalupe,208,Commissioner of the General Land Office,,LIB,Matt Pina,73,52,20,1
+Guadalupe,209,Commissioner of the General Land Office,,,Under Votes,11,3,8,0
+Guadalupe,209,Commissioner of the General Land Office,,REP,George P. Bush,91,51,34,6
+Guadalupe,209,Commissioner of the General Land Office,,DEM,Miguel Suazo,209,101,90,18
+Guadalupe,209,Commissioner of the General Land Office,,LIB,Matt Pina,11,6,5,0
+Guadalupe,210,Commissioner of the General Land Office,,,Under Votes,12,5,6,1
+Guadalupe,210,Commissioner of the General Land Office,,REP,George P. Bush,271,174,78,19
+Guadalupe,210,Commissioner of the General Land Office,,DEM,Miguel Suazo,182,121,46,15
+Guadalupe,210,Commissioner of the General Land Office,,LIB,Matt Pina,18,13,4,1
+Guadalupe,211,Commissioner of the General Land Office,,,Under Votes,0,0,0,0
+Guadalupe,211,Commissioner of the General Land Office,,REP,George P. Bush,41,32,8,1
+Guadalupe,211,Commissioner of the General Land Office,,DEM,Miguel Suazo,35,28,3,4
+Guadalupe,211,Commissioner of the General Land Office,,LIB,Matt Pina,4,4,0,0
+Guadalupe,212,Commissioner of the General Land Office,,,Under Votes,2,1,0,1
+Guadalupe,212,Commissioner of the General Land Office,,REP,George P. Bush,37,31,6,0
+Guadalupe,212,Commissioner of the General Land Office,,DEM,Miguel Suazo,40,23,14,3
+Guadalupe,212,Commissioner of the General Land Office,,LIB,Matt Pina,7,6,1,0
+Guadalupe,213,Commissioner of the General Land Office,,,Under Votes,24,14,8,2
+Guadalupe,213,Commissioner of the General Land Office,,REP,George P. Bush,826,568,229,29
+Guadalupe,213,Commissioner of the General Land Office,,DEM,Miguel Suazo,332,222,95,15
+Guadalupe,213,Commissioner of the General Land Office,,LIB,Matt Pina,53,34,17,2
+Guadalupe,214,Commissioner of the General Land Office,,,Under Votes,5,3,2,0
+Guadalupe,214,Commissioner of the General Land Office,,REP,George P. Bush,270,188,72,10
+Guadalupe,214,Commissioner of the General Land Office,,DEM,Miguel Suazo,82,52,22,8
+Guadalupe,214,Commissioner of the General Land Office,,LIB,Matt Pina,14,12,2,0
+Guadalupe,215,Commissioner of the General Land Office,,,Under Votes,15,12,3,0
+Guadalupe,215,Commissioner of the General Land Office,,REP,George P. Bush,376,247,101,28
+Guadalupe,215,Commissioner of the General Land Office,,DEM,Miguel Suazo,136,96,29,11
+Guadalupe,215,Commissioner of the General Land Office,,LIB,Matt Pina,15,10,4,1
+Guadalupe,216,Commissioner of the General Land Office,,,Under Votes,0,0,0,0
+Guadalupe,216,Commissioner of the General Land Office,,REP,George P. Bush,29,16,9,4
+Guadalupe,216,Commissioner of the General Land Office,,DEM,Miguel Suazo,7,5,2,0
+Guadalupe,216,Commissioner of the General Land Office,,LIB,Matt Pina,1,1,0,0
+Guadalupe,217,Commissioner of the General Land Office,,,Under Votes,0,0,0,0
+Guadalupe,217,Commissioner of the General Land Office,,REP,George P. Bush,29,13,15,1
+Guadalupe,217,Commissioner of the General Land Office,,DEM,Miguel Suazo,34,9,25,0
+Guadalupe,217,Commissioner of the General Land Office,,LIB,Matt Pina,2,0,0,2
+Guadalupe,218,Commissioner of the General Land Office,,,Under Votes,0,0,0,0
+Guadalupe,218,Commissioner of the General Land Office,,REP,George P. Bush,11,9,1,1
+Guadalupe,218,Commissioner of the General Land Office,,DEM,Miguel Suazo,23,19,4,0
+Guadalupe,218,Commissioner of the General Land Office,,LIB,Matt Pina,4,4,0,0
+Guadalupe,219,Commissioner of the General Land Office,,,Under Votes,0,0,0,0
+Guadalupe,219,Commissioner of the General Land Office,,REP,George P. Bush,29,23,6,0
+Guadalupe,219,Commissioner of the General Land Office,,DEM,Miguel Suazo,22,18,3,1
+Guadalupe,219,Commissioner of the General Land Office,,LIB,Matt Pina,0,0,0,0
+Guadalupe,220,Commissioner of the General Land Office,,,Under Votes,2,1,1,0
+Guadalupe,220,Commissioner of the General Land Office,,REP,George P. Bush,22,15,6,1
+Guadalupe,220,Commissioner of the General Land Office,,DEM,Miguel Suazo,18,14,3,1
+Guadalupe,220,Commissioner of the General Land Office,,LIB,Matt Pina,1,1,0,0
+Guadalupe,221,Commissioner of the General Land Office,,,Under Votes,0,0,0,0
+Guadalupe,221,Commissioner of the General Land Office,,REP,George P. Bush,11,8,3,0
+Guadalupe,221,Commissioner of the General Land Office,,DEM,Miguel Suazo,5,1,1,3
+Guadalupe,221,Commissioner of the General Land Office,,LIB,Matt Pina,0,0,0,0
+Guadalupe,222,Commissioner of the General Land Office,,,Under Votes,0,0,0,0
+Guadalupe,222,Commissioner of the General Land Office,,REP,George P. Bush,0,0,0,0
+Guadalupe,222,Commissioner of the General Land Office,,DEM,Miguel Suazo,0,0,0,0
+Guadalupe,222,Commissioner of the General Land Office,,LIB,Matt Pina,0,0,0,0
+Guadalupe,223,Commissioner of the General Land Office,,,Under Votes,1,1,0,0
+Guadalupe,223,Commissioner of the General Land Office,,REP,George P. Bush,74,43,26,5
+Guadalupe,223,Commissioner of the General Land Office,,DEM,Miguel Suazo,74,58,10,6
+Guadalupe,223,Commissioner of the General Land Office,,LIB,Matt Pina,10,8,2,0
+Guadalupe,224,Commissioner of the General Land Office,,,Under Votes,0,0,0,0
+Guadalupe,224,Commissioner of the General Land Office,,REP,George P. Bush,13,4,9,0
+Guadalupe,224,Commissioner of the General Land Office,,DEM,Miguel Suazo,47,23,17,7
+Guadalupe,224,Commissioner of the General Land Office,,LIB,Matt Pina,0,0,0,0
+Guadalupe,225,Commissioner of the General Land Office,,,Under Votes,1,1,0,0
+Guadalupe,225,Commissioner of the General Land Office,,REP,George P. Bush,2,0,2,0
+Guadalupe,225,Commissioner of the General Land Office,,DEM,Miguel Suazo,8,7,1,0
+Guadalupe,225,Commissioner of the General Land Office,,LIB,Matt Pina,0,0,0,0
+Guadalupe,226,Commissioner of the General Land Office,,,Under Votes,4,3,0,1
+Guadalupe,226,Commissioner of the General Land Office,,REP,George P. Bush,95,64,28,3
+Guadalupe,226,Commissioner of the General Land Office,,DEM,Miguel Suazo,50,25,23,2
+Guadalupe,226,Commissioner of the General Land Office,,LIB,Matt Pina,11,7,4,0
+Guadalupe,301,Commissioner of the General Land Office,,,Under Votes,32,15,16,1
+Guadalupe,301,Commissioner of the General Land Office,,REP,George P. Bush,990,615,318,57
+Guadalupe,301,Commissioner of the General Land Office,,DEM,Miguel Suazo,648,449,179,20
+Guadalupe,301,Commissioner of the General Land Office,,LIB,Matt Pina,74,52,22,0
+Guadalupe,302,Commissioner of the General Land Office,,,Under Votes,44,28,13,3
+Guadalupe,302,Commissioner of the General Land Office,,REP,George P. Bush,1230,832,350,48
+Guadalupe,302,Commissioner of the General Land Office,,DEM,Miguel Suazo,943,612,280,51
+Guadalupe,302,Commissioner of the General Land Office,,LIB,Matt Pina,107,77,28,2
+Guadalupe,303,Commissioner of the General Land Office,,,Under Votes,10,5,4,1
+Guadalupe,303,Commissioner of the General Land Office,,REP,George P. Bush,526,408,89,29
+Guadalupe,303,Commissioner of the General Land Office,,DEM,Miguel Suazo,246,177,52,17
+Guadalupe,303,Commissioner of the General Land Office,,LIB,Matt Pina,26,14,8,4
+Guadalupe,304,Commissioner of the General Land Office,,,Under Votes,24,11,9,4
+Guadalupe,304,Commissioner of the General Land Office,,REP,George P. Bush,1436,1105,263,68
+Guadalupe,304,Commissioner of the General Land Office,,DEM,Miguel Suazo,796,598,146,52
+Guadalupe,304,Commissioner of the General Land Office,,LIB,Matt Pina,80,61,14,5
+Guadalupe,305,Commissioner of the General Land Office,,,Under Votes,40,23,12,5
+Guadalupe,305,Commissioner of the General Land Office,,REP,George P. Bush,1387,975,350,62
+Guadalupe,305,Commissioner of the General Land Office,,DEM,Miguel Suazo,912,644,204,64
+Guadalupe,305,Commissioner of the General Land Office,,LIB,Matt Pina,71,39,28,4
+Guadalupe,306,Commissioner of the General Land Office,,,Under Votes,20,17,3,0
+Guadalupe,306,Commissioner of the General Land Office,,REP,George P. Bush,1484,1168,250,66
+Guadalupe,306,Commissioner of the General Land Office,,DEM,Miguel Suazo,832,644,131,57
+Guadalupe,306,Commissioner of the General Land Office,,LIB,Matt Pina,75,61,13,1
+Guadalupe,307,Commissioner of the General Land Office,,,Under Votes,34,23,8,3
+Guadalupe,307,Commissioner of the General Land Office,,REP,George P. Bush,1447,1129,256,62
+Guadalupe,307,Commissioner of the General Land Office,,DEM,Miguel Suazo,949,733,179,37
+Guadalupe,307,Commissioner of the General Land Office,,LIB,Matt Pina,109,72,34,3
+Guadalupe,308,Commissioner of the General Land Office,,,Under Votes,24,14,5,5
+Guadalupe,308,Commissioner of the General Land Office,,REP,George P. Bush,821,642,133,46
+Guadalupe,308,Commissioner of the General Land Office,,DEM,Miguel Suazo,387,263,88,36
+Guadalupe,308,Commissioner of the General Land Office,,LIB,Matt Pina,50,37,10,3
+Guadalupe,401,Commissioner of the General Land Office,,,Under Votes,9,4,5,0
+Guadalupe,401,Commissioner of the General Land Office,,REP,George P. Bush,665,373,250,42
+Guadalupe,401,Commissioner of the General Land Office,,DEM,Miguel Suazo,162,94,57,11
+Guadalupe,401,Commissioner of the General Land Office,,LIB,Matt Pina,38,27,10,1
+Guadalupe,402,Commissioner of the General Land Office,,,Under Votes,16,11,2,3
+Guadalupe,402,Commissioner of the General Land Office,,REP,George P. Bush,530,367,118,45
+Guadalupe,402,Commissioner of the General Land Office,,DEM,Miguel Suazo,326,192,99,35
+Guadalupe,402,Commissioner of the General Land Office,,LIB,Matt Pina,43,27,14,2
+Guadalupe,403,Commissioner of the General Land Office,,,Under Votes,21,15,5,1
+Guadalupe,403,Commissioner of the General Land Office,,REP,George P. Bush,773,523,191,59
+Guadalupe,403,Commissioner of the General Land Office,,DEM,Miguel Suazo,463,277,114,72
+Guadalupe,403,Commissioner of the General Land Office,,LIB,Matt Pina,63,43,16,4
+Guadalupe,404,Commissioner of the General Land Office,,,Under Votes,26,15,11,0
+Guadalupe,404,Commissioner of the General Land Office,,REP,George P. Bush,975,583,315,77
+Guadalupe,404,Commissioner of the General Land Office,,DEM,Miguel Suazo,602,373,184,45
+Guadalupe,404,Commissioner of the General Land Office,,LIB,Matt Pina,64,35,23,6
+Guadalupe,405,Commissioner of the General Land Office,,,Under Votes,14,10,4,0
+Guadalupe,405,Commissioner of the General Land Office,,REP,George P. Bush,885,523,327,35
+Guadalupe,405,Commissioner of the General Land Office,,DEM,Miguel Suazo,184,114,61,9
+Guadalupe,405,Commissioner of the General Land Office,,LIB,Matt Pina,32,16,15,1
+Guadalupe,406,Commissioner of the General Land Office,,,Under Votes,21,15,4,2
+Guadalupe,406,Commissioner of the General Land Office,,REP,George P. Bush,970,724,204,42
+Guadalupe,406,Commissioner of the General Land Office,,DEM,Miguel Suazo,178,122,45,11
+Guadalupe,406,Commissioner of the General Land Office,,LIB,Matt Pina,51,42,8,1
+Guadalupe,407,Commissioner of the General Land Office,,,Under Votes,19,14,5,0
+Guadalupe,407,Commissioner of the General Land Office,,REP,George P. Bush,840,600,204,36
+Guadalupe,407,Commissioner of the General Land Office,,DEM,Miguel Suazo,175,107,48,20
+Guadalupe,407,Commissioner of the General Land Office,,LIB,Matt Pina,50,34,9,7
+Guadalupe,408,Commissioner of the General Land Office,,,Under Votes,38,17,17,4
+Guadalupe,408,Commissioner of the General Land Office,,REP,George P. Bush,1542,1009,407,126
+Guadalupe,408,Commissioner of the General Land Office,,DEM,Miguel Suazo,675,443,194,38
+Guadalupe,408,Commissioner of the General Land Office,,LIB,Matt Pina,97,61,24,12
+Guadalupe,409,Commissioner of the General Land Office,,,Under Votes,34,15,16,3
+Guadalupe,409,Commissioner of the General Land Office,,REP,George P. Bush,1260,912,301,47
+Guadalupe,409,Commissioner of the General Land Office,,DEM,Miguel Suazo,1253,907,288,58
+Guadalupe,409,Commissioner of the General Land Office,,LIB,Matt Pina,91,68,22,1
+Guadalupe,410,Commissioner of the General Land Office,,,Under Votes,2,2,0,0
+Guadalupe,410,Commissioner of the General Land Office,,REP,George P. Bush,56,46,10,0
+Guadalupe,410,Commissioner of the General Land Office,,DEM,Miguel Suazo,22,17,5,0
+Guadalupe,410,Commissioner of the General Land Office,,LIB,Matt Pina,3,0,3,0
+Guadalupe,411,Commissioner of the General Land Office,,,Under Votes,32,19,9,4
+Guadalupe,411,Commissioner of the General Land Office,,REP,George P. Bush,1205,861,288,56
+Guadalupe,411,Commissioner of the General Land Office,,DEM,Miguel Suazo,689,521,128,40
+Guadalupe,411,Commissioner of the General Land Office,,LIB,Matt Pina,72,58,14,0
+Guadalupe,101,Commissioner of Agriculture,,,Under Votes,8,3,2,3
+Guadalupe,101,Commissioner of Agriculture,,REP,Sid Miller,261,176,69,16
+Guadalupe,101,Commissioner of Agriculture,,DEM,Kim Olson,88,57,22,9
+Guadalupe,101,Commissioner of Agriculture,,LIB,Richard Carpenter,12,8,4,0
+Guadalupe,102,Commissioner of Agriculture,,,Under Votes,14,9,5,0
+Guadalupe,102,Commissioner of Agriculture,,REP,Sid Miller,396,300,62,34
+Guadalupe,102,Commissioner of Agriculture,,DEM,Kim Olson,169,102,49,18
+Guadalupe,102,Commissioner of Agriculture,,LIB,Richard Carpenter,19,11,6,2
+Guadalupe,103,Commissioner of Agriculture,,,Under Votes,7,5,2,0
+Guadalupe,103,Commissioner of Agriculture,,REP,Sid Miller,320,238,64,18
+Guadalupe,103,Commissioner of Agriculture,,DEM,Kim Olson,122,78,33,11
+Guadalupe,103,Commissioner of Agriculture,,LIB,Richard Carpenter,10,3,6,1
+Guadalupe,104,Commissioner of Agriculture,,,Under Votes,17,13,4,0
+Guadalupe,104,Commissioner of Agriculture,,REP,Sid Miller,276,198,59,19
+Guadalupe,104,Commissioner of Agriculture,,DEM,Kim Olson,206,125,61,20
+Guadalupe,104,Commissioner of Agriculture,,LIB,Richard Carpenter,21,14,7,0
+Guadalupe,105,Commissioner of Agriculture,,,Under Votes,21,14,6,1
+Guadalupe,105,Commissioner of Agriculture,,REP,Sid Miller,1136,694,374,68
+Guadalupe,105,Commissioner of Agriculture,,DEM,Kim Olson,314,180,102,32
+Guadalupe,105,Commissioner of Agriculture,,LIB,Richard Carpenter,43,18,22,3
+Guadalupe,106,Commissioner of Agriculture,,,Under Votes,29,19,9,1
+Guadalupe,106,Commissioner of Agriculture,,REP,Sid Miller,1271,924,237,110
+Guadalupe,106,Commissioner of Agriculture,,DEM,Kim Olson,565,396,122,47
+Guadalupe,106,Commissioner of Agriculture,,LIB,Richard Carpenter,40,28,9,3
+Guadalupe,107,Commissioner of Agriculture,,,Under Votes,8,2,5,1
+Guadalupe,107,Commissioner of Agriculture,,REP,Sid Miller,555,306,222,27
+Guadalupe,107,Commissioner of Agriculture,,DEM,Kim Olson,129,76,49,4
+Guadalupe,107,Commissioner of Agriculture,,LIB,Richard Carpenter,16,4,11,1
+Guadalupe,108,Commissioner of Agriculture,,,Under Votes,5,0,5,0
+Guadalupe,108,Commissioner of Agriculture,,REP,Sid Miller,260,101,131,28
+Guadalupe,108,Commissioner of Agriculture,,DEM,Kim Olson,152,66,71,15
+Guadalupe,108,Commissioner of Agriculture,,LIB,Richard Carpenter,14,1,11,2
+Guadalupe,109,Commissioner of Agriculture,,,Under Votes,5,3,2,0
+Guadalupe,109,Commissioner of Agriculture,,REP,Sid Miller,241,114,118,9
+Guadalupe,109,Commissioner of Agriculture,,DEM,Kim Olson,54,27,24,3
+Guadalupe,109,Commissioner of Agriculture,,LIB,Richard Carpenter,12,8,4,0
+Guadalupe,110,Commissioner of Agriculture,,,Under Votes,6,2,3,1
+Guadalupe,110,Commissioner of Agriculture,,REP,Sid Miller,81,66,13,2
+Guadalupe,110,Commissioner of Agriculture,,DEM,Kim Olson,61,46,10,5
+Guadalupe,110,Commissioner of Agriculture,,LIB,Richard Carpenter,3,3,0,0
+Guadalupe,111,Commissioner of Agriculture,,,Under Votes,4,1,2,1
+Guadalupe,111,Commissioner of Agriculture,,REP,Sid Miller,31,20,6,5
+Guadalupe,111,Commissioner of Agriculture,,DEM,Kim Olson,27,11,8,8
+Guadalupe,111,Commissioner of Agriculture,,LIB,Richard Carpenter,2,2,0,0
+Guadalupe,112,Commissioner of Agriculture,,,Under Votes,17,7,9,1
+Guadalupe,112,Commissioner of Agriculture,,REP,Sid Miller,65,25,40,0
+Guadalupe,112,Commissioner of Agriculture,,DEM,Kim Olson,140,52,88,0
+Guadalupe,112,Commissioner of Agriculture,,LIB,Richard Carpenter,4,1,3,0
+Guadalupe,113,Commissioner of Agriculture,,,Under Votes,8,6,2,0
+Guadalupe,113,Commissioner of Agriculture,,REP,Sid Miller,384,275,90,19
+Guadalupe,113,Commissioner of Agriculture,,DEM,Kim Olson,171,111,51,9
+Guadalupe,113,Commissioner of Agriculture,,LIB,Richard Carpenter,21,12,9,0
+Guadalupe,114,Commissioner of Agriculture,,,Under Votes,6,3,2,1
+Guadalupe,114,Commissioner of Agriculture,,REP,Sid Miller,279,203,59,17
+Guadalupe,114,Commissioner of Agriculture,,DEM,Kim Olson,155,101,46,8
+Guadalupe,114,Commissioner of Agriculture,,LIB,Richard Carpenter,11,9,2,0
+Guadalupe,115,Commissioner of Agriculture,,,Under Votes,4,2,1,1
+Guadalupe,115,Commissioner of Agriculture,,REP,Sid Miller,145,106,38,1
+Guadalupe,115,Commissioner of Agriculture,,DEM,Kim Olson,25,17,6,2
+Guadalupe,115,Commissioner of Agriculture,,LIB,Richard Carpenter,2,1,1,0
+Guadalupe,116,Commissioner of Agriculture,,,Under Votes,25,9,14,2
+Guadalupe,116,Commissioner of Agriculture,,REP,Sid Miller,958,649,248,61
+Guadalupe,116,Commissioner of Agriculture,,DEM,Kim Olson,331,172,134,25
+Guadalupe,116,Commissioner of Agriculture,,LIB,Richard Carpenter,27,16,10,1
+Guadalupe,117,Commissioner of Agriculture,,,Under Votes,40,27,10,3
+Guadalupe,117,Commissioner of Agriculture,,REP,Sid Miller,1730,1274,376,80
+Guadalupe,117,Commissioner of Agriculture,,DEM,Kim Olson,696,484,170,42
+Guadalupe,117,Commissioner of Agriculture,,LIB,Richard Carpenter,72,44,26,2
+Guadalupe,118,Commissioner of Agriculture,,,Under Votes,0,0,0,0
+Guadalupe,118,Commissioner of Agriculture,,REP,Sid Miller,25,19,6,0
+Guadalupe,118,Commissioner of Agriculture,,DEM,Kim Olson,17,10,7,0
+Guadalupe,118,Commissioner of Agriculture,,LIB,Richard Carpenter,1,0,0,1
+Guadalupe,119,Commissioner of Agriculture,,,Under Votes,18,12,5,1
+Guadalupe,119,Commissioner of Agriculture,,REP,Sid Miller,800,609,150,41
+Guadalupe,119,Commissioner of Agriculture,,DEM,Kim Olson,248,184,49,15
+Guadalupe,119,Commissioner of Agriculture,,LIB,Richard Carpenter,34,21,12,1
+Guadalupe,120,Commissioner of Agriculture,,,Under Votes,10,5,5,0
+Guadalupe,120,Commissioner of Agriculture,,REP,Sid Miller,530,371,114,45
+Guadalupe,120,Commissioner of Agriculture,,DEM,Kim Olson,163,106,39,18
+Guadalupe,120,Commissioner of Agriculture,,LIB,Richard Carpenter,17,11,6,0
+Guadalupe,121,Commissioner of Agriculture,,,Under Votes,8,5,3,0
+Guadalupe,121,Commissioner of Agriculture,,REP,Sid Miller,59,50,7,2
+Guadalupe,121,Commissioner of Agriculture,,DEM,Kim Olson,25,22,1,2
+Guadalupe,121,Commissioner of Agriculture,,LIB,Richard Carpenter,2,2,0,0
+Guadalupe,122,Commissioner of Agriculture,,,Under Votes,1,0,0,1
+Guadalupe,122,Commissioner of Agriculture,,REP,Sid Miller,18,14,1,3
+Guadalupe,122,Commissioner of Agriculture,,DEM,Kim Olson,8,3,0,5
+Guadalupe,122,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0,0
+Guadalupe,123,Commissioner of Agriculture,,,Under Votes,0,0,0,0
+Guadalupe,123,Commissioner of Agriculture,,REP,Sid Miller,0,0,0,0
+Guadalupe,123,Commissioner of Agriculture,,DEM,Kim Olson,1,0,0,1
+Guadalupe,123,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0,0
+Guadalupe,124,Commissioner of Agriculture,,,Under Votes,1,1,0,0
+Guadalupe,124,Commissioner of Agriculture,,REP,Sid Miller,0,0,0,0
+Guadalupe,124,Commissioner of Agriculture,,DEM,Kim Olson,1,1,0,0
+Guadalupe,124,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0,0
+Guadalupe,125,Commissioner of Agriculture,,,Under Votes,2,2,0,0
+Guadalupe,125,Commissioner of Agriculture,,REP,Sid Miller,88,66,11,11
+Guadalupe,125,Commissioner of Agriculture,,DEM,Kim Olson,19,11,7,1
+Guadalupe,125,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0,0
+Guadalupe,126,Commissioner of Agriculture,,,Under Votes,0,0,0,0
+Guadalupe,126,Commissioner of Agriculture,,REP,Sid Miller,12,4,7,1
+Guadalupe,126,Commissioner of Agriculture,,DEM,Kim Olson,2,2,0,0
+Guadalupe,126,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0,0
+Guadalupe,127,Commissioner of Agriculture,,,Under Votes,0,0,0,0
+Guadalupe,127,Commissioner of Agriculture,,REP,Sid Miller,9,3,5,1
+Guadalupe,127,Commissioner of Agriculture,,DEM,Kim Olson,4,0,4,0
+Guadalupe,127,Commissioner of Agriculture,,LIB,Richard Carpenter,2,1,1,0
+Guadalupe,201,Commissioner of Agriculture,,,Under Votes,4,1,2,1
+Guadalupe,201,Commissioner of Agriculture,,REP,Sid Miller,117,80,30,7
+Guadalupe,201,Commissioner of Agriculture,,DEM,Kim Olson,86,54,22,10
+Guadalupe,201,Commissioner of Agriculture,,LIB,Richard Carpenter,5,4,1,0
+Guadalupe,202,Commissioner of Agriculture,,,Under Votes,20,6,12,2
+Guadalupe,202,Commissioner of Agriculture,,REP,Sid Miller,129,81,40,8
+Guadalupe,202,Commissioner of Agriculture,,DEM,Kim Olson,298,159,106,33
+Guadalupe,202,Commissioner of Agriculture,,LIB,Richard Carpenter,16,9,5,2
+Guadalupe,203,Commissioner of Agriculture,,,Under Votes,7,4,3,0
+Guadalupe,203,Commissioner of Agriculture,,REP,Sid Miller,43,25,14,4
+Guadalupe,203,Commissioner of Agriculture,,DEM,Kim Olson,127,54,63,10
+Guadalupe,203,Commissioner of Agriculture,,LIB,Richard Carpenter,3,2,1,0
+Guadalupe,204,Commissioner of Agriculture,,,Under Votes,16,5,11,0
+Guadalupe,204,Commissioner of Agriculture,,REP,Sid Miller,240,137,97,6
+Guadalupe,204,Commissioner of Agriculture,,DEM,Kim Olson,358,202,134,22
+Guadalupe,204,Commissioner of Agriculture,,LIB,Richard Carpenter,14,7,5,2
+Guadalupe,205,Commissioner of Agriculture,,,Under Votes,20,10,10,0
+Guadalupe,205,Commissioner of Agriculture,,REP,Sid Miller,462,273,172,17
+Guadalupe,205,Commissioner of Agriculture,,DEM,Kim Olson,167,96,65,6
+Guadalupe,205,Commissioner of Agriculture,,LIB,Richard Carpenter,18,7,11,0
+Guadalupe,206,Commissioner of Agriculture,,,Under Votes,16,5,11,0
+Guadalupe,206,Commissioner of Agriculture,,REP,Sid Miller,351,140,196,15
+Guadalupe,206,Commissioner of Agriculture,,DEM,Kim Olson,577,181,366,30
+Guadalupe,206,Commissioner of Agriculture,,LIB,Richard Carpenter,27,9,17,1
+Guadalupe,207,Commissioner of Agriculture,,,Under Votes,13,8,4,1
+Guadalupe,207,Commissioner of Agriculture,,REP,Sid Miller,147,101,37,9
+Guadalupe,207,Commissioner of Agriculture,,DEM,Kim Olson,237,145,75,17
+Guadalupe,207,Commissioner of Agriculture,,LIB,Richard Carpenter,11,8,2,1
+Guadalupe,208,Commissioner of Agriculture,,,Under Votes,28,23,4,1
+Guadalupe,208,Commissioner of Agriculture,,REP,Sid Miller,1406,1024,303,79
+Guadalupe,208,Commissioner of Agriculture,,DEM,Kim Olson,415,291,99,25
+Guadalupe,208,Commissioner of Agriculture,,LIB,Richard Carpenter,43,26,16,1
+Guadalupe,209,Commissioner of Agriculture,,,Under Votes,13,5,8,0
+Guadalupe,209,Commissioner of Agriculture,,REP,Sid Miller,84,46,32,6
+Guadalupe,209,Commissioner of Agriculture,,DEM,Kim Olson,219,107,94,18
+Guadalupe,209,Commissioner of Agriculture,,LIB,Richard Carpenter,6,3,3,0
+Guadalupe,210,Commissioner of Agriculture,,,Under Votes,16,7,9,0
+Guadalupe,210,Commissioner of Agriculture,,REP,Sid Miller,244,157,72,15
+Guadalupe,210,Commissioner of Agriculture,,DEM,Kim Olson,204,135,50,19
+Guadalupe,210,Commissioner of Agriculture,,LIB,Richard Carpenter,19,14,3,2
+Guadalupe,211,Commissioner of Agriculture,,,Under Votes,0,0,0,0
+Guadalupe,211,Commissioner of Agriculture,,REP,Sid Miller,38,29,8,1
+Guadalupe,211,Commissioner of Agriculture,,DEM,Kim Olson,38,31,3,4
+Guadalupe,211,Commissioner of Agriculture,,LIB,Richard Carpenter,4,4,0,0
+Guadalupe,212,Commissioner of Agriculture,,,Under Votes,2,1,0,1
+Guadalupe,212,Commissioner of Agriculture,,REP,Sid Miller,36,29,7,0
+Guadalupe,212,Commissioner of Agriculture,,DEM,Kim Olson,46,29,14,3
+Guadalupe,212,Commissioner of Agriculture,,LIB,Richard Carpenter,2,2,0,0
+Guadalupe,213,Commissioner of Agriculture,,,Under Votes,20,12,7,1
+Guadalupe,213,Commissioner of Agriculture,,REP,Sid Miller,822,570,225,27
+Guadalupe,213,Commissioner of Agriculture,,DEM,Kim Olson,350,233,99,18
+Guadalupe,213,Commissioner of Agriculture,,LIB,Richard Carpenter,43,23,18,2
+Guadalupe,214,Commissioner of Agriculture,,,Under Votes,4,4,0,0
+Guadalupe,214,Commissioner of Agriculture,,REP,Sid Miller,266,189,69,8
+Guadalupe,214,Commissioner of Agriculture,,DEM,Kim Olson,89,54,25,10
+Guadalupe,214,Commissioner of Agriculture,,LIB,Richard Carpenter,12,8,4,0
+Guadalupe,215,Commissioner of Agriculture,,,Under Votes,13,8,4,1
+Guadalupe,215,Commissioner of Agriculture,,REP,Sid Miller,372,247,98,27
+Guadalupe,215,Commissioner of Agriculture,,DEM,Kim Olson,147,102,33,12
+Guadalupe,215,Commissioner of Agriculture,,LIB,Richard Carpenter,10,8,2,0
+Guadalupe,216,Commissioner of Agriculture,,,Under Votes,0,0,0,0
+Guadalupe,216,Commissioner of Agriculture,,REP,Sid Miller,26,15,8,3
+Guadalupe,216,Commissioner of Agriculture,,DEM,Kim Olson,8,5,3,0
+Guadalupe,216,Commissioner of Agriculture,,LIB,Richard Carpenter,3,2,0,1
+Guadalupe,217,Commissioner of Agriculture,,,Under Votes,0,0,0,0
+Guadalupe,217,Commissioner of Agriculture,,REP,Sid Miller,27,10,14,3
+Guadalupe,217,Commissioner of Agriculture,,DEM,Kim Olson,38,12,26,0
+Guadalupe,217,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0,0
+Guadalupe,218,Commissioner of Agriculture,,,Under Votes,1,1,0,0
+Guadalupe,218,Commissioner of Agriculture,,REP,Sid Miller,15,13,1,1
+Guadalupe,218,Commissioner of Agriculture,,DEM,Kim Olson,22,18,4,0
+Guadalupe,218,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0,0
+Guadalupe,219,Commissioner of Agriculture,,,Under Votes,2,2,0,0
+Guadalupe,219,Commissioner of Agriculture,,REP,Sid Miller,25,19,5,1
+Guadalupe,219,Commissioner of Agriculture,,DEM,Kim Olson,21,17,4,0
+Guadalupe,219,Commissioner of Agriculture,,LIB,Richard Carpenter,3,3,0,0
+Guadalupe,220,Commissioner of Agriculture,,,Under Votes,1,1,0,0
+Guadalupe,220,Commissioner of Agriculture,,REP,Sid Miller,18,13,5,0
+Guadalupe,220,Commissioner of Agriculture,,DEM,Kim Olson,23,17,4,2
+Guadalupe,220,Commissioner of Agriculture,,LIB,Richard Carpenter,1,0,1,0
+Guadalupe,221,Commissioner of Agriculture,,,Under Votes,0,0,0,0
+Guadalupe,221,Commissioner of Agriculture,,REP,Sid Miller,11,8,3,0
+Guadalupe,221,Commissioner of Agriculture,,DEM,Kim Olson,4,1,1,2
+Guadalupe,221,Commissioner of Agriculture,,LIB,Richard Carpenter,1,0,0,1
+Guadalupe,222,Commissioner of Agriculture,,,Under Votes,0,0,0,0
+Guadalupe,222,Commissioner of Agriculture,,REP,Sid Miller,0,0,0,0
+Guadalupe,222,Commissioner of Agriculture,,DEM,Kim Olson,0,0,0,0
+Guadalupe,222,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0,0
+Guadalupe,223,Commissioner of Agriculture,,,Under Votes,3,3,0,0
+Guadalupe,223,Commissioner of Agriculture,,REP,Sid Miller,71,40,26,5
+Guadalupe,223,Commissioner of Agriculture,,DEM,Kim Olson,76,60,10,6
+Guadalupe,223,Commissioner of Agriculture,,LIB,Richard Carpenter,9,7,2,0
+Guadalupe,224,Commissioner of Agriculture,,,Under Votes,1,1,0,0
+Guadalupe,224,Commissioner of Agriculture,,REP,Sid Miller,11,4,7,0
+Guadalupe,224,Commissioner of Agriculture,,DEM,Kim Olson,48,22,19,7
+Guadalupe,224,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0,0
+Guadalupe,225,Commissioner of Agriculture,,,Under Votes,2,1,1,0
+Guadalupe,225,Commissioner of Agriculture,,REP,Sid Miller,0,0,0,0
+Guadalupe,225,Commissioner of Agriculture,,DEM,Kim Olson,8,7,1,0
+Guadalupe,225,Commissioner of Agriculture,,LIB,Richard Carpenter,1,0,1,0
+Guadalupe,226,Commissioner of Agriculture,,,Under Votes,3,2,0,1
+Guadalupe,226,Commissioner of Agriculture,,REP,Sid Miller,99,65,32,2
+Guadalupe,226,Commissioner of Agriculture,,DEM,Kim Olson,54,28,23,3
+Guadalupe,226,Commissioner of Agriculture,,LIB,Richard Carpenter,4,4,0,0
+Guadalupe,301,Commissioner of Agriculture,,,Under Votes,31,14,14,3
+Guadalupe,301,Commissioner of Agriculture,,REP,Sid Miller,965,606,305,54
+Guadalupe,301,Commissioner of Agriculture,,DEM,Kim Olson,698,476,201,21
+Guadalupe,301,Commissioner of Agriculture,,LIB,Richard Carpenter,50,35,15,0
+Guadalupe,302,Commissioner of Agriculture,,,Under Votes,46,27,16,3
+Guadalupe,302,Commissioner of Agriculture,,REP,Sid Miller,1207,828,331,48
+Guadalupe,302,Commissioner of Agriculture,,DEM,Kim Olson,997,648,299,50
+Guadalupe,302,Commissioner of Agriculture,,LIB,Richard Carpenter,74,46,25,3
+Guadalupe,303,Commissioner of Agriculture,,,Under Votes,10,7,2,1
+Guadalupe,303,Commissioner of Agriculture,,REP,Sid Miller,501,384,88,29
+Guadalupe,303,Commissioner of Agriculture,,DEM,Kim Olson,274,197,57,20
+Guadalupe,303,Commissioner of Agriculture,,LIB,Richard Carpenter,23,16,6,1
+Guadalupe,304,Commissioner of Agriculture,,,Under Votes,30,14,13,3
+Guadalupe,304,Commissioner of Agriculture,,REP,Sid Miller,1372,1054,251,67
+Guadalupe,304,Commissioner of Agriculture,,DEM,Kim Olson,863,657,149,57
+Guadalupe,304,Commissioner of Agriculture,,LIB,Richard Carpenter,71,50,19,2
+Guadalupe,305,Commissioner of Agriculture,,,Under Votes,54,32,17,5
+Guadalupe,305,Commissioner of Agriculture,,REP,Sid Miller,1288,911,321,56
+Guadalupe,305,Commissioner of Agriculture,,DEM,Kim Olson,1009,702,233,74
+Guadalupe,305,Commissioner of Agriculture,,LIB,Richard Carpenter,59,36,23,0
+Guadalupe,306,Commissioner of Agriculture,,,Under Votes,29,22,7,0
+Guadalupe,306,Commissioner of Agriculture,,REP,Sid Miller,1421,1128,233,60
+Guadalupe,306,Commissioner of Agriculture,,DEM,Kim Olson,903,698,145,60
+Guadalupe,306,Commissioner of Agriculture,,LIB,Richard Carpenter,58,42,12,4
+Guadalupe,307,Commissioner of Agriculture,,,Under Votes,37,25,10,2
+Guadalupe,307,Commissioner of Agriculture,,REP,Sid Miller,1392,1083,251,58
+Guadalupe,307,Commissioner of Agriculture,,DEM,Kim Olson,1029,796,190,43
+Guadalupe,307,Commissioner of Agriculture,,LIB,Richard Carpenter,81,53,26,2
+Guadalupe,308,Commissioner of Agriculture,,,Under Votes,23,12,6,5
+Guadalupe,308,Commissioner of Agriculture,,REP,Sid Miller,787,617,125,45
+Guadalupe,308,Commissioner of Agriculture,,DEM,Kim Olson,427,294,97,36
+Guadalupe,308,Commissioner of Agriculture,,LIB,Richard Carpenter,45,33,8,4
+Guadalupe,401,Commissioner of Agriculture,,,Under Votes,11,2,8,1
+Guadalupe,401,Commissioner of Agriculture,,REP,Sid Miller,646,366,240,40
+Guadalupe,401,Commissioner of Agriculture,,DEM,Kim Olson,197,116,69,12
+Guadalupe,401,Commissioner of Agriculture,,LIB,Richard Carpenter,20,14,5,1
+Guadalupe,402,Commissioner of Agriculture,,,Under Votes,15,11,1,3
+Guadalupe,402,Commissioner of Agriculture,,REP,Sid Miller,505,348,114,43
+Guadalupe,402,Commissioner of Agriculture,,DEM,Kim Olson,357,215,104,38
+Guadalupe,402,Commissioner of Agriculture,,LIB,Richard Carpenter,38,23,14,1
+Guadalupe,403,Commissioner of Agriculture,,,Under Votes,23,15,7,1
+Guadalupe,403,Commissioner of Agriculture,,REP,Sid Miller,740,508,172,60
+Guadalupe,403,Commissioner of Agriculture,,DEM,Kim Olson,498,302,125,71
+Guadalupe,403,Commissioner of Agriculture,,LIB,Richard Carpenter,59,33,22,4
+Guadalupe,404,Commissioner of Agriculture,,,Under Votes,32,15,15,2
+Guadalupe,404,Commissioner of Agriculture,,REP,Sid Miller,916,552,291,73
+Guadalupe,404,Commissioner of Agriculture,,DEM,Kim Olson,672,417,204,51
+Guadalupe,404,Commissioner of Agriculture,,LIB,Richard Carpenter,47,22,23,2
+Guadalupe,405,Commissioner of Agriculture,,,Under Votes,18,15,3,0
+Guadalupe,405,Commissioner of Agriculture,,REP,Sid Miller,873,513,325,35
+Guadalupe,405,Commissioner of Agriculture,,DEM,Kim Olson,202,124,70,8
+Guadalupe,405,Commissioner of Agriculture,,LIB,Richard Carpenter,22,11,9,2
+Guadalupe,406,Commissioner of Agriculture,,,Under Votes,19,12,6,1
+Guadalupe,406,Commissioner of Agriculture,,REP,Sid Miller,987,748,200,39
+Guadalupe,406,Commissioner of Agriculture,,DEM,Kim Olson,188,126,47,15
+Guadalupe,406,Commissioner of Agriculture,,LIB,Richard Carpenter,26,17,8,1
+Guadalupe,407,Commissioner of Agriculture,,,Under Votes,17,11,6,0
+Guadalupe,407,Commissioner of Agriculture,,REP,Sid Miller,844,611,194,39
+Guadalupe,407,Commissioner of Agriculture,,DEM,Kim Olson,199,123,56,20
+Guadalupe,407,Commissioner of Agriculture,,LIB,Richard Carpenter,24,10,10,4
+Guadalupe,408,Commissioner of Agriculture,,,Under Votes,35,14,18,3
+Guadalupe,408,Commissioner of Agriculture,,REP,Sid Miller,1536,1006,402,128
+Guadalupe,408,Commissioner of Agriculture,,DEM,Kim Olson,730,480,206,44
+Guadalupe,408,Commissioner of Agriculture,,LIB,Richard Carpenter,51,30,16,5
+Guadalupe,409,Commissioner of Agriculture,,,Under Votes,39,16,21,2
+Guadalupe,409,Commissioner of Agriculture,,REP,Sid Miller,1182,851,286,45
+Guadalupe,409,Commissioner of Agriculture,,DEM,Kim Olson,1333,970,303,60
+Guadalupe,409,Commissioner of Agriculture,,LIB,Richard Carpenter,84,65,17,2
+Guadalupe,410,Commissioner of Agriculture,,,Under Votes,1,1,0,0
+Guadalupe,410,Commissioner of Agriculture,,REP,Sid Miller,58,47,11,0
+Guadalupe,410,Commissioner of Agriculture,,DEM,Kim Olson,22,17,5,0
+Guadalupe,410,Commissioner of Agriculture,,LIB,Richard Carpenter,2,0,2,0
+Guadalupe,411,Commissioner of Agriculture,,,Under Votes,34,22,8,4
+Guadalupe,411,Commissioner of Agriculture,,REP,Sid Miller,1165,839,276,50
+Guadalupe,411,Commissioner of Agriculture,,DEM,Kim Olson,736,557,136,43
+Guadalupe,411,Commissioner of Agriculture,,LIB,Richard Carpenter,63,41,19,3
+Guadalupe,101,Railroad Commissioner,,,Under Votes,8,2,3,3
+Guadalupe,101,Railroad Commissioner,,REP,Christi Craddick,268,179,70,19
+Guadalupe,101,Railroad Commissioner,,DEM,Roman McAllen,83,57,20,6
+Guadalupe,101,Railroad Commissioner,,LIB,Mike Wright,10,6,4,0
+Guadalupe,102,Railroad Commissioner,,,Under Votes,13,7,5,1
+Guadalupe,102,Railroad Commissioner,,REP,Christi Craddick,416,311,69,36
+Guadalupe,102,Railroad Commissioner,,DEM,Roman McAllen,152,94,42,16
+Guadalupe,102,Railroad Commissioner,,LIB,Mike Wright,17,10,6,1
+Guadalupe,103,Railroad Commissioner,,,Under Votes,8,6,2,0
+Guadalupe,103,Railroad Commissioner,,REP,Christi Craddick,328,240,68,20
+Guadalupe,103,Railroad Commissioner,,DEM,Roman McAllen,110,72,28,10
+Guadalupe,103,Railroad Commissioner,,LIB,Mike Wright,13,6,7,0
+Guadalupe,104,Railroad Commissioner,,,Under Votes,17,14,3,0
+Guadalupe,104,Railroad Commissioner,,REP,Christi Craddick,286,207,60,19
+Guadalupe,104,Railroad Commissioner,,DEM,Roman McAllen,199,115,65,19
+Guadalupe,104,Railroad Commissioner,,LIB,Mike Wright,18,14,3,1
+Guadalupe,105,Railroad Commissioner,,,Under Votes,24,15,6,3
+Guadalupe,105,Railroad Commissioner,,REP,Christi Craddick,1154,700,381,73
+Guadalupe,105,Railroad Commissioner,,DEM,Roman McAllen,300,173,100,27
+Guadalupe,105,Railroad Commissioner,,LIB,Mike Wright,36,18,17,1
+Guadalupe,106,Railroad Commissioner,,,Under Votes,37,24,11,2
+Guadalupe,106,Railroad Commissioner,,REP,Christi Craddick,1317,964,243,110
+Guadalupe,106,Railroad Commissioner,,DEM,Roman McAllen,503,346,112,45
+Guadalupe,106,Railroad Commissioner,,LIB,Mike Wright,48,33,11,4
+Guadalupe,107,Railroad Commissioner,,,Under Votes,13,5,8,0
+Guadalupe,107,Railroad Commissioner,,REP,Christi Craddick,558,306,222,30
+Guadalupe,107,Railroad Commissioner,,DEM,Roman McAllen,121,71,47,3
+Guadalupe,107,Railroad Commissioner,,LIB,Mike Wright,16,6,10,0
+Guadalupe,108,Railroad Commissioner,,,Under Votes,4,0,4,0
+Guadalupe,108,Railroad Commissioner,,REP,Christi Craddick,267,99,139,29
+Guadalupe,108,Railroad Commissioner,,DEM,Roman McAllen,150,67,68,15
+Guadalupe,108,Railroad Commissioner,,LIB,Mike Wright,10,2,7,1
+Guadalupe,109,Railroad Commissioner,,,Under Votes,6,2,4,0
+Guadalupe,109,Railroad Commissioner,,REP,Christi Craddick,252,123,119,10
+Guadalupe,109,Railroad Commissioner,,DEM,Roman McAllen,45,21,22,2
+Guadalupe,109,Railroad Commissioner,,LIB,Mike Wright,9,6,3,0
+Guadalupe,110,Railroad Commissioner,,,Under Votes,7,4,2,1
+Guadalupe,110,Railroad Commissioner,,REP,Christi Craddick,84,67,15,2
+Guadalupe,110,Railroad Commissioner,,DEM,Roman McAllen,56,42,9,5
+Guadalupe,110,Railroad Commissioner,,LIB,Mike Wright,4,4,0,0
+Guadalupe,111,Railroad Commissioner,,,Under Votes,4,1,2,1
+Guadalupe,111,Railroad Commissioner,,REP,Christi Craddick,32,20,6,6
+Guadalupe,111,Railroad Commissioner,,DEM,Roman McAllen,27,12,8,7
+Guadalupe,111,Railroad Commissioner,,LIB,Mike Wright,1,1,0,0
+Guadalupe,112,Railroad Commissioner,,,Under Votes,18,7,10,1
+Guadalupe,112,Railroad Commissioner,,REP,Christi Craddick,73,28,45,0
+Guadalupe,112,Railroad Commissioner,,DEM,Roman McAllen,129,49,80,0
+Guadalupe,112,Railroad Commissioner,,LIB,Mike Wright,6,1,5,0
+Guadalupe,113,Railroad Commissioner,,,Under Votes,8,7,1,0
+Guadalupe,113,Railroad Commissioner,,REP,Christi Craddick,389,279,92,18
+Guadalupe,113,Railroad Commissioner,,DEM,Roman McAllen,162,102,50,10
+Guadalupe,113,Railroad Commissioner,,LIB,Mike Wright,25,16,9,0
+Guadalupe,114,Railroad Commissioner,,,Under Votes,9,3,3,3
+Guadalupe,114,Railroad Commissioner,,REP,Christi Craddick,282,204,61,17
+Guadalupe,114,Railroad Commissioner,,DEM,Roman McAllen,146,97,43,6
+Guadalupe,114,Railroad Commissioner,,LIB,Mike Wright,14,12,2,0
+Guadalupe,115,Railroad Commissioner,,,Under Votes,5,1,3,1
+Guadalupe,115,Railroad Commissioner,,REP,Christi Craddick,147,108,38,1
+Guadalupe,115,Railroad Commissioner,,DEM,Roman McAllen,23,17,4,2
+Guadalupe,115,Railroad Commissioner,,LIB,Mike Wright,1,0,1,0
+Guadalupe,116,Railroad Commissioner,,,Under Votes,31,12,14,5
+Guadalupe,116,Railroad Commissioner,,REP,Christi Craddick,995,670,265,60
+Guadalupe,116,Railroad Commissioner,,DEM,Roman McAllen,285,149,115,21
+Guadalupe,116,Railroad Commissioner,,LIB,Mike Wright,30,15,12,3
+Guadalupe,117,Railroad Commissioner,,,Under Votes,42,27,12,3
+Guadalupe,117,Railroad Commissioner,,REP,Christi Craddick,1802,1323,397,82
+Guadalupe,117,Railroad Commissioner,,DEM,Roman McAllen,619,426,151,42
+Guadalupe,117,Railroad Commissioner,,LIB,Mike Wright,75,53,22,0
+Guadalupe,118,Railroad Commissioner,,,Under Votes,0,0,0,0
+Guadalupe,118,Railroad Commissioner,,REP,Christi Craddick,26,20,6,0
+Guadalupe,118,Railroad Commissioner,,DEM,Roman McAllen,17,9,7,1
+Guadalupe,118,Railroad Commissioner,,LIB,Mike Wright,0,0,0,0
+Guadalupe,119,Railroad Commissioner,,,Under Votes,21,15,5,1
+Guadalupe,119,Railroad Commissioner,,REP,Christi Craddick,825,631,151,43
+Guadalupe,119,Railroad Commissioner,,DEM,Roman McAllen,222,161,48,13
+Guadalupe,119,Railroad Commissioner,,LIB,Mike Wright,32,19,12,1
+Guadalupe,120,Railroad Commissioner,,,Under Votes,16,10,6,0
+Guadalupe,120,Railroad Commissioner,,REP,Christi Craddick,558,382,127,49
+Guadalupe,120,Railroad Commissioner,,DEM,Roman McAllen,128,86,28,14
+Guadalupe,120,Railroad Commissioner,,LIB,Mike Wright,18,15,3,0
+Guadalupe,121,Railroad Commissioner,,,Under Votes,9,6,3,0
+Guadalupe,121,Railroad Commissioner,,REP,Christi Craddick,57,49,6,2
+Guadalupe,121,Railroad Commissioner,,DEM,Roman McAllen,24,20,2,2
+Guadalupe,121,Railroad Commissioner,,LIB,Mike Wright,4,4,0,0
+Guadalupe,122,Railroad Commissioner,,,Under Votes,0,0,0,0
+Guadalupe,122,Railroad Commissioner,,REP,Christi Craddick,19,16,1,2
+Guadalupe,122,Railroad Commissioner,,DEM,Roman McAllen,7,1,0,6
+Guadalupe,122,Railroad Commissioner,,LIB,Mike Wright,1,0,0,1
+Guadalupe,123,Railroad Commissioner,,,Under Votes,0,0,0,0
+Guadalupe,123,Railroad Commissioner,,REP,Christi Craddick,0,0,0,0
+Guadalupe,123,Railroad Commissioner,,DEM,Roman McAllen,1,0,0,1
+Guadalupe,123,Railroad Commissioner,,LIB,Mike Wright,0,0,0,0
+Guadalupe,124,Railroad Commissioner,,,Under Votes,1,1,0,0
+Guadalupe,124,Railroad Commissioner,,REP,Christi Craddick,1,1,0,0
+Guadalupe,124,Railroad Commissioner,,DEM,Roman McAllen,0,0,0,0
+Guadalupe,124,Railroad Commissioner,,LIB,Mike Wright,0,0,0,0
+Guadalupe,125,Railroad Commissioner,,,Under Votes,1,1,0,0
+Guadalupe,125,Railroad Commissioner,,REP,Christi Craddick,89,66,12,11
+Guadalupe,125,Railroad Commissioner,,DEM,Roman McAllen,19,12,6,1
+Guadalupe,125,Railroad Commissioner,,LIB,Mike Wright,0,0,0,0
+Guadalupe,126,Railroad Commissioner,,,Under Votes,0,0,0,0
+Guadalupe,126,Railroad Commissioner,,REP,Christi Craddick,12,4,7,1
+Guadalupe,126,Railroad Commissioner,,DEM,Roman McAllen,2,2,0,0
+Guadalupe,126,Railroad Commissioner,,LIB,Mike Wright,0,0,0,0
+Guadalupe,127,Railroad Commissioner,,,Under Votes,1,0,1,0
+Guadalupe,127,Railroad Commissioner,,REP,Christi Craddick,8,3,4,1
+Guadalupe,127,Railroad Commissioner,,DEM,Roman McAllen,5,1,4,0
+Guadalupe,127,Railroad Commissioner,,LIB,Mike Wright,1,0,1,0
+Guadalupe,201,Railroad Commissioner,,,Under Votes,3,0,2,1
+Guadalupe,201,Railroad Commissioner,,REP,Christi Craddick,123,84,30,9
+Guadalupe,201,Railroad Commissioner,,DEM,Roman McAllen,80,50,22,8
+Guadalupe,201,Railroad Commissioner,,LIB,Mike Wright,6,5,1,0
+Guadalupe,202,Railroad Commissioner,,,Under Votes,23,7,12,4
+Guadalupe,202,Railroad Commissioner,,REP,Christi Craddick,127,80,40,7
+Guadalupe,202,Railroad Commissioner,,DEM,Roman McAllen,297,158,105,34
+Guadalupe,202,Railroad Commissioner,,LIB,Mike Wright,16,10,6,0
+Guadalupe,203,Railroad Commissioner,,,Under Votes,7,4,3,0
+Guadalupe,203,Railroad Commissioner,,REP,Christi Craddick,45,26,15,4
+Guadalupe,203,Railroad Commissioner,,DEM,Roman McAllen,122,51,61,10
+Guadalupe,203,Railroad Commissioner,,LIB,Mike Wright,6,4,2,0
+Guadalupe,204,Railroad Commissioner,,,Under Votes,15,5,10,0
+Guadalupe,204,Railroad Commissioner,,REP,Christi Craddick,250,148,94,8
+Guadalupe,204,Railroad Commissioner,,DEM,Roman McAllen,345,195,130,20
+Guadalupe,204,Railroad Commissioner,,LIB,Mike Wright,18,3,13,2
+Guadalupe,205,Railroad Commissioner,,,Under Votes,19,12,7,0
+Guadalupe,205,Railroad Commissioner,,REP,Christi Craddick,476,279,181,16
+Guadalupe,205,Railroad Commissioner,,DEM,Roman McAllen,154,89,58,7
+Guadalupe,205,Railroad Commissioner,,LIB,Mike Wright,18,6,12,0
+Guadalupe,206,Railroad Commissioner,,,Under Votes,23,7,16,0
+Guadalupe,206,Railroad Commissioner,,REP,Christi Craddick,351,138,196,17
+Guadalupe,206,Railroad Commissioner,,DEM,Roman McAllen,562,175,358,29
+Guadalupe,206,Railroad Commissioner,,LIB,Mike Wright,35,15,20,0
+Guadalupe,207,Railroad Commissioner,,,Under Votes,11,5,5,1
+Guadalupe,207,Railroad Commissioner,,REP,Christi Craddick,159,109,38,12
+Guadalupe,207,Railroad Commissioner,,DEM,Roman McAllen,225,139,71,15
+Guadalupe,207,Railroad Commissioner,,LIB,Mike Wright,13,9,4,0
+Guadalupe,208,Railroad Commissioner,,,Under Votes,34,29,4,1
+Guadalupe,208,Railroad Commissioner,,REP,Christi Craddick,1441,1044,315,82
+Guadalupe,208,Railroad Commissioner,,DEM,Roman McAllen,364,258,88,18
+Guadalupe,208,Railroad Commissioner,,LIB,Mike Wright,53,33,15,5
+Guadalupe,209,Railroad Commissioner,,,Under Votes,13,5,8,0
+Guadalupe,209,Railroad Commissioner,,REP,Christi Craddick,84,45,33,6
+Guadalupe,209,Railroad Commissioner,,DEM,Roman McAllen,217,106,93,18
+Guadalupe,209,Railroad Commissioner,,LIB,Mike Wright,8,5,3,0
+Guadalupe,210,Railroad Commissioner,,,Under Votes,16,9,7,0
+Guadalupe,210,Railroad Commissioner,,REP,Christi Craddick,256,165,74,17
+Guadalupe,210,Railroad Commissioner,,DEM,Roman McAllen,189,125,47,17
+Guadalupe,210,Railroad Commissioner,,LIB,Mike Wright,22,14,6,2
+Guadalupe,211,Railroad Commissioner,,,Under Votes,0,0,0,0
+Guadalupe,211,Railroad Commissioner,,REP,Christi Craddick,39,30,8,1
+Guadalupe,211,Railroad Commissioner,,DEM,Roman McAllen,37,30,3,4
+Guadalupe,211,Railroad Commissioner,,LIB,Mike Wright,4,4,0,0
+Guadalupe,212,Railroad Commissioner,,,Under Votes,5,2,2,1
+Guadalupe,212,Railroad Commissioner,,REP,Christi Craddick,35,29,6,0
+Guadalupe,212,Railroad Commissioner,,DEM,Roman McAllen,46,30,13,3
+Guadalupe,212,Railroad Commissioner,,LIB,Mike Wright,0,0,0,0
+Guadalupe,213,Railroad Commissioner,,,Under Votes,19,11,7,1
+Guadalupe,213,Railroad Commissioner,,REP,Christi Craddick,831,572,232,27
+Guadalupe,213,Railroad Commissioner,,DEM,Roman McAllen,332,223,91,18
+Guadalupe,213,Railroad Commissioner,,LIB,Mike Wright,53,32,19,2
+Guadalupe,214,Railroad Commissioner,,,Under Votes,4,3,1,0
+Guadalupe,214,Railroad Commissioner,,REP,Christi Craddick,272,191,71,10
+Guadalupe,214,Railroad Commissioner,,DEM,Roman McAllen,82,50,24,8
+Guadalupe,214,Railroad Commissioner,,LIB,Mike Wright,13,11,2,0
+Guadalupe,215,Railroad Commissioner,,,Under Votes,18,12,5,1
+Guadalupe,215,Railroad Commissioner,,REP,Christi Craddick,380,253,99,28
+Guadalupe,215,Railroad Commissioner,,DEM,Roman McAllen,136,94,32,10
+Guadalupe,215,Railroad Commissioner,,LIB,Mike Wright,8,6,1,1
+Guadalupe,216,Railroad Commissioner,,,Under Votes,0,0,0,0
+Guadalupe,216,Railroad Commissioner,,REP,Christi Craddick,29,16,9,4
+Guadalupe,216,Railroad Commissioner,,DEM,Roman McAllen,7,5,2,0
+Guadalupe,216,Railroad Commissioner,,LIB,Mike Wright,1,1,0,0
+Guadalupe,217,Railroad Commissioner,,,Under Votes,0,0,0,0
+Guadalupe,217,Railroad Commissioner,,REP,Christi Craddick,30,12,15,3
+Guadalupe,217,Railroad Commissioner,,DEM,Roman McAllen,34,9,25,0
+Guadalupe,217,Railroad Commissioner,,LIB,Mike Wright,1,1,0,0
+Guadalupe,218,Railroad Commissioner,,,Under Votes,0,0,0,0
+Guadalupe,218,Railroad Commissioner,,REP,Christi Craddick,14,12,1,1
+Guadalupe,218,Railroad Commissioner,,DEM,Roman McAllen,23,19,4,0
+Guadalupe,218,Railroad Commissioner,,LIB,Mike Wright,1,1,0,0
+Guadalupe,219,Railroad Commissioner,,,Under Votes,2,2,0,0
+Guadalupe,219,Railroad Commissioner,,REP,Christi Craddick,26,21,5,0
+Guadalupe,219,Railroad Commissioner,,DEM,Roman McAllen,22,18,4,0
+Guadalupe,219,Railroad Commissioner,,LIB,Mike Wright,1,0,0,1
+Guadalupe,220,Railroad Commissioner,,,Under Votes,0,0,0,0
+Guadalupe,220,Railroad Commissioner,,REP,Christi Craddick,20,15,5,0
+Guadalupe,220,Railroad Commissioner,,DEM,Roman McAllen,22,15,5,2
+Guadalupe,220,Railroad Commissioner,,LIB,Mike Wright,1,1,0,0
+Guadalupe,221,Railroad Commissioner,,,Under Votes,0,0,0,0
+Guadalupe,221,Railroad Commissioner,,REP,Christi Craddick,11,8,3,0
+Guadalupe,221,Railroad Commissioner,,DEM,Roman McAllen,5,1,1,3
+Guadalupe,221,Railroad Commissioner,,LIB,Mike Wright,0,0,0,0
+Guadalupe,222,Railroad Commissioner,,,Under Votes,0,0,0,0
+Guadalupe,222,Railroad Commissioner,,REP,Christi Craddick,0,0,0,0
+Guadalupe,222,Railroad Commissioner,,DEM,Roman McAllen,0,0,0,0
+Guadalupe,222,Railroad Commissioner,,LIB,Mike Wright,0,0,0,0
+Guadalupe,223,Railroad Commissioner,,,Under Votes,2,2,0,0
+Guadalupe,223,Railroad Commissioner,,REP,Christi Craddick,76,44,27,5
+Guadalupe,223,Railroad Commissioner,,DEM,Roman McAllen,75,60,9,6
+Guadalupe,223,Railroad Commissioner,,LIB,Mike Wright,6,4,2,0
+Guadalupe,224,Railroad Commissioner,,,Under Votes,1,1,0,0
+Guadalupe,224,Railroad Commissioner,,REP,Christi Craddick,10,3,7,0
+Guadalupe,224,Railroad Commissioner,,DEM,Roman McAllen,49,23,19,7
+Guadalupe,224,Railroad Commissioner,,LIB,Mike Wright,0,0,0,0
+Guadalupe,225,Railroad Commissioner,,,Under Votes,2,1,1,0
+Guadalupe,225,Railroad Commissioner,,REP,Christi Craddick,0,0,0,0
+Guadalupe,225,Railroad Commissioner,,DEM,Roman McAllen,9,7,2,0
+Guadalupe,225,Railroad Commissioner,,LIB,Mike Wright,0,0,0,0
+Guadalupe,226,Railroad Commissioner,,,Under Votes,3,2,0,1
+Guadalupe,226,Railroad Commissioner,,REP,Christi Craddick,101,66,33,2
+Guadalupe,226,Railroad Commissioner,,DEM,Roman McAllen,51,27,22,2
+Guadalupe,226,Railroad Commissioner,,LIB,Mike Wright,5,4,0,1
+Guadalupe,301,Railroad Commissioner,,,Under Votes,35,17,16,2
+Guadalupe,301,Railroad Commissioner,,REP,Christi Craddick,1012,633,322,57
+Guadalupe,301,Railroad Commissioner,,DEM,Roman McAllen,654,449,187,18
+Guadalupe,301,Railroad Commissioner,,LIB,Mike Wright,43,32,10,1
+Guadalupe,302,Railroad Commissioner,,,Under Votes,50,31,16,3
+Guadalupe,302,Railroad Commissioner,,REP,Christi Craddick,1256,849,356,51
+Guadalupe,302,Railroad Commissioner,,DEM,Roman McAllen,938,621,271,46
+Guadalupe,302,Railroad Commissioner,,LIB,Mike Wright,80,48,28,4
+Guadalupe,303,Railroad Commissioner,,,Under Votes,12,7,4,1
+Guadalupe,303,Railroad Commissioner,,REP,Christi Craddick,523,401,90,32
+Guadalupe,303,Railroad Commissioner,,DEM,Roman McAllen,242,173,52,17
+Guadalupe,303,Railroad Commissioner,,LIB,Mike Wright,31,23,7,1
+Guadalupe,304,Railroad Commissioner,,,Under Votes,33,16,14,3
+Guadalupe,304,Railroad Commissioner,,REP,Christi Craddick,1430,1106,255,69
+Guadalupe,304,Railroad Commissioner,,DEM,Roman McAllen,800,604,145,51
+Guadalupe,304,Railroad Commissioner,,LIB,Mike Wright,73,49,18,6
+Guadalupe,305,Railroad Commissioner,,,Under Votes,50,30,14,6
+Guadalupe,305,Railroad Commissioner,,REP,Christi Craddick,1352,954,338,60
+Guadalupe,305,Railroad Commissioner,,DEM,Roman McAllen,940,658,216,66
+Guadalupe,305,Railroad Commissioner,,LIB,Mike Wright,68,39,26,3
+Guadalupe,306,Railroad Commissioner,,,Under Votes,36,24,10,2
+Guadalupe,306,Railroad Commissioner,,REP,Christi Craddick,1486,1176,245,65
+Guadalupe,306,Railroad Commissioner,,DEM,Roman McAllen,827,642,131,54
+Guadalupe,306,Railroad Commissioner,,LIB,Mike Wright,62,48,11,3
+Guadalupe,307,Railroad Commissioner,,,Under Votes,43,28,11,4
+Guadalupe,307,Railroad Commissioner,,REP,Christi Craddick,1471,1151,260,60
+Guadalupe,307,Railroad Commissioner,,DEM,Roman McAllen,949,732,180,37
+Guadalupe,307,Railroad Commissioner,,LIB,Mike Wright,76,46,26,4
+Guadalupe,308,Railroad Commissioner,,,Under Votes,26,16,5,5
+Guadalupe,308,Railroad Commissioner,,REP,Christi Craddick,823,642,133,48
+Guadalupe,308,Railroad Commissioner,,DEM,Roman McAllen,374,257,81,36
+Guadalupe,308,Railroad Commissioner,,LIB,Mike Wright,59,41,17,1
+Guadalupe,401,Railroad Commissioner,,,Under Votes,13,4,9,0
+Guadalupe,401,Railroad Commissioner,,REP,Christi Craddick,654,372,240,42
+Guadalupe,401,Railroad Commissioner,,DEM,Roman McAllen,180,106,62,12
+Guadalupe,401,Railroad Commissioner,,LIB,Mike Wright,27,16,11,0
+Guadalupe,402,Railroad Commissioner,,,Under Votes,16,10,3,3
+Guadalupe,402,Railroad Commissioner,,REP,Christi Craddick,531,368,120,43
+Guadalupe,402,Railroad Commissioner,,DEM,Roman McAllen,331,198,95,38
+Guadalupe,402,Railroad Commissioner,,LIB,Mike Wright,37,21,15,1
+Guadalupe,403,Railroad Commissioner,,,Under Votes,28,18,9,1
+Guadalupe,403,Railroad Commissioner,,REP,Christi Craddick,769,530,174,65
+Guadalupe,403,Railroad Commissioner,,DEM,Roman McAllen,475,287,119,69
+Guadalupe,403,Railroad Commissioner,,LIB,Mike Wright,48,23,24,1
+Guadalupe,404,Railroad Commissioner,,,Under Votes,39,17,21,1
+Guadalupe,404,Railroad Commissioner,,REP,Christi Craddick,964,582,306,76
+Guadalupe,404,Railroad Commissioner,,DEM,Roman McAllen,610,379,184,47
+Guadalupe,404,Railroad Commissioner,,LIB,Mike Wright,54,28,22,4
+Guadalupe,405,Railroad Commissioner,,,Under Votes,20,13,7,0
+Guadalupe,405,Railroad Commissioner,,REP,Christi Craddick,894,532,328,34
+Guadalupe,405,Railroad Commissioner,,DEM,Roman McAllen,175,107,57,11
+Guadalupe,405,Railroad Commissioner,,LIB,Mike Wright,26,11,15,0
+Guadalupe,406,Railroad Commissioner,,,Under Votes,30,22,6,2
+Guadalupe,406,Railroad Commissioner,,REP,Christi Craddick,998,752,207,39
+Guadalupe,406,Railroad Commissioner,,DEM,Roman McAllen,162,108,40,14
+Guadalupe,406,Railroad Commissioner,,LIB,Mike Wright,30,21,8,1
+Guadalupe,407,Railroad Commissioner,,,Under Votes,24,16,8,0
+Guadalupe,407,Railroad Commissioner,,REP,Christi Craddick,843,607,197,39
+Guadalupe,407,Railroad Commissioner,,DEM,Roman McAllen,190,115,55,20
+Guadalupe,407,Railroad Commissioner,,LIB,Mike Wright,27,17,6,4
+Guadalupe,408,Railroad Commissioner,,,Under Votes,44,18,22,4
+Guadalupe,408,Railroad Commissioner,,REP,Christi Craddick,1567,1037,401,129
+Guadalupe,408,Railroad Commissioner,,DEM,Roman McAllen,681,445,195,41
+Guadalupe,408,Railroad Commissioner,,LIB,Mike Wright,60,30,24,6
+Guadalupe,409,Railroad Commissioner,,,Under Votes,46,20,23,3
+Guadalupe,409,Railroad Commissioner,,REP,Christi Craddick,1212,873,294,45
+Guadalupe,409,Railroad Commissioner,,DEM,Roman McAllen,1285,941,286,58
+Guadalupe,409,Railroad Commissioner,,LIB,Mike Wright,95,68,24,3
+Guadalupe,410,Railroad Commissioner,,,Under Votes,1,1,0,0
+Guadalupe,410,Railroad Commissioner,,REP,Christi Craddick,57,47,10,0
+Guadalupe,410,Railroad Commissioner,,DEM,Roman McAllen,23,17,6,0
+Guadalupe,410,Railroad Commissioner,,LIB,Mike Wright,2,0,2,0
+Guadalupe,411,Railroad Commissioner,,,Under Votes,45,25,16,4
+Guadalupe,411,Railroad Commissioner,,REP,Christi Craddick,1194,861,278,55
+Guadalupe,411,Railroad Commissioner,,DEM,Roman McAllen,693,528,126,39
+Guadalupe,411,Railroad Commissioner,,LIB,Mike Wright,66,45,19,2
+Guadalupe,101,"Justice, Supreme Court, Place 2",,,Under Votes,12,7,2,3
+Guadalupe,101,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,263,175,71,17
+Guadalupe,101,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,94,62,24,8
+Guadalupe,102,"Justice, Supreme Court, Place 2",,,Under Votes,17,11,5,1
+Guadalupe,102,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,412,309,67,36
+Guadalupe,102,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,169,102,50,17
+Guadalupe,103,"Justice, Supreme Court, Place 2",,,Under Votes,11,9,2,0
+Guadalupe,103,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,327,242,66,19
+Guadalupe,103,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,121,73,37,11
+Guadalupe,104,"Justice, Supreme Court, Place 2",,,Under Votes,20,16,3,1
+Guadalupe,104,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,275,201,57,17
+Guadalupe,104,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,225,133,71,21
+Guadalupe,105,"Justice, Supreme Court, Place 2",,,Under Votes,26,16,7,3
+Guadalupe,105,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1160,701,386,73
+Guadalupe,105,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,328,189,111,28
+Guadalupe,106,"Justice, Supreme Court, Place 2",,,Under Votes,47,31,10,6
+Guadalupe,106,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1306,957,238,111
+Guadalupe,106,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,552,379,129,44
+Guadalupe,107,"Justice, Supreme Court, Place 2",,,Under Votes,13,5,8,0
+Guadalupe,107,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,565,307,229,29
+Guadalupe,107,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,130,76,50,4
+Guadalupe,108,"Justice, Supreme Court, Place 2",,,Under Votes,5,0,5,0
+Guadalupe,108,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,268,101,139,28
+Guadalupe,108,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,158,67,74,17
+Guadalupe,109,"Justice, Supreme Court, Place 2",,,Under Votes,7,2,5,0
+Guadalupe,109,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,251,123,118,10
+Guadalupe,109,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,54,27,25,2
+Guadalupe,110,"Justice, Supreme Court, Place 2",,,Under Votes,7,4,2,1
+Guadalupe,110,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,84,68,14,2
+Guadalupe,110,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,60,45,10,5
+Guadalupe,111,"Justice, Supreme Court, Place 2",,,Under Votes,4,1,2,1
+Guadalupe,111,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,32,20,6,6
+Guadalupe,111,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,28,13,8,7
+Guadalupe,112,"Justice, Supreme Court, Place 2",,,Under Votes,19,8,10,1
+Guadalupe,112,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,68,25,43,0
+Guadalupe,112,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,139,52,87,0
+Guadalupe,113,"Justice, Supreme Court, Place 2",,,Under Votes,7,6,1,0
+Guadalupe,113,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,393,279,96,18
+Guadalupe,113,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,184,119,55,10
+Guadalupe,114,"Justice, Supreme Court, Place 2",,,Under Votes,8,5,1,2
+Guadalupe,114,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,289,209,64,16
+Guadalupe,114,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,154,102,44,8
+Guadalupe,115,"Justice, Supreme Court, Place 2",,,Under Votes,5,1,3,1
+Guadalupe,115,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,146,107,38,1
+Guadalupe,115,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,25,18,5,2
+Guadalupe,116,"Justice, Supreme Court, Place 2",,,Under Votes,34,12,19,3
+Guadalupe,116,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,982,664,256,62
+Guadalupe,116,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,325,170,131,24
+Guadalupe,117,"Justice, Supreme Court, Place 2",,,Under Votes,50,31,16,3
+Guadalupe,117,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1784,1316,390,78
+Guadalupe,117,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,704,482,176,46
+Guadalupe,118,"Justice, Supreme Court, Place 2",,,Under Votes,0,0,0,0
+Guadalupe,118,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,23,17,6,0
+Guadalupe,118,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,20,12,7,1
+Guadalupe,119,"Justice, Supreme Court, Place 2",,,Under Votes,16,11,4,1
+Guadalupe,119,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,831,634,154,43
+Guadalupe,119,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,253,181,58,14
+Guadalupe,120,"Justice, Supreme Court, Place 2",,,Under Votes,20,10,10,0
+Guadalupe,120,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,547,380,120,47
+Guadalupe,120,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,153,103,34,16
+Guadalupe,121,"Justice, Supreme Court, Place 2",,,Under Votes,9,6,3,0
+Guadalupe,121,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,59,51,6,2
+Guadalupe,121,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,26,22,2,2
+Guadalupe,122,"Justice, Supreme Court, Place 2",,,Under Votes,0,0,0,0
+Guadalupe,122,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,20,16,1,3
+Guadalupe,122,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,7,1,0,6
+Guadalupe,123,"Justice, Supreme Court, Place 2",,,Under Votes,0,0,0,0
+Guadalupe,123,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,0,0,0,0
+Guadalupe,123,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,1,0,0,1
+Guadalupe,124,"Justice, Supreme Court, Place 2",,,Under Votes,1,1,0,0
+Guadalupe,124,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,0,0,0,0
+Guadalupe,124,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,1,1,0,0
+Guadalupe,125,"Justice, Supreme Court, Place 2",,,Under Votes,2,1,1,0
+Guadalupe,125,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,88,66,11,11
+Guadalupe,125,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,19,12,6,1
+Guadalupe,126,"Justice, Supreme Court, Place 2",,,Under Votes,0,0,0,0
+Guadalupe,126,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,12,4,7,1
+Guadalupe,126,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,2,2,0,0
+Guadalupe,127,"Justice, Supreme Court, Place 2",,,Under Votes,1,0,1,0
+Guadalupe,127,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,9,3,5,1
+Guadalupe,127,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,5,1,4,0
+Guadalupe,201,"Justice, Supreme Court, Place 2",,,Under Votes,5,2,3,0
+Guadalupe,201,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,121,83,29,9
+Guadalupe,201,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,86,54,23,9
+Guadalupe,202,"Justice, Supreme Court, Place 2",,,Under Votes,27,10,14,3
+Guadalupe,202,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,128,84,38,6
+Guadalupe,202,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,308,161,111,36
+Guadalupe,203,"Justice, Supreme Court, Place 2",,,Under Votes,7,4,3,0
+Guadalupe,203,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,46,26,16,4
+Guadalupe,203,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,127,55,62,10
+Guadalupe,204,"Justice, Supreme Court, Place 2",,,Under Votes,18,6,11,1
+Guadalupe,204,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,252,143,102,7
+Guadalupe,204,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,358,202,134,22
+Guadalupe,205,"Justice, Supreme Court, Place 2",,,Under Votes,19,13,6,0
+Guadalupe,205,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,477,274,187,16
+Guadalupe,205,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,171,99,65,7
+Guadalupe,206,"Justice, Supreme Court, Place 2",,,Under Votes,29,10,19,0
+Guadalupe,206,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,363,139,207,17
+Guadalupe,206,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,579,186,364,29
+Guadalupe,207,"Justice, Supreme Court, Place 2",,,Under Votes,12,6,4,2
+Guadalupe,207,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,149,102,38,9
+Guadalupe,207,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,247,154,76,17
+Guadalupe,208,"Justice, Supreme Court, Place 2",,,Under Votes,44,35,7,2
+Guadalupe,208,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1440,1045,314,81
+Guadalupe,208,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,408,284,101,23
+Guadalupe,209,"Justice, Supreme Court, Place 2",,,Under Votes,12,5,7,0
+Guadalupe,209,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,87,48,33,6
+Guadalupe,209,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,223,108,97,18
+Guadalupe,210,"Justice, Supreme Court, Place 2",,,Under Votes,19,9,10,0
+Guadalupe,210,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,259,167,75,17
+Guadalupe,210,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,205,137,49,19
+Guadalupe,211,"Justice, Supreme Court, Place 2",,,Under Votes,1,1,0,0
+Guadalupe,211,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,43,34,8,1
+Guadalupe,211,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,36,29,3,4
+Guadalupe,212,"Justice, Supreme Court, Place 2",,,Under Votes,3,1,1,1
+Guadalupe,212,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,31,28,3,0
+Guadalupe,212,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,52,32,17,3
+Guadalupe,213,"Justice, Supreme Court, Place 2",,,Under Votes,28,17,10,1
+Guadalupe,213,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,840,578,233,29
+Guadalupe,213,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,367,243,106,18
+Guadalupe,214,"Justice, Supreme Court, Place 2",,,Under Votes,3,2,1,0
+Guadalupe,214,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,276,196,72,8
+Guadalupe,214,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,92,57,25,10
+Guadalupe,215,"Justice, Supreme Court, Place 2",,,Under Votes,17,12,4,1
+Guadalupe,215,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,377,252,97,28
+Guadalupe,215,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,148,101,36,11
+Guadalupe,216,"Justice, Supreme Court, Place 2",,,Under Votes,1,0,1,0
+Guadalupe,216,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,29,16,9,4
+Guadalupe,216,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,7,6,1,0
+Guadalupe,217,"Justice, Supreme Court, Place 2",,,Under Votes,1,0,1,0
+Guadalupe,217,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,28,11,14,3
+Guadalupe,217,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,36,11,25,0
+Guadalupe,218,"Justice, Supreme Court, Place 2",,,Under Votes,0,0,0,0
+Guadalupe,218,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,14,12,1,1
+Guadalupe,218,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,24,20,4,0
+Guadalupe,219,"Justice, Supreme Court, Place 2",,,Under Votes,2,2,0,0
+Guadalupe,219,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,27,22,5,0
+Guadalupe,219,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,22,17,4,1
+Guadalupe,220,"Justice, Supreme Court, Place 2",,,Under Votes,2,2,0,0
+Guadalupe,220,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,19,13,6,0
+Guadalupe,220,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,22,16,4,2
+Guadalupe,221,"Justice, Supreme Court, Place 2",,,Under Votes,0,0,0,0
+Guadalupe,221,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,11,8,3,0
+Guadalupe,221,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,5,1,1,3
+Guadalupe,222,"Justice, Supreme Court, Place 2",,,Under Votes,0,0,0,0
+Guadalupe,222,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,0,0,0,0
+Guadalupe,222,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,0,0,0,0
+Guadalupe,223,"Justice, Supreme Court, Place 2",,,Under Votes,3,2,1,0
+Guadalupe,223,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,76,46,26,4
+Guadalupe,223,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,80,62,11,7
+Guadalupe,224,"Justice, Supreme Court, Place 2",,,Under Votes,1,1,0,0
+Guadalupe,224,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,10,3,7,0
+Guadalupe,224,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,49,23,19,7
+Guadalupe,225,"Justice, Supreme Court, Place 2",,,Under Votes,2,1,1,0
+Guadalupe,225,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,0,0,0,0
+Guadalupe,225,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,9,7,2,0
+Guadalupe,226,"Justice, Supreme Court, Place 2",,,Under Votes,4,3,0,1
+Guadalupe,226,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,99,66,31,2
+Guadalupe,226,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,57,30,24,3
+Guadalupe,301,"Justice, Supreme Court, Place 2",,,Under Votes,33,16,16,1
+Guadalupe,301,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1012,634,323,55
+Guadalupe,301,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,699,481,196,22
+Guadalupe,302,"Justice, Supreme Court, Place 2",,,Under Votes,53,30,19,4
+Guadalupe,302,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1252,856,348,48
+Guadalupe,302,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,1019,663,304,52
+Guadalupe,303,"Justice, Supreme Court, Place 2",,,Under Votes,14,9,4,1
+Guadalupe,303,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,525,403,93,29
+Guadalupe,303,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,269,192,56,21
+Guadalupe,304,"Justice, Supreme Court, Place 2",,,Under Votes,40,23,15,2
+Guadalupe,304,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1438,1105,262,71
+Guadalupe,304,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,858,647,155,56
+Guadalupe,305,"Justice, Supreme Court, Place 2",,,Under Votes,64,37,20,7
+Guadalupe,305,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1357,957,344,56
+Guadalupe,305,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,989,687,230,72
+Guadalupe,306,"Justice, Supreme Court, Place 2",,,Under Votes,32,20,10,2
+Guadalupe,306,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1485,1178,246,61
+Guadalupe,306,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,894,692,141,61
+Guadalupe,307,"Justice, Supreme Court, Place 2",,,Under Votes,42,31,10,1
+Guadalupe,307,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1446,1121,265,60
+Guadalupe,307,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,1051,805,202,44
+Guadalupe,308,"Justice, Supreme Court, Place 2",,,Under Votes,28,18,6,4
+Guadalupe,308,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,821,634,138,49
+Guadalupe,308,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,433,304,92,37
+Guadalupe,401,"Justice, Supreme Court, Place 2",,,Under Votes,18,5,12,1
+Guadalupe,401,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,649,369,239,41
+Guadalupe,401,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,207,124,71,12
+Guadalupe,402,"Justice, Supreme Court, Place 2",,,Under Votes,18,12,3,3
+Guadalupe,402,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,525,366,120,39
+Guadalupe,402,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,372,219,110,43
+Guadalupe,403,"Justice, Supreme Court, Place 2",,,Under Votes,40,24,14,2
+Guadalupe,403,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,759,520,178,61
+Guadalupe,403,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,521,314,134,73
+Guadalupe,404,"Justice, Supreme Court, Place 2",,,Under Votes,42,18,20,4
+Guadalupe,404,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,960,577,308,75
+Guadalupe,404,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,665,411,205,49
+Guadalupe,405,"Justice, Supreme Court, Place 2",,,Under Votes,22,14,8,0
+Guadalupe,405,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,896,529,332,35
+Guadalupe,405,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,197,120,67,10
+Guadalupe,406,"Justice, Supreme Court, Place 2",,,Under Votes,34,23,8,3
+Guadalupe,406,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1002,757,207,38
+Guadalupe,406,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,184,123,46,15
+Guadalupe,407,"Justice, Supreme Court, Place 2",,,Under Votes,32,21,9,2
+Guadalupe,407,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,850,615,195,40
+Guadalupe,407,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,202,119,62,21
+Guadalupe,408,"Justice, Supreme Court, Place 2",,,Under Votes,54,22,27,5
+Guadalupe,408,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1578,1035,413,130
+Guadalupe,408,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,720,473,202,45
+Guadalupe,409,"Justice, Supreme Court, Place 2",,,Under Votes,46,23,19,4
+Guadalupe,409,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1232,885,299,48
+Guadalupe,409,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,1360,994,309,57
+Guadalupe,410,"Justice, Supreme Court, Place 2",,,Under Votes,2,1,1,0
+Guadalupe,410,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,55,44,11,0
+Guadalupe,410,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,26,20,6,0
+Guadalupe,411,"Justice, Supreme Court, Place 2",,,Under Votes,47,30,12,5
+Guadalupe,411,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1190,859,280,51
+Guadalupe,411,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,761,570,147,44
+Guadalupe,101,"Justice, Supreme Court, Place 4",,,Under Votes,12,6,3,3
+Guadalupe,101,"Justice, Supreme Court, Place 4",,REP,John Devine,265,177,71,17
+Guadalupe,101,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,92,61,23,8
+Guadalupe,102,"Justice, Supreme Court, Place 4",,,Under Votes,20,13,6,1
+Guadalupe,102,"Justice, Supreme Court, Place 4",,REP,John Devine,414,310,66,38
+Guadalupe,102,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,164,99,50,15
+Guadalupe,103,"Justice, Supreme Court, Place 4",,,Under Votes,11,9,2,0
+Guadalupe,103,"Justice, Supreme Court, Place 4",,REP,John Devine,328,240,68,20
+Guadalupe,103,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,120,75,35,10
+Guadalupe,104,"Justice, Supreme Court, Place 4",,,Under Votes,22,17,4,1
+Guadalupe,104,"Justice, Supreme Court, Place 4",,REP,John Devine,294,212,63,19
+Guadalupe,104,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,204,121,64,19
+Guadalupe,105,"Justice, Supreme Court, Place 4",,,Under Votes,30,18,9,3
+Guadalupe,105,"Justice, Supreme Court, Place 4",,REP,John Devine,1171,709,389,73
+Guadalupe,105,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,313,179,106,28
+Guadalupe,106,"Justice, Supreme Court, Place 4",,,Under Votes,50,35,10,5
+Guadalupe,106,"Justice, Supreme Court, Place 4",,REP,John Devine,1333,974,244,115
+Guadalupe,106,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,522,358,123,41
+Guadalupe,107,"Justice, Supreme Court, Place 4",,,Under Votes,16,5,10,1
+Guadalupe,107,"Justice, Supreme Court, Place 4",,REP,John Devine,562,307,227,28
+Guadalupe,107,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,130,76,50,4
+Guadalupe,108,"Justice, Supreme Court, Place 4",,,Under Votes,5,0,5,0
+Guadalupe,108,"Justice, Supreme Court, Place 4",,REP,John Devine,270,102,140,28
+Guadalupe,108,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,156,66,73,17
+Guadalupe,109,"Justice, Supreme Court, Place 4",,,Under Votes,8,3,4,1
+Guadalupe,109,"Justice, Supreme Court, Place 4",,REP,John Devine,254,125,120,9
+Guadalupe,109,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,50,24,24,2
+Guadalupe,110,"Justice, Supreme Court, Place 4",,,Under Votes,6,3,2,1
+Guadalupe,110,"Justice, Supreme Court, Place 4",,REP,John Devine,86,70,14,2
+Guadalupe,110,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,59,44,10,5
+Guadalupe,111,"Justice, Supreme Court, Place 4",,,Under Votes,4,1,2,1
+Guadalupe,111,"Justice, Supreme Court, Place 4",,REP,John Devine,33,21,6,6
+Guadalupe,111,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,27,12,8,7
+Guadalupe,112,"Justice, Supreme Court, Place 4",,,Under Votes,17,7,9,1
+Guadalupe,112,"Justice, Supreme Court, Place 4",,REP,John Devine,69,26,43,0
+Guadalupe,112,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,140,52,88,0
+Guadalupe,113,"Justice, Supreme Court, Place 4",,,Under Votes,9,8,1,0
+Guadalupe,113,"Justice, Supreme Court, Place 4",,REP,John Devine,396,281,96,19
+Guadalupe,113,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,179,115,55,9
+Guadalupe,114,"Justice, Supreme Court, Place 4",,,Under Votes,10,7,1,2
+Guadalupe,114,"Justice, Supreme Court, Place 4",,REP,John Devine,289,209,64,16
+Guadalupe,114,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,152,100,44,8
+Guadalupe,115,"Justice, Supreme Court, Place 4",,,Under Votes,5,1,3,1
+Guadalupe,115,"Justice, Supreme Court, Place 4",,REP,John Devine,146,107,38,1
+Guadalupe,115,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,25,18,5,2
+Guadalupe,116,"Justice, Supreme Court, Place 4",,,Under Votes,40,15,20,5
+Guadalupe,116,"Justice, Supreme Court, Place 4",,REP,John Devine,994,671,262,61
+Guadalupe,116,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,307,160,124,23
+Guadalupe,117,"Justice, Supreme Court, Place 4",,,Under Votes,55,34,18,3
+Guadalupe,117,"Justice, Supreme Court, Place 4",,REP,John Devine,1797,1324,393,80
+Guadalupe,117,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,686,471,171,44
+Guadalupe,118,"Justice, Supreme Court, Place 4",,,Under Votes,0,0,0,0
+Guadalupe,118,"Justice, Supreme Court, Place 4",,REP,John Devine,24,18,6,0
+Guadalupe,118,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,19,11,7,1
+Guadalupe,119,"Justice, Supreme Court, Place 4",,,Under Votes,20,12,7,1
+Guadalupe,119,"Justice, Supreme Court, Place 4",,REP,John Devine,840,643,154,43
+Guadalupe,119,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,240,171,55,14
+Guadalupe,120,"Justice, Supreme Court, Place 4",,,Under Votes,23,13,10,0
+Guadalupe,120,"Justice, Supreme Court, Place 4",,REP,John Devine,549,380,123,46
+Guadalupe,120,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,148,100,31,17
+Guadalupe,121,"Justice, Supreme Court, Place 4",,,Under Votes,8,5,3,0
+Guadalupe,121,"Justice, Supreme Court, Place 4",,REP,John Devine,61,53,6,2
+Guadalupe,121,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,25,21,2,2
+Guadalupe,122,"Justice, Supreme Court, Place 4",,,Under Votes,0,0,0,0
+Guadalupe,122,"Justice, Supreme Court, Place 4",,REP,John Devine,20,16,1,3
+Guadalupe,122,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,7,1,0,6
+Guadalupe,123,"Justice, Supreme Court, Place 4",,,Under Votes,0,0,0,0
+Guadalupe,123,"Justice, Supreme Court, Place 4",,REP,John Devine,0,0,0,0
+Guadalupe,123,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,1,0,0,1
+Guadalupe,124,"Justice, Supreme Court, Place 4",,,Under Votes,1,1,0,0
+Guadalupe,124,"Justice, Supreme Court, Place 4",,REP,John Devine,1,1,0,0
+Guadalupe,124,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,0,0,0,0
+Guadalupe,125,"Justice, Supreme Court, Place 4",,,Under Votes,2,1,1,0
+Guadalupe,125,"Justice, Supreme Court, Place 4",,REP,John Devine,88,66,11,11
+Guadalupe,125,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,19,12,6,1
+Guadalupe,126,"Justice, Supreme Court, Place 4",,,Under Votes,0,0,0,0
+Guadalupe,126,"Justice, Supreme Court, Place 4",,REP,John Devine,12,4,7,1
+Guadalupe,126,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,2,2,0,0
+Guadalupe,127,"Justice, Supreme Court, Place 4",,,Under Votes,1,0,1,0
+Guadalupe,127,"Justice, Supreme Court, Place 4",,REP,John Devine,9,3,5,1
+Guadalupe,127,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,5,1,4,0
+Guadalupe,201,"Justice, Supreme Court, Place 4",,,Under Votes,4,1,3,0
+Guadalupe,201,"Justice, Supreme Court, Place 4",,REP,John Devine,119,81,29,9
+Guadalupe,201,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,89,57,23,9
+Guadalupe,202,"Justice, Supreme Court, Place 4",,,Under Votes,27,10,15,2
+Guadalupe,202,"Justice, Supreme Court, Place 4",,REP,John Devine,132,83,41,8
+Guadalupe,202,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,304,162,107,35
+Guadalupe,203,"Justice, Supreme Court, Place 4",,,Under Votes,7,3,4,0
+Guadalupe,203,"Justice, Supreme Court, Place 4",,REP,John Devine,47,28,15,4
+Guadalupe,203,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,126,54,62,10
+Guadalupe,204,"Justice, Supreme Court, Place 4",,,Under Votes,20,6,13,1
+Guadalupe,204,"Justice, Supreme Court, Place 4",,REP,John Devine,252,147,98,7
+Guadalupe,204,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,356,198,136,22
+Guadalupe,205,"Justice, Supreme Court, Place 4",,,Under Votes,21,13,8,0
+Guadalupe,205,"Justice, Supreme Court, Place 4",,REP,John Devine,482,280,185,17
+Guadalupe,205,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,164,93,65,6
+Guadalupe,206,"Justice, Supreme Court, Place 4",,,Under Votes,30,11,19,0
+Guadalupe,206,"Justice, Supreme Court, Place 4",,REP,John Devine,365,140,208,17
+Guadalupe,206,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,576,184,363,29
+Guadalupe,207,"Justice, Supreme Court, Place 4",,,Under Votes,15,9,4,2
+Guadalupe,207,"Justice, Supreme Court, Place 4",,REP,John Devine,151,104,38,9
+Guadalupe,207,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,242,149,76,17
+Guadalupe,208,"Justice, Supreme Court, Place 4",,,Under Votes,47,38,7,2
+Guadalupe,208,"Justice, Supreme Court, Place 4",,REP,John Devine,1448,1055,312,81
+Guadalupe,208,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,397,271,103,23
+Guadalupe,209,"Justice, Supreme Court, Place 4",,,Under Votes,13,5,8,0
+Guadalupe,209,"Justice, Supreme Court, Place 4",,REP,John Devine,89,50,33,6
+Guadalupe,209,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,220,106,96,18
+Guadalupe,210,"Justice, Supreme Court, Place 4",,,Under Votes,22,9,12,1
+Guadalupe,210,"Justice, Supreme Court, Place 4",,REP,John Devine,261,170,74,17
+Guadalupe,210,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,200,134,48,18
+Guadalupe,211,"Justice, Supreme Court, Place 4",,,Under Votes,0,0,0,0
+Guadalupe,211,"Justice, Supreme Court, Place 4",,REP,John Devine,44,35,8,1
+Guadalupe,211,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,36,29,3,4
+Guadalupe,212,"Justice, Supreme Court, Place 4",,,Under Votes,4,2,1,1
+Guadalupe,212,"Justice, Supreme Court, Place 4",,REP,John Devine,36,30,5,1
+Guadalupe,212,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,46,29,15,2
+Guadalupe,213,"Justice, Supreme Court, Place 4",,,Under Votes,29,17,11,1
+Guadalupe,213,"Justice, Supreme Court, Place 4",,REP,John Devine,849,584,235,30
+Guadalupe,213,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,357,237,103,17
+Guadalupe,214,"Justice, Supreme Court, Place 4",,,Under Votes,3,2,1,0
+Guadalupe,214,"Justice, Supreme Court, Place 4",,REP,John Devine,279,199,71,9
+Guadalupe,214,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,89,54,26,9
+Guadalupe,215,"Justice, Supreme Court, Place 4",,,Under Votes,17,12,4,1
+Guadalupe,215,"Justice, Supreme Court, Place 4",,REP,John Devine,380,252,99,29
+Guadalupe,215,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,145,101,34,10
+Guadalupe,216,"Justice, Supreme Court, Place 4",,,Under Votes,1,0,1,0
+Guadalupe,216,"Justice, Supreme Court, Place 4",,REP,John Devine,28,16,8,4
+Guadalupe,216,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,8,6,2,0
+Guadalupe,217,"Justice, Supreme Court, Place 4",,,Under Votes,0,0,0,0
+Guadalupe,217,"Justice, Supreme Court, Place 4",,REP,John Devine,29,12,14,3
+Guadalupe,217,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,36,10,26,0
+Guadalupe,218,"Justice, Supreme Court, Place 4",,,Under Votes,0,0,0,0
+Guadalupe,218,"Justice, Supreme Court, Place 4",,REP,John Devine,15,13,1,1
+Guadalupe,218,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,23,19,4,0
+Guadalupe,219,"Justice, Supreme Court, Place 4",,,Under Votes,2,2,0,0
+Guadalupe,219,"Justice, Supreme Court, Place 4",,REP,John Devine,27,22,5,0
+Guadalupe,219,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,22,17,4,1
+Guadalupe,220,"Justice, Supreme Court, Place 4",,,Under Votes,2,2,0,0
+Guadalupe,220,"Justice, Supreme Court, Place 4",,REP,John Devine,20,14,6,0
+Guadalupe,220,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,21,15,4,2
+Guadalupe,221,"Justice, Supreme Court, Place 4",,,Under Votes,0,0,0,0
+Guadalupe,221,"Justice, Supreme Court, Place 4",,REP,John Devine,11,8,3,0
+Guadalupe,221,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,5,1,1,3
+Guadalupe,222,"Justice, Supreme Court, Place 4",,,Under Votes,0,0,0,0
+Guadalupe,222,"Justice, Supreme Court, Place 4",,REP,John Devine,0,0,0,0
+Guadalupe,222,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,0,0,0,0
+Guadalupe,223,"Justice, Supreme Court, Place 4",,,Under Votes,3,2,1,0
+Guadalupe,223,"Justice, Supreme Court, Place 4",,REP,John Devine,77,46,26,5
+Guadalupe,223,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,79,62,11,6
+Guadalupe,224,"Justice, Supreme Court, Place 4",,,Under Votes,1,1,0,0
+Guadalupe,224,"Justice, Supreme Court, Place 4",,REP,John Devine,8,2,6,0
+Guadalupe,224,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,51,24,20,7
+Guadalupe,225,"Justice, Supreme Court, Place 4",,,Under Votes,2,1,1,0
+Guadalupe,225,"Justice, Supreme Court, Place 4",,REP,John Devine,1,0,1,0
+Guadalupe,225,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,8,7,1,0
+Guadalupe,226,"Justice, Supreme Court, Place 4",,,Under Votes,4,3,0,1
+Guadalupe,226,"Justice, Supreme Court, Place 4",,REP,John Devine,102,67,32,3
+Guadalupe,226,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,54,29,23,2
+Guadalupe,301,"Justice, Supreme Court, Place 4",,,Under Votes,41,22,18,1
+Guadalupe,301,"Justice, Supreme Court, Place 4",,REP,John Devine,1021,645,323,53
+Guadalupe,301,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,682,464,194,24
+Guadalupe,302,"Justice, Supreme Court, Place 4",,,Under Votes,59,34,20,5
+Guadalupe,302,"Justice, Supreme Court, Place 4",,REP,John Devine,1266,865,353,48
+Guadalupe,302,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,999,650,298,51
+Guadalupe,303,"Justice, Supreme Court, Place 4",,,Under Votes,16,11,4,1
+Guadalupe,303,"Justice, Supreme Court, Place 4",,REP,John Devine,534,409,94,31
+Guadalupe,303,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,258,184,55,19
+Guadalupe,304,"Justice, Supreme Court, Place 4",,,Under Votes,42,26,14,2
+Guadalupe,304,"Justice, Supreme Court, Place 4",,REP,John Devine,1451,1116,265,70
+Guadalupe,304,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,843,633,153,57
+Guadalupe,305,"Justice, Supreme Court, Place 4",,,Under Votes,68,41,19,8
+Guadalupe,305,"Justice, Supreme Court, Place 4",,REP,John Devine,1374,965,350,59
+Guadalupe,305,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,968,675,225,68
+Guadalupe,306,"Justice, Supreme Court, Place 4",,,Under Votes,37,25,10,2
+Guadalupe,306,"Justice, Supreme Court, Place 4",,REP,John Devine,1491,1181,247,63
+Guadalupe,306,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,883,684,140,59
+Guadalupe,307,"Justice, Supreme Court, Place 4",,,Under Votes,47,33,12,2
+Guadalupe,307,"Justice, Supreme Court, Place 4",,REP,John Devine,1457,1132,263,62
+Guadalupe,307,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,1035,792,202,41
+Guadalupe,308,"Justice, Supreme Court, Place 4",,,Under Votes,27,17,6,4
+Guadalupe,308,"Justice, Supreme Court, Place 4",,REP,John Devine,841,647,144,50
+Guadalupe,308,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,414,292,86,36
+Guadalupe,401,"Justice, Supreme Court, Place 4",,,Under Votes,18,5,12,1
+Guadalupe,401,"Justice, Supreme Court, Place 4",,REP,John Devine,660,376,243,41
+Guadalupe,401,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,196,117,67,12
+Guadalupe,402,"Justice, Supreme Court, Place 4",,,Under Votes,18,12,3,3
+Guadalupe,402,"Justice, Supreme Court, Place 4",,REP,John Devine,539,374,124,41
+Guadalupe,402,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,358,211,106,41
+Guadalupe,403,"Justice, Supreme Court, Place 4",,,Under Votes,45,25,17,3
+Guadalupe,403,"Justice, Supreme Court, Place 4",,REP,John Devine,782,539,180,63
+Guadalupe,403,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,493,294,129,70
+Guadalupe,404,"Justice, Supreme Court, Place 4",,,Under Votes,45,20,21,4
+Guadalupe,404,"Justice, Supreme Court, Place 4",,REP,John Devine,969,583,310,76
+Guadalupe,404,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,653,403,202,48
+Guadalupe,405,"Justice, Supreme Court, Place 4",,,Under Votes,26,15,11,0
+Guadalupe,405,"Justice, Supreme Court, Place 4",,REP,John Devine,896,532,330,34
+Guadalupe,405,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,193,116,66,11
+Guadalupe,406,"Justice, Supreme Court, Place 4",,,Under Votes,34,24,8,2
+Guadalupe,406,"Justice, Supreme Court, Place 4",,REP,John Devine,1008,762,207,39
+Guadalupe,406,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,178,117,46,15
+Guadalupe,407,"Justice, Supreme Court, Place 4",,,Under Votes,33,22,9,2
+Guadalupe,407,"Justice, Supreme Court, Place 4",,REP,John Devine,859,616,203,40
+Guadalupe,407,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,192,117,54,21
+Guadalupe,408,"Justice, Supreme Court, Place 4",,,Under Votes,57,23,28,6
+Guadalupe,408,"Justice, Supreme Court, Place 4",,REP,John Devine,1583,1040,411,132
+Guadalupe,408,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,712,467,203,42
+Guadalupe,409,"Justice, Supreme Court, Place 4",,,Under Votes,46,21,21,4
+Guadalupe,409,"Justice, Supreme Court, Place 4",,REP,John Devine,1250,904,296,50
+Guadalupe,409,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,1342,977,310,55
+Guadalupe,410,"Justice, Supreme Court, Place 4",,,Under Votes,3,2,1,0
+Guadalupe,410,"Justice, Supreme Court, Place 4",,REP,John Devine,55,44,11,0
+Guadalupe,410,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,25,19,6,0
+Guadalupe,411,"Justice, Supreme Court, Place 4",,,Under Votes,50,33,12,5
+Guadalupe,411,"Justice, Supreme Court, Place 4",,REP,John Devine,1198,864,280,54
+Guadalupe,411,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,750,562,147,41
+Guadalupe,101,"Justice, Supreme Court, Place 6",,,Under Votes,10,5,2,3
+Guadalupe,101,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,265,176,72,17
+Guadalupe,101,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,94,63,23,8
+Guadalupe,102,"Justice, Supreme Court, Place 6",,,Under Votes,19,13,5,1
+Guadalupe,102,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,410,308,66,36
+Guadalupe,102,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,169,101,51,17
+Guadalupe,103,"Justice, Supreme Court, Place 6",,,Under Votes,11,9,2,0
+Guadalupe,103,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,329,239,69,21
+Guadalupe,103,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,119,76,34,9
+Guadalupe,104,"Justice, Supreme Court, Place 6",,,Under Votes,22,17,4,1
+Guadalupe,104,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,286,208,59,19
+Guadalupe,104,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,212,125,68,19
+Guadalupe,105,"Justice, Supreme Court, Place 6",,,Under Votes,31,19,9,3
+Guadalupe,105,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1169,710,387,72
+Guadalupe,105,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,314,177,108,29
+Guadalupe,106,"Justice, Supreme Court, Place 6",,,Under Votes,46,31,10,5
+Guadalupe,106,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1333,974,242,117
+Guadalupe,106,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,526,362,125,39
+Guadalupe,107,"Justice, Supreme Court, Place 6",,,Under Votes,19,7,11,1
+Guadalupe,107,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,562,308,226,28
+Guadalupe,107,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,127,73,50,4
+Guadalupe,108,"Justice, Supreme Court, Place 6",,,Under Votes,5,0,5,0
+Guadalupe,108,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,271,102,141,28
+Guadalupe,108,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,155,66,72,17
+Guadalupe,109,"Justice, Supreme Court, Place 6",,,Under Votes,8,3,5,0
+Guadalupe,109,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,249,124,116,9
+Guadalupe,109,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,55,25,27,3
+Guadalupe,110,"Justice, Supreme Court, Place 6",,,Under Votes,6,3,2,1
+Guadalupe,110,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,85,69,14,2
+Guadalupe,110,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,60,45,10,5
+Guadalupe,111,"Justice, Supreme Court, Place 6",,,Under Votes,4,1,2,1
+Guadalupe,111,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,33,22,6,5
+Guadalupe,111,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,27,11,8,8
+Guadalupe,112,"Justice, Supreme Court, Place 6",,,Under Votes,18,7,10,1
+Guadalupe,112,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,71,27,44,0
+Guadalupe,112,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,137,51,86,0
+Guadalupe,113,"Justice, Supreme Court, Place 6",,,Under Votes,7,6,1,0
+Guadalupe,113,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,396,281,96,19
+Guadalupe,113,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,181,117,55,9
+Guadalupe,114,"Justice, Supreme Court, Place 6",,,Under Votes,11,6,2,3
+Guadalupe,114,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,289,209,63,17
+Guadalupe,114,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,151,101,44,6
+Guadalupe,115,"Justice, Supreme Court, Place 6",,,Under Votes,5,1,3,1
+Guadalupe,115,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,146,107,38,1
+Guadalupe,115,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,25,18,5,2
+Guadalupe,116,"Justice, Supreme Court, Place 6",,,Under Votes,35,12,19,4
+Guadalupe,116,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,979,661,255,63
+Guadalupe,116,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,327,173,132,22
+Guadalupe,117,"Justice, Supreme Court, Place 6",,,Under Votes,50,31,16,3
+Guadalupe,117,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1793,1327,388,78
+Guadalupe,117,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,695,471,178,46
+Guadalupe,118,"Justice, Supreme Court, Place 6",,,Under Votes,0,0,0,0
+Guadalupe,118,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,25,19,6,0
+Guadalupe,118,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,18,10,7,1
+Guadalupe,119,"Justice, Supreme Court, Place 6",,,Under Votes,19,11,7,1
+Guadalupe,119,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,834,639,153,42
+Guadalupe,119,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,247,176,56,15
+Guadalupe,120,"Justice, Supreme Court, Place 6",,,Under Votes,22,13,9,0
+Guadalupe,120,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,546,378,120,48
+Guadalupe,120,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,152,102,35,15
+Guadalupe,121,"Justice, Supreme Court, Place 6",,,Under Votes,10,7,3,0
+Guadalupe,121,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,59,51,6,2
+Guadalupe,121,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,25,21,2,2
+Guadalupe,122,"Justice, Supreme Court, Place 6",,,Under Votes,0,0,0,0
+Guadalupe,122,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,20,16,1,3
+Guadalupe,122,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,7,1,0,6
+Guadalupe,123,"Justice, Supreme Court, Place 6",,,Under Votes,0,0,0,0
+Guadalupe,123,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,0,0,0,0
+Guadalupe,123,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,1,0,0,1
+Guadalupe,124,"Justice, Supreme Court, Place 6",,,Under Votes,0,0,0,0
+Guadalupe,124,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,2,2,0,0
+Guadalupe,124,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,0,0,0,0
+Guadalupe,125,"Justice, Supreme Court, Place 6",,,Under Votes,2,1,1,0
+Guadalupe,125,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,88,66,11,11
+Guadalupe,125,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,19,12,6,1
+Guadalupe,126,"Justice, Supreme Court, Place 6",,,Under Votes,0,0,0,0
+Guadalupe,126,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,12,4,7,1
+Guadalupe,126,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,2,2,0,0
+Guadalupe,127,"Justice, Supreme Court, Place 6",,,Under Votes,1,0,1,0
+Guadalupe,127,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,9,3,5,1
+Guadalupe,127,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,5,1,4,0
+Guadalupe,201,"Justice, Supreme Court, Place 6",,,Under Votes,4,1,2,1
+Guadalupe,201,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,119,82,28,9
+Guadalupe,201,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,89,56,25,8
+Guadalupe,202,"Justice, Supreme Court, Place 6",,,Under Votes,24,8,14,2
+Guadalupe,202,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,133,84,39,10
+Guadalupe,202,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,306,163,110,33
+Guadalupe,203,"Justice, Supreme Court, Place 6",,,Under Votes,8,4,4,0
+Guadalupe,203,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,45,26,15,4
+Guadalupe,203,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,127,55,62,10
+Guadalupe,204,"Justice, Supreme Court, Place 6",,,Under Votes,17,6,11,0
+Guadalupe,204,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,257,144,104,9
+Guadalupe,204,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,354,201,132,21
+Guadalupe,205,"Justice, Supreme Court, Place 6",,,Under Votes,20,12,8,0
+Guadalupe,205,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,482,281,185,16
+Guadalupe,205,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,165,93,65,7
+Guadalupe,206,"Justice, Supreme Court, Place 6",,,Under Votes,28,11,17,0
+Guadalupe,206,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,367,141,209,17
+Guadalupe,206,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,576,183,364,29
+Guadalupe,207,"Justice, Supreme Court, Place 6",,,Under Votes,14,8,4,2
+Guadalupe,207,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,159,106,43,10
+Guadalupe,207,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,235,148,71,16
+Guadalupe,208,"Justice, Supreme Court, Place 6",,,Under Votes,45,36,7,2
+Guadalupe,208,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1442,1051,311,80
+Guadalupe,208,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,405,277,104,24
+Guadalupe,209,"Justice, Supreme Court, Place 6",,,Under Votes,14,6,8,0
+Guadalupe,209,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,85,46,33,6
+Guadalupe,209,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,223,109,96,18
+Guadalupe,210,"Justice, Supreme Court, Place 6",,,Under Votes,22,10,11,1
+Guadalupe,210,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,261,171,73,17
+Guadalupe,210,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,200,132,50,18
+Guadalupe,211,"Justice, Supreme Court, Place 6",,,Under Votes,0,0,0,0
+Guadalupe,211,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,42,33,8,1
+Guadalupe,211,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,38,31,3,4
+Guadalupe,212,"Justice, Supreme Court, Place 6",,,Under Votes,3,2,0,1
+Guadalupe,212,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,35,30,5,0
+Guadalupe,212,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,48,29,16,3
+Guadalupe,213,"Justice, Supreme Court, Place 6",,,Under Votes,31,17,13,1
+Guadalupe,213,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,843,580,233,30
+Guadalupe,213,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,361,241,103,17
+Guadalupe,214,"Justice, Supreme Court, Place 6",,,Under Votes,6,4,2,0
+Guadalupe,214,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,277,198,70,9
+Guadalupe,214,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,88,53,26,9
+Guadalupe,215,"Justice, Supreme Court, Place 6",,,Under Votes,16,11,4,1
+Guadalupe,215,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,380,255,97,28
+Guadalupe,215,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,146,99,36,11
+Guadalupe,216,"Justice, Supreme Court, Place 6",,,Under Votes,1,0,1,0
+Guadalupe,216,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,28,16,8,4
+Guadalupe,216,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,8,6,2,0
+Guadalupe,217,"Justice, Supreme Court, Place 6",,,Under Votes,0,0,0,0
+Guadalupe,217,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,29,12,14,3
+Guadalupe,217,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,36,10,26,0
+Guadalupe,218,"Justice, Supreme Court, Place 6",,,Under Votes,0,0,0,0
+Guadalupe,218,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,15,13,1,1
+Guadalupe,218,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,23,19,4,0
+Guadalupe,219,"Justice, Supreme Court, Place 6",,,Under Votes,2,2,0,0
+Guadalupe,219,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,26,21,5,0
+Guadalupe,219,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,23,18,4,1
+Guadalupe,220,"Justice, Supreme Court, Place 6",,,Under Votes,1,1,0,0
+Guadalupe,220,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,20,15,5,0
+Guadalupe,220,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,22,15,5,2
+Guadalupe,221,"Justice, Supreme Court, Place 6",,,Under Votes,0,0,0,0
+Guadalupe,221,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,11,8,3,0
+Guadalupe,221,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,5,1,1,3
+Guadalupe,222,"Justice, Supreme Court, Place 6",,,Under Votes,0,0,0,0
+Guadalupe,222,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,0,0,0,0
+Guadalupe,222,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,0,0,0,0
+Guadalupe,223,"Justice, Supreme Court, Place 6",,,Under Votes,3,2,1,0
+Guadalupe,223,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,79,48,26,5
+Guadalupe,223,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,77,60,11,6
+Guadalupe,224,"Justice, Supreme Court, Place 6",,,Under Votes,1,1,0,0
+Guadalupe,224,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,9,2,7,0
+Guadalupe,224,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,50,24,19,7
+Guadalupe,225,"Justice, Supreme Court, Place 6",,,Under Votes,2,1,1,0
+Guadalupe,225,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,0,0,0,0
+Guadalupe,225,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,9,7,2,0
+Guadalupe,226,"Justice, Supreme Court, Place 6",,,Under Votes,4,3,0,1
+Guadalupe,226,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,101,67,31,3
+Guadalupe,226,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,55,29,24,2
+Guadalupe,301,"Justice, Supreme Court, Place 6",,,Under Votes,35,18,16,1
+Guadalupe,301,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1024,646,321,57
+Guadalupe,301,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,685,467,198,20
+Guadalupe,302,"Justice, Supreme Court, Place 6",,,Under Votes,53,32,18,3
+Guadalupe,302,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1257,859,349,49
+Guadalupe,302,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,1014,658,304,52
+Guadalupe,303,"Justice, Supreme Court, Place 6",,,Under Votes,14,9,4,1
+Guadalupe,303,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,519,403,89,27
+Guadalupe,303,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,275,192,60,23
+Guadalupe,304,"Justice, Supreme Court, Place 6",,,Under Votes,41,23,16,2
+Guadalupe,304,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1436,1102,265,69
+Guadalupe,304,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,859,650,151,58
+Guadalupe,305,"Justice, Supreme Court, Place 6",,,Under Votes,62,39,16,7
+Guadalupe,305,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1357,945,350,62
+Guadalupe,305,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,991,697,228,66
+Guadalupe,306,"Justice, Supreme Court, Place 6",,,Under Votes,30,20,8,2
+Guadalupe,306,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1476,1166,248,62
+Guadalupe,306,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,905,704,141,60
+Guadalupe,307,"Justice, Supreme Court, Place 6",,,Under Votes,41,28,11,2
+Guadalupe,307,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1443,1127,256,60
+Guadalupe,307,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,1055,802,210,43
+Guadalupe,308,"Justice, Supreme Court, Place 6",,,Under Votes,26,16,6,4
+Guadalupe,308,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,829,639,142,48
+Guadalupe,308,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,427,301,88,38
+Guadalupe,401,"Justice, Supreme Court, Place 6",,,Under Votes,18,5,12,1
+Guadalupe,401,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,656,374,241,41
+Guadalupe,401,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,200,119,69,12
+Guadalupe,402,"Justice, Supreme Court, Place 6",,,Under Votes,20,14,3,3
+Guadalupe,402,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,529,368,121,40
+Guadalupe,402,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,366,215,109,42
+Guadalupe,403,"Justice, Supreme Court, Place 6",,,Under Votes,41,24,15,2
+Guadalupe,403,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,767,525,179,63
+Guadalupe,403,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,512,309,132,71
+Guadalupe,404,"Justice, Supreme Court, Place 6",,,Under Votes,41,17,21,3
+Guadalupe,404,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,958,576,306,76
+Guadalupe,404,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,668,413,206,49
+Guadalupe,405,"Justice, Supreme Court, Place 6",,,Under Votes,27,18,9,0
+Guadalupe,405,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,890,529,328,33
+Guadalupe,405,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,198,116,70,12
+Guadalupe,406,"Justice, Supreme Court, Place 6",,,Under Votes,36,25,8,3
+Guadalupe,406,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1012,764,210,38
+Guadalupe,406,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,172,114,43,15
+Guadalupe,407,"Justice, Supreme Court, Place 6",,,Under Votes,33,22,9,2
+Guadalupe,407,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,852,611,201,40
+Guadalupe,407,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,199,122,56,21
+Guadalupe,408,"Justice, Supreme Court, Place 6",,,Under Votes,54,21,27,6
+Guadalupe,408,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1584,1044,410,130
+Guadalupe,408,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,714,465,205,44
+Guadalupe,409,"Justice, Supreme Court, Place 6",,,Under Votes,45,22,19,4
+Guadalupe,409,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1229,885,294,50
+Guadalupe,409,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,1364,995,314,55
+Guadalupe,410,"Justice, Supreme Court, Place 6",,,Under Votes,2,1,1,0
+Guadalupe,410,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,58,46,12,0
+Guadalupe,410,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,23,18,5,0
+Guadalupe,411,"Justice, Supreme Court, Place 6",,,Under Votes,50,34,12,4
+Guadalupe,411,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1195,862,281,52
+Guadalupe,411,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,753,563,146,44
+Guadalupe,101,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,9,4,2,3
+Guadalupe,101,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,260,173,70,17
+Guadalupe,101,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,91,61,22,8
+Guadalupe,101,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,9,6,3,0
+Guadalupe,102,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,15,11,3,1
+Guadalupe,102,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,414,309,69,36
+Guadalupe,102,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,157,97,44,16
+Guadalupe,102,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,12,5,6,1
+Guadalupe,103,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,10,8,2,0
+Guadalupe,103,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,320,237,64,19
+Guadalupe,103,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,117,75,32,10
+Guadalupe,103,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,12,4,7,1
+Guadalupe,104,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,21,16,4,1
+Guadalupe,104,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,275,200,57,18
+Guadalupe,104,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,205,120,65,20
+Guadalupe,104,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,19,14,5,0
+Guadalupe,105,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,26,18,6,2
+Guadalupe,105,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1143,689,380,74
+Guadalupe,105,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,311,182,102,27
+Guadalupe,105,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,34,17,16,1
+Guadalupe,106,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,46,31,10,5
+Guadalupe,106,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1303,952,235,116
+Guadalupe,106,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,519,361,119,39
+Guadalupe,106,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,37,23,13,1
+Guadalupe,107,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,14,5,9,0
+Guadalupe,107,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,558,309,220,29
+Guadalupe,107,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,121,70,47,4
+Guadalupe,107,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,15,4,11,0
+Guadalupe,108,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,5,0,5,0
+Guadalupe,108,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,267,101,137,29
+Guadalupe,108,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,150,65,70,15
+Guadalupe,108,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,9,2,6,1
+Guadalupe,109,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,7,3,4,0
+Guadalupe,109,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,248,124,115,9
+Guadalupe,109,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,48,20,25,3
+Guadalupe,109,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,9,5,4,0
+Guadalupe,110,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,6,3,2,1
+Guadalupe,110,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,83,67,14,2
+Guadalupe,110,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,59,44,10,5
+Guadalupe,110,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,3,3,0,0
+Guadalupe,111,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,4,1,2,1
+Guadalupe,111,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,32,20,6,6
+Guadalupe,111,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,26,11,8,7
+Guadalupe,111,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,2,2,0,0
+Guadalupe,112,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,19,7,11,1
+Guadalupe,112,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,65,26,39,0
+Guadalupe,112,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,136,51,85,0
+Guadalupe,112,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,6,1,5,0
+Guadalupe,113,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,5,4,1,0
+Guadalupe,113,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,384,276,90,18
+Guadalupe,113,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,172,110,53,9
+Guadalupe,113,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,23,14,8,1
+Guadalupe,114,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,8,5,1,2
+Guadalupe,114,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,285,206,62,17
+Guadalupe,114,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,148,97,44,7
+Guadalupe,114,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,10,8,2,0
+Guadalupe,115,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,4,2,1,1
+Guadalupe,115,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,148,107,40,1
+Guadalupe,115,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,22,17,3,2
+Guadalupe,115,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,2,0,2,0
+Guadalupe,116,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,33,12,17,4
+Guadalupe,116,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,975,658,256,61
+Guadalupe,116,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,311,165,124,22
+Guadalupe,116,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,22,11,9,2
+Guadalupe,117,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,58,40,15,3
+Guadalupe,117,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1747,1288,379,80
+Guadalupe,117,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,665,453,168,44
+Guadalupe,117,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,68,48,20,0
+Guadalupe,118,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,0,0,0,0
+Guadalupe,118,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,23,17,6,0
+Guadalupe,118,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,19,11,7,1
+Guadalupe,118,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,1,1,0,0
+Guadalupe,119,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,21,14,6,1
+Guadalupe,119,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,815,624,149,42
+Guadalupe,119,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,232,170,47,15
+Guadalupe,119,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,32,18,14,0
+Guadalupe,120,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,20,12,8,0
+Guadalupe,120,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,542,375,119,48
+Guadalupe,120,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,140,92,33,15
+Guadalupe,120,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,18,14,4,0
+Guadalupe,121,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,8,5,3,0
+Guadalupe,121,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,59,51,6,2
+Guadalupe,121,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,25,21,2,2
+Guadalupe,121,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,2,2,0,0
+Guadalupe,122,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,0,0,0,0
+Guadalupe,122,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,20,16,1,3
+Guadalupe,122,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,7,1,0,6
+Guadalupe,122,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,0,0,0,0
+Guadalupe,123,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,0,0,0,0
+Guadalupe,123,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,0,0,0,0
+Guadalupe,123,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,1,0,0,1
+Guadalupe,123,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,0,0,0,0
+Guadalupe,124,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,1,1,0,0
+Guadalupe,124,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,0,0,0,0
+Guadalupe,124,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,1,1,0,0
+Guadalupe,124,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,0,0,0,0
+Guadalupe,125,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,2,1,1,0
+Guadalupe,125,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,87,65,11,11
+Guadalupe,125,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,19,13,5,1
+Guadalupe,125,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,1,0,1,0
+Guadalupe,126,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,0,0,0,0
+Guadalupe,126,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,11,3,7,1
+Guadalupe,126,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,2,2,0,0
+Guadalupe,126,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,1,1,0,0
+Guadalupe,127,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,0,0,0,0
+Guadalupe,127,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,8,4,4,0
+Guadalupe,127,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,6,0,5,1
+Guadalupe,127,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,1,0,1,0
+Guadalupe,201,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,3,1,2,0
+Guadalupe,201,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,115,80,27,8
+Guadalupe,201,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,89,56,25,8
+Guadalupe,201,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,5,2,1,2
+Guadalupe,202,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,23,8,13,2
+Guadalupe,202,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,123,79,36,8
+Guadalupe,202,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,299,157,108,34
+Guadalupe,202,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,18,11,6,1
+Guadalupe,203,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,9,5,4,0
+Guadalupe,203,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,45,26,15,4
+Guadalupe,203,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,124,52,62,10
+Guadalupe,203,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,2,2,0,0
+Guadalupe,204,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,14,6,8,0
+Guadalupe,204,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,242,142,94,6
+Guadalupe,204,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,356,200,134,22
+Guadalupe,204,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,16,3,11,2
+Guadalupe,205,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,23,15,8,0
+Guadalupe,205,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,473,275,183,15
+Guadalupe,205,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,156,91,58,7
+Guadalupe,205,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,15,5,9,1
+Guadalupe,206,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,23,9,14,0
+Guadalupe,206,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,347,136,194,17
+Guadalupe,206,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,569,177,363,29
+Guadalupe,206,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,32,13,19,0
+Guadalupe,207,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,12,6,4,2
+Guadalupe,207,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,148,102,38,8
+Guadalupe,207,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,236,146,74,16
+Guadalupe,207,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,12,8,2,2
+Guadalupe,208,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,45,37,7,1
+Guadalupe,208,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1415,1032,303,80
+Guadalupe,208,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,387,267,96,24
+Guadalupe,208,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,45,28,16,1
+Guadalupe,209,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,12,4,8,0
+Guadalupe,209,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,83,46,32,5
+Guadalupe,209,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,221,108,95,18
+Guadalupe,209,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,6,3,2,1
+Guadalupe,210,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,21,10,10,1
+Guadalupe,210,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,252,164,72,16
+Guadalupe,210,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,194,127,49,18
+Guadalupe,210,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,16,12,3,1
+Guadalupe,211,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,0,0,0,0
+Guadalupe,211,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,41,32,8,1
+Guadalupe,211,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,35,28,3,4
+Guadalupe,211,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,4,4,0,0
+Guadalupe,212,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,4,2,1,1
+Guadalupe,212,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,34,29,5,0
+Guadalupe,212,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,47,29,15,3
+Guadalupe,212,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,1,1,0,0
+Guadalupe,213,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,22,13,8,1
+Guadalupe,213,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,827,569,231,27
+Guadalupe,213,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,341,226,97,18
+Guadalupe,213,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,45,30,13,2
+Guadalupe,214,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,4,3,1,0
+Guadalupe,214,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,267,191,68,8
+Guadalupe,214,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,87,52,26,9
+Guadalupe,214,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,13,9,3,1
+Guadalupe,215,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,16,11,4,1
+Guadalupe,215,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,372,249,95,28
+Guadalupe,215,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,139,96,33,10
+Guadalupe,215,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,15,9,5,1
+Guadalupe,216,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,1,0,1,0
+Guadalupe,216,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,28,16,8,4
+Guadalupe,216,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,6,5,1,0
+Guadalupe,216,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,2,1,1,0
+Guadalupe,217,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,0,0,0,0
+Guadalupe,217,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,30,12,15,3
+Guadalupe,217,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,34,9,25,0
+Guadalupe,217,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,1,1,0,0
+Guadalupe,218,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,0,0,0,0
+Guadalupe,218,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,14,12,1,1
+Guadalupe,218,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,23,19,4,0
+Guadalupe,218,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,1,1,0,0
+Guadalupe,219,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,1,1,0,0
+Guadalupe,219,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,28,23,5,0
+Guadalupe,219,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,20,16,4,0
+Guadalupe,219,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,2,1,0,1
+Guadalupe,220,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,3,2,1,0
+Guadalupe,220,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,19,14,5,0
+Guadalupe,220,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,21,15,4,2
+Guadalupe,220,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,0,0,0,0
+Guadalupe,221,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,0,0,0,0
+Guadalupe,221,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,11,8,3,0
+Guadalupe,221,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,5,1,1,3
+Guadalupe,221,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,0,0,0,0
+Guadalupe,222,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,0,0,0,0
+Guadalupe,222,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,0,0,0,0
+Guadalupe,222,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,0,0,0,0
+Guadalupe,222,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,0,0,0,0
+Guadalupe,223,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,2,2,0,0
+Guadalupe,223,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,75,43,27,5
+Guadalupe,223,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,74,59,9,6
+Guadalupe,223,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,8,6,2,0
+Guadalupe,224,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,1,1,0,0
+Guadalupe,224,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,11,3,7,1
+Guadalupe,224,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,47,22,19,6
+Guadalupe,224,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,1,1,0,0
+Guadalupe,225,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,2,1,1,0
+Guadalupe,225,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1,0,1,0
+Guadalupe,225,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,8,7,1,0
+Guadalupe,225,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,0,0,0,0
+Guadalupe,226,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,4,3,0,1
+Guadalupe,226,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,100,65,32,3
+Guadalupe,226,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,52,27,23,2
+Guadalupe,226,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,4,4,0,0
+Guadalupe,301,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,30,16,13,1
+Guadalupe,301,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,986,618,313,55
+Guadalupe,301,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,682,466,194,22
+Guadalupe,301,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,46,31,15,0
+Guadalupe,302,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,48,29,17,2
+Guadalupe,302,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1223,838,337,48
+Guadalupe,302,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,977,638,288,51
+Guadalupe,302,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,76,44,29,3
+Guadalupe,303,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,13,8,4,1
+Guadalupe,303,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,512,398,86,28
+Guadalupe,303,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,260,185,54,21
+Guadalupe,303,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,23,13,9,1
+Guadalupe,304,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,36,20,14,2
+Guadalupe,304,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1390,1074,247,69
+Guadalupe,304,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,850,642,155,53
+Guadalupe,304,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,60,39,16,5
+Guadalupe,305,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,61,38,14,9
+Guadalupe,305,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1318,927,335,56
+Guadalupe,305,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,965,675,221,69
+Guadalupe,305,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,66,41,24,1
+Guadalupe,306,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,32,23,7,2
+Guadalupe,306,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1447,1151,233,63
+Guadalupe,306,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,874,682,136,56
+Guadalupe,306,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,58,34,21,3
+Guadalupe,307,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,42,30,10,2
+Guadalupe,307,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1423,1116,248,59
+Guadalupe,307,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,1010,774,195,41
+Guadalupe,307,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,64,37,24,3
+Guadalupe,308,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,22,12,6,4
+Guadalupe,308,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,811,627,137,47
+Guadalupe,308,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,406,282,87,37
+Guadalupe,308,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,43,35,6,2
+Guadalupe,401,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,17,3,12,2
+Guadalupe,401,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,640,364,237,39
+Guadalupe,401,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,193,116,65,12
+Guadalupe,401,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,24,15,8,1
+Guadalupe,402,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,14,9,2,3
+Guadalupe,402,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,524,364,119,41
+Guadalupe,402,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,347,209,100,38
+Guadalupe,402,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,30,15,12,3
+Guadalupe,403,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,29,18,9,2
+Guadalupe,403,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,753,520,173,60
+Guadalupe,403,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,491,296,122,73
+Guadalupe,403,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,47,24,22,1
+Guadalupe,404,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,38,15,19,4
+Guadalupe,404,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,931,570,287,74
+Guadalupe,404,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,646,394,203,49
+Guadalupe,404,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,52,27,24,1
+Guadalupe,405,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,25,16,9,0
+Guadalupe,405,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,880,523,324,33
+Guadalupe,405,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,188,111,67,10
+Guadalupe,405,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,22,13,7,2
+Guadalupe,406,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,36,23,10,3
+Guadalupe,406,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,987,747,204,36
+Guadalupe,406,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,172,117,42,13
+Guadalupe,406,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,25,16,5,4
+Guadalupe,407,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,28,18,9,1
+Guadalupe,407,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,841,606,196,39
+Guadalupe,407,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,194,119,55,20
+Guadalupe,407,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,21,12,6,3
+Guadalupe,408,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,51,20,25,6
+Guadalupe,408,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1551,1028,396,127
+Guadalupe,408,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,684,449,195,40
+Guadalupe,408,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,66,33,26,7
+Guadalupe,409,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,42,19,18,5
+Guadalupe,409,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1202,868,289,45
+Guadalupe,409,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,1324,961,306,57
+Guadalupe,409,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,70,54,14,2
+Guadalupe,410,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,2,2,0,0
+Guadalupe,410,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,54,44,10,0
+Guadalupe,410,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,22,17,5,0
+Guadalupe,410,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,5,2,3,0
+Guadalupe,411,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,46,29,13,4
+Guadalupe,411,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1172,850,268,54
+Guadalupe,411,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. Jackson,723,545,138,40
+Guadalupe,411,"Presiding Judge, Court of Criminal Appeals",,LIB,William Strange,57,35,20,2
+Guadalupe,101,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,12,7,2,3
+Guadalupe,101,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,273,180,73,20
+Guadalupe,101,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,84,57,22,5
+Guadalupe,102,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,20,13,5,2
+Guadalupe,102,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,419,312,72,35
+Guadalupe,102,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,159,97,45,17
+Guadalupe,103,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,12,9,2,1
+Guadalupe,103,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,331,243,68,20
+Guadalupe,103,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,116,72,35,9
+Guadalupe,104,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,22,16,5,1
+Guadalupe,104,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,289,213,58,18
+Guadalupe,104,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,209,121,68,20
+Guadalupe,105,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,35,20,11,4
+Guadalupe,105,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,1170,707,388,75
+Guadalupe,105,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,309,179,105,25
+Guadalupe,106,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,53,37,11,5
+Guadalupe,106,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,1337,975,244,118
+Guadalupe,106,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,515,355,122,38
+Guadalupe,107,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,21,9,11,1
+Guadalupe,107,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,565,309,227,29
+Guadalupe,107,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,122,70,49,3
+Guadalupe,108,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,6,0,6,0
+Guadalupe,108,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,273,102,141,30
+Guadalupe,108,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,152,66,71,15
+Guadalupe,109,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,9,4,5,0
+Guadalupe,109,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,252,125,118,9
+Guadalupe,109,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,51,23,25,3
+Guadalupe,110,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,6,3,2,1
+Guadalupe,110,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,85,69,14,2
+Guadalupe,110,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,60,45,10,5
+Guadalupe,111,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,4,1,2,1
+Guadalupe,111,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,35,23,6,6
+Guadalupe,111,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,25,10,8,7
+Guadalupe,112,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,19,7,11,1
+Guadalupe,112,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,71,27,44,0
+Guadalupe,112,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,136,51,85,0
+Guadalupe,113,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,7,6,1,0
+Guadalupe,113,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,401,282,99,20
+Guadalupe,113,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,176,116,52,8
+Guadalupe,114,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,12,9,1,2
+Guadalupe,114,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,292,211,63,18
+Guadalupe,114,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,147,96,45,6
+Guadalupe,115,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,6,2,3,1
+Guadalupe,115,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,146,107,38,1
+Guadalupe,115,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,24,17,5,2
+Guadalupe,116,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,39,16,19,4
+Guadalupe,116,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,992,672,258,62
+Guadalupe,116,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,310,158,129,23
+Guadalupe,117,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,61,41,17,3
+Guadalupe,117,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,1806,1333,393,80
+Guadalupe,117,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,671,455,172,44
+Guadalupe,118,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,0,0,0,0
+Guadalupe,118,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,23,17,6,0
+Guadalupe,118,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,20,12,7,1
+Guadalupe,119,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,19,12,6,1
+Guadalupe,119,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,844,647,157,40
+Guadalupe,119,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,237,167,53,17
+Guadalupe,120,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,24,15,9,0
+Guadalupe,120,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,553,384,121,48
+Guadalupe,120,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,143,94,34,15
+Guadalupe,121,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,8,5,3,0
+Guadalupe,121,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,60,52,6,2
+Guadalupe,121,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,26,22,2,2
+Guadalupe,122,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,0,0,0,0
+Guadalupe,122,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,20,16,1,3
+Guadalupe,122,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,7,1,0,6
+Guadalupe,123,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,0,0,0,0
+Guadalupe,123,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,0,0,0,0
+Guadalupe,123,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,1,0,0,1
+Guadalupe,124,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,1,1,0,0
+Guadalupe,124,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,1,1,0,0
+Guadalupe,124,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0,0,0
+Guadalupe,125,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,1,1,0,0
+Guadalupe,125,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,88,65,12,11
+Guadalupe,125,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,20,13,6,1
+Guadalupe,126,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,0,0,0,0
+Guadalupe,126,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,12,4,7,1
+Guadalupe,126,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,2,2,0,0
+Guadalupe,127,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,2,0,2,0
+Guadalupe,127,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,9,4,5,0
+Guadalupe,127,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,4,0,3,1
+Guadalupe,201,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,4,2,2,0
+Guadalupe,201,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,121,82,30,9
+Guadalupe,201,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,87,55,23,9
+Guadalupe,202,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,27,11,14,2
+Guadalupe,202,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,132,83,40,9
+Guadalupe,202,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,304,161,109,34
+Guadalupe,203,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,7,4,3,0
+Guadalupe,203,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,49,28,17,4
+Guadalupe,203,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,124,53,61,10
+Guadalupe,204,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,19,7,11,1
+Guadalupe,204,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,251,144,100,7
+Guadalupe,204,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,358,200,136,22
+Guadalupe,205,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,23,15,8,0
+Guadalupe,205,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,479,275,187,17
+Guadalupe,205,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,165,96,63,6
+Guadalupe,206,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,29,10,19,0
+Guadalupe,206,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,357,140,200,17
+Guadalupe,206,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,585,185,371,29
+Guadalupe,207,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,15,8,5,2
+Guadalupe,207,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,155,106,39,10
+Guadalupe,207,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,238,148,74,16
+Guadalupe,208,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,49,40,7,2
+Guadalupe,208,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,1457,1059,316,82
+Guadalupe,208,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,386,265,99,22
+Guadalupe,209,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,13,4,9,0
+Guadalupe,209,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,89,48,34,7
+Guadalupe,209,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,220,109,94,17
+Guadalupe,210,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,22,10,11,1
+Guadalupe,210,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,255,163,74,18
+Guadalupe,210,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,206,140,49,17
+Guadalupe,211,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,1,1,0,0
+Guadalupe,211,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,44,35,8,1
+Guadalupe,211,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,35,28,3,4
+Guadalupe,212,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,3,1,1,1
+Guadalupe,212,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,36,31,5,0
+Guadalupe,212,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,47,29,15,3
+Guadalupe,213,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,32,20,11,1
+Guadalupe,213,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,853,581,242,30
+Guadalupe,213,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,350,237,96,17
+Guadalupe,214,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,3,3,0,0
+Guadalupe,214,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,280,199,71,10
+Guadalupe,214,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,88,53,27,8
+Guadalupe,215,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,17,12,4,1
+Guadalupe,215,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,381,253,99,29
+Guadalupe,215,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,144,100,34,10
+Guadalupe,216,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,1,0,1,0
+Guadalupe,216,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,30,17,9,4
+Guadalupe,216,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,6,5,1,0
+Guadalupe,217,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,0,0,0,0
+Guadalupe,217,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,29,12,14,3
+Guadalupe,217,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,36,10,26,0
+Guadalupe,218,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,0,0,0,0
+Guadalupe,218,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,14,12,1,1
+Guadalupe,218,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,24,20,4,0
+Guadalupe,219,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,1,1,0,0
+Guadalupe,219,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,29,24,5,0
+Guadalupe,219,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,21,16,4,1
+Guadalupe,220,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,2,1,1,0
+Guadalupe,220,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,20,15,5,0
+Guadalupe,220,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,21,15,4,2
+Guadalupe,221,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,0,0,0,0
+Guadalupe,221,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,11,8,3,0
+Guadalupe,221,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,5,1,1,3
+Guadalupe,222,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,0,0,0,0
+Guadalupe,222,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,0,0,0,0
+Guadalupe,222,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0,0,0
+Guadalupe,223,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,6,3,2,1
+Guadalupe,223,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,78,47,26,5
+Guadalupe,223,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,75,60,10,5
+Guadalupe,224,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,1,1,0,0
+Guadalupe,224,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,9,2,7,0
+Guadalupe,224,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,50,24,19,7
+Guadalupe,225,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,2,1,1,0
+Guadalupe,225,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,1,0,1,0
+Guadalupe,225,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,8,7,1,0
+Guadalupe,226,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,4,3,0,1
+Guadalupe,226,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,102,67,32,3
+Guadalupe,226,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,54,29,23,2
+Guadalupe,301,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,38,18,19,1
+Guadalupe,301,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,1022,644,321,57
+Guadalupe,301,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,684,469,195,20
+Guadalupe,302,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,56,34,19,3
+Guadalupe,302,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,1264,861,352,51
+Guadalupe,302,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,1004,654,300,50
+Guadalupe,303,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,12,7,4,1
+Guadalupe,303,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,534,413,92,29
+Guadalupe,303,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,262,184,57,21
+Guadalupe,304,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,46,28,15,3
+Guadalupe,304,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,1437,1104,263,70
+Guadalupe,304,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,853,643,154,56
+Guadalupe,305,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,67,39,20,8
+Guadalupe,305,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,1377,966,351,60
+Guadalupe,305,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,966,676,223,67
+Guadalupe,306,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,39,25,12,2
+Guadalupe,306,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,1498,1186,248,64
+Guadalupe,306,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,874,679,137,58
+Guadalupe,307,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,52,34,14,4
+Guadalupe,307,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,1474,1145,268,61
+Guadalupe,307,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,1013,778,195,40
+Guadalupe,308,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,24,17,3,4
+Guadalupe,308,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,854,659,145,50
+Guadalupe,308,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,404,280,88,36
+Guadalupe,401,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,18,6,10,2
+Guadalupe,401,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,663,375,247,41
+Guadalupe,401,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,193,117,65,11
+Guadalupe,402,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,19,13,3,3
+Guadalupe,402,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,538,372,125,41
+Guadalupe,402,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,358,212,105,41
+Guadalupe,403,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,38,20,15,3
+Guadalupe,403,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,774,531,183,60
+Guadalupe,403,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,508,307,128,73
+Guadalupe,404,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,50,23,23,4
+Guadalupe,404,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,980,588,314,78
+Guadalupe,404,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,637,395,196,46
+Guadalupe,405,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,26,18,8,0
+Guadalupe,405,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,895,527,333,35
+Guadalupe,405,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,194,118,66,10
+Guadalupe,406,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,37,23,10,4
+Guadalupe,406,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,1017,770,209,38
+Guadalupe,406,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,166,110,42,14
+Guadalupe,407,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,33,21,10,2
+Guadalupe,407,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,864,620,204,40
+Guadalupe,407,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,187,114,52,21
+Guadalupe,408,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,62,27,28,7
+Guadalupe,408,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,1584,1039,413,132
+Guadalupe,408,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,706,464,201,41
+Guadalupe,409,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,50,26,19,5
+Guadalupe,409,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,1237,893,298,46
+Guadalupe,409,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,1351,983,310,58
+Guadalupe,410,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,3,2,1,0
+Guadalupe,410,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,56,44,12,0
+Guadalupe,410,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,24,19,5,0
+Guadalupe,411,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,51,29,18,4
+Guadalupe,411,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Hervey,1206,873,278,55
+Guadalupe,411,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,741,557,143,41
+Guadalupe,101,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,49,34,12,3
+Guadalupe,101,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,280,185,74,21
+Guadalupe,101,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,40,25,11,4
+Guadalupe,102,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,90,50,30,10
+Guadalupe,102,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,442,331,74,37
+Guadalupe,102,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,66,41,18,7
+Guadalupe,103,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,58,36,18,4
+Guadalupe,103,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,349,255,73,21
+Guadalupe,103,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,52,33,14,5
+Guadalupe,104,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,120,77,34,9
+Guadalupe,104,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,309,221,67,21
+Guadalupe,104,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,91,52,30,9
+Guadalupe,105,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,194,113,62,19
+Guadalupe,105,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1176,710,389,77
+Guadalupe,105,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,144,83,53,8
+Guadalupe,106,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,283,187,70,26
+Guadalupe,106,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1405,1018,263,124
+Guadalupe,106,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,217,162,44,11
+Guadalupe,107,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,76,47,27,2
+Guadalupe,107,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,569,312,228,29
+Guadalupe,107,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,63,29,32,2
+Guadalupe,108,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,85,37,40,8
+Guadalupe,108,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,283,108,145,30
+Guadalupe,108,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,63,23,33,7
+Guadalupe,109,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,26,8,16,2
+Guadalupe,109,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,256,127,119,10
+Guadalupe,109,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,30,17,13,0
+Guadalupe,110,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,41,29,9,3
+Guadalupe,110,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,86,68,14,4
+Guadalupe,110,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,24,20,3,1
+Guadalupe,111,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,23,10,8,5
+Guadalupe,111,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,33,21,6,6
+Guadalupe,111,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,8,3,2,3
+Guadalupe,112,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,87,28,58,1
+Guadalupe,112,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,86,32,54,0
+Guadalupe,112,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,53,25,28,0
+Guadalupe,113,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,91,55,31,5
+Guadalupe,113,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,407,288,100,19
+Guadalupe,113,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,86,61,21,4
+Guadalupe,114,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,101,61,34,6
+Guadalupe,114,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,309,225,65,19
+Guadalupe,114,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,41,30,10,1
+Guadalupe,115,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,18,12,5,1
+Guadalupe,115,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,152,110,40,2
+Guadalupe,115,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,6,4,1,1
+Guadalupe,116,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,182,86,85,11
+Guadalupe,116,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1038,683,289,66
+Guadalupe,116,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,121,77,32,12
+Guadalupe,117,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,342,216,99,27
+Guadalupe,117,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1867,1367,415,85
+Guadalupe,117,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,329,246,68,15
+Guadalupe,118,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,10,5,4,1
+Guadalupe,118,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,25,19,6,0
+Guadalupe,118,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,8,5,3,0
+Guadalupe,119,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,138,100,27,11
+Guadalupe,119,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,867,663,161,43
+Guadalupe,119,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,95,63,28,4
+Guadalupe,120,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,81,44,27,10
+Guadalupe,120,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,568,396,123,49
+Guadalupe,120,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,71,53,14,4
+Guadalupe,121,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,18,11,5,2
+Guadalupe,121,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,62,54,6,2
+Guadalupe,121,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,14,14,0,0
+Guadalupe,122,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,4,1,0,3
+Guadalupe,122,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,20,16,1,3
+Guadalupe,122,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,3,0,0,3
+Guadalupe,123,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,0,0,0,0
+Guadalupe,123,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,0,0,0,0
+Guadalupe,123,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,1,0,0,1
+Guadalupe,124,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,1,1,0,0
+Guadalupe,124,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1,1,0,0
+Guadalupe,124,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,0,0,0,0
+Guadalupe,125,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,10,6,4,0
+Guadalupe,125,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,90,68,11,11
+Guadalupe,125,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,9,5,3,1
+Guadalupe,126,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,0,0,0,0
+Guadalupe,126,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,12,4,7,1
+Guadalupe,126,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,2,2,0,0
+Guadalupe,127,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,2,0,2,0
+Guadalupe,127,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,11,4,6,1
+Guadalupe,127,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,2,0,2,0
+Guadalupe,201,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,38,27,11,0
+Guadalupe,201,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,132,86,35,11
+Guadalupe,201,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,42,26,9,7
+Guadalupe,202,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,216,101,89,26
+Guadalupe,202,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,157,95,50,12
+Guadalupe,202,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,90,59,24,7
+Guadalupe,203,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,90,39,43,8
+Guadalupe,203,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,54,29,21,4
+Guadalupe,203,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,36,17,17,2
+Guadalupe,204,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,220,117,88,15
+Guadalupe,204,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,299,170,121,8
+Guadalupe,204,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,109,64,38,7
+Guadalupe,205,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,123,75,44,4
+Guadalupe,205,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,484,279,189,16
+Guadalupe,205,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,60,32,25,3
+Guadalupe,206,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,344,87,240,17
+Guadalupe,206,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,405,154,233,18
+Guadalupe,206,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,222,94,117,11
+Guadalupe,207,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,143,79,54,10
+Guadalupe,207,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,171,118,43,10
+Guadalupe,207,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,94,65,21,8
+Guadalupe,208,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,224,155,61,8
+Guadalupe,208,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1485,1075,324,86
+Guadalupe,208,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,183,134,37,12
+Guadalupe,209,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,146,65,68,13
+Guadalupe,209,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,103,55,42,6
+Guadalupe,209,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,73,41,27,5
+Guadalupe,210,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,106,65,32,9
+Guadalupe,210,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,277,180,79,18
+Guadalupe,210,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,100,68,23,9
+Guadalupe,211,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,18,14,1,3
+Guadalupe,211,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,50,38,10,2
+Guadalupe,211,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,12,12,0,0
+Guadalupe,212,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,21,10,8,3
+Guadalupe,212,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,44,34,9,1
+Guadalupe,212,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,21,17,4,0
+Guadalupe,213,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,176,110,55,11
+Guadalupe,213,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,879,605,245,29
+Guadalupe,213,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,180,123,49,8
+Guadalupe,214,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,43,25,12,6
+Guadalupe,214,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,290,204,76,10
+Guadalupe,214,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,38,26,10,2
+Guadalupe,215,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,79,56,19,4
+Guadalupe,215,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,398,262,107,29
+Guadalupe,215,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,65,47,11,7
+Guadalupe,216,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,3,2,1,0
+Guadalupe,216,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,29,17,8,4
+Guadalupe,216,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,5,3,2,0
+Guadalupe,217,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,21,5,16,0
+Guadalupe,217,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,33,14,16,3
+Guadalupe,217,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,11,3,8,0
+Guadalupe,218,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,13,11,2,0
+Guadalupe,218,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,18,16,1,1
+Guadalupe,218,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,7,5,2,0
+Guadalupe,219,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,7,5,2,0
+Guadalupe,219,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,32,25,6,1
+Guadalupe,219,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,12,11,1,0
+Guadalupe,220,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,11,8,3,0
+Guadalupe,220,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,24,18,5,1
+Guadalupe,220,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,8,5,2,1
+Guadalupe,221,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,3,1,0,2
+Guadalupe,221,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,11,8,3,0
+Guadalupe,221,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,2,0,1,1
+Guadalupe,222,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,0,0,0,0
+Guadalupe,222,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,0,0,0,0
+Guadalupe,222,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,0,0,0,0
+Guadalupe,223,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,35,30,5,0
+Guadalupe,223,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,85,52,28,5
+Guadalupe,223,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,39,28,5,6
+Guadalupe,224,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,29,13,12,4
+Guadalupe,224,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,14,5,9,0
+Guadalupe,224,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,17,9,5,3
+Guadalupe,225,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,8,7,1,0
+Guadalupe,225,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,2,1,1,0
+Guadalupe,225,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,1,0,1,0
+Guadalupe,226,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,37,18,17,2
+Guadalupe,226,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,107,69,35,3
+Guadalupe,226,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,16,12,3,1
+Guadalupe,301,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,382,269,105,8
+Guadalupe,301,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1076,677,341,58
+Guadalupe,301,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,286,185,89,12
+Guadalupe,302,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,553,363,170,20
+Guadalupe,302,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1347,913,380,54
+Guadalupe,302,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,424,273,121,30
+Guadalupe,303,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,118,80,30,8
+Guadalupe,303,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,548,423,93,32
+Guadalupe,303,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,142,101,30,11
+Guadalupe,304,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,402,291,80,31
+Guadalupe,304,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1529,1169,286,74
+Guadalupe,304,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,405,315,66,24
+Guadalupe,305,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,505,344,119,42
+Guadalupe,305,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1465,1028,373,64
+Guadalupe,305,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,440,309,102,29
+Guadalupe,306,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,451,361,67,23
+Guadalupe,306,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1586,1249,265,72
+Guadalupe,306,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,374,280,65,29
+Guadalupe,307,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,531,407,109,15
+Guadalupe,307,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1572,1219,287,66
+Guadalupe,307,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,436,331,81,24
+Guadalupe,308,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,195,127,43,25
+Guadalupe,308,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,876,679,148,49
+Guadalupe,308,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,211,150,45,16
+Guadalupe,401,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,101,55,43,3
+Guadalupe,401,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,691,389,258,44
+Guadalupe,401,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,82,54,21,7
+Guadalupe,402,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,177,109,50,18
+Guadalupe,402,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,578,398,134,46
+Guadalupe,402,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,160,90,49,21
+Guadalupe,403,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,293,181,68,44
+Guadalupe,403,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,837,573,198,66
+Guadalupe,403,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,190,104,60,26
+Guadalupe,404,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,336,206,105,25
+Guadalupe,404,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1047,629,341,77
+Guadalupe,404,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,284,171,87,26
+Guadalupe,405,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,113,73,35,5
+Guadalupe,405,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,917,540,344,33
+Guadalupe,405,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,85,50,28,7
+Guadalupe,406,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,96,63,25,8
+Guadalupe,406,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1026,771,217,38
+Guadalupe,406,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,98,69,19,10
+Guadalupe,407,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,118,75,34,9
+Guadalupe,407,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,872,626,204,42
+Guadalupe,407,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,94,54,28,12
+Guadalupe,408,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,375,232,119,24
+Guadalupe,408,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1664,1102,432,130
+Guadalupe,408,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,313,196,91,26
+Guadalupe,409,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,683,475,184,24
+Guadalupe,409,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1356,976,329,51
+Guadalupe,409,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,599,451,114,34
+Guadalupe,410,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,11,8,3,0
+Guadalupe,410,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,60,49,11,0
+Guadalupe,410,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,12,8,4,0
+Guadalupe,411,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,355,271,61,23
+Guadalupe,411,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1290,933,296,61
+Guadalupe,411,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,353,255,82,16
+Guadalupe,101,State Senator,25,,Under Votes,6,2,1,3
+Guadalupe,101,State Senator,25,REP,Donna Campbell,267,176,74,17
+Guadalupe,101,State Senator,25,DEM,Steven Kling,96,66,22,8
+Guadalupe,112,State Senator,25,,Under Votes,19,7,11,1
+Guadalupe,112,State Senator,25,REP,Donna Campbell,72,28,44,0
+Guadalupe,112,State Senator,25,DEM,Steven Kling,135,50,85,0
+Guadalupe,113,State Senator,25,,Under Votes,5,4,1,0
+Guadalupe,113,State Senator,25,REP,Donna Campbell,399,282,98,19
+Guadalupe,113,State Senator,25,DEM,Steven Kling,180,118,53,9
+Guadalupe,114,State Senator,25,,Under Votes,7,3,2,2
+Guadalupe,114,State Senator,25,REP,Donna Campbell,289,211,62,16
+Guadalupe,114,State Senator,25,DEM,Steven Kling,155,102,45,8
+Guadalupe,116,State Senator,25,,Under Votes,29,12,15,2
+Guadalupe,116,State Senator,25,REP,Donna Campbell,998,669,266,63
+Guadalupe,116,State Senator,25,DEM,Steven Kling,314,165,125,24
+Guadalupe,117,State Senator,25,,Under Votes,41,23,12,6
+Guadalupe,117,State Senator,25,REP,Donna Campbell,1798,1317,403,78
+Guadalupe,117,State Senator,25,DEM,Steven Kling,699,489,167,43
+Guadalupe,118,State Senator,25,,Under Votes,0,0,0,0
+Guadalupe,118,State Senator,25,REP,Donna Campbell,23,17,6,0
+Guadalupe,118,State Senator,25,DEM,Steven Kling,20,12,7,1
+Guadalupe,121,State Senator,25,,Under Votes,2,0,2,0
+Guadalupe,121,State Senator,25,REP,Donna Campbell,64,55,7,2
+Guadalupe,121,State Senator,25,DEM,Steven Kling,28,24,2,2
+Guadalupe,122,State Senator,25,,Under Votes,0,0,0,0
+Guadalupe,122,State Senator,25,REP,Donna Campbell,20,16,1,3
+Guadalupe,122,State Senator,25,DEM,Steven Kling,7,1,0,6
+Guadalupe,124,State Senator,25,,Under Votes,1,1,0,0
+Guadalupe,124,State Senator,25,REP,Donna Campbell,0,0,0,0
+Guadalupe,124,State Senator,25,DEM,Steven Kling,1,1,0,0
+Guadalupe,125,State Senator,25,,Under Votes,0,0,0,0
+Guadalupe,125,State Senator,25,REP,Donna Campbell,91,68,12,11
+Guadalupe,125,State Senator,25,DEM,Steven Kling,18,11,6,1
+Guadalupe,208,State Senator,25,,Under Votes,27,21,2,4
+Guadalupe,208,State Senator,25,REP,Donna Campbell,1444,1046,321,77
+Guadalupe,208,State Senator,25,DEM,Steven Kling,421,297,99,25
+Guadalupe,213,State Senator,25,,Under Votes,28,14,9,5
+Guadalupe,213,State Senator,25,REP,Donna Campbell,853,588,241,24
+Guadalupe,213,State Senator,25,DEM,Steven Kling,354,236,99,19
+Guadalupe,215,State Senator,25,,Under Votes,22,12,3,7
+Guadalupe,215,State Senator,25,REP,Donna Campbell,371,250,98,23
+Guadalupe,215,State Senator,25,DEM,Steven Kling,149,103,36,10
+Guadalupe,217,State Senator,25,,Under Votes,0,0,0,0
+Guadalupe,217,State Senator,25,REP,Donna Campbell,30,12,15,3
+Guadalupe,217,State Senator,25,DEM,Steven Kling,35,10,25,0
+Guadalupe,301,State Senator,25,,Under Votes,42,20,18,4
+Guadalupe,301,State Senator,25,REP,Donna Campbell,1042,653,334,55
+Guadalupe,301,State Senator,25,DEM,Steven Kling,660,458,183,19
+Guadalupe,302,State Senator,25,,Under Votes,50,25,19,6
+Guadalupe,302,State Senator,25,REP,Donna Campbell,1280,871,358,51
+Guadalupe,302,State Senator,25,DEM,Steven Kling,994,653,294,47
+Guadalupe,303,State Senator,25,,Under Votes,9,5,3,1
+Guadalupe,303,State Senator,25,REP,Donna Campbell,536,405,99,32
+Guadalupe,303,State Senator,25,DEM,Steven Kling,263,194,51,18
+Guadalupe,304,State Senator,25,,Under Votes,34,13,13,8
+Guadalupe,304,State Senator,25,REP,Donna Campbell,1452,1125,260,67
+Guadalupe,304,State Senator,25,DEM,Steven Kling,850,637,159,54
+Guadalupe,305,State Senator,25,,Under Votes,52,25,14,13
+Guadalupe,305,State Senator,25,REP,Donna Campbell,1386,974,357,55
+Guadalupe,305,State Senator,25,DEM,Steven Kling,972,682,223,67
+Guadalupe,306,State Senator,25,,Under Votes,29,19,8,2
+Guadalupe,306,State Senator,25,REP,Donna Campbell,1501,1183,252,66
+Guadalupe,306,State Senator,25,DEM,Steven Kling,881,688,137,56
+Guadalupe,307,State Senator,25,,Under Votes,44,28,8,8
+Guadalupe,307,State Senator,25,REP,Donna Campbell,1476,1140,276,60
+Guadalupe,307,State Senator,25,DEM,Steven Kling,1019,789,193,37
+Guadalupe,308,State Senator,25,,Under Votes,29,12,5,12
+Guadalupe,308,State Senator,25,REP,Donna Campbell,821,639,138,44
+Guadalupe,308,State Senator,25,DEM,Steven Kling,432,305,93,34
+Guadalupe,401,State Senator,25,,Under Votes,18,7,8,3
+Guadalupe,401,State Senator,25,REP,Donna Campbell,666,379,247,40
+Guadalupe,401,State Senator,25,DEM,Steven Kling,190,112,67,11
+Guadalupe,402,State Senator,25,,Under Votes,17,11,2,4
+Guadalupe,402,State Senator,25,REP,Donna Campbell,555,383,128,44
+Guadalupe,402,State Senator,25,DEM,Steven Kling,343,203,103,37
+Guadalupe,403,State Senator,25,,Under Votes,30,13,12,5
+Guadalupe,403,State Senator,25,REP,Donna Campbell,793,546,186,61
+Guadalupe,403,State Senator,25,DEM,Steven Kling,497,299,128,70
+Guadalupe,404,State Senator,25,,Under Votes,45,15,16,14
+Guadalupe,404,State Senator,25,REP,Donna Campbell,969,582,318,69
+Guadalupe,404,State Senator,25,DEM,Steven Kling,653,409,199,45
+Guadalupe,405,State Senator,25,,Under Votes,23,15,6,2
+Guadalupe,405,State Senator,25,REP,Donna Campbell,895,528,334,33
+Guadalupe,405,State Senator,25,DEM,Steven Kling,197,120,67,10
+Guadalupe,408,State Senator,25,,Under Votes,58,21,20,17
+Guadalupe,408,State Senator,25,REP,Donna Campbell,1600,1044,428,128
+Guadalupe,408,State Senator,25,DEM,Steven Kling,694,465,194,35
+Guadalupe,409,State Senator,25,,Under Votes,47,17,19,11
+Guadalupe,409,State Senator,25,REP,Donna Campbell,1272,921,305,46
+Guadalupe,409,State Senator,25,DEM,Steven Kling,1319,964,303,52
+Guadalupe,410,State Senator,25,,Under Votes,2,1,1,0
+Guadalupe,410,State Senator,25,REP,Donna Campbell,59,47,12,0
+Guadalupe,410,State Senator,25,DEM,Steven Kling,22,17,5,0
+Guadalupe,411,State Senator,25,,Under Votes,52,27,14,11
+Guadalupe,411,State Senator,25,REP,Donna Campbell,1196,863,283,50
+Guadalupe,411,State Senator,25,DEM,Steven Kling,750,569,142,39
+Guadalupe,101,State Representative,44,,Under Votes,6,2,1,3
+Guadalupe,101,State Representative,44,REP,John Kuempel,292,195,77,20
+Guadalupe,101,State Representative,44,DEM,John D. Rodgers,71,47,19,5
+Guadalupe,102,State Representative,44,,Under Votes,7,4,3,0
+Guadalupe,102,State Representative,44,REP,John Kuempel,442,331,73,38
+Guadalupe,102,State Representative,44,DEM,John D. Rodgers,149,87,46,16
+Guadalupe,103,State Representative,44,,Under Votes,11,7,2,2
+Guadalupe,103,State Representative,44,REP,John Kuempel,352,255,75,22
+Guadalupe,103,State Representative,44,DEM,John D. Rodgers,96,62,28,6
+Guadalupe,104,State Representative,44,,Under Votes,16,9,4,3
+Guadalupe,104,State Representative,44,REP,John Kuempel,319,231,66,22
+Guadalupe,104,State Representative,44,DEM,John D. Rodgers,185,110,61,14
+Guadalupe,105,State Representative,44,,Under Votes,21,10,5,6
+Guadalupe,105,State Representative,44,REP,John Kuempel,1183,719,392,72
+Guadalupe,105,State Representative,44,DEM,John D. Rodgers,310,177,107,26
+Guadalupe,106,State Representative,44,,Under Votes,33,8,7,18
+Guadalupe,106,State Representative,44,REP,John Kuempel,1411,1039,264,108
+Guadalupe,106,State Representative,44,DEM,John D. Rodgers,461,320,106,35
+Guadalupe,107,State Representative,44,,Under Votes,20,7,8,5
+Guadalupe,107,State Representative,44,REP,John Kuempel,566,311,230,25
+Guadalupe,107,State Representative,44,DEM,John D. Rodgers,122,70,49,3
+Guadalupe,108,State Representative,44,,Under Votes,10,0,5,5
+Guadalupe,108,State Representative,44,REP,John Kuempel,273,104,143,26
+Guadalupe,108,State Representative,44,DEM,John D. Rodgers,148,64,70,14
+Guadalupe,109,State Representative,44,,Under Votes,5,2,3,0
+Guadalupe,109,State Representative,44,REP,John Kuempel,260,129,122,9
+Guadalupe,109,State Representative,44,DEM,John D. Rodgers,47,21,23,3
+Guadalupe,110,State Representative,44,,Under Votes,2,1,1,0
+Guadalupe,110,State Representative,44,REP,John Kuempel,90,72,15,3
+Guadalupe,110,State Representative,44,DEM,John D. Rodgers,59,44,10,5
+Guadalupe,111,State Representative,44,,Under Votes,2,0,1,1
+Guadalupe,111,State Representative,44,REP,John Kuempel,36,23,7,6
+Guadalupe,111,State Representative,44,DEM,John D. Rodgers,26,11,8,7
+Guadalupe,112,State Representative,44,,Under Votes,20,7,12,1
+Guadalupe,112,State Representative,44,REP,John Kuempel,70,29,41,0
+Guadalupe,112,State Representative,44,DEM,John D. Rodgers,136,49,87,0
+Guadalupe,113,State Representative,44,,Under Votes,10,5,2,3
+Guadalupe,113,State Representative,44,REP,John Kuempel,398,285,96,17
+Guadalupe,113,State Representative,44,DEM,John D. Rodgers,176,114,54,8
+Guadalupe,114,State Representative,44,,Under Votes,9,3,1,5
+Guadalupe,114,State Representative,44,REP,John Kuempel,294,212,66,16
+Guadalupe,114,State Representative,44,DEM,John D. Rodgers,148,101,42,5
+Guadalupe,115,State Representative,44,,Under Votes,2,2,0,0
+Guadalupe,115,State Representative,44,REP,John Kuempel,153,109,42,2
+Guadalupe,115,State Representative,44,DEM,John D. Rodgers,21,15,4,2
+Guadalupe,116,State Representative,44,,Under Votes,29,12,12,5
+Guadalupe,116,State Representative,44,REP,John Kuempel,1024,681,280,63
+Guadalupe,116,State Representative,44,DEM,John D. Rodgers,288,153,114,21
+Guadalupe,117,State Representative,44,,Under Votes,61,26,13,22
+Guadalupe,117,State Representative,44,REP,John Kuempel,1806,1343,401,62
+Guadalupe,117,State Representative,44,DEM,John D. Rodgers,671,460,168,43
+Guadalupe,118,State Representative,44,,Under Votes,0,0,0,0
+Guadalupe,118,State Representative,44,REP,John Kuempel,26,20,6,0
+Guadalupe,118,State Representative,44,DEM,John D. Rodgers,17,9,7,1
+Guadalupe,119,State Representative,44,,Under Votes,15,6,3,6
+Guadalupe,119,State Representative,44,REP,John Kuempel,857,654,163,40
+Guadalupe,119,State Representative,44,DEM,John D. Rodgers,228,166,50,12
+Guadalupe,120,State Representative,44,,Under Votes,12,6,5,1
+Guadalupe,120,State Representative,44,REP,John Kuempel,578,401,129,48
+Guadalupe,120,State Representative,44,DEM,John D. Rodgers,130,86,30,14
+Guadalupe,121,State Representative,44,,Under Votes,4,2,2,0
+Guadalupe,121,State Representative,44,REP,John Kuempel,70,59,9,2
+Guadalupe,121,State Representative,44,DEM,John D. Rodgers,20,18,0,2
+Guadalupe,122,State Representative,44,,Under Votes,1,0,0,1
+Guadalupe,122,State Representative,44,REP,John Kuempel,21,16,1,4
+Guadalupe,122,State Representative,44,DEM,John D. Rodgers,5,1,0,4
+Guadalupe,123,State Representative,44,,Under Votes,1,0,0,1
+Guadalupe,123,State Representative,44,REP,John Kuempel,0,0,0,0
+Guadalupe,123,State Representative,44,DEM,John D. Rodgers,0,0,0,0
+Guadalupe,124,State Representative,44,,Under Votes,0,0,0,0
+Guadalupe,124,State Representative,44,REP,John Kuempel,2,2,0,0
+Guadalupe,124,State Representative,44,DEM,John D. Rodgers,0,0,0,0
+Guadalupe,125,State Representative,44,,Under Votes,3,2,0,1
+Guadalupe,125,State Representative,44,REP,John Kuempel,89,68,12,9
+Guadalupe,125,State Representative,44,DEM,John D. Rodgers,17,9,6,2
+Guadalupe,126,State Representative,44,,Under Votes,0,0,0,0
+Guadalupe,126,State Representative,44,REP,John Kuempel,12,4,7,1
+Guadalupe,126,State Representative,44,DEM,John D. Rodgers,2,2,0,0
+Guadalupe,127,State Representative,44,,Under Votes,0,0,0,0
+Guadalupe,127,State Representative,44,REP,John Kuempel,10,4,6,0
+Guadalupe,127,State Representative,44,DEM,John D. Rodgers,5,0,4,1
+Guadalupe,201,State Representative,44,,Under Votes,7,1,2,4
+Guadalupe,201,State Representative,44,REP,John Kuempel,128,86,34,8
+Guadalupe,201,State Representative,44,DEM,John D. Rodgers,77,52,19,6
+Guadalupe,202,State Representative,44,,Under Votes,21,3,11,7
+Guadalupe,202,State Representative,44,REP,John Kuempel,160,101,53,6
+Guadalupe,202,State Representative,44,DEM,John D. Rodgers,282,151,99,32
+Guadalupe,203,State Representative,44,,Under Votes,7,4,3,0
+Guadalupe,203,State Representative,44,REP,John Kuempel,59,32,23,4
+Guadalupe,203,State Representative,44,DEM,John D. Rodgers,114,49,55,10
+Guadalupe,204,State Representative,44,,Under Votes,17,5,8,4
+Guadalupe,204,State Representative,44,REP,John Kuempel,290,165,120,5
+Guadalupe,204,State Representative,44,DEM,John D. Rodgers,321,181,119,21
+Guadalupe,205,State Representative,44,,Under Votes,17,8,7,2
+Guadalupe,205,State Representative,44,REP,John Kuempel,498,289,194,15
+Guadalupe,205,State Representative,44,DEM,John D. Rodgers,152,89,57,6
+Guadalupe,206,State Representative,44,,Under Votes,28,8,19,1
+Guadalupe,206,State Representative,44,REP,John Kuempel,368,142,209,17
+Guadalupe,206,State Representative,44,DEM,John D. Rodgers,575,185,362,28
+Guadalupe,207,State Representative,44,,Under Votes,10,4,4,2
+Guadalupe,207,State Representative,44,REP,John Kuempel,181,124,47,10
+Guadalupe,207,State Representative,44,DEM,John D. Rodgers,217,134,67,16
+Guadalupe,208,State Representative,44,,Under Votes,39,21,7,11
+Guadalupe,208,State Representative,44,REP,John Kuempel,1480,1085,321,74
+Guadalupe,208,State Representative,44,DEM,John D. Rodgers,373,258,94,21
+Guadalupe,209,State Representative,44,,Under Votes,9,2,6,1
+Guadalupe,209,State Representative,44,REP,John Kuempel,107,60,41,6
+Guadalupe,209,State Representative,44,DEM,John D. Rodgers,206,99,90,17
+Guadalupe,210,State Representative,44,,Under Votes,13,6,3,4
+Guadalupe,210,State Representative,44,REP,John Kuempel,296,193,85,18
+Guadalupe,210,State Representative,44,DEM,John D. Rodgers,174,114,46,14
+Guadalupe,211,State Representative,44,,Under Votes,2,2,0,0
+Guadalupe,211,State Representative,44,REP,John Kuempel,46,35,9,2
+Guadalupe,211,State Representative,44,DEM,John D. Rodgers,32,27,2,3
+Guadalupe,212,State Representative,44,,Under Votes,1,0,0,1
+Guadalupe,212,State Representative,44,REP,John Kuempel,42,34,8,0
+Guadalupe,212,State Representative,44,DEM,John D. Rodgers,43,27,13,3
+Guadalupe,213,State Representative,44,,Under Votes,38,18,10,10
+Guadalupe,213,State Representative,44,REP,John Kuempel,847,586,237,24
+Guadalupe,213,State Representative,44,DEM,John D. Rodgers,350,234,102,14
+Guadalupe,214,State Representative,44,,Under Votes,10,5,0,5
+Guadalupe,214,State Representative,44,REP,John Kuempel,283,201,77,5
+Guadalupe,214,State Representative,44,DEM,John D. Rodgers,78,49,21,8
+Guadalupe,215,State Representative,44,,Under Votes,21,9,4,8
+Guadalupe,215,State Representative,44,REP,John Kuempel,386,260,104,22
+Guadalupe,215,State Representative,44,DEM,John D. Rodgers,135,96,29,10
+Guadalupe,216,State Representative,44,,Under Votes,1,1,0,0
+Guadalupe,216,State Representative,44,REP,John Kuempel,30,16,10,4
+Guadalupe,216,State Representative,44,DEM,John D. Rodgers,6,5,1,0
+Guadalupe,217,State Representative,44,,Under Votes,0,0,0,0
+Guadalupe,217,State Representative,44,REP,John Kuempel,34,14,17,3
+Guadalupe,217,State Representative,44,DEM,John D. Rodgers,31,8,23,0
+Guadalupe,218,State Representative,44,,Under Votes,1,0,0,1
+Guadalupe,218,State Representative,44,REP,John Kuempel,17,16,1,0
+Guadalupe,218,State Representative,44,DEM,John D. Rodgers,20,16,4,0
+Guadalupe,219,State Representative,44,,Under Votes,2,1,0,1
+Guadalupe,219,State Representative,44,REP,John Kuempel,32,25,7,0
+Guadalupe,219,State Representative,44,DEM,John D. Rodgers,17,15,2,0
+Guadalupe,220,State Representative,44,,Under Votes,1,0,1,0
+Guadalupe,220,State Representative,44,REP,John Kuempel,26,17,7,2
+Guadalupe,220,State Representative,44,DEM,John D. Rodgers,16,14,2,0
+Guadalupe,221,State Representative,44,,Under Votes,0,0,0,0
+Guadalupe,221,State Representative,44,REP,John Kuempel,11,8,3,0
+Guadalupe,221,State Representative,44,DEM,John D. Rodgers,5,1,1,3
+Guadalupe,222,State Representative,44,,Under Votes,0,0,0,0
+Guadalupe,222,State Representative,44,REP,John Kuempel,0,0,0,0
+Guadalupe,222,State Representative,44,DEM,John D. Rodgers,0,0,0,0
+Guadalupe,223,State Representative,44,,Under Votes,3,1,1,1
+Guadalupe,223,State Representative,44,REP,John Kuempel,85,51,27,7
+Guadalupe,223,State Representative,44,DEM,John D. Rodgers,71,58,10,3
+Guadalupe,224,State Representative,44,,Under Votes,2,0,0,2
+Guadalupe,224,State Representative,44,REP,John Kuempel,13,3,10,0
+Guadalupe,224,State Representative,44,DEM,John D. Rodgers,45,24,16,5
+Guadalupe,225,State Representative,44,,Under Votes,1,1,0,0
+Guadalupe,225,State Representative,44,REP,John Kuempel,4,2,2,0
+Guadalupe,225,State Representative,44,DEM,John D. Rodgers,6,5,1,0
+Guadalupe,226,State Representative,44,,Under Votes,3,2,0,1
+Guadalupe,226,State Representative,44,REP,John Kuempel,104,69,32,3
+Guadalupe,226,State Representative,44,DEM,John D. Rodgers,53,28,23,2
+Guadalupe,301,State Representative,44,,Under Votes,45,15,20,10
+Guadalupe,301,State Representative,44,REP,John Kuempel,1025,646,328,51
+Guadalupe,301,State Representative,44,DEM,John D. Rodgers,674,470,187,17
+Guadalupe,302,State Representative,44,,Under Votes,60,30,21,9
+Guadalupe,302,State Representative,44,REP,John Kuempel,1273,870,354,49
+Guadalupe,302,State Representative,44,DEM,John D. Rodgers,991,649,296,46
+Guadalupe,303,State Representative,44,,Under Votes,11,7,2,2
+Guadalupe,303,State Representative,44,REP,John Kuempel,538,414,94,30
+Guadalupe,303,State Representative,44,DEM,John D. Rodgers,259,183,57,19
+Guadalupe,304,State Representative,44,,Under Votes,41,18,14,9
+Guadalupe,304,State Representative,44,REP,John Kuempel,1438,1112,262,64
+Guadalupe,304,State Representative,44,DEM,John D. Rodgers,857,645,156,56
+Guadalupe,305,State Representative,44,,Under Votes,74,35,18,21
+Guadalupe,305,State Representative,44,REP,John Kuempel,1371,975,343,53
+Guadalupe,305,State Representative,44,DEM,John D. Rodgers,965,671,233,61
+Guadalupe,306,State Representative,44,,Under Votes,37,22,11,4
+Guadalupe,306,State Representative,44,REP,John Kuempel,1493,1183,248,62
+Guadalupe,306,State Representative,44,DEM,John D. Rodgers,881,685,138,58
+Guadalupe,307,State Representative,44,,Under Votes,51,32,9,10
+Guadalupe,307,State Representative,44,REP,John Kuempel,1459,1132,269,58
+Guadalupe,307,State Representative,44,DEM,John D. Rodgers,1029,793,199,37
+Guadalupe,308,State Representative,44,,Under Votes,34,16,4,14
+Guadalupe,308,State Representative,44,REP,John Kuempel,831,649,140,42
+Guadalupe,308,State Representative,44,DEM,John D. Rodgers,417,291,92,34
+Guadalupe,401,State Representative,44,,Under Votes,19,6,8,5
+Guadalupe,401,State Representative,44,REP,John Kuempel,666,378,249,39
+Guadalupe,401,State Representative,44,DEM,John D. Rodgers,189,114,65,10
+Guadalupe,402,State Representative,44,,Under Votes,21,12,3,6
+Guadalupe,402,State Representative,44,REP,John Kuempel,538,377,124,37
+Guadalupe,402,State Representative,44,DEM,John D. Rodgers,356,208,106,42
+Guadalupe,403,State Representative,44,,Under Votes,39,20,13,6
+Guadalupe,403,State Representative,44,REP,John Kuempel,791,541,186,64
+Guadalupe,403,State Representative,44,DEM,John D. Rodgers,490,297,127,66
+Guadalupe,404,State Representative,44,,Under Votes,62,25,19,18
+Guadalupe,404,State Representative,44,REP,John Kuempel,955,584,306,65
+Guadalupe,404,State Representative,44,DEM,John D. Rodgers,650,397,208,45
+Guadalupe,405,State Representative,44,,Under Votes,25,16,7,2
+Guadalupe,405,State Representative,44,REP,John Kuempel,906,537,337,32
+Guadalupe,405,State Representative,44,DEM,John D. Rodgers,184,110,63,11
+Guadalupe,406,State Representative,44,,Under Votes,22,11,5,6
+Guadalupe,406,State Representative,44,REP,John Kuempel,1042,785,218,39
+Guadalupe,406,State Representative,44,DEM,John D. Rodgers,156,107,38,11
+Guadalupe,407,State Representative,44,,Under Votes,22,9,7,6
+Guadalupe,407,State Representative,44,REP,John Kuempel,886,637,210,39
+Guadalupe,407,State Representative,44,DEM,John D. Rodgers,176,109,49,18
+Guadalupe,408,State Representative,44,,Under Votes,71,17,25,29
+Guadalupe,408,State Representative,44,REP,John Kuempel,1598,1059,424,115
+Guadalupe,408,State Representative,44,DEM,John D. Rodgers,683,454,193,36
+Guadalupe,409,State Representative,44,,Under Votes,60,23,20,17
+Guadalupe,409,State Representative,44,REP,John Kuempel,1239,892,300,47
+Guadalupe,409,State Representative,44,DEM,John D. Rodgers,1339,987,307,45
+Guadalupe,410,State Representative,44,,Under Votes,1,0,1,0
+Guadalupe,410,State Representative,44,REP,John Kuempel,57,46,11,0
+Guadalupe,410,State Representative,44,DEM,John D. Rodgers,25,19,6,0
+Guadalupe,411,State Representative,44,,Under Votes,53,30,11,12
+Guadalupe,411,State Representative,44,REP,John Kuempel,1215,878,288,49
+Guadalupe,411,State Representative,44,DEM,John D. Rodgers,730,551,140,39
+Guadalupe,101,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,10,5,2,3
+Guadalupe,101,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,267,177,73,17
+Guadalupe,101,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,92,62,22,8
+Guadalupe,102,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,21,14,5,2
+Guadalupe,102,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,417,313,68,36
+Guadalupe,102,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,160,95,49,16
+Guadalupe,103,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,16,10,3,3
+Guadalupe,103,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,327,243,67,17
+Guadalupe,103,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,116,71,35,10
+Guadalupe,104,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,20,14,4,2
+Guadalupe,104,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,289,210,60,19
+Guadalupe,104,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,211,126,67,18
+Guadalupe,105,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,34,19,9,6
+Guadalupe,105,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,1163,704,388,71
+Guadalupe,105,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,317,183,107,27
+Guadalupe,106,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,67,38,12,17
+Guadalupe,106,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,1314,968,240,106
+Guadalupe,106,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,524,361,125,38
+Guadalupe,107,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,23,8,12,3
+Guadalupe,107,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,562,309,226,27
+Guadalupe,107,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,123,71,49,3
+Guadalupe,108,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,11,0,7,4
+Guadalupe,108,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,266,103,137,26
+Guadalupe,108,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,154,65,74,15
+Guadalupe,109,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,9,5,4,0
+Guadalupe,109,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,249,125,115,9
+Guadalupe,109,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,54,22,29,3
+Guadalupe,110,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,5,2,2,1
+Guadalupe,110,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,86,70,14,2
+Guadalupe,110,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,60,45,10,5
+Guadalupe,111,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,5,1,2,2
+Guadalupe,111,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,33,22,6,5
+Guadalupe,111,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,26,11,8,7
+Guadalupe,112,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,19,7,11,1
+Guadalupe,112,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,66,26,40,0
+Guadalupe,112,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,141,52,89,0
+Guadalupe,113,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,11,7,1,3
+Guadalupe,113,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,393,280,96,17
+Guadalupe,113,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,180,117,55,8
+Guadalupe,114,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,12,5,2,5
+Guadalupe,114,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,287,210,61,16
+Guadalupe,114,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,152,101,46,5
+Guadalupe,115,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,6,2,3,1
+Guadalupe,115,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,146,107,38,1
+Guadalupe,115,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,24,17,5,2
+Guadalupe,116,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,42,16,20,6
+Guadalupe,116,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,977,661,256,60
+Guadalupe,116,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,322,169,130,23
+Guadalupe,117,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,83,45,17,21
+Guadalupe,117,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,1770,1317,391,62
+Guadalupe,117,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,685,467,174,44
+Guadalupe,118,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,0,0,0,0
+Guadalupe,118,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,24,18,6,0
+Guadalupe,118,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,19,11,7,1
+Guadalupe,119,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,21,14,6,1
+Guadalupe,119,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,841,641,158,42
+Guadalupe,119,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,238,171,52,15
+Guadalupe,120,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,25,16,8,1
+Guadalupe,120,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,548,382,119,47
+Guadalupe,120,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,147,95,37,15
+Guadalupe,121,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,9,6,3,0
+Guadalupe,121,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,60,51,7,2
+Guadalupe,121,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,25,22,1,2
+Guadalupe,122,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,1,0,0,1
+Guadalupe,122,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,20,16,1,3
+Guadalupe,122,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,6,1,0,5
+Guadalupe,123,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,1,0,0,1
+Guadalupe,123,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,0,0,0,0
+Guadalupe,123,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,0,0,0,0
+Guadalupe,124,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,1,1,0,0
+Guadalupe,124,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,1,1,0,0
+Guadalupe,124,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,0,0,0,0
+Guadalupe,125,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,1,1,0,0
+Guadalupe,125,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,88,65,12,11
+Guadalupe,125,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,20,13,6,1
+Guadalupe,126,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,0,0,0,0
+Guadalupe,126,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,12,4,7,1
+Guadalupe,126,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,2,2,0,0
+Guadalupe,127,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,1,0,1,0
+Guadalupe,127,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,9,3,5,1
+Guadalupe,127,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,5,1,4,0
+Guadalupe,201,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,5,2,2,1
+Guadalupe,201,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,122,83,31,8
+Guadalupe,201,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,85,54,22,9
+Guadalupe,202,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,33,11,15,7
+Guadalupe,202,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,127,81,41,5
+Guadalupe,202,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,303,163,107,33
+Guadalupe,203,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,7,3,4,0
+Guadalupe,203,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,49,27,18,4
+Guadalupe,203,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,124,55,59,10
+Guadalupe,204,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,21,5,12,4
+Guadalupe,204,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,256,151,101,4
+Guadalupe,204,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,351,195,134,22
+Guadalupe,205,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,25,15,9,1
+Guadalupe,205,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,480,278,187,15
+Guadalupe,205,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,162,93,62,7
+Guadalupe,206,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,36,11,24,1
+Guadalupe,206,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,360,138,205,17
+Guadalupe,206,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,575,186,361,28
+Guadalupe,207,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,14,8,4,2
+Guadalupe,207,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,154,106,39,9
+Guadalupe,207,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,240,148,75,17
+Guadalupe,208,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,55,39,7,9
+Guadalupe,208,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,1439,1051,313,75
+Guadalupe,208,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,398,274,102,22
+Guadalupe,209,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,15,6,9,0
+Guadalupe,209,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,89,50,33,6
+Guadalupe,209,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,218,105,95,18
+Guadalupe,210,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,25,12,12,1
+Guadalupe,210,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,261,169,74,18
+Guadalupe,210,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,197,132,48,17
+Guadalupe,211,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,1,1,0,0
+Guadalupe,211,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,44,35,8,1
+Guadalupe,211,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,35,28,3,4
+Guadalupe,212,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,4,2,1,1
+Guadalupe,212,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,36,31,5,0
+Guadalupe,212,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,46,28,15,3
+Guadalupe,213,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,42,21,12,9
+Guadalupe,213,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,832,578,231,23
+Guadalupe,213,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,361,239,106,16
+Guadalupe,214,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,10,5,0,5
+Guadalupe,214,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,277,198,74,5
+Guadalupe,214,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,84,52,24,8
+Guadalupe,215,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,20,11,6,3
+Guadalupe,215,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,376,255,94,27
+Guadalupe,215,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,146,99,37,10
+Guadalupe,216,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,1,0,1,0
+Guadalupe,216,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,29,16,9,4
+Guadalupe,216,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,7,6,1,0
+Guadalupe,217,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,0,0,0,0
+Guadalupe,217,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,29,12,14,3
+Guadalupe,217,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,36,10,26,0
+Guadalupe,218,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,0,0,0,0
+Guadalupe,218,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,16,14,1,1
+Guadalupe,218,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,22,18,4,0
+Guadalupe,219,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,2,1,0,1
+Guadalupe,219,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,28,23,5,0
+Guadalupe,219,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,21,17,4,0
+Guadalupe,220,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,4,2,2,0
+Guadalupe,220,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,19,14,5,0
+Guadalupe,220,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,20,15,3,2
+Guadalupe,221,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,0,0,0,0
+Guadalupe,221,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,11,8,3,0
+Guadalupe,221,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,5,1,1,3
+Guadalupe,222,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,0,0,0,0
+Guadalupe,222,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,0,0,0,0
+Guadalupe,222,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,0,0,0,0
+Guadalupe,223,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,7,3,2,2
+Guadalupe,223,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,78,46,27,5
+Guadalupe,223,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,74,61,9,4
+Guadalupe,224,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,1,1,0,0
+Guadalupe,224,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,9,3,6,0
+Guadalupe,224,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,50,23,20,7
+Guadalupe,225,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,2,1,1,0
+Guadalupe,225,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,0,0,0,0
+Guadalupe,225,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,9,7,2,0
+Guadalupe,226,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,4,3,0,1
+Guadalupe,226,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,102,68,32,2
+Guadalupe,226,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,54,28,23,3
+Guadalupe,301,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,40,20,18,2
+Guadalupe,301,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,1012,638,317,57
+Guadalupe,301,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,692,473,200,19
+Guadalupe,302,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,68,39,22,7
+Guadalupe,302,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,1261,859,354,48
+Guadalupe,302,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,995,651,295,49
+Guadalupe,303,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,14,9,4,1
+Guadalupe,303,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,533,406,95,32
+Guadalupe,303,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,261,189,54,18
+Guadalupe,304,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,45,24,15,6
+Guadalupe,304,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,1440,1111,261,68
+Guadalupe,304,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,851,640,156,55
+Guadalupe,305,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,70,37,19,14
+Guadalupe,305,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,1373,962,353,58
+Guadalupe,305,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,967,682,222,63
+Guadalupe,306,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,45,26,14,5
+Guadalupe,306,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,1480,1170,247,63
+Guadalupe,306,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,886,694,136,56
+Guadalupe,307,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,57,33,17,7
+Guadalupe,307,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,1449,1125,266,58
+Guadalupe,307,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,1033,799,194,40
+Guadalupe,308,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,28,14,5,9
+Guadalupe,308,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,838,649,143,46
+Guadalupe,308,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,416,293,88,35
+Guadalupe,401,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,19,7,10,2
+Guadalupe,401,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,658,375,243,40
+Guadalupe,401,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,197,116,69,12
+Guadalupe,402,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,22,13,4,5
+Guadalupe,402,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,535,373,122,40
+Guadalupe,402,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,358,211,107,40
+Guadalupe,403,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,43,21,14,8
+Guadalupe,403,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,770,529,181,60
+Guadalupe,403,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,507,308,131,68
+Guadalupe,404,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,59,23,23,13
+Guadalupe,404,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,958,579,312,67
+Guadalupe,404,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,650,404,198,48
+Guadalupe,405,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,29,19,10,0
+Guadalupe,405,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,894,530,330,34
+Guadalupe,405,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,192,114,67,11
+Guadalupe,406,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,39,24,10,5
+Guadalupe,406,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,1010,764,209,37
+Guadalupe,406,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,171,115,42,14
+Guadalupe,407,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,38,20,12,6
+Guadalupe,407,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,850,616,199,35
+Guadalupe,407,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,196,119,55,22
+Guadalupe,408,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,87,29,30,28
+Guadalupe,408,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,1564,1036,413,115
+Guadalupe,408,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,701,465,199,37
+Guadalupe,409,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,56,23,22,11
+Guadalupe,409,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,1230,894,292,44
+Guadalupe,409,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,1352,985,313,54
+Guadalupe,410,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,4,3,1,0
+Guadalupe,410,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,56,44,12,0
+Guadalupe,410,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,23,18,5,0
+Guadalupe,411,"Justice, 4th Court of Appeals, Place 2",,,Under Votes,60,32,19,9
+Guadalupe,411,"Justice, 4th Court of Appeals, Place 2",,REP,Marialyn Barnard,1195,866,278,51
+Guadalupe,411,"Justice, 4th Court of Appeals, Place 2",,DEM,Beth Watkins,743,561,142,40
+Guadalupe,101,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,13,8,2,3
+Guadalupe,101,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,264,174,73,17
+Guadalupe,101,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,92,62,22,8
+Guadalupe,102,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,19,13,4,2
+Guadalupe,102,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,414,309,69,36
+Guadalupe,102,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,165,100,49,16
+Guadalupe,103,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,15,10,3,2
+Guadalupe,103,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,328,240,70,18
+Guadalupe,103,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,116,74,32,10
+Guadalupe,104,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,24,18,4,2
+Guadalupe,104,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,285,206,61,18
+Guadalupe,104,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,211,126,66,19
+Guadalupe,105,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,34,19,9,6
+Guadalupe,105,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,1162,704,388,70
+Guadalupe,105,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,318,183,107,28
+Guadalupe,106,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,64,37,11,16
+Guadalupe,106,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,1310,964,239,107
+Guadalupe,106,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,531,366,127,38
+Guadalupe,107,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,23,9,11,3
+Guadalupe,107,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,558,304,228,26
+Guadalupe,107,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,127,75,48,4
+Guadalupe,108,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,11,0,7,4
+Guadalupe,108,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,267,103,139,25
+Guadalupe,108,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,153,65,72,16
+Guadalupe,109,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,8,4,4,0
+Guadalupe,109,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,253,125,119,9
+Guadalupe,109,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,51,23,25,3
+Guadalupe,110,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,6,3,2,1
+Guadalupe,110,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,85,69,14,2
+Guadalupe,110,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,60,45,10,5
+Guadalupe,111,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,4,1,2,1
+Guadalupe,111,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,32,21,6,5
+Guadalupe,111,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,28,12,8,8
+Guadalupe,112,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,18,7,10,1
+Guadalupe,112,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,69,27,42,0
+Guadalupe,112,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,139,51,88,0
+Guadalupe,113,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,12,8,1,3
+Guadalupe,113,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,394,281,95,18
+Guadalupe,113,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,178,115,56,7
+Guadalupe,114,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,14,7,2,5
+Guadalupe,114,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,284,208,60,16
+Guadalupe,114,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,153,101,47,5
+Guadalupe,115,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,5,2,2,1
+Guadalupe,115,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,146,106,39,1
+Guadalupe,115,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,25,18,5,2
+Guadalupe,116,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,38,14,19,5
+Guadalupe,116,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,983,663,260,60
+Guadalupe,116,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,320,169,127,24
+Guadalupe,117,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,85,47,18,20
+Guadalupe,117,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,1767,1315,389,63
+Guadalupe,117,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,686,467,175,44
+Guadalupe,118,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,0,0,0,0
+Guadalupe,118,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,25,19,6,0
+Guadalupe,118,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,18,10,7,1
+Guadalupe,119,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,23,16,6,1
+Guadalupe,119,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,828,630,156,42
+Guadalupe,119,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,249,180,54,15
+Guadalupe,120,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,24,14,9,1
+Guadalupe,120,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,541,375,121,45
+Guadalupe,120,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,155,104,34,17
+Guadalupe,121,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,9,6,3,0
+Guadalupe,121,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,61,52,7,2
+Guadalupe,121,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,24,21,1,2
+Guadalupe,122,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,1,0,0,1
+Guadalupe,122,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,19,16,1,2
+Guadalupe,122,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,7,1,0,6
+Guadalupe,123,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,1,0,0,1
+Guadalupe,123,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,0,0,0,0
+Guadalupe,123,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,0,0,0,0
+Guadalupe,124,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,1,1,0,0
+Guadalupe,124,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,1,1,0,0
+Guadalupe,124,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,0,0,0,0
+Guadalupe,125,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,2,1,1,0
+Guadalupe,125,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,88,66,11,11
+Guadalupe,125,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,19,12,6,1
+Guadalupe,126,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,0,0,0,0
+Guadalupe,126,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,12,4,7,1
+Guadalupe,126,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,2,2,0,0
+Guadalupe,127,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,1,0,1,0
+Guadalupe,127,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,8,4,4,0
+Guadalupe,127,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,6,0,5,1
+Guadalupe,201,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,5,3,1,1
+Guadalupe,201,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,118,82,28,8
+Guadalupe,201,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,89,54,26,9
+Guadalupe,202,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,29,10,12,7
+Guadalupe,202,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,125,82,39,4
+Guadalupe,202,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,309,163,112,34
+Guadalupe,203,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,7,4,3,0
+Guadalupe,203,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,45,27,14,4
+Guadalupe,203,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,128,54,64,10
+Guadalupe,204,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,19,5,11,3
+Guadalupe,204,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,238,140,94,4
+Guadalupe,204,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,371,206,142,23
+Guadalupe,205,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,24,14,9,1
+Guadalupe,205,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,476,277,184,15
+Guadalupe,205,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,167,95,65,7
+Guadalupe,206,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,35,12,22,1
+Guadalupe,206,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,353,138,198,17
+Guadalupe,206,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,583,185,370,28
+Guadalupe,207,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,12,5,5,2
+Guadalupe,207,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,150,104,36,10
+Guadalupe,207,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,246,153,77,16
+Guadalupe,208,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,57,41,7,9
+Guadalupe,208,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,1440,1052,313,75
+Guadalupe,208,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,395,271,102,22
+Guadalupe,209,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,15,6,9,0
+Guadalupe,209,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,86,46,34,6
+Guadalupe,209,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,221,109,94,18
+Guadalupe,210,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,25,12,11,2
+Guadalupe,210,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,254,168,69,17
+Guadalupe,210,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,204,133,54,17
+Guadalupe,211,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,0,0,0,0
+Guadalupe,211,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,43,34,8,1
+Guadalupe,211,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,37,30,3,4
+Guadalupe,212,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,3,2,0,1
+Guadalupe,212,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,34,29,5,0
+Guadalupe,212,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,49,30,16,3
+Guadalupe,213,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,43,22,12,9
+Guadalupe,213,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,832,578,230,24
+Guadalupe,213,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,360,238,107,15
+Guadalupe,214,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,11,5,1,5
+Guadalupe,214,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,273,197,71,5
+Guadalupe,214,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,87,53,26,8
+Guadalupe,215,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,19,11,5,3
+Guadalupe,215,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,376,252,97,27
+Guadalupe,215,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,147,102,35,10
+Guadalupe,216,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,1,0,1,0
+Guadalupe,216,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,29,17,8,4
+Guadalupe,216,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,7,5,2,0
+Guadalupe,217,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,0,0,0,0
+Guadalupe,217,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,29,12,14,3
+Guadalupe,217,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,36,10,26,0
+Guadalupe,218,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,0,0,0,0
+Guadalupe,218,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,14,12,1,1
+Guadalupe,218,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,24,20,4,0
+Guadalupe,219,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,3,2,0,1
+Guadalupe,219,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,26,21,5,0
+Guadalupe,219,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,22,18,4,0
+Guadalupe,220,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,3,1,2,0
+Guadalupe,220,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,19,15,4,0
+Guadalupe,220,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,21,15,4,2
+Guadalupe,221,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,0,0,0,0
+Guadalupe,221,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,11,8,3,0
+Guadalupe,221,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,5,1,1,3
+Guadalupe,222,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,0,0,0,0
+Guadalupe,222,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,0,0,0,0
+Guadalupe,222,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,0,0,0,0
+Guadalupe,223,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,7,3,2,2
+Guadalupe,223,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,75,45,25,5
+Guadalupe,223,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,77,62,11,4
+Guadalupe,224,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,0,0,0,0
+Guadalupe,224,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,8,2,6,0
+Guadalupe,224,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,52,25,20,7
+Guadalupe,225,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,2,1,1,0
+Guadalupe,225,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,0,0,0,0
+Guadalupe,225,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,9,7,2,0
+Guadalupe,226,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,4,3,0,1
+Guadalupe,226,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,102,67,32,3
+Guadalupe,226,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,54,29,23,2
+Guadalupe,301,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,36,16,18,2
+Guadalupe,301,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,1024,650,317,57
+Guadalupe,301,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,684,465,200,19
+Guadalupe,302,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,67,38,22,7
+Guadalupe,302,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,1242,852,343,47
+Guadalupe,302,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,1015,659,306,50
+Guadalupe,303,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,13,8,4,1
+Guadalupe,303,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,530,408,93,29
+Guadalupe,303,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,265,188,56,21
+Guadalupe,304,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,47,26,15,6
+Guadalupe,304,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,1424,1096,260,68
+Guadalupe,304,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,865,653,157,55
+Guadalupe,305,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,74,41,19,14
+Guadalupe,305,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,1363,952,353,58
+Guadalupe,305,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,973,688,222,63
+Guadalupe,306,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,43,25,13,5
+Guadalupe,306,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,1466,1162,244,60
+Guadalupe,306,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,902,703,140,59
+Guadalupe,307,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,54,33,14,7
+Guadalupe,307,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,1452,1134,262,56
+Guadalupe,307,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,1033,790,201,42
+Guadalupe,308,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,32,18,5,9
+Guadalupe,308,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,830,646,137,47
+Guadalupe,308,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,420,292,94,34
+Guadalupe,401,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,20,6,11,3
+Guadalupe,401,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,651,372,241,38
+Guadalupe,401,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,203,120,70,13
+Guadalupe,402,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,22,14,3,5
+Guadalupe,402,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,527,365,122,40
+Guadalupe,402,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,366,218,108,40
+Guadalupe,403,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,44,22,15,7
+Guadalupe,403,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,768,528,181,59
+Guadalupe,403,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,508,308,130,70
+Guadalupe,404,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,56,22,22,12
+Guadalupe,404,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,946,577,304,65
+Guadalupe,404,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,665,407,207,51
+Guadalupe,405,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,29,20,9,0
+Guadalupe,405,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,883,525,325,33
+Guadalupe,405,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,203,118,73,12
+Guadalupe,406,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,38,25,8,5
+Guadalupe,406,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,1008,758,211,39
+Guadalupe,406,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,174,120,42,12
+Guadalupe,407,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,34,20,9,5
+Guadalupe,407,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,860,619,203,38
+Guadalupe,407,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,190,116,54,20
+Guadalupe,408,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,86,29,30,27
+Guadalupe,408,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,1559,1033,412,114
+Guadalupe,408,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,707,468,200,39
+Guadalupe,409,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,55,22,21,12
+Guadalupe,409,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,1231,895,292,44
+Guadalupe,409,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,1352,985,314,53
+Guadalupe,410,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,5,4,1,0
+Guadalupe,410,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,55,44,11,0
+Guadalupe,410,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,23,17,6,0
+Guadalupe,411,"Justice, 4th Court of Appeals, Place 3",,,Under Votes,61,33,19,9
+Guadalupe,411,"Justice, 4th Court of Appeals, Place 3",,REP,Jason Pulliam,1188,860,276,52
+Guadalupe,411,"Justice, 4th Court of Appeals, Place 3",,DEM,Patricia Alvaraz,749,566,144,39
+Guadalupe,101,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,11,6,2,3
+Guadalupe,101,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,264,172,75,17
+Guadalupe,101,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,94,66,20,8
+Guadalupe,102,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,16,10,5,1
+Guadalupe,102,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,416,312,68,36
+Guadalupe,102,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,166,100,49,17
+Guadalupe,103,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,14,9,3,2
+Guadalupe,103,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,326,239,69,18
+Guadalupe,103,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,119,76,33,10
+Guadalupe,104,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,23,16,5,2
+Guadalupe,104,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,283,204,60,19
+Guadalupe,104,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,214,130,66,18
+Guadalupe,105,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,35,20,9,6
+Guadalupe,105,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,1158,700,387,71
+Guadalupe,105,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,321,186,108,27
+Guadalupe,106,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,62,35,10,17
+Guadalupe,106,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,1310,967,237,106
+Guadalupe,106,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,533,365,130,38
+Guadalupe,107,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,24,9,12,3
+Guadalupe,107,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,563,309,228,26
+Guadalupe,107,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,121,70,47,4
+Guadalupe,108,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,11,0,7,4
+Guadalupe,108,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,267,102,140,25
+Guadalupe,108,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,153,66,71,16
+Guadalupe,109,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,9,4,5,0
+Guadalupe,109,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,255,127,119,9
+Guadalupe,109,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,48,21,24,3
+Guadalupe,110,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,6,3,2,1
+Guadalupe,110,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,85,69,14,2
+Guadalupe,110,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,60,45,10,5
+Guadalupe,111,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,3,1,1,1
+Guadalupe,111,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,33,22,6,5
+Guadalupe,111,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,28,11,9,8
+Guadalupe,112,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,18,7,10,1
+Guadalupe,112,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,71,27,44,0
+Guadalupe,112,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,137,51,86,0
+Guadalupe,113,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,11,7,1,3
+Guadalupe,113,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,398,284,96,18
+Guadalupe,113,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,175,113,55,7
+Guadalupe,114,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,15,8,2,5
+Guadalupe,114,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,285,209,61,15
+Guadalupe,114,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,151,99,46,6
+Guadalupe,115,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,6,2,3,1
+Guadalupe,115,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,146,107,38,1
+Guadalupe,115,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,24,17,5,2
+Guadalupe,116,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,40,15,19,6
+Guadalupe,116,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,986,668,258,60
+Guadalupe,116,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,315,163,129,23
+Guadalupe,117,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,84,47,17,20
+Guadalupe,117,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,1768,1314,392,62
+Guadalupe,117,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,686,468,173,45
+Guadalupe,118,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,0,0,0,0
+Guadalupe,118,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,23,17,6,0
+Guadalupe,118,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,20,12,7,1
+Guadalupe,119,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,23,17,5,1
+Guadalupe,119,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,841,637,161,43
+Guadalupe,119,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,236,172,50,14
+Guadalupe,120,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,26,14,11,1
+Guadalupe,120,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,548,382,121,45
+Guadalupe,120,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,146,97,32,17
+Guadalupe,121,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,9,6,3,0
+Guadalupe,121,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,61,53,6,2
+Guadalupe,121,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,24,20,2,2
+Guadalupe,122,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,1,0,0,1
+Guadalupe,122,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,19,16,1,2
+Guadalupe,122,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,7,1,0,6
+Guadalupe,123,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,1,0,0,1
+Guadalupe,123,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,0,0,0,0
+Guadalupe,123,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,0,0,0,0
+Guadalupe,124,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,1,1,0,0
+Guadalupe,124,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,1,1,0,0
+Guadalupe,124,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,0,0,0,0
+Guadalupe,125,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,2,1,1,0
+Guadalupe,125,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,87,65,11,11
+Guadalupe,125,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,20,13,6,1
+Guadalupe,126,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,0,0,0,0
+Guadalupe,126,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,12,4,7,1
+Guadalupe,126,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,2,2,0,0
+Guadalupe,127,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,1,0,1,0
+Guadalupe,127,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,8,3,4,1
+Guadalupe,127,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,6,1,5,0
+Guadalupe,201,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,5,2,2,1
+Guadalupe,201,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,120,82,29,9
+Guadalupe,201,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,87,55,24,8
+Guadalupe,202,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,29,9,12,8
+Guadalupe,202,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,122,81,38,3
+Guadalupe,202,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,312,165,113,34
+Guadalupe,203,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,7,4,3,0
+Guadalupe,203,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,46,28,14,4
+Guadalupe,203,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,127,53,64,10
+Guadalupe,204,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,20,6,11,3
+Guadalupe,204,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,240,143,92,5
+Guadalupe,204,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,368,202,144,22
+Guadalupe,205,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,27,16,10,1
+Guadalupe,205,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,473,275,184,14
+Guadalupe,205,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,167,95,64,8
+Guadalupe,206,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,34,11,22,1
+Guadalupe,206,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,350,136,197,17
+Guadalupe,206,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,587,188,371,28
+Guadalupe,207,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,15,8,5,2
+Guadalupe,207,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,148,103,35,10
+Guadalupe,207,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,245,151,78,16
+Guadalupe,208,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,59,43,7,9
+Guadalupe,208,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,1431,1046,313,72
+Guadalupe,208,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,402,275,102,25
+Guadalupe,209,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,14,5,9,0
+Guadalupe,209,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,82,44,32,6
+Guadalupe,209,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,226,112,96,18
+Guadalupe,210,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,23,11,10,2
+Guadalupe,210,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,258,169,72,17
+Guadalupe,210,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,202,133,52,17
+Guadalupe,211,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,1,0,0,1
+Guadalupe,211,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,45,36,8,1
+Guadalupe,211,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,34,28,3,3
+Guadalupe,212,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,2,1,0,1
+Guadalupe,212,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,34,29,5,0
+Guadalupe,212,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,50,31,16,3
+Guadalupe,213,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,44,23,12,9
+Guadalupe,213,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,831,573,234,24
+Guadalupe,213,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,360,242,103,15
+Guadalupe,214,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,8,3,0,5
+Guadalupe,214,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,274,198,71,5
+Guadalupe,214,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,89,54,27,8
+Guadalupe,215,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,19,11,5,3
+Guadalupe,215,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,375,253,95,27
+Guadalupe,215,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,148,101,37,10
+Guadalupe,216,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,1,0,1,0
+Guadalupe,216,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,29,17,8,4
+Guadalupe,216,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,7,5,2,0
+Guadalupe,217,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,0,0,0,0
+Guadalupe,217,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,27,10,14,3
+Guadalupe,217,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,38,12,26,0
+Guadalupe,218,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,0,0,0,0
+Guadalupe,218,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,15,13,1,1
+Guadalupe,218,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,23,19,4,0
+Guadalupe,219,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,2,1,0,1
+Guadalupe,219,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,26,21,5,0
+Guadalupe,219,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,23,19,4,0
+Guadalupe,220,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,3,1,2,0
+Guadalupe,220,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,19,15,4,0
+Guadalupe,220,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,21,15,4,2
+Guadalupe,221,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,0,0,0,0
+Guadalupe,221,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,11,8,3,0
+Guadalupe,221,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,5,1,1,3
+Guadalupe,222,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,0,0,0,0
+Guadalupe,222,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,0,0,0,0
+Guadalupe,222,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,0,0,0,0
+Guadalupe,223,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,7,3,2,2
+Guadalupe,223,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,76,44,27,5
+Guadalupe,223,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,76,63,9,4
+Guadalupe,224,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,1,1,0,0
+Guadalupe,224,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,8,2,6,0
+Guadalupe,224,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,51,24,20,7
+Guadalupe,225,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,2,1,1,0
+Guadalupe,225,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,0,0,0,0
+Guadalupe,225,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,9,7,2,0
+Guadalupe,226,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,4,3,0,1
+Guadalupe,226,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,101,66,32,3
+Guadalupe,226,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,55,30,23,2
+Guadalupe,301,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,41,19,20,2
+Guadalupe,301,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,1016,638,322,56
+Guadalupe,301,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,687,474,193,20
+Guadalupe,302,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,70,43,20,7
+Guadalupe,302,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,1244,855,342,47
+Guadalupe,302,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,1010,651,309,50
+Guadalupe,303,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,13,8,4,1
+Guadalupe,303,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,527,403,94,30
+Guadalupe,303,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,268,193,55,20
+Guadalupe,304,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,47,25,16,6
+Guadalupe,304,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,1422,1099,255,68
+Guadalupe,304,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,867,651,161,55
+Guadalupe,305,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,73,42,18,13
+Guadalupe,305,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,1331,934,340,57
+Guadalupe,305,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,1006,705,236,65
+Guadalupe,306,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,43,26,12,5
+Guadalupe,306,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,1463,1160,241,62
+Guadalupe,306,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,905,704,144,57
+Guadalupe,307,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,56,34,15,7
+Guadalupe,307,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,1449,1125,267,57
+Guadalupe,307,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,1034,798,195,41
+Guadalupe,308,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,30,17,4,9
+Guadalupe,308,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,817,637,135,45
+Guadalupe,308,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,435,302,97,36
+Guadalupe,401,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,21,7,10,4
+Guadalupe,401,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,653,370,244,39
+Guadalupe,401,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,200,121,68,11
+Guadalupe,402,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,20,13,2,5
+Guadalupe,402,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,536,367,128,41
+Guadalupe,402,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,359,217,103,39
+Guadalupe,403,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,46,25,15,6
+Guadalupe,403,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,770,531,177,62
+Guadalupe,403,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,504,302,134,68
+Guadalupe,404,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,57,24,21,12
+Guadalupe,404,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,950,572,311,67
+Guadalupe,404,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,660,410,201,49
+Guadalupe,405,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,31,22,9,0
+Guadalupe,405,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,887,524,329,34
+Guadalupe,405,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,197,117,69,11
+Guadalupe,406,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,40,25,10,5
+Guadalupe,406,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,1013,766,210,37
+Guadalupe,406,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,167,112,41,14
+Guadalupe,407,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,34,20,10,4
+Guadalupe,407,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,858,615,205,38
+Guadalupe,407,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,192,120,51,21
+Guadalupe,408,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,87,29,31,27
+Guadalupe,408,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,1552,1032,405,115
+Guadalupe,408,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,713,469,206,38
+Guadalupe,409,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,56,21,23,12
+Guadalupe,409,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,1219,884,290,45
+Guadalupe,409,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,1363,997,314,52
+Guadalupe,410,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,4,3,1,0
+Guadalupe,410,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,55,44,11,0
+Guadalupe,410,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,24,18,6,0
+Guadalupe,411,"Justice, 4th Court of Appeals, Place 4",,,Under Votes,62,34,19,9
+Guadalupe,411,"Justice, 4th Court of Appeals, Place 4",,REP,Patrick Ballantyne,1196,867,280,49
+Guadalupe,411,"Justice, 4th Court of Appeals, Place 4",,DEM,Luz Elena Chapa,740,558,140,42
+Guadalupe,101,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,11,6,2,3
+Guadalupe,101,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,266,176,73,17
+Guadalupe,101,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,92,62,22,8
+Guadalupe,102,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,18,12,5,1
+Guadalupe,102,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,423,314,72,37
+Guadalupe,102,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,157,96,45,16
+Guadalupe,103,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,14,9,2,3
+Guadalupe,103,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,327,239,70,18
+Guadalupe,103,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,118,76,33,9
+Guadalupe,104,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,23,16,5,2
+Guadalupe,104,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,285,208,58,19
+Guadalupe,104,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,212,126,68,18
+Guadalupe,105,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,35,20,8,7
+Guadalupe,105,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,1167,704,390,73
+Guadalupe,105,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,312,182,106,24
+Guadalupe,106,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,60,34,10,16
+Guadalupe,106,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,1318,970,243,105
+Guadalupe,106,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,527,363,124,40
+Guadalupe,107,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,23,9,11,3
+Guadalupe,107,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,563,309,228,26
+Guadalupe,107,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,122,70,48,4
+Guadalupe,108,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,11,0,7,4
+Guadalupe,108,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,268,102,140,26
+Guadalupe,108,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,152,66,71,15
+Guadalupe,109,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,8,4,4,0
+Guadalupe,109,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,256,128,119,9
+Guadalupe,109,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,48,20,25,3
+Guadalupe,110,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,7,4,2,1
+Guadalupe,110,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,84,68,14,2
+Guadalupe,110,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,60,45,10,5
+Guadalupe,111,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,3,1,1,1
+Guadalupe,111,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,33,21,6,6
+Guadalupe,111,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,28,12,9,7
+Guadalupe,112,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,19,7,11,1
+Guadalupe,112,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,71,27,44,0
+Guadalupe,112,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,136,51,85,0
+Guadalupe,113,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,11,7,1,3
+Guadalupe,113,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,401,286,97,18
+Guadalupe,113,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,172,111,54,7
+Guadalupe,114,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,16,8,3,5
+Guadalupe,114,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,280,206,59,15
+Guadalupe,114,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,155,102,47,6
+Guadalupe,115,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,6,2,3,1
+Guadalupe,115,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,146,107,38,1
+Guadalupe,115,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,24,17,5,2
+Guadalupe,116,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,37,14,18,5
+Guadalupe,116,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,992,666,265,61
+Guadalupe,116,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,312,166,123,23
+Guadalupe,117,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,82,46,16,20
+Guadalupe,117,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,1778,1323,392,63
+Guadalupe,117,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,678,460,174,44
+Guadalupe,118,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,0,0,0,0
+Guadalupe,118,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,25,19,6,0
+Guadalupe,118,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,18,10,7,1
+Guadalupe,119,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,21,14,5,2
+Guadalupe,119,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,846,646,157,43
+Guadalupe,119,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,233,166,54,13
+Guadalupe,120,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,28,15,12,1
+Guadalupe,120,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,548,381,120,47
+Guadalupe,120,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,144,97,32,15
+Guadalupe,121,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,10,7,3,0
+Guadalupe,121,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,58,50,6,2
+Guadalupe,121,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,26,22,2,2
+Guadalupe,122,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,1,0,0,1
+Guadalupe,122,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,19,16,1,2
+Guadalupe,122,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,7,1,0,6
+Guadalupe,123,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,1,0,0,1
+Guadalupe,123,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,0,0,0,0
+Guadalupe,123,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,0,0,0,0
+Guadalupe,124,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,1,1,0,0
+Guadalupe,124,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,1,1,0,0
+Guadalupe,124,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,0,0,0,0
+Guadalupe,125,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,1,1,0,0
+Guadalupe,125,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,88,65,12,11
+Guadalupe,125,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,20,13,6,1
+Guadalupe,126,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,0,0,0,0
+Guadalupe,126,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,12,4,7,1
+Guadalupe,126,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,2,2,0,0
+Guadalupe,127,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,1,0,1,0
+Guadalupe,127,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,9,3,5,1
+Guadalupe,127,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,5,1,4,0
+Guadalupe,201,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,5,2,2,1
+Guadalupe,201,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,120,83,29,8
+Guadalupe,201,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,87,54,24,9
+Guadalupe,202,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,28,8,13,7
+Guadalupe,202,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,128,80,41,7
+Guadalupe,202,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,307,167,109,31
+Guadalupe,203,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,8,4,3,1
+Guadalupe,203,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,46,27,15,4
+Guadalupe,203,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,126,54,63,9
+Guadalupe,204,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,21,6,11,4
+Guadalupe,204,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,240,143,93,4
+Guadalupe,204,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,367,202,143,22
+Guadalupe,205,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,26,17,8,1
+Guadalupe,205,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,480,278,186,16
+Guadalupe,205,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,161,91,64,6
+Guadalupe,206,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,32,10,21,1
+Guadalupe,206,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,344,137,190,17
+Guadalupe,206,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,595,188,379,28
+Guadalupe,207,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,15,8,5,2
+Guadalupe,207,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,147,103,34,10
+Guadalupe,207,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,246,151,79,16
+Guadalupe,208,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,56,39,8,9
+Guadalupe,208,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,1444,1053,316,75
+Guadalupe,208,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,392,272,98,22
+Guadalupe,209,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,15,6,9,0
+Guadalupe,209,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,83,45,32,6
+Guadalupe,209,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,224,110,96,18
+Guadalupe,210,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,22,9,11,2
+Guadalupe,210,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,258,169,74,15
+Guadalupe,210,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,203,135,49,19
+Guadalupe,211,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,1,1,0,0
+Guadalupe,211,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,45,34,9,2
+Guadalupe,211,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,34,29,2,3
+Guadalupe,212,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,2,1,0,1
+Guadalupe,212,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,34,29,5,0
+Guadalupe,212,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,50,31,16,3
+Guadalupe,213,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,44,23,12,9
+Guadalupe,213,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,830,576,230,24
+Guadalupe,213,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,361,239,107,15
+Guadalupe,214,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,12,7,0,5
+Guadalupe,214,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,272,196,71,5
+Guadalupe,214,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,87,52,27,8
+Guadalupe,215,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,20,12,5,3
+Guadalupe,215,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,377,253,97,27
+Guadalupe,215,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,145,100,35,10
+Guadalupe,216,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,1,0,1,0
+Guadalupe,216,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,29,17,8,4
+Guadalupe,216,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,7,5,2,0
+Guadalupe,217,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,0,0,0,0
+Guadalupe,217,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,29,12,14,3
+Guadalupe,217,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,36,10,26,0
+Guadalupe,218,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,0,0,0,0
+Guadalupe,218,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,14,12,1,1
+Guadalupe,218,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,24,20,4,0
+Guadalupe,219,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,2,1,0,1
+Guadalupe,219,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,27,21,6,0
+Guadalupe,219,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,22,19,3,0
+Guadalupe,220,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,3,1,2,0
+Guadalupe,220,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,20,16,4,0
+Guadalupe,220,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,20,14,4,2
+Guadalupe,221,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,0,0,0,0
+Guadalupe,221,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,12,8,3,1
+Guadalupe,221,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,4,1,1,2
+Guadalupe,222,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,0,0,0,0
+Guadalupe,222,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,0,0,0,0
+Guadalupe,222,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,0,0,0,0
+Guadalupe,223,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,7,3,2,2
+Guadalupe,223,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,74,44,25,5
+Guadalupe,223,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,78,63,11,4
+Guadalupe,224,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,0,0,0,0
+Guadalupe,224,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,8,2,6,0
+Guadalupe,224,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,52,25,20,7
+Guadalupe,225,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,2,1,1,0
+Guadalupe,225,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,1,0,1,0
+Guadalupe,225,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,8,7,1,0
+Guadalupe,226,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,4,3,0,1
+Guadalupe,226,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,101,66,32,3
+Guadalupe,226,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,55,30,23,2
+Guadalupe,301,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,39,17,20,2
+Guadalupe,301,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,1024,646,321,57
+Guadalupe,301,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,681,468,194,19
+Guadalupe,302,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,66,38,21,7
+Guadalupe,302,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,1262,866,346,50
+Guadalupe,302,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,996,645,304,47
+Guadalupe,303,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,13,9,3,1
+Guadalupe,303,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,539,412,96,31
+Guadalupe,303,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,256,183,54,19
+Guadalupe,304,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,44,22,16,6
+Guadalupe,304,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,1433,1107,259,67
+Guadalupe,304,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,859,646,157,56
+Guadalupe,305,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,72,41,17,14
+Guadalupe,305,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,1364,959,347,58
+Guadalupe,305,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,974,681,230,63
+Guadalupe,306,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,41,25,11,5
+Guadalupe,306,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,1475,1168,246,61
+Guadalupe,306,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,895,697,140,58
+Guadalupe,307,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,53,33,13,7
+Guadalupe,307,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,1456,1137,261,58
+Guadalupe,307,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,1030,787,203,40
+Guadalupe,308,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,30,17,4,9
+Guadalupe,308,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,836,648,141,47
+Guadalupe,308,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,416,291,91,34
+Guadalupe,401,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,20,6,10,4
+Guadalupe,401,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,659,378,242,39
+Guadalupe,401,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,195,114,70,11
+Guadalupe,402,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,18,12,1,5
+Guadalupe,402,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,542,375,128,39
+Guadalupe,402,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,355,210,104,41
+Guadalupe,403,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,48,26,15,7
+Guadalupe,403,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,780,534,185,61
+Guadalupe,403,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,492,298,126,68
+Guadalupe,404,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,55,22,21,12
+Guadalupe,404,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,963,589,309,65
+Guadalupe,404,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,649,395,203,51
+Guadalupe,405,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,30,22,8,0
+Guadalupe,405,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,887,526,327,34
+Guadalupe,405,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,198,115,72,11
+Guadalupe,406,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,40,25,10,5
+Guadalupe,406,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,1020,770,212,38
+Guadalupe,406,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,160,108,39,13
+Guadalupe,407,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,33,19,9,5
+Guadalupe,407,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,866,622,206,38
+Guadalupe,407,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,185,114,51,20
+Guadalupe,408,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,83,28,28,27
+Guadalupe,408,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,1557,1035,407,115
+Guadalupe,408,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,712,467,207,38
+Guadalupe,409,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,57,21,24,12
+Guadalupe,409,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,1238,896,298,44
+Guadalupe,409,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,1343,985,305,53
+Guadalupe,410,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,4,3,1,0
+Guadalupe,410,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,57,45,12,0
+Guadalupe,410,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,22,17,5,0
+Guadalupe,411,"JUSTICE, 4TH COURT OF APPEALS PL 5",,,Under Votes,61,33,19,9
+Guadalupe,411,"JUSTICE, 4TH COURT OF APPEALS PL 5",,REP,Rebecca Simmons,1208,876,280,52
+Guadalupe,411,"JUSTICE, 4TH COURT OF APPEALS PL 5",,DEM,Liza Rodriguez,729,550,140,39
+Guadalupe,101,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,9,4,2,3
+Guadalupe,101,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,269,175,75,19
+Guadalupe,101,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,91,65,20,6
+Guadalupe,102,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,15,12,2,1
+Guadalupe,102,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,415,308,71,36
+Guadalupe,102,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,168,102,49,17
+Guadalupe,103,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,14,9,3,2
+Guadalupe,103,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,326,240,69,17
+Guadalupe,103,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,119,75,33,11
+Guadalupe,104,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,24,17,5,2
+Guadalupe,104,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,278,202,58,18
+Guadalupe,104,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,218,131,68,19
+Guadalupe,105,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,32,17,9,6
+Guadalupe,105,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,1160,704,385,71
+Guadalupe,105,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,322,185,110,27
+Guadalupe,106,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,58,33,9,16
+Guadalupe,106,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,1310,964,241,105
+Guadalupe,106,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,537,370,127,40
+Guadalupe,107,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,25,10,12,3
+Guadalupe,107,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,558,306,225,27
+Guadalupe,107,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,125,72,50,3
+Guadalupe,108,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,11,0,7,4
+Guadalupe,108,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,265,101,139,25
+Guadalupe,108,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,155,67,72,16
+Guadalupe,109,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,9,4,5,0
+Guadalupe,109,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,253,128,116,9
+Guadalupe,109,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,50,20,27,3
+Guadalupe,110,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,6,3,2,1
+Guadalupe,110,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,85,69,14,2
+Guadalupe,110,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,60,45,10,5
+Guadalupe,111,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,3,1,1,1
+Guadalupe,111,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,32,21,6,5
+Guadalupe,111,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,29,12,9,8
+Guadalupe,112,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,19,7,11,1
+Guadalupe,112,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,67,26,41,0
+Guadalupe,112,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,140,52,88,0
+Guadalupe,113,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,11,7,1,3
+Guadalupe,113,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,395,282,95,18
+Guadalupe,113,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,178,115,56,7
+Guadalupe,114,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,15,7,2,6
+Guadalupe,114,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,281,207,60,14
+Guadalupe,114,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,155,102,47,6
+Guadalupe,115,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,6,2,3,1
+Guadalupe,115,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,147,108,38,1
+Guadalupe,115,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,23,16,5,2
+Guadalupe,116,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,40,16,18,6
+Guadalupe,116,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,987,669,260,58
+Guadalupe,116,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,314,161,128,25
+Guadalupe,117,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,84,50,15,19
+Guadalupe,117,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,1756,1310,387,59
+Guadalupe,117,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,698,469,180,49
+Guadalupe,118,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,0,0,0,0
+Guadalupe,118,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,25,19,6,0
+Guadalupe,118,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,18,10,7,1
+Guadalupe,119,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,20,13,6,1
+Guadalupe,119,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,827,631,155,41
+Guadalupe,119,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,253,182,55,16
+Guadalupe,120,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,24,13,10,1
+Guadalupe,120,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,543,379,117,47
+Guadalupe,120,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,153,101,37,15
+Guadalupe,121,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,7,4,3,0
+Guadalupe,121,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,60,52,6,2
+Guadalupe,121,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,27,23,2,2
+Guadalupe,122,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,1,0,0,1
+Guadalupe,122,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,19,16,1,2
+Guadalupe,122,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,7,1,0,6
+Guadalupe,123,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,1,0,0,1
+Guadalupe,123,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,0,0,0,0
+Guadalupe,123,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,0,0,0,0
+Guadalupe,124,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,1,1,0,0
+Guadalupe,124,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,1,1,0,0
+Guadalupe,124,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,0,0,0,0
+Guadalupe,125,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,1,1,0,0
+Guadalupe,125,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,88,65,12,11
+Guadalupe,125,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,20,13,6,1
+Guadalupe,126,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,0,0,0,0
+Guadalupe,126,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,12,4,7,1
+Guadalupe,126,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,2,2,0,0
+Guadalupe,127,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,1,0,1,0
+Guadalupe,127,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,9,4,4,1
+Guadalupe,127,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,5,0,5,0
+Guadalupe,201,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,5,2,2,1
+Guadalupe,201,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,121,83,30,8
+Guadalupe,201,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,86,54,23,9
+Guadalupe,202,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,28,9,12,7
+Guadalupe,202,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,123,81,37,5
+Guadalupe,202,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,312,165,114,33
+Guadalupe,203,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,8,5,3,0
+Guadalupe,203,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,43,24,15,4
+Guadalupe,203,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,129,56,63,10
+Guadalupe,204,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,18,6,9,3
+Guadalupe,204,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,238,141,92,5
+Guadalupe,204,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,372,204,146,22
+Guadalupe,205,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,24,15,8,1
+Guadalupe,205,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,474,277,183,14
+Guadalupe,205,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,169,94,67,8
+Guadalupe,206,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,32,11,20,1
+Guadalupe,206,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,348,136,195,17
+Guadalupe,206,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,591,188,375,28
+Guadalupe,207,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,15,8,5,2
+Guadalupe,207,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,147,101,36,10
+Guadalupe,207,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,246,153,77,16
+Guadalupe,208,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,55,39,7,9
+Guadalupe,208,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,1433,1048,315,70
+Guadalupe,208,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,404,277,100,27
+Guadalupe,209,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,13,5,8,0
+Guadalupe,209,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,82,44,32,6
+Guadalupe,209,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,227,112,97,18
+Guadalupe,210,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,18,9,7,2
+Guadalupe,210,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,254,165,73,16
+Guadalupe,210,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,211,139,54,18
+Guadalupe,211,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,0,0,0,0
+Guadalupe,211,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,45,36,8,1
+Guadalupe,211,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,35,28,3,4
+Guadalupe,212,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,2,1,0,1
+Guadalupe,212,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,36,30,6,0
+Guadalupe,212,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,48,30,15,3
+Guadalupe,213,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,43,22,12,9
+Guadalupe,213,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,826,571,232,23
+Guadalupe,213,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,366,245,105,16
+Guadalupe,214,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,9,3,1,5
+Guadalupe,214,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,271,197,69,5
+Guadalupe,214,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,91,55,28,8
+Guadalupe,215,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,20,12,5,3
+Guadalupe,215,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,375,251,97,27
+Guadalupe,215,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,147,102,35,10
+Guadalupe,216,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,1,0,1,0
+Guadalupe,216,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,29,17,8,4
+Guadalupe,216,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,7,5,2,0
+Guadalupe,217,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,0,0,0,0
+Guadalupe,217,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,29,12,14,3
+Guadalupe,217,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,36,10,26,0
+Guadalupe,218,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,0,0,0,0
+Guadalupe,218,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,14,12,1,1
+Guadalupe,218,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,24,20,4,0
+Guadalupe,219,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,1,0,0,1
+Guadalupe,219,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,26,21,5,0
+Guadalupe,219,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,24,20,4,0
+Guadalupe,220,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,3,1,2,0
+Guadalupe,220,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,20,16,4,0
+Guadalupe,220,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,20,14,4,2
+Guadalupe,221,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,0,0,0,0
+Guadalupe,221,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,11,8,3,0
+Guadalupe,221,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,5,1,1,3
+Guadalupe,222,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,0,0,0,0
+Guadalupe,222,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,0,0,0,0
+Guadalupe,222,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,0,0,0,0
+Guadalupe,223,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,7,3,2,2
+Guadalupe,223,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,74,43,26,5
+Guadalupe,223,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,78,64,10,4
+Guadalupe,224,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,0,0,0,0
+Guadalupe,224,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,9,3,6,0
+Guadalupe,224,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,51,24,20,7
+Guadalupe,225,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,2,1,1,0
+Guadalupe,225,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,0,0,0,0
+Guadalupe,225,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,9,7,2,0
+Guadalupe,226,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,3,2,0,1
+Guadalupe,226,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,104,69,32,3
+Guadalupe,226,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,53,28,23,2
+Guadalupe,301,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,39,18,19,2
+Guadalupe,301,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,1013,643,316,54
+Guadalupe,301,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,692,470,200,22
+Guadalupe,302,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,67,38,22,7
+Guadalupe,302,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,1241,854,341,46
+Guadalupe,302,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,1016,657,308,51
+Guadalupe,303,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,14,9,4,1
+Guadalupe,303,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,524,402,92,30
+Guadalupe,303,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,270,193,57,20
+Guadalupe,304,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,51,28,16,7
+Guadalupe,304,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,1420,1103,251,66
+Guadalupe,304,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,865,644,165,56
+Guadalupe,305,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,73,41,19,13
+Guadalupe,305,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,1341,942,344,55
+Guadalupe,305,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,996,698,231,67
+Guadalupe,306,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,41,25,11,5
+Guadalupe,306,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,1469,1165,245,59
+Guadalupe,306,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,901,700,141,60
+Guadalupe,307,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,50,30,13,7
+Guadalupe,307,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,1433,1114,262,57
+Guadalupe,307,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,1056,813,202,41
+Guadalupe,308,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,31,16,6,9
+Guadalupe,308,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,817,633,139,45
+Guadalupe,308,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,434,307,91,36
+Guadalupe,401,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,21,7,11,3
+Guadalupe,401,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,647,372,236,39
+Guadalupe,401,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,206,119,75,12
+Guadalupe,402,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,22,14,3,5
+Guadalupe,402,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,533,370,121,42
+Guadalupe,402,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,360,213,109,38
+Guadalupe,403,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,42,23,13,6
+Guadalupe,403,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,768,526,179,63
+Guadalupe,403,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,510,309,134,67
+Guadalupe,404,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,56,22,20,14
+Guadalupe,404,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,944,576,302,66
+Guadalupe,404,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,667,408,211,48
+Guadalupe,405,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,28,20,8,0
+Guadalupe,405,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,887,525,328,34
+Guadalupe,405,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,200,118,71,11
+Guadalupe,406,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,30,17,8,5
+Guadalupe,406,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,1023,774,211,38
+Guadalupe,406,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,167,112,42,13
+Guadalupe,407,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,29,18,8,3
+Guadalupe,407,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,866,621,206,39
+Guadalupe,407,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,189,116,52,21
+Guadalupe,408,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,84,29,28,27
+Guadalupe,408,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,1549,1030,405,114
+Guadalupe,408,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,719,471,209,39
+Guadalupe,409,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,57,22,23,12
+Guadalupe,409,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,1208,878,287,43
+Guadalupe,409,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,1373,1002,317,54
+Guadalupe,410,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,4,3,1,0
+Guadalupe,410,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,57,45,12,0
+Guadalupe,410,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,22,17,5,0
+Guadalupe,411,"Justice, 4th Court of Appeals, Place 7",,,Under Votes,59,31,19,9
+Guadalupe,411,"Justice, 4th Court of Appeals, Place 7",,REP,Shane Stolarczyk,1190,860,279,51
+Guadalupe,411,"Justice, 4th Court of Appeals, Place 7",,DEM,Rebeca Martinez,749,568,141,40
+Guadalupe,101,"District Judge, 274th Judicial District",,,Under Votes,64,42,15,7
+Guadalupe,101,"District Judge, 274th Judicial District",,REP,Gary L. Steel,305,202,82,21
+Guadalupe,102,"District Judge, 274th Judicial District",,,Under Votes,136,81,41,14
+Guadalupe,102,"District Judge, 274th Judicial District",,REP,Gary L. Steel,462,341,81,40
+Guadalupe,103,"District Judge, 274th Judicial District",,,Under Votes,91,61,22,8
+Guadalupe,103,"District Judge, 274th Judicial District",,REP,Gary L. Steel,368,263,83,22
+Guadalupe,104,"District Judge, 274th Judicial District",,,Under Votes,171,104,50,17
+Guadalupe,104,"District Judge, 274th Judicial District",,REP,Gary L. Steel,349,246,81,22
+Guadalupe,105,"District Judge, 274th Judicial District",,,Under Votes,270,155,91,24
+Guadalupe,105,"District Judge, 274th Judicial District",,REP,Gary L. Steel,1244,751,413,80
+Guadalupe,106,"District Judge, 274th Judicial District",,,Under Votes,408,275,87,46
+Guadalupe,106,"District Judge, 274th Judicial District",,REP,Gary L. Steel,1497,1092,290,115
+Guadalupe,107,"District Judge, 274th Judicial District",,,Under Votes,123,70,47,6
+Guadalupe,107,"District Judge, 274th Judicial District",,REP,Gary L. Steel,585,318,240,27
+Guadalupe,108,"District Judge, 274th Judicial District",,,Under Votes,133,55,62,16
+Guadalupe,108,"District Judge, 274th Judicial District",,REP,Gary L. Steel,298,113,156,29
+Guadalupe,109,"District Judge, 274th Judicial District",,,Under Votes,43,17,24,2
+Guadalupe,109,"District Judge, 274th Judicial District",,REP,Gary L. Steel,269,135,124,10
+Guadalupe,110,"District Judge, 274th Judicial District",,,Under Votes,50,36,9,5
+Guadalupe,110,"District Judge, 274th Judicial District",,REP,Gary L. Steel,101,81,17,3
+Guadalupe,111,"District Judge, 274th Judicial District",,,Under Votes,24,10,8,6
+Guadalupe,111,"District Judge, 274th Judicial District",,REP,Gary L. Steel,40,24,8,8
+Guadalupe,112,"District Judge, 274th Judicial District",,,Under Votes,106,38,67,1
+Guadalupe,112,"District Judge, 274th Judicial District",,REP,Gary L. Steel,120,47,73,0
+Guadalupe,113,"District Judge, 274th Judicial District",,,Under Votes,135,90,37,8
+Guadalupe,113,"District Judge, 274th Judicial District",,REP,Gary L. Steel,449,314,115,20
+Guadalupe,114,"District Judge, 274th Judicial District",,,Under Votes,130,83,38,9
+Guadalupe,114,"District Judge, 274th Judicial District",,REP,Gary L. Steel,321,233,71,17
+Guadalupe,115,"District Judge, 274th Judicial District",,,Under Votes,22,14,6,2
+Guadalupe,115,"District Judge, 274th Judicial District",,REP,Gary L. Steel,154,112,40,2
+Guadalupe,116,"District Judge, 274th Judicial District",,,Under Votes,254,132,100,22
+Guadalupe,116,"District Judge, 274th Judicial District",,REP,Gary L. Steel,1087,714,306,67
+Guadalupe,117,"District Judge, 274th Judicial District",,,Under Votes,546,372,130,44
+Guadalupe,117,"District Judge, 274th Judicial District",,REP,Gary L. Steel,1992,1457,452,83
+Guadalupe,118,"District Judge, 274th Judicial District",,,Under Votes,12,6,5,1
+Guadalupe,118,"District Judge, 274th Judicial District",,REP,Gary L. Steel,31,23,8,0
+Guadalupe,119,"District Judge, 274th Judicial District",,,Under Votes,197,144,37,16
+Guadalupe,119,"District Judge, 274th Judicial District",,REP,Gary L. Steel,903,682,179,42
+Guadalupe,120,"District Judge, 274th Judicial District",,,Under Votes,112,65,34,13
+Guadalupe,120,"District Judge, 274th Judicial District",,REP,Gary L. Steel,608,428,130,50
+Guadalupe,121,"District Judge, 274th Judicial District",,,Under Votes,27,21,4,2
+Guadalupe,121,"District Judge, 274th Judicial District",,REP,Gary L. Steel,67,58,7,2
+Guadalupe,122,"District Judge, 274th Judicial District",,,Under Votes,8,1,0,7
+Guadalupe,122,"District Judge, 274th Judicial District",,REP,Gary L. Steel,19,16,1,2
+Guadalupe,123,"District Judge, 274th Judicial District",,,Under Votes,1,0,0,1
+Guadalupe,123,"District Judge, 274th Judicial District",,REP,Gary L. Steel,0,0,0,0
+Guadalupe,124,"District Judge, 274th Judicial District",,,Under Votes,1,1,0,0
+Guadalupe,124,"District Judge, 274th Judicial District",,REP,Gary L. Steel,1,1,0,0
+Guadalupe,125,"District Judge, 274th Judicial District",,,Under Votes,15,9,5,1
+Guadalupe,125,"District Judge, 274th Judicial District",,REP,Gary L. Steel,94,70,13,11
+Guadalupe,126,"District Judge, 274th Judicial District",,,Under Votes,2,2,0,0
+Guadalupe,126,"District Judge, 274th Judicial District",,REP,Gary L. Steel,12,4,7,1
+Guadalupe,127,"District Judge, 274th Judicial District",,,Under Votes,3,0,3,0
+Guadalupe,127,"District Judge, 274th Judicial District",,REP,Gary L. Steel,12,4,7,1
+Guadalupe,201,"District Judge, 274th Judicial District",,,Under Votes,69,42,17,10
+Guadalupe,201,"District Judge, 274th Judicial District",,REP,Gary L. Steel,143,97,38,8
+Guadalupe,202,"District Judge, 274th Judicial District",,,Under Votes,281,146,98,37
+Guadalupe,202,"District Judge, 274th Judicial District",,REP,Gary L. Steel,182,109,65,8
+Guadalupe,203,"District Judge, 274th Judicial District",,,Under Votes,105,48,48,9
+Guadalupe,203,"District Judge, 274th Judicial District",,REP,Gary L. Steel,75,37,33,5
+Guadalupe,204,"District Judge, 274th Judicial District",,,Under Votes,278,150,106,22
+Guadalupe,204,"District Judge, 274th Judicial District",,REP,Gary L. Steel,350,201,141,8
+Guadalupe,205,"District Judge, 274th Judicial District",,,Under Votes,166,95,62,9
+Guadalupe,205,"District Judge, 274th Judicial District",,REP,Gary L. Steel,501,291,196,14
+Guadalupe,206,"District Judge, 274th Judicial District",,,Under Votes,496,155,314,27
+Guadalupe,206,"District Judge, 274th Judicial District",,REP,Gary L. Steel,475,180,276,19
+Guadalupe,207,"District Judge, 274th Judicial District",,,Under Votes,197,114,67,16
+Guadalupe,207,"District Judge, 274th Judicial District",,REP,Gary L. Steel,211,148,51,12
+Guadalupe,208,"District Judge, 274th Judicial District",,,Under Votes,338,229,80,29
+Guadalupe,208,"District Judge, 274th Judicial District",,REP,Gary L. Steel,1554,1135,342,77
+Guadalupe,209,"District Judge, 274th Judicial District",,,Under Votes,187,84,84,19
+Guadalupe,209,"District Judge, 274th Judicial District",,REP,Gary L. Steel,135,77,53,5
+Guadalupe,210,"District Judge, 274th Judicial District",,,Under Votes,160,102,42,16
+Guadalupe,210,"District Judge, 274th Judicial District",,REP,Gary L. Steel,323,211,92,20
+Guadalupe,211,"District Judge, 274th Judicial District",,,Under Votes,28,24,1,3
+Guadalupe,211,"District Judge, 274th Judicial District",,REP,Gary L. Steel,52,40,10,2
+Guadalupe,212,"District Judge, 274th Judicial District",,,Under Votes,31,17,11,3
+Guadalupe,212,"District Judge, 274th Judicial District",,REP,Gary L. Steel,55,44,10,1
+Guadalupe,213,"District Judge, 274th Judicial District",,,Under Votes,285,190,76,19
+Guadalupe,213,"District Judge, 274th Judicial District",,REP,Gary L. Steel,950,648,273,29
+Guadalupe,214,"District Judge, 274th Judicial District",,,Under Votes,65,32,22,11
+Guadalupe,214,"District Judge, 274th Judicial District",,REP,Gary L. Steel,306,223,76,7
+Guadalupe,215,"District Judge, 274th Judicial District",,,Under Votes,120,81,26,13
+Guadalupe,215,"District Judge, 274th Judicial District",,REP,Gary L. Steel,422,284,111,27
+Guadalupe,216,"District Judge, 274th Judicial District",,,Under Votes,10,7,3,0
+Guadalupe,216,"District Judge, 274th Judicial District",,REP,Gary L. Steel,27,15,8,4
+Guadalupe,217,"District Judge, 274th Judicial District",,,Under Votes,28,6,22,0
+Guadalupe,217,"District Judge, 274th Judicial District",,REP,Gary L. Steel,37,16,18,3
+Guadalupe,218,"District Judge, 274th Judicial District",,,Under Votes,18,13,4,1
+Guadalupe,218,"District Judge, 274th Judicial District",,REP,Gary L. Steel,20,19,1,0
+Guadalupe,219,"District Judge, 274th Judicial District",,,Under Votes,15,12,2,1
+Guadalupe,219,"District Judge, 274th Judicial District",,REP,Gary L. Steel,36,29,7,0
+Guadalupe,220,"District Judge, 274th Judicial District",,,Under Votes,17,12,5,0
+Guadalupe,220,"District Judge, 274th Judicial District",,REP,Gary L. Steel,26,19,5,2
+Guadalupe,221,"District Judge, 274th Judicial District",,,Under Votes,5,1,1,3
+Guadalupe,221,"District Judge, 274th Judicial District",,REP,Gary L. Steel,11,8,3,0
+Guadalupe,222,"District Judge, 274th Judicial District",,,Under Votes,0,0,0,0
+Guadalupe,222,"District Judge, 274th Judicial District",,REP,Gary L. Steel,0,0,0,0
+Guadalupe,223,"District Judge, 274th Judicial District",,,Under Votes,61,49,7,5
+Guadalupe,223,"District Judge, 274th Judicial District",,REP,Gary L. Steel,98,61,31,6
+Guadalupe,224,"District Judge, 274th Judicial District",,,Under Votes,35,19,10,6
+Guadalupe,224,"District Judge, 274th Judicial District",,REP,Gary L. Steel,25,8,16,1
+Guadalupe,225,"District Judge, 274th Judicial District",,,Under Votes,9,8,1,0
+Guadalupe,225,"District Judge, 274th Judicial District",,REP,Gary L. Steel,2,0,2,0
+Guadalupe,226,"District Judge, 274th Judicial District",,,Under Votes,51,27,21,3
+Guadalupe,226,"District Judge, 274th Judicial District",,REP,Gary L. Steel,109,72,34,3
+Guadalupe,301,"District Judge, 274th Judicial District",,,Under Votes,609,417,169,23
+Guadalupe,301,"District Judge, 274th Judicial District",,REP,Gary L. Steel,1135,714,366,55
+Guadalupe,302,"District Judge, 274th Judicial District",,,Under Votes,839,552,236,51
+Guadalupe,302,"District Judge, 274th Judicial District",,REP,Gary L. Steel,1485,997,435,53
+Guadalupe,303,"District Judge, 274th Judicial District",,,Under Votes,211,149,43,19
+Guadalupe,303,"District Judge, 274th Judicial District",,REP,Gary L. Steel,597,455,110,32
+Guadalupe,304,"District Judge, 274th Judicial District",,,Under Votes,702,519,127,56
+Guadalupe,304,"District Judge, 274th Judicial District",,REP,Gary L. Steel,1634,1256,305,73
+Guadalupe,305,"District Judge, 274th Judicial District",,,Under Votes,836,575,191,70
+Guadalupe,305,"District Judge, 274th Judicial District",,REP,Gary L. Steel,1574,1106,403,65
+Guadalupe,306,"District Judge, 274th Judicial District",,,Under Votes,733,575,111,47
+Guadalupe,306,"District Judge, 274th Judicial District",,REP,Gary L. Steel,1678,1315,286,77
+Guadalupe,307,"District Judge, 274th Judicial District",,,Under Votes,852,652,163,37
+Guadalupe,307,"District Judge, 274th Judicial District",,REP,Gary L. Steel,1687,1305,314,68
+Guadalupe,308,"District Judge, 274th Judicial District",,,Under Votes,333,221,72,40
+Guadalupe,308,"District Judge, 274th Judicial District",,REP,Gary L. Steel,949,735,164,50
+Guadalupe,401,"District Judge, 274th Judicial District",,,Under Votes,160,91,57,12
+Guadalupe,401,"District Judge, 274th Judicial District",,REP,Gary L. Steel,714,407,265,42
+Guadalupe,402,"District Judge, 274th Judicial District",,,Under Votes,283,173,75,35
+Guadalupe,402,"District Judge, 274th Judicial District",,REP,Gary L. Steel,632,424,158,50
+Guadalupe,403,"District Judge, 274th Judicial District",,,Under Votes,439,262,108,69
+Guadalupe,403,"District Judge, 274th Judicial District",,REP,Gary L. Steel,881,596,218,67
+Guadalupe,404,"District Judge, 274th Judicial District",,,Under Votes,551,338,161,52
+Guadalupe,404,"District Judge, 274th Judicial District",,REP,Gary L. Steel,1116,668,372,76
+Guadalupe,405,"District Judge, 274th Judicial District",,,Under Votes,179,112,56,11
+Guadalupe,405,"District Judge, 274th Judicial District",,REP,Gary L. Steel,936,551,351,34
+Guadalupe,406,"District Judge, 274th Judicial District",,,Under Votes,165,108,42,15
+Guadalupe,406,"District Judge, 274th Judicial District",,REP,Gary L. Steel,1055,795,219,41
+Guadalupe,407,"District Judge, 274th Judicial District",,,Under Votes,180,114,42,24
+Guadalupe,407,"District Judge, 274th Judicial District",,REP,Gary L. Steel,904,641,224,39
+Guadalupe,408,"District Judge, 274th Judicial District",,,Under Votes,618,376,180,62
+Guadalupe,408,"District Judge, 274th Judicial District",,REP,Gary L. Steel,1734,1154,462,118
+Guadalupe,409,"District Judge, 274th Judicial District",,,Under Votes,1109,797,259,53
+Guadalupe,409,"District Judge, 274th Judicial District",,REP,Gary L. Steel,1529,1105,368,56
+Guadalupe,410,"District Judge, 274th Judicial District",,,Under Votes,22,15,7,0
+Guadalupe,410,"District Judge, 274th Judicial District",,REP,Gary L. Steel,61,50,11,0
+Guadalupe,411,"District Judge, 274th Judicial District",,,Under Votes,592,433,112,47
+Guadalupe,411,"District Judge, 274th Judicial District",,REP,Gary L. Steel,1406,1026,327,53
+Guadalupe,401,"County Commissioner, Precinct 4",,,Under Votes,22,7,8,7
+Guadalupe,401,"County Commissioner, Precinct 4",,REP,Judy Cope,646,367,246,33
+Guadalupe,401,"County Commissioner, Precinct 4",,DEM,Rebecca Tucker,206,124,68,14
+Guadalupe,402,"County Commissioner, Precinct 4",,,Under Votes,25,14,4,7
+Guadalupe,402,"County Commissioner, Precinct 4",,REP,Judy Cope,531,370,122,39
+Guadalupe,402,"County Commissioner, Precinct 4",,DEM,Rebecca Tucker,359,213,107,39
+Guadalupe,403,"County Commissioner, Precinct 4",,,Under Votes,46,22,15,9
+Guadalupe,403,"County Commissioner, Precinct 4",,REP,Judy Cope,773,532,180,61
+Guadalupe,403,"County Commissioner, Precinct 4",,DEM,Rebecca Tucker,501,304,131,66
+Guadalupe,404,"County Commissioner, Precinct 4",,,Under Votes,60,21,19,20
+Guadalupe,404,"County Commissioner, Precinct 4",,REP,Judy Cope,963,583,313,67
+Guadalupe,404,"County Commissioner, Precinct 4",,DEM,Rebecca Tucker,644,402,201,41
+Guadalupe,405,"County Commissioner, Precinct 4",,,Under Votes,31,21,8,2
+Guadalupe,405,"County Commissioner, Precinct 4",,REP,Judy Cope,879,519,328,32
+Guadalupe,405,"County Commissioner, Precinct 4",,DEM,Rebecca Tucker,205,123,71,11
+Guadalupe,406,"County Commissioner, Precinct 4",,,Under Votes,29,17,6,6
+Guadalupe,406,"County Commissioner, Precinct 4",,REP,Judy Cope,1014,764,211,39
+Guadalupe,406,"County Commissioner, Precinct 4",,DEM,Rebecca Tucker,177,122,44,11
+Guadalupe,407,"County Commissioner, Precinct 4",,,Under Votes,19,7,6,6
+Guadalupe,407,"County Commissioner, Precinct 4",,REP,Judy Cope,867,627,203,37
+Guadalupe,407,"County Commissioner, Precinct 4",,DEM,Rebecca Tucker,198,121,57,20
+Guadalupe,408,"County Commissioner, Precinct 4",,,Under Votes,85,27,28,30
+Guadalupe,408,"County Commissioner, Precinct 4",,REP,Judy Cope,1562,1038,410,114
+Guadalupe,408,"County Commissioner, Precinct 4",,DEM,Rebecca Tucker,705,465,204,36
+Guadalupe,409,"County Commissioner, Precinct 4",,,Under Votes,64,23,23,18
+Guadalupe,409,"County Commissioner, Precinct 4",,REP,Judy Cope,1214,881,290,43
+Guadalupe,409,"County Commissioner, Precinct 4",,DEM,Rebecca Tucker,1360,998,314,48
+Guadalupe,410,"County Commissioner, Precinct 4",,,Under Votes,3,2,1,0
+Guadalupe,410,"County Commissioner, Precinct 4",,REP,Judy Cope,54,43,11,0
+Guadalupe,410,"County Commissioner, Precinct 4",,DEM,Rebecca Tucker,26,20,6,0
+Guadalupe,411,"County Commissioner, Precinct 4",,,Under Votes,63,33,16,14
+Guadalupe,411,"County Commissioner, Precinct 4",,REP,Judy Cope,1191,865,278,48
+Guadalupe,411,"County Commissioner, Precinct 4",,DEM,Rebecca Tucker,744,561,145,38
+Guadalupe,301,"Justice of the Peace, Precinct 3",,,Under Votes,49,20,20,9
+Guadalupe,301,"Justice of the Peace, Precinct 3",,REP,John Terry,1015,641,325,49
+Guadalupe,301,"Justice of the Peace, Precinct 3",,DEM,Peggy Ornelas,680,470,190,20
+Guadalupe,302,"Justice of the Peace, Precinct 3",,,Under Votes,68,39,19,10
+Guadalupe,302,"Justice of the Peace, Precinct 3",,REP,John Terry,1264,867,351,46
+Guadalupe,302,"Justice of the Peace, Precinct 3",,DEM,Peggy Ornelas,992,643,301,48
+Guadalupe,303,"Justice of the Peace, Precinct 3",,,Under Votes,14,9,3,2
+Guadalupe,303,"Justice of the Peace, Precinct 3",,REP,John Terry,522,402,91,29
+Guadalupe,303,"Justice of the Peace, Precinct 3",,DEM,Peggy Ornelas,272,193,59,20
+Guadalupe,304,"Justice of the Peace, Precinct 3",,,Under Votes,49,24,16,9
+Guadalupe,304,"Justice of the Peace, Precinct 3",,REP,John Terry,1423,1099,260,64
+Guadalupe,304,"Justice of the Peace, Precinct 3",,DEM,Peggy Ornelas,864,652,156,56
+Guadalupe,305,"Justice of the Peace, Precinct 3",,,Under Votes,79,41,17,21
+Guadalupe,305,"Justice of the Peace, Precinct 3",,REP,John Terry,1343,942,350,51
+Guadalupe,305,"Justice of the Peace, Precinct 3",,DEM,Peggy Ornelas,988,698,227,63
+Guadalupe,306,"Justice of the Peace, Precinct 3",,,Under Votes,45,27,12,6
+Guadalupe,306,"Justice of the Peace, Precinct 3",,REP,John Terry,1484,1179,245,60
+Guadalupe,306,"Justice of the Peace, Precinct 3",,DEM,Peggy Ornelas,882,684,140,58
+Guadalupe,307,"Justice of the Peace, Precinct 3",,,Under Votes,51,30,12,9
+Guadalupe,307,"Justice of the Peace, Precinct 3",,REP,John Terry,1466,1135,273,58
+Guadalupe,307,"Justice of the Peace, Precinct 3",,DEM,Peggy Ornelas,1022,792,192,38
+Guadalupe,308,"Justice of the Peace, Precinct 3",,,Under Votes,37,18,5,14
+Guadalupe,308,"Justice of the Peace, Precinct 3",,REP,John Terry,837,651,143,43
+Guadalupe,308,"Justice of the Peace, Precinct 3",,DEM,Peggy Ornelas,408,287,88,33


### PR DESCRIPTION
This county used GEMS. Thankfully, it only took 18 minutes to process using `gems.py` (modified, because the format was slightly different), as opposed to the four hours Collin County took.