### PR TITLE
Add precinct-level results for the 2018 general election in Galveston County

### DIFF
--- a/2018/20181106__tx__general__galveston__precinct.csv
+++ b/2018/20181106__tx__general__galveston__precinct.csv
@@ -1,0 +1,8312 @@
+county,precinct,office,district,party,candidate,votes,early_voting,election_day,absentee
+Galveston,103,Ballots Cast,,,,734,525,143,66
+Galveston,103,Straight Party,,REP,Republican,403,294,72,37
+Galveston,103,Straight Party,,DEM,Democrat,87,59,10,18
+Galveston,103,Straight Party,,LIB,Libertarian,2,1,1,0
+Galveston,103,U.S. Senate,,REP,Ted Cruz,557,406,108,43
+Galveston,103,U.S. Senate,,DEM,Beto O'Rourke,163,111,30,22
+Galveston,103,U.S. Senate,,LIB,Neal M. Dikeman,5,3,1,1
+Galveston,103,U.S. House,14,REP,Randy Weber,555,409,103,43
+Galveston,103,U.S. House,14,DEM,Adrienne Bell,158,105,30,23
+Galveston,103,U.S. House,14,LIB,Don E. Conley III,11,7,4,0
+Galveston,103,Governor,,REP,Greg Abbott,574,420,110,44
+Galveston,103,Governor,,DEM,Lupe Valdez,143,94,27,22
+Galveston,103,Governor,,LIB,Mark Jay Tippetts,10,7,3,0
+Galveston,103,Lieutenant Governor,,REP,Dan Patrick,556,406,106,44
+Galveston,103,Lieutenant Governor,,DEM,Mike Collier,157,106,29,22
+Galveston,103,Lieutenant Governor,,LIB,Kerry Douglas McKennon,12,9,3,0
+Galveston,103,Attorney General,,REP,Ken Paxton,543,398,102,43
+Galveston,103,Attorney General,,DEM,Justin Nelson,162,109,31,22
+Galveston,103,Attorney General,,LIB,Michael Ray Harris,18,12,5,1
+Galveston,103,Comptroller of Public Accounts,,REP,Glenn Hegar,555,413,100,42
+Galveston,103,Comptroller of Public Accounts,,DEM,Joi Chevalier,146,97,27,22
+Galveston,103,Comptroller of Public Accounts,,LIB,Ben Sanders,23,11,10,2
+Galveston,103,Commissioner of General Land Office,,REP,George P. Bush,536,393,100,43
+Galveston,103,Commissioner of General Land Office,,DEM,Miguel Suazo,152,100,30,22
+Galveston,103,Commissioner of General Land Office,,LIB,Matt Pina,37,28,8,1
+Galveston,103,Commissioner of Agriculture,,REP,Sid Miller,544,402,99,43
+Galveston,103,Commissioner of Agriculture,,DEM,Kim Olson,163,110,31,22
+Galveston,103,Commissioner of Agriculture,,LIB,Richard Carpenter,16,8,7,1
+Galveston,103,Railroad Commissioner,,REP,Christi Craddick,555,409,103,43
+Galveston,103,Railroad Commissioner,,DEM,Roman McAllen,149,99,28,22
+Galveston,103,Railroad Commissioner,,LIB,Mike Wright,19,12,6,1
+Galveston,103,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,556,408,105,43
+Galveston,103,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,165,110,32,23
+Galveston,103,"Justice, Supreme Court, Place 4",,REP,John Devine,558,409,106,43
+Galveston,103,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,166,112,31,23
+Galveston,103,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,561,413,105,43
+Galveston,103,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,161,107,31,23
+Galveston,103,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,551,408,102,41
+Galveston,103,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,155,103,29,23
+Galveston,103,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,15,8,6,1
+Galveston,103,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,556,407,106,43
+Galveston,103,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,164,110,31,23
+Galveston,103,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,566,417,105,44
+Galveston,103,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,80,51,23,6
+Galveston,103,"Member, State Board of Education, District 7",,REP,Matt Robinson,556,411,105,40
+Galveston,103,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",162,108,32,22
+Galveston,103,State Representative,23,REP,Mayes Middleton,561,415,105,41
+Galveston,103,State Representative,23,DEM,Amanda Jamrok,149,97,31,21
+Galveston,103,State Representative,23,LIB,Lawrence Johnson,9,7,2,0
+Galveston,103,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,559,409,108,42
+Galveston,103,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,157,106,29,22
+Galveston,103,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,549,406,103,40
+Galveston,103,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,167,111,34,22
+Galveston,103,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,554,410,104,40
+Galveston,103,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,162,107,33,22
+Galveston,103,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,549,405,104,40
+Galveston,103,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,168,112,33,23
+Galveston,103,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,561,414,106,41
+Galveston,103,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,156,104,31,21
+Galveston,103,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,559,413,106,40
+Galveston,103,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,157,104,31,22
+Galveston,103,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,560,416,105,39
+Galveston,103,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,157,102,32,23
+Galveston,103,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,558,410,107,41
+Galveston,103,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,156,105,30,21
+Galveston,103,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,548,405,104,39
+Galveston,103,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,166,110,33,23
+Galveston,103,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,556,408,108,40
+Galveston,103,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",161,110,29,22
+Galveston,103,"District Judge, 122nd Judicial District",,REP,John Ellisor,591,434,115,42
+Galveston,103,"District Judge, 212th Judicial District",,REP,Patricia Grady,594,434,118,42
+Galveston,103,"District Judge, 306th Judicial District",,REP,Anne B. Darring,589,431,116,42
+Galveston,103,Criminal District Attorney,,REP,Jack Roady,591,434,115,42
+Galveston,103,County Judge,,REP,Mark Henry,590,432,115,43
+Galveston,103,"Judge, County Court-at-Law No. 1",,REP,John Grady,587,431,114,42
+Galveston,103,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,560,412,107,41
+Galveston,103,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,156,105,30,21
+Galveston,103,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,592,434,116,42
+Galveston,103,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,593,434,116,43
+Galveston,103,District Clerk,,REP,John D Kinard,589,432,115,42
+Galveston,103,County Clerk,,REP,Dwight Sullivan,592,433,117,42
+Galveston,103,County Treasurer,,REP,Kevin C. Walsh,595,436,117,42
+Galveston,103,Justice of the Peace Pct. 3,,DEM,"Billy A. Williams, Jr.",266,183,56,27
+Galveston,103,Trustee Position 1  - High Island ISD,,,Bennie Barrow,105,62,35,8
+Galveston,103,Trustee Position 1  - High Island ISD,,,Jo Ball,45,25,13,7
+Galveston,103,Trustee Position 2  - High Island ISD,,,Tony Perea,34,0,34,0
+Galveston,103,Trustee Position 6  - High Island ISD,,,Karen Faggard,40,0,40,0
+Galveston,103,Trustee Position 7  - High Island ISD,,,Buffy Diebel,37,0,37,0
+Galveston,104,Ballots Cast,,,,541,405,107,29
+Galveston,104,Straight Party,,REP,Republican,333,257,60,16
+Galveston,104,Straight Party,,DEM,Democrat,58,38,14,6
+Galveston,104,Straight Party,,LIB,Libertarian,2,1,0,1
+Galveston,104,U.S. Senate,,REP,Ted Cruz,430,331,79,20
+Galveston,104,U.S. Senate,,DEM,Beto O'Rourke,103,69,25,9
+Galveston,104,U.S. Senate,,LIB,Neal M. Dikeman,5,2,3,0
+Galveston,104,U.S. House,14,REP,Randy Weber,424,322,82,20
+Galveston,104,U.S. House,14,DEM,Adrienne Bell,100,69,22,9
+Galveston,104,U.S. House,14,LIB,Don E. Conley III,6,5,1,0
+Galveston,104,Governor,,REP,Greg Abbott,445,335,90,20
+Galveston,104,Governor,,DEM,Lupe Valdez,86,62,16,8
+Galveston,104,Governor,,LIB,Mark Jay Tippetts,7,5,1,1
+Galveston,104,Lieutenant Governor,,REP,Dan Patrick,420,320,80,20
+Galveston,104,Lieutenant Governor,,DEM,Mike Collier,107,75,23,9
+Galveston,104,Lieutenant Governor,,LIB,Kerry Douglas McKennon,10,7,3,0
+Galveston,104,Attorney General,,REP,Ken Paxton,417,317,81,19
+Galveston,104,Attorney General,,DEM,Justin Nelson,107,76,21,10
+Galveston,104,Attorney General,,LIB,Michael Ray Harris,13,8,5,0
+Galveston,104,Comptroller of Public Accounts,,REP,Glenn Hegar,424,323,82,19
+Galveston,104,Comptroller of Public Accounts,,DEM,Joi Chevalier,92,65,19,8
+Galveston,104,Comptroller of Public Accounts,,LIB,Ben Sanders,13,8,4,1
+Galveston,104,Commissioner of General Land Office,,REP,George P. Bush,417,312,85,20
+Galveston,104,Commissioner of General Land Office,,DEM,Miguel Suazo,94,67,18,9
+Galveston,104,Commissioner of General Land Office,,LIB,Matt Pina,23,20,3,0
+Galveston,104,Commissioner of Agriculture,,REP,Sid Miller,422,323,80,19
+Galveston,104,Commissioner of Agriculture,,DEM,Kim Olson,103,73,20,10
+Galveston,104,Commissioner of Agriculture,,LIB,Richard Carpenter,8,3,5,0
+Galveston,104,Railroad Commissioner,,REP,Christi Craddick,433,329,85,19
+Galveston,104,Railroad Commissioner,,DEM,Roman McAllen,97,69,19,9
+Galveston,104,Railroad Commissioner,,LIB,Mike Wright,6,3,2,1
+Galveston,104,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,429,326,84,19
+Galveston,104,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,105,73,23,9
+Galveston,104,"Justice, Supreme Court, Place 4",,REP,John Devine,426,326,81,19
+Galveston,104,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,107,73,25,9
+Galveston,104,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,427,328,80,19
+Galveston,104,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,107,72,26,9
+Galveston,104,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,425,324,82,19
+Galveston,104,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,101,70,22,9
+Galveston,104,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,6,4,2,0
+Galveston,104,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,432,329,84,19
+Galveston,104,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,98,68,21,9
+Galveston,104,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,449,342,88,19
+Galveston,104,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,37,28,6,3
+Galveston,104,"Member, State Board of Education, District 7",,REP,Matt Robinson,425,325,81,19
+Galveston,104,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",106,73,24,9
+Galveston,104,State Representative,23,REP,Mayes Middleton,436,332,85,19
+Galveston,104,State Representative,23,DEM,Amanda Jamrok,93,66,19,8
+Galveston,104,State Representative,23,LIB,Lawrence Johnson,7,3,2,2
+Galveston,104,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,433,328,86,19
+Galveston,104,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,99,71,19,9
+Galveston,104,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,424,326,80,18
+Galveston,104,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,108,74,25,9
+Galveston,104,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,425,326,81,18
+Galveston,104,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,107,74,24,9
+Galveston,104,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,427,325,84,18
+Galveston,104,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,104,74,21,9
+Galveston,104,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,430,327,85,18
+Galveston,104,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,102,73,20,9
+Galveston,104,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,427,326,83,18
+Galveston,104,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,102,72,21,9
+Galveston,104,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,430,326,86,18
+Galveston,104,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,100,72,19,9
+Galveston,104,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,428,325,85,18
+Galveston,104,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,100,71,20,9
+Galveston,104,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,426,327,81,18
+Galveston,104,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,103,70,24,9
+Galveston,104,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,426,327,81,18
+Galveston,104,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",102,70,23,9
+Galveston,104,"District Judge, 122nd Judicial District",,REP,John Ellisor,451,345,88,18
+Galveston,104,"District Judge, 212th Judicial District",,REP,Patricia Grady,450,344,88,18
+Galveston,104,"District Judge, 306th Judicial District",,REP,Anne B. Darring,450,343,89,18
+Galveston,104,Criminal District Attorney,,REP,Jack Roady,451,344,88,19
+Galveston,104,County Judge,,REP,Mark Henry,444,338,86,20
+Galveston,104,"Judge, County Court-at-Law No. 1",,REP,John Grady,452,345,88,19
+Galveston,104,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,422,324,80,18
+Galveston,104,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,108,73,25,10
+Galveston,104,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,451,342,89,20
+Galveston,104,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,452,344,89,19
+Galveston,104,District Clerk,,REP,John D Kinard,450,343,88,19
+Galveston,104,County Clerk,,REP,Dwight Sullivan,450,343,88,19
+Galveston,104,County Treasurer,,REP,Kevin C. Walsh,452,344,89,19
+Galveston,104,Justice of the Peace Pct. 3,,DEM,"Billy A. Williams, Jr.",152,109,36,7
+Galveston,105,Ballots Cast,,,,187,110,61,16
+Galveston,105,Straight Party,,REP,Republican,43,27,15,1
+Galveston,105,Straight Party,,DEM,Democrat,37,22,12,3
+Galveston,105,Straight Party,,LIB,Libertarian,10,2,0,8
+Galveston,105,U.S. Senate,,REP,Ted Cruz,83,46,27,10
+Galveston,105,U.S. Senate,,DEM,Beto O'Rourke,102,62,34,6
+Galveston,105,U.S. Senate,,LIB,Neal M. Dikeman,2,2,0,0
+Galveston,105,U.S. House,14,REP,Randy Weber,89,47,32,10
+Galveston,105,U.S. House,14,DEM,Adrienne Bell,76,45,26,5
+Galveston,105,U.S. House,14,LIB,Don E. Conley III,14,13,0,1
+Galveston,105,Governor,,REP,Greg Abbott,98,50,38,10
+Galveston,105,Governor,,DEM,Lupe Valdez,74,47,22,5
+Galveston,105,Governor,,LIB,Mark Jay Tippetts,11,10,0,1
+Galveston,105,Lieutenant Governor,,REP,Dan Patrick,83,43,30,10
+Galveston,105,Lieutenant Governor,,DEM,Mike Collier,80,50,25,5
+Galveston,105,Lieutenant Governor,,LIB,Kerry Douglas McKennon,15,12,2,1
+Galveston,105,Attorney General,,REP,Ken Paxton,84,44,31,9
+Galveston,105,Attorney General,,DEM,Justin Nelson,81,50,25,6
+Galveston,105,Attorney General,,LIB,Michael Ray Harris,13,10,2,1
+Galveston,105,Comptroller of Public Accounts,,REP,Glenn Hegar,89,48,31,10
+Galveston,105,Comptroller of Public Accounts,,DEM,Joi Chevalier,70,42,23,5
+Galveston,105,Comptroller of Public Accounts,,LIB,Ben Sanders,16,12,3,1
+Galveston,105,Commissioner of General Land Office,,REP,George P. Bush,96,53,33,10
+Galveston,105,Commissioner of General Land Office,,DEM,Miguel Suazo,70,42,24,4
+Galveston,105,Commissioner of General Land Office,,LIB,Matt Pina,11,9,0,2
+Galveston,105,Commissioner of Agriculture,,REP,Sid Miller,90,50,30,10
+Galveston,105,Commissioner of Agriculture,,DEM,Kim Olson,78,47,26,5
+Galveston,105,Commissioner of Agriculture,,LIB,Richard Carpenter,10,8,1,1
+Galveston,105,Railroad Commissioner,,REP,Christi Craddick,85,47,29,9
+Galveston,105,Railroad Commissioner,,DEM,Roman McAllen,79,48,26,5
+Galveston,105,Railroad Commissioner,,LIB,Mike Wright,11,8,1,2
+Galveston,105,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,86,47,30,9
+Galveston,105,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,91,58,27,6
+Galveston,105,"Justice, Supreme Court, Place 4",,REP,John Devine,88,50,29,9
+Galveston,105,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,88,54,28,6
+Galveston,105,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,94,53,31,10
+Galveston,105,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,82,51,26,5
+Galveston,105,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,86,44,32,10
+Galveston,105,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,75,47,23,5
+Galveston,105,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,16,14,1,1
+Galveston,105,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,86,45,32,9
+Galveston,105,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,90,60,24,6
+Galveston,105,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,104,56,38,10
+Galveston,105,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,52,33,14,5
+Galveston,105,"Member, State Board of Education, District 7",,REP,Matt Robinson,83,50,30,3
+Galveston,105,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",83,51,27,5
+Galveston,105,State Representative,23,REP,Mayes Middleton,83,48,32,3
+Galveston,105,State Representative,23,DEM,Amanda Jamrok,72,45,23,4
+Galveston,105,State Representative,23,LIB,Lawrence Johnson,14,8,0,6
+Galveston,105,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,88,51,31,6
+Galveston,105,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,80,49,24,7
+Galveston,105,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,84,50,31,3
+Galveston,105,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,77,50,24,3
+Galveston,105,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,83,49,32,2
+Galveston,105,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,78,52,23,3
+Galveston,105,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,82,49,30,3
+Galveston,105,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,79,52,25,2
+Galveston,105,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,84,50,32,2
+Galveston,105,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,77,51,23,3
+Galveston,105,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,83,51,29,3
+Galveston,105,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,79,49,26,4
+Galveston,105,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,84,51,30,3
+Galveston,105,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,77,49,25,3
+Galveston,105,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,81,49,29,3
+Galveston,105,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,81,51,26,4
+Galveston,105,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,84,50,31,3
+Galveston,105,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,78,50,24,4
+Galveston,105,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,83,51,29,3
+Galveston,105,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",78,49,26,3
+Galveston,105,"District Judge, 122nd Judicial District",,REP,John Ellisor,113,70,40,3
+Galveston,105,"District Judge, 212th Judicial District",,REP,Patricia Grady,113,70,40,3
+Galveston,105,"District Judge, 306th Judicial District",,REP,Anne B. Darring,113,70,40,3
+Galveston,105,Criminal District Attorney,,REP,Jack Roady,119,70,42,7
+Galveston,105,County Judge,,REP,Mark Henry,119,71,40,8
+Galveston,105,"Judge, County Court-at-Law No. 1",,REP,John Grady,112,70,40,2
+Galveston,105,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,75,43,30,2
+Galveston,105,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,81,54,24,3
+Galveston,105,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,117,70,40,7
+Galveston,105,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,115,70,40,5
+Galveston,105,District Clerk,,REP,John D Kinard,118,70,41,7
+Galveston,105,County Clerk,,REP,Dwight Sullivan,116,70,41,5
+Galveston,105,County Treasurer,,REP,Kevin C. Walsh,113,69,40,4
+Galveston,105,Justice of the Peace Pct. 3,,DEM,"Billy A. Williams, Jr.",105,64,38,3
+Galveston,105,Commissioner  - GC Navigation Dist 1,,,"Thomas E. ""Ted"" Farmer, Jr.",72,41,28,3
+Galveston,105,Commissioner  - GC Navigation Dist 1,,,Robert Mihovil,39,22,11,6
+Galveston,105-1,Ballots Cast,,,,353,228,84,41
+Galveston,105-1,Straight Party,,REP,Republican,98,60,27,11
+Galveston,105-1,Straight Party,,DEM,Democrat,93,66,18,9
+Galveston,105-1,Straight Party,,LIB,Libertarian,6,0,3,3
+Galveston,105-1,U.S. Senate,,REP,Ted Cruz,151,88,50,13
+Galveston,105-1,U.S. Senate,,DEM,Beto O'Rourke,198,138,32,28
+Galveston,105-1,U.S. Senate,,LIB,Neal M. Dikeman,3,2,1,0
+Galveston,105-1,U.S. House,14,REP,Randy Weber,155,90,48,17
+Galveston,105-1,U.S. House,14,DEM,Adrienne Bell,176,127,27,22
+Galveston,105-1,U.S. House,14,LIB,Don E. Conley III,15,9,5,1
+Galveston,105-1,Governor,,REP,Greg Abbott,163,98,50,15
+Galveston,105-1,Governor,,DEM,Lupe Valdez,175,124,27,24
+Galveston,105-1,Governor,,LIB,Mark Jay Tippetts,11,6,4,1
+Galveston,105-1,Lieutenant Governor,,REP,Dan Patrick,154,91,47,16
+Galveston,105-1,Lieutenant Governor,,DEM,Mike Collier,178,127,27,24
+Galveston,105-1,Lieutenant Governor,,LIB,Kerry Douglas McKennon,14,10,4,0
+Galveston,105-1,Attorney General,,REP,Ken Paxton,150,87,48,15
+Galveston,105-1,Attorney General,,DEM,Justin Nelson,184,130,29,25
+Galveston,105-1,Attorney General,,LIB,Michael Ray Harris,11,8,3,0
+Galveston,105-1,Comptroller of Public Accounts,,REP,Glenn Hegar,159,97,46,16
+Galveston,105-1,Comptroller of Public Accounts,,DEM,Joi Chevalier,169,120,27,22
+Galveston,105-1,Comptroller of Public Accounts,,LIB,Ben Sanders,16,7,7,2
+Galveston,105-1,Commissioner of General Land Office,,REP,George P. Bush,162,101,44,17
+Galveston,105-1,Commissioner of General Land Office,,DEM,Miguel Suazo,169,119,29,21
+Galveston,105-1,Commissioner of General Land Office,,LIB,Matt Pina,12,3,8,1
+Galveston,105-1,Commissioner of Agriculture,,REP,Sid Miller,149,89,45,15
+Galveston,105-1,Commissioner of Agriculture,,DEM,Kim Olson,179,128,27,24
+Galveston,105-1,Commissioner of Agriculture,,LIB,Richard Carpenter,14,7,6,1
+Galveston,105-1,Railroad Commissioner,,REP,Christi Craddick,158,96,46,16
+Galveston,105-1,Railroad Commissioner,,DEM,Roman McAllen,164,119,25,20
+Galveston,105-1,Railroad Commissioner,,LIB,Mike Wright,17,8,7,2
+Galveston,105-1,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,153,92,46,15
+Galveston,105-1,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,181,130,28,23
+Galveston,105-1,"Justice, Supreme Court, Place 4",,REP,John Devine,156,94,47,15
+Galveston,105-1,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,179,128,28,23
+Galveston,105-1,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,157,95,46,16
+Galveston,105-1,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,179,128,29,22
+Galveston,105-1,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,150,91,45,14
+Galveston,105-1,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,176,126,27,23
+Galveston,105-1,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,13,7,5,1
+Galveston,105-1,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,158,95,47,16
+Galveston,105-1,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,177,127,28,22
+Galveston,105-1,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,178,105,54,19
+Galveston,105-1,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,103,80,15,8
+Galveston,105-1,"Member, State Board of Education, District 7",,REP,Matt Robinson,153,93,45,15
+Galveston,105-1,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",182,130,32,20
+Galveston,105-1,State Representative,23,REP,Mayes Middleton,154,96,45,13
+Galveston,105-1,State Representative,23,DEM,Amanda Jamrok,169,120,27,22
+Galveston,105-1,State Representative,23,LIB,Lawrence Johnson,15,6,6,3
+Galveston,105-1,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,164,98,48,18
+Galveston,105-1,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,173,124,29,20
+Galveston,105-1,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,157,96,45,16
+Galveston,105-1,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,178,127,31,20
+Galveston,105-1,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,158,97,46,15
+Galveston,105-1,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,178,126,30,22
+Galveston,105-1,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,155,94,46,15
+Galveston,105-1,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,179,129,29,21
+Galveston,105-1,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,158,96,47,15
+Galveston,105-1,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,177,126,30,21
+Galveston,105-1,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,160,97,47,16
+Galveston,105-1,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,175,125,30,20
+Galveston,105-1,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,157,96,45,16
+Galveston,105-1,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,176,125,31,20
+Galveston,105-1,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,157,96,45,16
+Galveston,105-1,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,178,126,31,21
+Galveston,105-1,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,156,95,44,17
+Galveston,105-1,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,180,127,32,21
+Galveston,105-1,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,157,96,45,16
+Galveston,105-1,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",178,127,31,20
+Galveston,105-1,"District Judge, 122nd Judicial District",,REP,John Ellisor,199,124,54,21
+Galveston,105-1,"District Judge, 212th Judicial District",,REP,Patricia Grady,199,126,52,21
+Galveston,105-1,"District Judge, 306th Judicial District",,REP,Anne B. Darring,201,127,55,19
+Galveston,105-1,Criminal District Attorney,,REP,Jack Roady,200,125,54,21
+Galveston,105-1,County Judge,,REP,Mark Henry,197,126,53,18
+Galveston,105-1,"Judge, County Court-at-Law No. 1",,REP,John Grady,191,121,50,20
+Galveston,105-1,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,156,95,46,15
+Galveston,105-1,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,175,124,30,21
+Galveston,105-1,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,201,127,53,21
+Galveston,105-1,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,203,128,54,21
+Galveston,105-1,District Clerk,,REP,John D Kinard,197,124,53,20
+Galveston,105-1,County Clerk,,REP,Dwight Sullivan,201,126,54,21
+Galveston,105-1,County Treasurer,,REP,Kevin C. Walsh,199,124,55,20
+Galveston,105-1,Justice of the Peace Pct. 2,,REP,Mike Nelson,199,124,53,22
+Galveston,105-1,Commissioner  - GC Navigation Dist 1,,,"Thomas E. ""Ted"" Farmer, Jr.",85,53,25,7
+Galveston,105-1,Commissioner  - GC Navigation Dist 1,,,Robert Mihovil,147,96,30,21
+Galveston,142,Ballots Cast,,,,1266,860,283,123
+Galveston,142,Straight Party,,REP,Republican,435,305,82,48
+Galveston,142,Straight Party,,DEM,Democrat,399,246,102,51
+Galveston,142,Straight Party,,LIB,Libertarian,1,1,0,0
+Galveston,142,U.S. Senate,,REP,Ted Cruz,663,470,131,62
+Galveston,142,U.S. Senate,,DEM,Beto O'Rourke,584,377,147,60
+Galveston,142,U.S. Senate,,LIB,Neal M. Dikeman,11,10,1,0
+Galveston,142,U.S. House,14,REP,Randy Weber,670,480,130,60
+Galveston,142,U.S. House,14,DEM,Adrienne Bell,566,361,143,62
+Galveston,142,U.S. House,14,LIB,Don E. Conley III,19,12,6,1
+Galveston,142,Governor,,REP,Greg Abbott,706,505,137,64
+Galveston,142,Governor,,DEM,Lupe Valdez,536,342,136,58
+Galveston,142,Governor,,LIB,Mark Jay Tippetts,16,10,5,1
+Galveston,142,Lieutenant Governor,,REP,Dan Patrick,660,474,128,58
+Galveston,142,Lieutenant Governor,,DEM,Mike Collier,574,369,141,64
+Galveston,142,Lieutenant Governor,,LIB,Kerry Douglas McKennon,22,12,9,1
+Galveston,142,Attorney General,,REP,Ken Paxton,638,458,123,57
+Galveston,142,Attorney General,,DEM,Justin Nelson,590,375,151,64
+Galveston,142,Attorney General,,LIB,Michael Ray Harris,29,21,6,2
+Galveston,142,Comptroller of Public Accounts,,REP,Glenn Hegar,653,469,125,59
+Galveston,142,Comptroller of Public Accounts,,DEM,Joi Chevalier,557,356,141,60
+Galveston,142,Comptroller of Public Accounts,,LIB,Ben Sanders,31,19,10,2
+Galveston,142,Commissioner of General Land Office,,REP,George P. Bush,662,469,129,64
+Galveston,142,Commissioner of General Land Office,,DEM,Miguel Suazo,554,355,140,59
+Galveston,142,Commissioner of General Land Office,,LIB,Matt Pina,37,29,8,0
+Galveston,142,Commissioner of Agriculture,,REP,Sid Miller,636,455,122,59
+Galveston,142,Commissioner of Agriculture,,DEM,Kim Olson,587,378,148,61
+Galveston,142,Commissioner of Agriculture,,LIB,Richard Carpenter,25,17,6,2
+Galveston,142,Railroad Commissioner,,REP,Christi Craddick,648,463,125,60
+Galveston,142,Railroad Commissioner,,DEM,Roman McAllen,561,361,141,59
+Galveston,142,Railroad Commissioner,,LIB,Mike Wright,36,24,10,2
+Galveston,142,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,657,471,125,61
+Galveston,142,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,589,378,152,59
+Galveston,142,"Justice, Supreme Court, Place 4",,REP,John Devine,657,470,128,59
+Galveston,142,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,585,378,147,60
+Galveston,142,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,664,474,131,59
+Galveston,142,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,581,374,145,62
+Galveston,142,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,648,465,125,58
+Galveston,142,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,567,362,144,61
+Galveston,142,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,29,21,7,1
+Galveston,142,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,664,474,130,60
+Galveston,142,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,580,372,147,61
+Galveston,142,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,712,503,145,64
+Galveston,142,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,216,162,46,8
+Galveston,142,"Member, State Board of Education, District 7",,REP,Matt Robinson,659,470,128,61
+Galveston,142,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",582,375,148,59
+Galveston,142,State Representative,23,REP,Mayes Middleton,657,470,129,58
+Galveston,142,State Representative,23,DEM,Amanda Jamrok,563,366,136,61
+Galveston,142,State Representative,23,LIB,Lawrence Johnson,28,14,11,3
+Galveston,142,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,661,474,129,58
+Galveston,142,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,578,371,144,63
+Galveston,142,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,655,470,127,58
+Galveston,142,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,584,375,148,61
+Galveston,142,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,660,470,130,60
+Galveston,142,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,578,375,145,58
+Galveston,142,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,647,464,125,58
+Galveston,142,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,591,381,151,59
+Galveston,142,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,668,475,131,62
+Galveston,142,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,569,369,144,56
+Galveston,142,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,671,479,131,61
+Galveston,142,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,568,366,144,58
+Galveston,142,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,660,473,129,58
+Galveston,142,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,578,371,147,60
+Galveston,142,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,672,479,132,61
+Galveston,142,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,565,365,143,57
+Galveston,142,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,656,470,127,59
+Galveston,142,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,581,374,148,59
+Galveston,142,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,660,473,128,59
+Galveston,142,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",577,372,146,59
+Galveston,142,"District Judge, 122nd Judicial District",,REP,John Ellisor,767,544,156,67
+Galveston,142,"District Judge, 212th Judicial District",,REP,Patricia Grady,770,545,160,65
+Galveston,142,"District Judge, 306th Judicial District",,REP,Anne B. Darring,765,541,158,66
+Galveston,142,Criminal District Attorney,,REP,Jack Roady,766,543,156,67
+Galveston,142,County Judge,,REP,Mark Henry,758,529,160,69
+Galveston,142,"Judge, County Court-at-Law No. 1",,REP,John Grady,754,533,154,67
+Galveston,142,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,660,473,130,57
+Galveston,142,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,579,371,145,63
+Galveston,142,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,765,541,157,67
+Galveston,142,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,764,540,156,68
+Galveston,142,District Clerk,,REP,John D Kinard,760,537,157,66
+Galveston,142,County Clerk,,REP,Dwight Sullivan,762,534,157,71
+Galveston,142,County Treasurer,,REP,Kevin C. Walsh,766,541,156,69
+Galveston,142,Justice of the Peace Pct. 1,,REP,Greg Rikard,760,536,156,68
+Galveston,142,College of the Mainland Proposition A,,,FOR,805,545,180,80
+Galveston,142,College of the Mainland Proposition A,,,AGAINST,248,172,47,29
+Galveston,144,Ballots Cast,,,,1288,959,242,87
+Galveston,144,Straight Party,,REP,Republican,601,463,94,44
+Galveston,144,Straight Party,,DEM,Democrat,238,160,59,19
+Galveston,144,Straight Party,,LIB,Libertarian,2,2,0,0
+Galveston,144,U.S. Senate,,REP,Ted Cruz,844,654,135,55
+Galveston,144,U.S. Senate,,DEM,Beto O'Rourke,418,287,100,31
+Galveston,144,U.S. Senate,,LIB,Neal M. Dikeman,11,7,4,0
+Galveston,144,U.S. House,14,REP,Randy Weber,844,657,133,54
+Galveston,144,U.S. House,14,DEM,Adrienne Bell,398,271,96,31
+Galveston,144,U.S. House,14,LIB,Don E. Conley III,22,15,7,0
+Galveston,144,Governor,,REP,Greg Abbott,885,682,147,56
+Galveston,144,Governor,,DEM,Lupe Valdez,367,251,86,30
+Galveston,144,Governor,,LIB,Mark Jay Tippetts,23,18,5,0
+Galveston,144,Lieutenant Governor,,REP,Dan Patrick,835,641,140,54
+Galveston,144,Lieutenant Governor,,DEM,Mike Collier,404,280,94,30
+Galveston,144,Lieutenant Governor,,LIB,Kerry Douglas McKennon,30,23,5,2
+Galveston,144,Attorney General,,REP,Ken Paxton,822,642,130,50
+Galveston,144,Attorney General,,DEM,Justin Nelson,417,286,97,34
+Galveston,144,Attorney General,,LIB,Michael Ray Harris,30,19,9,2
+Galveston,144,Comptroller of Public Accounts,,REP,Glenn Hegar,841,659,130,52
+Galveston,144,Comptroller of Public Accounts,,DEM,Joi Chevalier,376,250,93,33
+Galveston,144,Comptroller of Public Accounts,,LIB,Ben Sanders,44,33,11,0
+Galveston,144,Commissioner of General Land Office,,REP,George P. Bush,848,658,136,54
+Galveston,144,Commissioner of General Land Office,,DEM,Miguel Suazo,371,249,91,31
+Galveston,144,Commissioner of General Land Office,,LIB,Matt Pina,48,36,10,2
+Galveston,144,Commissioner of Agriculture,,REP,Sid Miller,817,635,130,52
+Galveston,144,Commissioner of Agriculture,,DEM,Kim Olson,424,291,99,34
+Galveston,144,Commissioner of Agriculture,,LIB,Richard Carpenter,26,18,8,0
+Galveston,144,Railroad Commissioner,,REP,Christi Craddick,839,659,129,51
+Galveston,144,Railroad Commissioner,,DEM,Roman McAllen,379,250,94,35
+Galveston,144,Railroad Commissioner,,LIB,Mike Wright,46,35,11,0
+Galveston,144,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,843,657,134,52
+Galveston,144,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,421,284,103,34
+Galveston,144,"Justice, Supreme Court, Place 4",,REP,John Devine,846,657,138,51
+Galveston,144,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,417,284,98,35
+Galveston,144,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,846,659,136,51
+Galveston,144,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,417,282,100,35
+Galveston,144,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,834,649,132,53
+Galveston,144,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,399,274,92,33
+Galveston,144,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,30,17,13,0
+Galveston,144,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,856,670,135,51
+Galveston,144,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,404,269,100,35
+Galveston,144,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,903,698,151,54
+Galveston,144,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,188,130,44,14
+Galveston,144,"Member, State Board of Education, District 7",,REP,Matt Robinson,845,660,132,53
+Galveston,144,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",416,278,104,34
+Galveston,144,State Representative,24,REP,Greg Bonnen,846,660,134,52
+Galveston,144,State Representative,24,DEM,John Y. Phelps,394,266,94,34
+Galveston,144,State Representative,24,LIB,Dick Illyes,28,18,9,1
+Galveston,144,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,862,672,139,51
+Galveston,144,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,397,266,96,35
+Galveston,144,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,850,662,135,53
+Galveston,144,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,409,277,99,33
+Galveston,144,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,844,656,136,52
+Galveston,144,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,415,283,98,34
+Galveston,144,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,847,661,135,51
+Galveston,144,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,413,276,102,35
+Galveston,144,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,856,666,138,52
+Galveston,144,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,404,273,97,34
+Galveston,144,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,859,668,138,53
+Galveston,144,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,398,270,95,33
+Galveston,144,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,857,663,140,54
+Galveston,144,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,399,275,92,32
+Galveston,144,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,862,668,140,54
+Galveston,144,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,394,271,91,32
+Galveston,144,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,847,659,135,53
+Galveston,144,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,410,280,97,33
+Galveston,144,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,854,662,138,54
+Galveston,144,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",404,277,95,32
+Galveston,144,"District Judge, 122nd Judicial District",,REP,John Ellisor,937,719,161,57
+Galveston,144,"District Judge, 212th Judicial District",,REP,Patricia Grady,932,713,160,59
+Galveston,144,"District Judge, 306th Judicial District",,REP,Anne B. Darring,931,713,161,57
+Galveston,144,Criminal District Attorney,,REP,Jack Roady,927,708,161,58
+Galveston,144,County Judge,,REP,Mark Henry,926,702,166,58
+Galveston,144,"Judge, County Court-at-Law No. 1",,REP,John Grady,927,711,160,56
+Galveston,144,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,853,663,138,52
+Galveston,144,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,402,273,95,34
+Galveston,144,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,934,720,160,54
+Galveston,144,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,934,717,162,55
+Galveston,144,District Clerk,,REP,John D Kinard,932,715,161,56
+Galveston,144,County Clerk,,REP,Dwight Sullivan,931,715,160,56
+Galveston,144,County Treasurer,,REP,Kevin C. Walsh,931,713,162,56
+Galveston,144,Justice of the Peace Pct. 1,,REP,Greg Rikard,931,714,161,56
+Galveston,144,College of the Mainland Proposition A,,,FOR,689,514,131,44
+Galveston,144,College of the Mainland Proposition A,,,AGAINST,342,255,59,28
+Galveston,146,Ballots Cast,,,,1574,1105,368,101
+Galveston,146,Straight Party,,REP,Republican,574,412,128,34
+Galveston,146,Straight Party,,DEM,Democrat,409,273,99,37
+Galveston,146,Straight Party,,LIB,Libertarian,8,3,4,1
+Galveston,146,U.S. Senate,,REP,Ted Cruz,900,653,201,46
+Galveston,146,U.S. Senate,,DEM,Beto O'Rourke,654,441,158,55
+Galveston,146,U.S. Senate,,LIB,Neal M. Dikeman,10,3,7,0
+Galveston,146,U.S. House,14,REP,Randy Weber,916,673,199,44
+Galveston,146,U.S. House,14,DEM,Adrienne Bell,612,403,155,54
+Galveston,146,U.S. House,14,LIB,Don E. Conley III,27,17,9,1
+Galveston,146,Governor,,REP,Greg Abbott,955,692,214,49
+Galveston,146,Governor,,DEM,Lupe Valdez,585,394,143,48
+Galveston,146,Governor,,LIB,Mark Jay Tippetts,22,13,7,2
+Galveston,146,Lieutenant Governor,,REP,Dan Patrick,888,646,196,46
+Galveston,146,Lieutenant Governor,,DEM,Mike Collier,631,429,149,53
+Galveston,146,Lieutenant Governor,,LIB,Kerry Douglas McKennon,38,21,17,0
+Galveston,146,Attorney General,,REP,Ken Paxton,872,641,190,41
+Galveston,146,Attorney General,,DEM,Justin Nelson,636,429,151,56
+Galveston,146,Attorney General,,LIB,Michael Ray Harris,47,25,21,1
+Galveston,146,Comptroller of Public Accounts,,REP,Glenn Hegar,902,663,195,44
+Galveston,146,Comptroller of Public Accounts,,DEM,Joi Chevalier,583,392,138,53
+Galveston,146,Comptroller of Public Accounts,,LIB,Ben Sanders,55,28,25,2
+Galveston,146,Commissioner of General Land Office,,REP,George P. Bush,919,671,203,45
+Galveston,146,Commissioner of General Land Office,,DEM,Miguel Suazo,581,391,138,52
+Galveston,146,Commissioner of General Land Office,,LIB,Matt Pina,55,34,20,1
+Galveston,146,Commissioner of Agriculture,,REP,Sid Miller,879,644,190,45
+Galveston,146,Commissioner of Agriculture,,DEM,Kim Olson,635,423,160,52
+Galveston,146,Commissioner of Agriculture,,LIB,Richard Carpenter,33,22,9,2
+Galveston,146,Railroad Commissioner,,REP,Christi Craddick,905,663,197,45
+Galveston,146,Railroad Commissioner,,DEM,Roman McAllen,584,388,145,51
+Galveston,146,Railroad Commissioner,,LIB,Mike Wright,49,30,16,3
+Galveston,146,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,898,655,200,43
+Galveston,146,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,641,427,158,56
+Galveston,146,"Justice, Supreme Court, Place 4",,REP,John Devine,916,667,206,43
+Galveston,146,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,619,412,152,55
+Galveston,146,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,914,668,202,44
+Galveston,146,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,622,410,157,55
+Galveston,146,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,889,649,196,44
+Galveston,146,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,614,414,146,54
+Galveston,146,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,34,17,16,1
+Galveston,146,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,926,673,209,44
+Galveston,146,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,607,402,151,54
+Galveston,146,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,989,711,227,51
+Galveston,146,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,261,178,70,13
+Galveston,146,"Member, State Board of Education, District 7",,REP,Matt Robinson,900,654,202,44
+Galveston,146,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",633,421,157,55
+Galveston,146,State Representative,23,REP,Mayes Middleton,913,673,200,40
+Galveston,146,State Representative,23,DEM,Amanda Jamrok,602,398,147,57
+Galveston,146,State Representative,23,LIB,Lawrence Johnson,33,19,11,3
+Galveston,146,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,917,666,208,43
+Galveston,146,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,612,408,150,54
+Galveston,146,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,906,657,206,43
+Galveston,146,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,624,418,152,54
+Galveston,146,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,916,664,207,45
+Galveston,146,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,614,410,151,53
+Galveston,146,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,906,660,202,44
+Galveston,146,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,622,413,156,53
+Galveston,146,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,922,667,209,46
+Galveston,146,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,608,407,149,52
+Galveston,146,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,911,658,209,44
+Galveston,146,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,612,409,149,54
+Galveston,146,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,914,665,205,44
+Galveston,146,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,613,406,152,55
+Galveston,146,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,921,666,210,45
+Galveston,146,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,607,405,148,54
+Galveston,146,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,897,656,198,43
+Galveston,146,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,630,415,159,56
+Galveston,146,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,907,657,207,43
+Galveston,146,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",617,413,149,55
+Galveston,146,"District Judge, 122nd Judicial District",,REP,John Ellisor,1059,750,254,55
+Galveston,146,"District Judge, 212th Judicial District",,REP,Patricia Grady,1056,748,254,54
+Galveston,146,"District Judge, 306th Judicial District",,REP,Anne B. Darring,1062,753,255,54
+Galveston,146,Criminal District Attorney,,REP,Jack Roady,1054,750,249,55
+Galveston,146,County Judge,,REP,Mark Henry,1049,746,251,52
+Galveston,146,"Judge, County Court-at-Law No. 1",,REP,John Grady,1037,735,248,54
+Galveston,146,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,907,659,204,44
+Galveston,146,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,623,418,151,54
+Galveston,146,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,1050,745,252,53
+Galveston,146,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,1054,748,252,54
+Galveston,146,District Clerk,,REP,John D Kinard,1050,743,251,56
+Galveston,146,County Clerk,,REP,Dwight Sullivan,1048,741,253,54
+Galveston,146,County Treasurer,,REP,Kevin C. Walsh,1043,738,252,53
+Galveston,146,Justice of the Peace Pct. 1,,REP,Greg Rikard,1045,741,253,51
+Galveston,146,College of the Mainland Proposition A,,,FOR,990,703,221,66
+Galveston,146,College of the Mainland Proposition A,,,AGAINST,333,238,74,21
+Galveston,148,Ballots Cast,,,,1873,1295,434,144
+Galveston,148,Straight Party,,REP,Republican,685,489,144,52
+Galveston,148,Straight Party,,DEM,Democrat,464,293,121,50
+Galveston,148,Straight Party,,LIB,Libertarian,7,4,2,1
+Galveston,148,U.S. Senate,,REP,Ted Cruz,1109,794,236,79
+Galveston,148,U.S. Senate,,DEM,Beto O'Rourke,723,480,183,60
+Galveston,148,U.S. Senate,,LIB,Neal M. Dikeman,22,9,11,2
+Galveston,148,U.S. House,14,REP,Randy Weber,1104,797,230,77
+Galveston,148,U.S. House,14,DEM,Adrienne Bell,702,454,185,63
+Galveston,148,U.S. House,14,LIB,Don E. Conley III,34,20,12,2
+Galveston,148,Governor,,REP,Greg Abbott,1154,830,244,80
+Galveston,148,Governor,,DEM,Lupe Valdez,667,435,172,60
+Galveston,148,Governor,,LIB,Mark Jay Tippetts,32,19,12,1
+Galveston,148,Lieutenant Governor,,REP,Dan Patrick,1092,778,235,79
+Galveston,148,Lieutenant Governor,,DEM,Mike Collier,709,472,175,62
+Galveston,148,Lieutenant Governor,,LIB,Kerry Douglas McKennon,38,20,17,1
+Galveston,148,Attorney General,,REP,Ken Paxton,1049,750,226,73
+Galveston,148,Attorney General,,DEM,Justin Nelson,738,491,181,66
+Galveston,148,Attorney General,,LIB,Michael Ray Harris,45,24,18,3
+Galveston,148,Comptroller of Public Accounts,,REP,Glenn Hegar,1079,784,220,75
+Galveston,148,Comptroller of Public Accounts,,DEM,Joi Chevalier,677,439,176,62
+Galveston,148,Comptroller of Public Accounts,,LIB,Ben Sanders,63,35,26,2
+Galveston,148,Commissioner of General Land Office,,REP,George P. Bush,1102,804,225,73
+Galveston,148,Commissioner of General Land Office,,DEM,Miguel Suazo,680,434,178,68
+Galveston,148,Commissioner of General Land Office,,LIB,Matt Pina,57,34,20,3
+Galveston,148,Commissioner of Agriculture,,REP,Sid Miller,1033,745,216,72
+Galveston,148,Commissioner of Agriculture,,DEM,Kim Olson,745,489,190,66
+Galveston,148,Commissioner of Agriculture,,LIB,Richard Carpenter,45,24,17,4
+Galveston,148,Railroad Commissioner,,REP,Christi Craddick,1085,785,225,75
+Galveston,148,Railroad Commissioner,,DEM,Roman McAllen,695,449,181,65
+Galveston,148,Railroad Commissioner,,LIB,Mike Wright,52,33,16,3
+Galveston,148,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1076,773,230,73
+Galveston,148,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,747,489,192,66
+Galveston,148,"Justice, Supreme Court, Place 4",,REP,John Devine,1093,790,229,74
+Galveston,148,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,726,471,190,65
+Galveston,148,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1096,787,232,77
+Galveston,148,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,724,472,189,63
+Galveston,148,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1065,771,220,74
+Galveston,148,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,701,459,180,62
+Galveston,148,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,56,29,22,5
+Galveston,148,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1097,785,237,75
+Galveston,148,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,720,472,184,64
+Galveston,148,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1178,848,251,79
+Galveston,148,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,281,191,71,19
+Galveston,148,"Member, State Board of Education, District 7",,REP,Matt Robinson,1088,784,229,75
+Galveston,148,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",735,479,191,65
+Galveston,148,State Representative,23,REP,Mayes Middleton,1116,802,237,77
+Galveston,148,State Representative,23,DEM,Amanda Jamrok,684,445,174,65
+Galveston,148,State Representative,23,LIB,Lawrence Johnson,44,27,15,2
+Galveston,148,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,1082,778,233,71
+Galveston,148,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,733,476,189,68
+Galveston,148,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,1082,779,230,73
+Galveston,148,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,735,476,192,67
+Galveston,148,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,1102,795,234,73
+Galveston,148,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,716,460,190,66
+Galveston,148,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,1074,772,231,71
+Galveston,148,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,746,487,191,68
+Galveston,148,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,1092,785,235,72
+Galveston,148,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,726,472,187,67
+Galveston,148,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,1084,779,232,73
+Galveston,148,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,733,477,189,67
+Galveston,148,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,1091,782,234,75
+Galveston,148,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,723,471,187,65
+Galveston,148,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,1100,791,235,74
+Galveston,148,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,712,461,186,65
+Galveston,148,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,1079,780,224,75
+Galveston,148,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,733,471,197,65
+Galveston,148,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,1091,787,230,74
+Galveston,148,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",722,465,191,66
+Galveston,148,"District Judge, 122nd Judicial District",,REP,John Ellisor,1249,892,273,84
+Galveston,148,"District Judge, 212th Judicial District",,REP,Patricia Grady,1247,889,274,84
+Galveston,148,"District Judge, 306th Judicial District",,REP,Anne B. Darring,1256,900,274,82
+Galveston,148,Criminal District Attorney,,REP,Jack Roady,1243,882,275,86
+Galveston,148,County Judge,,REP,Mark Henry,1221,869,273,79
+Galveston,148,"Judge, County Court-at-Law No. 1",,REP,John Grady,1219,869,268,82
+Galveston,148,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,1098,785,237,76
+Galveston,148,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,718,468,185,65
+Galveston,148,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,1241,885,273,83
+Galveston,148,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,1239,883,273,83
+Galveston,148,District Clerk,,REP,John D Kinard,1237,882,271,84
+Galveston,148,County Clerk,,REP,Dwight Sullivan,1234,876,273,85
+Galveston,148,County Treasurer,,REP,Kevin C. Walsh,1224,874,268,82
+Galveston,148,Justice of the Peace Pct. 1,,REP,Greg Rikard,1226,873,270,83
+Galveston,148,College of the Mainland Proposition A,,,FOR,1169,819,268,82
+Galveston,148,College of the Mainland Proposition A,,,AGAINST,373,266,66,41
+Galveston,150,Ballots Cast,,,,1294,939,259,96
+Galveston,150,Straight Party,,REP,Republican,533,399,104,30
+Galveston,150,Straight Party,,DEM,Democrat,307,202,72,33
+Galveston,150,Straight Party,,LIB,Libertarian,4,0,4,0
+Galveston,150,U.S. Senate,,REP,Ted Cruz,783,590,147,46
+Galveston,150,U.S. Senate,,DEM,Beto O'Rourke,497,344,103,50
+Galveston,150,U.S. Senate,,LIB,Neal M. Dikeman,8,3,5,0
+Galveston,150,U.S. House,14,REP,Randy Weber,787,596,147,44
+Galveston,150,U.S. House,14,DEM,Adrienne Bell,467,316,100,51
+Galveston,150,U.S. House,14,LIB,Don E. Conley III,25,17,8,0
+Galveston,150,Governor,,REP,Greg Abbott,826,623,155,48
+Galveston,150,Governor,,DEM,Lupe Valdez,434,291,97,46
+Galveston,150,Governor,,LIB,Mark Jay Tippetts,18,14,4,0
+Galveston,150,Lieutenant Governor,,REP,Dan Patrick,778,580,152,46
+Galveston,150,Lieutenant Governor,,DEM,Mike Collier,478,332,98,48
+Galveston,150,Lieutenant Governor,,LIB,Kerry Douglas McKennon,23,16,7,0
+Galveston,150,Attorney General,,REP,Ken Paxton,751,564,146,41
+Galveston,150,Attorney General,,DEM,Justin Nelson,502,348,103,51
+Galveston,150,Attorney General,,LIB,Michael Ray Harris,22,14,8,0
+Galveston,150,Comptroller of Public Accounts,,REP,Glenn Hegar,769,581,148,40
+Galveston,150,Comptroller of Public Accounts,,DEM,Joi Chevalier,452,304,100,48
+Galveston,150,Comptroller of Public Accounts,,LIB,Ben Sanders,39,29,8,2
+Galveston,150,Commissioner of General Land Office,,REP,George P. Bush,796,609,146,41
+Galveston,150,Commissioner of General Land Office,,DEM,Miguel Suazo,450,299,98,53
+Galveston,150,Commissioner of General Land Office,,LIB,Matt Pina,33,21,11,1
+Galveston,150,Commissioner of Agriculture,,REP,Sid Miller,749,569,142,38
+Galveston,150,Commissioner of Agriculture,,DEM,Kim Olson,491,333,106,52
+Galveston,150,Commissioner of Agriculture,,LIB,Richard Carpenter,28,20,7,1
+Galveston,150,Railroad Commissioner,,REP,Christi Craddick,771,582,149,40
+Galveston,150,Railroad Commissioner,,DEM,Roman McAllen,465,313,101,51
+Galveston,150,Railroad Commissioner,,LIB,Mike Wright,29,22,7,0
+Galveston,150,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,774,586,149,39
+Galveston,150,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,490,331,108,51
+Galveston,150,"Justice, Supreme Court, Place 4",,REP,John Devine,777,589,149,39
+Galveston,150,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,484,327,106,51
+Galveston,150,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,779,592,149,38
+Galveston,150,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,485,325,106,54
+Galveston,150,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,762,578,143,41
+Galveston,150,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,477,325,102,50
+Galveston,150,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,23,14,8,1
+Galveston,150,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,781,593,147,41
+Galveston,150,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,476,321,105,50
+Galveston,150,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,831,631,159,41
+Galveston,150,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,193,130,41,22
+Galveston,150,"Member, State Board of Education, District 7",,REP,Matt Robinson,777,586,152,39
+Galveston,150,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",487,332,103,52
+Galveston,150,State Representative,23,REP,Mayes Middleton,798,604,152,42
+Galveston,150,State Representative,23,DEM,Amanda Jamrok,459,313,95,51
+Galveston,150,State Representative,23,LIB,Lawrence Johnson,20,11,9,0
+Galveston,150,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,778,589,149,40
+Galveston,150,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,483,325,106,52
+Galveston,150,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,779,592,149,38
+Galveston,150,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,479,322,104,53
+Galveston,150,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,783,594,147,42
+Galveston,150,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,479,323,106,50
+Galveston,150,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,772,585,148,39
+Galveston,150,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,490,333,106,51
+Galveston,150,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,775,588,148,39
+Galveston,150,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,480,324,106,50
+Galveston,150,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,784,595,152,37
+Galveston,150,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,474,319,102,53
+Galveston,150,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,783,595,148,40
+Galveston,150,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,473,319,105,49
+Galveston,150,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,773,586,150,37
+Galveston,150,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,481,325,103,53
+Galveston,150,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,776,588,149,39
+Galveston,150,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,479,324,104,51
+Galveston,150,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,778,589,148,41
+Galveston,150,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",478,322,107,49
+Galveston,150,"District Judge, 122nd Judicial District",,REP,John Ellisor,880,661,175,44
+Galveston,150,"District Judge, 212th Judicial District",,REP,Patricia Grady,868,652,172,44
+Galveston,150,"District Judge, 306th Judicial District",,REP,Anne B. Darring,871,656,170,45
+Galveston,150,Criminal District Attorney,,REP,Jack Roady,880,659,177,44
+Galveston,150,County Judge,,REP,Mark Henry,860,643,175,42
+Galveston,150,"Judge, County Court-at-Law No. 1",,REP,John Grady,864,650,173,41
+Galveston,150,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,781,590,150,41
+Galveston,150,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,481,327,104,50
+Galveston,150,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,870,654,173,43
+Galveston,150,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,872,655,173,44
+Galveston,150,District Clerk,,REP,John D Kinard,866,652,172,42
+Galveston,150,County Clerk,,REP,Dwight Sullivan,868,650,175,43
+Galveston,150,County Treasurer,,REP,Kevin C. Walsh,862,647,174,41
+Galveston,150,Justice of the Peace Pct. 1,,REP,Greg Rikard,860,648,171,41
+Galveston,150,College of the Mainland Proposition A,,,FOR,761,573,137,51
+Galveston,150,College of the Mainland Proposition A,,,AGAINST,304,212,59,33
+Galveston,151,Ballots Cast,,,,1649,1132,422,95
+Galveston,151,Straight Party,,REP,Republican,903,649,212,42
+Galveston,151,Straight Party,,DEM,Democrat,239,157,59,23
+Galveston,151,Straight Party,,LIB,Libertarian,9,2,4,3
+Galveston,151,U.S. Senate,,REP,Ted Cruz,1211,855,298,58
+Galveston,151,U.S. Senate,,DEM,Beto O'Rourke,411,261,114,36
+Galveston,151,U.S. Senate,,LIB,Neal M. Dikeman,13,7,5,1
+Galveston,151,U.S. House,14,REP,Randy Weber,1198,852,290,56
+Galveston,151,U.S. House,14,DEM,Adrienne Bell,396,249,110,37
+Galveston,151,U.S. House,14,LIB,Don E. Conley III,35,19,14,2
+Galveston,151,Governor,,REP,Greg Abbott,1261,879,320,62
+Galveston,151,Governor,,DEM,Lupe Valdez,349,230,88,31
+Galveston,151,Governor,,LIB,Mark Jay Tippetts,27,15,11,1
+Galveston,151,Lieutenant Governor,,REP,Dan Patrick,1214,860,294,60
+Galveston,151,Lieutenant Governor,,DEM,Mike Collier,389,246,111,32
+Galveston,151,Lieutenant Governor,,LIB,Kerry Douglas McKennon,28,15,12,1
+Galveston,151,Attorney General,,REP,Ken Paxton,1178,838,283,57
+Galveston,151,Attorney General,,DEM,Justin Nelson,406,257,115,34
+Galveston,151,Attorney General,,LIB,Michael Ray Harris,46,27,16,3
+Galveston,151,Comptroller of Public Accounts,,REP,Glenn Hegar,1197,850,290,57
+Galveston,151,Comptroller of Public Accounts,,DEM,Joi Chevalier,365,233,98,34
+Galveston,151,Comptroller of Public Accounts,,LIB,Ben Sanders,58,31,24,3
+Galveston,151,Commissioner of General Land Office,,REP,George P. Bush,1191,839,293,59
+Galveston,151,Commissioner of General Land Office,,DEM,Miguel Suazo,370,236,102,32
+Galveston,151,Commissioner of General Land Office,,LIB,Matt Pina,65,42,21,2
+Galveston,151,Commissioner of Agriculture,,REP,Sid Miller,1170,836,278,56
+Galveston,151,Commissioner of Agriculture,,DEM,Kim Olson,414,261,118,35
+Galveston,151,Commissioner of Agriculture,,LIB,Richard Carpenter,39,20,16,3
+Galveston,151,Railroad Commissioner,,REP,Christi Craddick,1201,855,288,58
+Galveston,151,Railroad Commissioner,,DEM,Roman McAllen,372,236,104,32
+Galveston,151,Railroad Commissioner,,LIB,Mike Wright,49,25,19,5
+Galveston,151,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1208,853,297,58
+Galveston,151,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,416,265,115,36
+Galveston,151,"Justice, Supreme Court, Place 4",,REP,John Devine,1212,855,299,58
+Galveston,151,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,412,262,115,35
+Galveston,151,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1201,847,297,57
+Galveston,151,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,420,269,115,36
+Galveston,151,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1198,847,292,59
+Galveston,151,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,390,254,104,32
+Galveston,151,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,39,17,18,4
+Galveston,151,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1213,855,299,59
+Galveston,151,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,408,260,114,34
+Galveston,151,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1258,881,315,62
+Galveston,151,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,196,127,56,13
+Galveston,151,"Member, State Board of Education, District 7",,REP,Matt Robinson,1191,853,288,50
+Galveston,151,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",419,261,120,38
+Galveston,151,State Representative,23,REP,Mayes Middleton,1193,848,294,51
+Galveston,151,State Representative,23,DEM,Amanda Jamrok,392,252,106,34
+Galveston,151,State Representative,23,LIB,Lawrence Johnson,37,19,13,5
+Galveston,151,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,1219,865,298,56
+Galveston,151,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,397,251,111,35
+Galveston,151,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,1193,852,292,49
+Galveston,151,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,419,263,117,39
+Galveston,151,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,1197,854,294,49
+Galveston,151,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,411,261,112,38
+Galveston,151,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,1197,853,290,54
+Galveston,151,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,412,261,116,35
+Galveston,151,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,1212,859,300,53
+Galveston,151,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,397,255,107,35
+Galveston,151,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,1211,857,303,51
+Galveston,151,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,401,260,104,37
+Galveston,151,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,1211,858,300,53
+Galveston,151,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,400,258,106,36
+Galveston,151,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,1206,856,297,53
+Galveston,151,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,401,258,108,35
+Galveston,151,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,1192,853,288,51
+Galveston,151,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,417,261,119,37
+Galveston,151,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,1188,849,289,50
+Galveston,151,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",420,264,117,39
+Galveston,151,"District Judge, 122nd Judicial District",,REP,John Ellisor,1295,913,323,59
+Galveston,151,"District Judge, 212th Judicial District",,REP,Patricia Grady,1289,907,323,59
+Galveston,151,"District Judge, 306th Judicial District",,REP,Anne B. Darring,1286,905,322,59
+Galveston,151,Criminal District Attorney,,REP,Jack Roady,1288,909,318,61
+Galveston,151,County Judge,,REP,Mark Henry,1289,906,322,61
+Galveston,151,"Judge, County Court-at-Law No. 1",,REP,John Grady,1279,905,317,57
+Galveston,151,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,1198,856,290,52
+Galveston,151,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,404,254,115,35
+Galveston,151,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,1286,909,317,60
+Galveston,151,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,1287,908,320,59
+Galveston,151,District Clerk,,REP,John D Kinard,1285,907,320,58
+Galveston,151,County Clerk,,REP,Dwight Sullivan,1285,907,319,59
+Galveston,151,County Treasurer,,REP,Kevin C. Walsh,1281,904,319,58
+Galveston,151,Justice of the Peace Pct. 1,,REP,Greg Rikard,1285,905,319,61
+Galveston,151,College of the Mainland Proposition A,,,FOR,713,484,182,47
+Galveston,151,College of the Mainland Proposition A,,,AGAINST,536,385,121,30
+Galveston,152,Ballots Cast,,,,2981,2335,424,222
+Galveston,152,Straight Party,,REP,Republican,1285,1023,153,109
+Galveston,152,Straight Party,,DEM,Democrat,446,335,69,42
+Galveston,152,Straight Party,,LIB,Libertarian,8,7,0,1
+Galveston,152,U.S. Senate,,REP,Ted Cruz,1972,1570,261,141
+Galveston,152,U.S. Senate,,DEM,Beto O'Rourke,967,733,155,79
+Galveston,152,U.S. Senate,,LIB,Neal M. Dikeman,25,22,3,0
+Galveston,152,U.S. House,14,REP,Randy Weber,2018,1614,260,144
+Galveston,152,U.S. House,14,DEM,Adrienne Bell,866,656,136,74
+Galveston,152,U.S. House,14,LIB,Don E. Conley III,55,38,17,0
+Galveston,152,Governor,,REP,Greg Abbott,2136,1708,284,144
+Galveston,152,Governor,,DEM,Lupe Valdez,766,574,119,73
+Galveston,152,Governor,,LIB,Mark Jay Tippetts,53,41,11,1
+Galveston,152,Lieutenant Governor,,REP,Dan Patrick,1934,1541,255,138
+Galveston,152,Lieutenant Governor,,DEM,Mike Collier,930,708,142,80
+Galveston,152,Lieutenant Governor,,LIB,Kerry Douglas McKennon,74,59,15,0
+Galveston,152,Attorney General,,REP,Ken Paxton,1914,1534,243,137
+Galveston,152,Attorney General,,DEM,Justin Nelson,932,706,146,80
+Galveston,152,Attorney General,,LIB,Michael Ray Harris,84,64,20,0
+Galveston,152,Comptroller of Public Accounts,,REP,Glenn Hegar,2028,1625,258,145
+Galveston,152,Comptroller of Public Accounts,,DEM,Joi Chevalier,791,604,117,70
+Galveston,152,Comptroller of Public Accounts,,LIB,Ben Sanders,96,65,28,3
+Galveston,152,Commissioner of General Land Office,,REP,George P. Bush,2010,1613,254,143
+Galveston,152,Commissioner of General Land Office,,DEM,Miguel Suazo,795,594,130,71
+Galveston,152,Commissioner of General Land Office,,LIB,Matt Pina,117,94,21,2
+Galveston,152,Commissioner of Agriculture,,REP,Sid Miller,1945,1561,244,140
+Galveston,152,Commissioner of Agriculture,,DEM,Kim Olson,896,684,136,76
+Galveston,152,Commissioner of Agriculture,,LIB,Richard Carpenter,74,52,21,1
+Galveston,152,Railroad Commissioner,,REP,Christi Craddick,2038,1629,261,148
+Galveston,152,Railroad Commissioner,,DEM,Roman McAllen,789,608,115,66
+Galveston,152,Railroad Commissioner,,LIB,Mike Wright,82,56,24,2
+Galveston,152,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,2022,1614,264,144
+Galveston,152,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,880,671,138,71
+Galveston,152,"Justice, Supreme Court, Place 4",,REP,John Devine,2023,1613,267,143
+Galveston,152,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,881,671,137,73
+Galveston,152,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,2052,1633,271,148
+Galveston,152,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,853,653,132,68
+Galveston,152,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1986,1584,257,145
+Galveston,152,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,849,649,130,70
+Galveston,152,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,67,50,16,1
+Galveston,152,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,2048,1635,269,144
+Galveston,152,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,841,641,130,70
+Galveston,152,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,2137,1714,280,143
+Galveston,152,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,463,359,79,25
+Galveston,152,"Member, State Board of Education, District 7",,REP,Matt Robinson,1994,1597,255,142
+Galveston,152,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",909,692,146,71
+Galveston,152,State Representative,24,REP,Greg Bonnen,2021,1615,265,141
+Galveston,152,State Representative,24,DEM,John Y. Phelps,836,635,128,73
+Galveston,152,State Representative,24,LIB,Dick Illyes,62,47,13,2
+Galveston,152,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,2058,1636,273,149
+Galveston,152,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,826,635,125,66
+Galveston,152,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,2031,1618,269,144
+Galveston,152,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,856,657,128,71
+Galveston,152,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,2030,1621,266,143
+Galveston,152,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,854,651,131,72
+Galveston,152,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,2010,1606,260,144
+Galveston,152,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,872,669,132,71
+Galveston,152,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,2051,1640,268,143
+Galveston,152,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,831,634,125,72
+Galveston,152,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,2053,1638,270,145
+Galveston,152,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,826,632,125,69
+Galveston,152,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,2057,1643,267,147
+Galveston,152,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,821,628,125,68
+Galveston,152,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,2048,1633,271,144
+Galveston,152,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,827,633,123,71
+Galveston,152,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,2025,1617,264,144
+Galveston,152,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,854,653,130,71
+Galveston,152,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,2034,1622,269,143
+Galveston,152,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",845,648,125,72
+Galveston,152,"District Judge, 122nd Judicial District",,REP,John Ellisor,2256,1801,306,149
+Galveston,152,"District Judge, 212th Judicial District",,REP,Patricia Grady,2251,1797,306,148
+Galveston,152,"District Judge, 306th Judicial District",,REP,Anne B. Darring,2249,1794,305,150
+Galveston,152,Criminal District Attorney,,REP,Jack Roady,2246,1789,306,151
+Galveston,152,County Judge,,REP,Mark Henry,2247,1786,307,154
+Galveston,152,"Judge, County Court-at-Law No. 1",,REP,John Grady,2227,1774,303,150
+Galveston,152,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,2031,1630,261,140
+Galveston,152,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,826,630,129,67
+Galveston,152,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,2233,1781,301,151
+Galveston,152,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,2236,1782,303,151
+Galveston,152,District Clerk,,REP,John D Kinard,2237,1783,302,152
+Galveston,152,County Clerk,,REP,Dwight Sullivan,2232,1780,299,153
+Galveston,152,County Treasurer,,REP,Kevin C. Walsh,2227,1775,300,152
+Galveston,152,Justice of the Peace Pct. 1,,REP,Greg Rikard,2220,1770,299,151
+Galveston,152,Mayor  - League City,,,Sebastian Lofaro,601,484,95,22
+Galveston,152,Mayor  - League City,,,Pat Hallisey,1678,1328,216,134
+Galveston,152,Council Position 1  - League City,,,Andy Mann,1117,903,150,64
+Galveston,152,Council Position 1  - League City,,,Traci Jacobs,852,663,121,68
+Galveston,152,Council Position 2  - League City,,,Hank Dugie,1818,1443,253,122
+Galveston,152,Council Position 6  - League City,,,Silvio P. Vincenzo,445,356,66,23
+Galveston,152,Council Position 6  - League City,,,Chad Tressler,836,659,115,62
+Galveston,152,Council Position 6  - League City,,,Chris Gross,703,558,92,53
+Galveston,152,Council Position 7  - League City,,,Ange Mertens,669,535,90,44
+Galveston,152,Council Position 7  - League City,,,Nick Long,1491,1190,201,100
+Galveston,152,League City Proposition A,,,For,1798,1418,214,166
+Galveston,152,League City Proposition A,,,Against,502,394,89,19
+Galveston,152,League City Proposition B,,,For,2075,1640,266,169
+Galveston,152,League City Proposition B,,,Against,372,291,61,20
+Galveston,152,League City Proposition C,,,For,2080,1634,271,175
+Galveston,152,League City Proposition C,,,Against,288,231,43,14
+Galveston,152,League City Proposition D,,,For,1977,1563,246,168
+Galveston,152,League City Proposition D,,,Against,290,231,44,15
+Galveston,152,League City Proposition E,,,For,2194,1747,273,174
+Galveston,152,League City Proposition E,,,Against,167,118,34,15
+Galveston,152,League City Proposition F,,,For,2076,1642,257,177
+Galveston,152,League City Proposition F,,,Against,205,156,40,9
+Galveston,152,League City Proposition G,,,For,2159,1716,273,170
+Galveston,152,League City Proposition G,,,Against,169,125,29,15
+Galveston,152,League City Proposition H,,,For,1335,1077,159,99
+Galveston,152,League City Proposition H,,,Against,831,649,110,72
+Galveston,152,League City Proposition I,,,For,2092,1664,256,172
+Galveston,152,League City Proposition I,,,Against,194,146,39,9
+Galveston,152,League City Proposition J,,,For,1985,1566,247,172
+Galveston,152,League City Proposition J,,,Against,301,239,51,11
+Galveston,152,League City Proposition K,,,For,2056,1629,253,174
+Galveston,152,League City Proposition K,,,Against,205,161,37,7
+Galveston,152,League City Proposition L,,,For,1796,1431,217,148
+Galveston,152,League City Proposition L,,,Against,395,303,66,26
+Galveston,152,League City Proposition M,,,For,1960,1573,234,153
+Galveston,152,League City Proposition M,,,Against,253,187,48,18
+Galveston,152,League City Proposition N,,,For,1830,1461,213,156
+Galveston,152,League City Proposition N,,,Against,400,303,76,21
+Galveston,152,League City Proposition O,,,For,1838,1468,221,149
+Galveston,152,League City Proposition O,,,Against,377,293,58,26
+Galveston,159,Ballots Cast,,,,2020,1400,521,99
+Galveston,159,Straight Party,,REP,Republican,867,619,208,40
+Galveston,159,Straight Party,,DEM,Democrat,467,316,125,26
+Galveston,159,Straight Party,,LIB,Libertarian,7,2,3,2
+Galveston,159,U.S. Senate,,REP,Ted Cruz,1221,859,303,59
+Galveston,159,U.S. Senate,,DEM,Beto O'Rourke,772,525,207,40
+Galveston,159,U.S. Senate,,LIB,Neal M. Dikeman,14,6,8,0
+Galveston,159,U.S. House,14,REP,Randy Weber,1235,871,306,58
+Galveston,159,U.S. House,14,DEM,Adrienne Bell,731,499,193,39
+Galveston,159,U.S. House,14,LIB,Don E. Conley III,30,18,12,0
+Galveston,159,Governor,,REP,Greg Abbott,1283,898,324,61
+Galveston,159,Governor,,DEM,Lupe Valdez,687,471,178,38
+Galveston,159,Governor,,LIB,Mark Jay Tippetts,35,19,16,0
+Galveston,159,Lieutenant Governor,,REP,Dan Patrick,1224,862,300,62
+Galveston,159,Lieutenant Governor,,DEM,Mike Collier,736,505,194,37
+Galveston,159,Lieutenant Governor,,LIB,Kerry Douglas McKennon,45,23,22,0
+Galveston,159,Attorney General,,REP,Ken Paxton,1192,844,290,58
+Galveston,159,Attorney General,,DEM,Justin Nelson,749,508,201,40
+Galveston,159,Attorney General,,LIB,Michael Ray Harris,57,37,20,0
+Galveston,159,Comptroller of Public Accounts,,REP,Glenn Hegar,1233,879,296,58
+Galveston,159,Comptroller of Public Accounts,,DEM,Joi Chevalier,701,475,188,38
+Galveston,159,Comptroller of Public Accounts,,LIB,Ben Sanders,58,35,22,1
+Galveston,159,Commissioner of General Land Office,,REP,George P. Bush,1208,851,297,60
+Galveston,159,Commissioner of General Land Office,,DEM,Miguel Suazo,700,476,187,37
+Galveston,159,Commissioner of General Land Office,,LIB,Matt Pina,90,60,28,2
+Galveston,159,Commissioner of Agriculture,,REP,Sid Miller,1200,851,292,57
+Galveston,159,Commissioner of Agriculture,,DEM,Kim Olson,741,506,197,38
+Galveston,159,Commissioner of Agriculture,,LIB,Richard Carpenter,48,28,18,2
+Galveston,159,Railroad Commissioner,,REP,Christi Craddick,1224,870,296,58
+Galveston,159,Railroad Commissioner,,DEM,Roman McAllen,707,482,188,37
+Galveston,159,Railroad Commissioner,,LIB,Mike Wright,61,35,24,2
+Galveston,159,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1221,870,292,59
+Galveston,159,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,761,513,210,38
+Galveston,159,"Justice, Supreme Court, Place 4",,REP,John Devine,1239,882,298,59
+Galveston,159,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,741,499,204,38
+Galveston,159,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1233,876,298,59
+Galveston,159,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,749,506,205,38
+Galveston,159,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1224,870,295,59
+Galveston,159,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,717,488,192,37
+Galveston,159,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,50,27,22,1
+Galveston,159,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1247,884,303,60
+Galveston,159,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,734,497,200,37
+Galveston,159,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1306,919,326,61
+Galveston,159,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,346,240,97,9
+Galveston,159,"Member, State Board of Education, District 7",,REP,Matt Robinson,1227,866,302,59
+Galveston,159,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",753,516,201,36
+Galveston,159,State Representative,23,REP,Mayes Middleton,1230,877,296,57
+Galveston,159,State Representative,23,DEM,Amanda Jamrok,706,481,188,37
+Galveston,159,State Representative,23,LIB,Lawrence Johnson,59,31,25,3
+Galveston,159,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,1240,883,300,57
+Galveston,159,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,736,498,199,39
+Galveston,159,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,1237,879,301,57
+Galveston,159,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,739,502,199,38
+Galveston,159,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,1243,881,305,57
+Galveston,159,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,730,501,192,37
+Galveston,159,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,1224,869,298,57
+Galveston,159,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,751,511,202,38
+Galveston,159,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,1243,882,304,57
+Galveston,159,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,732,498,195,39
+Galveston,159,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,1243,884,303,56
+Galveston,159,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,726,493,194,39
+Galveston,159,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,1238,881,301,56
+Galveston,159,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,730,494,196,40
+Galveston,159,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,1239,882,298,59
+Galveston,159,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,727,492,199,36
+Galveston,159,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,1231,872,300,59
+Galveston,159,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,735,502,196,37
+Galveston,159,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,1235,876,302,57
+Galveston,159,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",730,498,194,38
+Galveston,159,"District Judge, 122nd Judicial District",,REP,John Ellisor,1376,963,351,62
+Galveston,159,"District Judge, 212th Judicial District",,REP,Patricia Grady,1386,969,353,64
+Galveston,159,"District Judge, 306th Judicial District",,REP,Anne B. Darring,1376,963,349,64
+Galveston,159,Criminal District Attorney,,REP,Jack Roady,1372,959,350,63
+Galveston,159,County Judge,,REP,Mark Henry,1378,966,348,64
+Galveston,159,"Judge, County Court-at-Law No. 1",,REP,John Grady,1369,957,348,64
+Galveston,159,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,1226,871,301,54
+Galveston,159,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,746,507,198,41
+Galveston,159,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,1375,961,351,63
+Galveston,159,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,1379,968,348,63
+Galveston,159,District Clerk,,REP,John D Kinard,1378,962,352,64
+Galveston,159,County Clerk,,REP,Dwight Sullivan,1379,965,350,64
+Galveston,159,County Treasurer,,REP,Kevin C. Walsh,1375,964,349,62
+Galveston,159,Justice of the Peace Pct. 1,,REP,Greg Rikard,1374,962,348,64
+Galveston,159,College of the Mainland Proposition A,,,FOR,823,576,208,39
+Galveston,159,College of the Mainland Proposition A,,,AGAINST,476,338,108,30
+Galveston,159,Supervisor  - Bayview MUD,,,Linda Elliott,99,72,23,4
+Galveston,159,Supervisor  - Bayview MUD,,,Nicole Loukanis,67,49,15,3
+Galveston,159,Supervisor  - Bayview MUD,,,Troy D Bradfield,76,52,22,2
+Galveston,159,Supervisor  - Bayview MUD,,,Toni Clawson Randall,88,60,21,7
+Galveston,165,Ballots Cast,,,,2729,2005,617,107
+Galveston,165,Straight Party,,REP,Republican,1232,901,284,47
+Galveston,165,Straight Party,,DEM,Democrat,459,359,77,23
+Galveston,165,Straight Party,,LIB,Libertarian,9,4,4,1
+Galveston,165,U.S. Senate,,REP,Ted Cruz,1802,1321,413,68
+Galveston,165,U.S. Senate,,DEM,Beto O'Rourke,898,668,192,38
+Galveston,165,U.S. Senate,,LIB,Neal M. Dikeman,18,7,10,1
+Galveston,165,U.S. House,14,REP,Randy Weber,1837,1349,422,66
+Galveston,165,U.S. House,14,DEM,Adrienne Bell,817,616,162,39
+Galveston,165,U.S. House,14,LIB,Don E. Conley III,50,24,24,2
+Galveston,165,Governor,,REP,Greg Abbott,1926,1406,452,68
+Galveston,165,Governor,,DEM,Lupe Valdez,745,567,140,38
+Galveston,165,Governor,,LIB,Mark Jay Tippetts,46,24,21,1
+Galveston,165,Lieutenant Governor,,REP,Dan Patrick,1821,1335,419,67
+Galveston,165,Lieutenant Governor,,DEM,Mike Collier,827,630,160,37
+Galveston,165,Lieutenant Governor,,LIB,Kerry Douglas McKennon,63,31,31,1
+Galveston,165,Attorney General,,REP,Ken Paxton,1768,1293,410,65
+Galveston,165,Attorney General,,DEM,Justin Nelson,860,653,169,38
+Galveston,165,Attorney General,,LIB,Michael Ray Harris,69,40,27,2
+Galveston,165,Comptroller of Public Accounts,,REP,Glenn Hegar,1835,1345,425,65
+Galveston,165,Comptroller of Public Accounts,,DEM,Joi Chevalier,751,574,141,36
+Galveston,165,Comptroller of Public Accounts,,LIB,Ben Sanders,94,54,37,3
+Galveston,165,Commissioner of General Land Office,,REP,George P. Bush,1836,1349,426,61
+Galveston,165,Commissioner of General Land Office,,DEM,Miguel Suazo,758,571,147,40
+Galveston,165,Commissioner of General Land Office,,LIB,Matt Pina,99,63,32,4
+Galveston,165,Commissioner of Agriculture,,REP,Sid Miller,1769,1303,401,65
+Galveston,165,Commissioner of Agriculture,,DEM,Kim Olson,842,631,174,37
+Galveston,165,Commissioner of Agriculture,,LIB,Richard Carpenter,66,36,27,3
+Galveston,165,Railroad Commissioner,,REP,Christi Craddick,1840,1345,428,67
+Galveston,165,Railroad Commissioner,,DEM,Roman McAllen,748,572,141,35
+Galveston,165,Railroad Commissioner,,LIB,Mike Wright,88,53,34,1
+Galveston,165,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1848,1345,434,69
+Galveston,165,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,835,630,170,35
+Galveston,165,"Justice, Supreme Court, Place 4",,REP,John Devine,1847,1349,432,66
+Galveston,165,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,831,623,172,36
+Galveston,165,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1853,1355,432,66
+Galveston,165,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,822,617,169,36
+Galveston,165,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1801,1326,410,65
+Galveston,165,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,809,610,163,36
+Galveston,165,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,67,34,30,3
+Galveston,165,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1871,1360,444,67
+Galveston,165,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,795,603,157,35
+Galveston,165,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1969,1438,464,67
+Galveston,165,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,436,323,100,13
+Galveston,165,"Member, State Board of Education, District 7",,REP,Matt Robinson,1821,1339,417,65
+Galveston,165,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",842,622,182,38
+Galveston,165,State Representative,23,REP,Mayes Middleton,1825,1339,419,67
+Galveston,165,State Representative,23,DEM,Amanda Jamrok,796,604,156,36
+Galveston,165,State Representative,23,LIB,Lawrence Johnson,66,37,27,2
+Galveston,165,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,1874,1362,446,66
+Galveston,165,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,785,597,152,36
+Galveston,165,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,1844,1348,430,66
+Galveston,165,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,816,611,168,37
+Galveston,165,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,1844,1342,435,67
+Galveston,165,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,814,616,163,35
+Galveston,165,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,1839,1341,433,65
+Galveston,165,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,817,616,163,38
+Galveston,165,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,1869,1361,442,66
+Galveston,165,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,789,598,156,35
+Galveston,165,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,1875,1364,444,67
+Galveston,165,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,786,597,154,35
+Galveston,165,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,1871,1368,435,68
+Galveston,165,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,786,591,161,34
+Galveston,165,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,1868,1364,437,67
+Galveston,165,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,790,594,160,36
+Galveston,165,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,1848,1350,431,67
+Galveston,165,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,809,607,166,36
+Galveston,165,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,1833,1341,425,67
+Galveston,165,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",828,619,173,36
+Galveston,165,"District Judge, 122nd Judicial District",,REP,John Ellisor,2076,1510,498,68
+Galveston,165,"District Judge, 212th Judicial District",,REP,Patricia Grady,2069,1506,495,68
+Galveston,165,"District Judge, 306th Judicial District",,REP,Anne B. Darring,2066,1502,496,68
+Galveston,165,Criminal District Attorney,,REP,Jack Roady,2074,1509,497,68
+Galveston,165,County Judge,,REP,Mark Henry,2071,1503,499,69
+Galveston,165,"Judge, County Court-at-Law No. 1",,REP,John Grady,2042,1481,493,68
+Galveston,165,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,1845,1348,430,67
+Galveston,165,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,808,605,168,35
+Galveston,165,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,2045,1489,488,68
+Galveston,165,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,2052,1491,492,69
+Galveston,165,District Clerk,,REP,John D Kinard,2047,1487,492,68
+Galveston,165,County Clerk,,REP,Dwight Sullivan,2042,1485,489,68
+Galveston,165,County Treasurer,,REP,Kevin C. Walsh,2040,1480,491,69
+Galveston,165,Justice of the Peace Pct. 1,,REP,Greg Rikard,2043,1483,491,69
+Galveston,165,College of the Mainland Proposition A,,,FOR,9,6,0,3
+Galveston,165,College of the Mainland Proposition A,,,AGAINST,6,5,1,0
+Galveston,165,Mayor  - League City,,,Sebastian Lofaro,679,492,162,25
+Galveston,165,Mayor  - League City,,,Pat Hallisey,1295,960,282,53
+Galveston,165,Council Position 1  - League City,,,Andy Mann,962,700,221,41
+Galveston,165,Council Position 1  - League City,,,Traci Jacobs,761,548,182,31
+Galveston,165,Council Position 2  - League City,,,Hank Dugie,1513,1109,350,54
+Galveston,165,Council Position 6  - League City,,,Silvio P. Vincenzo,492,352,126,14
+Galveston,165,Council Position 6  - League City,,,Chad Tressler,1009,737,225,47
+Galveston,165,Council Position 6  - League City,,,Chris Gross,307,233,63,11
+Galveston,165,Council Position 7  - League City,,,Ange Mertens,701,494,178,29
+Galveston,165,Council Position 7  - League City,,,Nick Long,1077,796,237,44
+Galveston,165,League City Proposition A,,,For,1536,1110,343,83
+Galveston,165,League City Proposition A,,,Against,516,382,126,8
+Galveston,165,League City Proposition B,,,For,1913,1395,426,92
+Galveston,165,League City Proposition B,,,Against,279,204,72,3
+Galveston,165,League City Proposition C,,,For,1901,1387,429,85
+Galveston,165,League City Proposition C,,,Against,223,159,56,8
+Galveston,165,League City Proposition D,,,For,1726,1265,378,83
+Galveston,165,League City Proposition D,,,Against,283,195,80,8
+Galveston,165,League City Proposition E,,,For,1990,1453,444,93
+Galveston,165,League City Proposition E,,,Against,115,78,37,0
+Galveston,165,League City Proposition F,,,For,1794,1313,395,86
+Galveston,165,League City Proposition F,,,Against,212,146,59,7
+Galveston,165,League City Proposition G,,,For,1935,1413,428,94
+Galveston,165,League City Proposition G,,,Against,127,86,38,3
+Galveston,165,League City Proposition H,,,For,1255,915,276,64
+Galveston,165,League City Proposition H,,,Against,669,481,159,29
+Galveston,165,League City Proposition I,,,For,1825,1336,399,90
+Galveston,165,League City Proposition I,,,Against,189,133,51,5
+Galveston,165,League City Proposition J,,,For,1754,1287,378,89
+Galveston,165,League City Proposition J,,,Against,268,187,75,6
+Galveston,165,League City Proposition K,,,For,1806,1326,392,88
+Galveston,165,League City Proposition K,,,Against,182,126,52,4
+Galveston,165,League City Proposition L,,,For,1551,1132,339,80
+Galveston,165,League City Proposition L,,,Against,381,267,100,14
+Galveston,165,League City Proposition M,,,For,1730,1271,378,81
+Galveston,165,League City Proposition M,,,Against,226,154,60,12
+Galveston,165,League City Proposition N,,,For,1524,1131,313,80
+Galveston,165,League City Proposition N,,,Against,421,282,126,13
+Galveston,165,League City Proposition O,,,For,1604,1170,358,76
+Galveston,165,League City Proposition O,,,Against,338,240,83,15
+Galveston,166,Ballots Cast,,,,1719,1256,347,116
+Galveston,166,Straight Party,,REP,Republican,797,596,153,48
+Galveston,166,Straight Party,,DEM,Democrat,300,211,57,32
+Galveston,166,Straight Party,,LIB,Libertarian,9,3,1,5
+Galveston,166,U.S. Senate,,REP,Ted Cruz,1098,808,230,60
+Galveston,166,U.S. Senate,,DEM,Beto O'Rourke,594,432,108,54
+Galveston,166,U.S. Senate,,LIB,Neal M. Dikeman,18,12,4,2
+Galveston,166,U.S. House,14,REP,Randy Weber,1118,828,230,60
+Galveston,166,U.S. House,14,DEM,Adrienne Bell,550,397,100,53
+Galveston,166,U.S. House,14,LIB,Don E. Conley III,37,24,11,2
+Galveston,166,Governor,,REP,Greg Abbott,1165,859,243,63
+Galveston,166,Governor,,DEM,Lupe Valdez,508,369,88,51
+Galveston,166,Governor,,LIB,Mark Jay Tippetts,27,15,10,2
+Galveston,166,Lieutenant Governor,,REP,Dan Patrick,1102,816,226,60
+Galveston,166,Lieutenant Governor,,DEM,Mike Collier,563,411,99,53
+Galveston,166,Lieutenant Governor,,LIB,Kerry Douglas McKennon,38,20,15,3
+Galveston,166,Attorney General,,REP,Ken Paxton,1073,794,220,59
+Galveston,166,Attorney General,,DEM,Justin Nelson,570,412,105,53
+Galveston,166,Attorney General,,LIB,Michael Ray Harris,56,37,16,3
+Galveston,166,Comptroller of Public Accounts,,REP,Glenn Hegar,1122,832,227,63
+Galveston,166,Comptroller of Public Accounts,,DEM,Joi Chevalier,499,360,90,49
+Galveston,166,Comptroller of Public Accounts,,LIB,Ben Sanders,70,42,24,4
+Galveston,166,Commissioner of General Land Office,,REP,George P. Bush,1115,822,235,58
+Galveston,166,Commissioner of General Land Office,,DEM,Miguel Suazo,513,371,87,55
+Galveston,166,Commissioner of General Land Office,,LIB,Matt Pina,70,50,18,2
+Galveston,166,Commissioner of Agriculture,,REP,Sid Miller,1075,795,220,60
+Galveston,166,Commissioner of Agriculture,,DEM,Kim Olson,557,405,99,53
+Galveston,166,Commissioner of Agriculture,,LIB,Richard Carpenter,56,34,20,2
+Galveston,166,Railroad Commissioner,,REP,Christi Craddick,1112,827,224,61
+Galveston,166,Railroad Commissioner,,DEM,Roman McAllen,512,368,95,49
+Galveston,166,Railroad Commissioner,,LIB,Mike Wright,62,39,21,2
+Galveston,166,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1120,824,235,61
+Galveston,166,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,565,405,108,52
+Galveston,166,"Justice, Supreme Court, Place 4",,REP,John Devine,1125,829,236,60
+Galveston,166,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,558,401,106,51
+Galveston,166,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1138,838,239,61
+Galveston,166,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,544,391,102,51
+Galveston,166,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1101,813,229,59
+Galveston,166,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,527,383,92,52
+Galveston,166,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,56,34,18,4
+Galveston,166,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1144,841,240,63
+Galveston,166,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,536,387,99,50
+Galveston,166,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1184,872,250,62
+Galveston,166,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,293,212,56,25
+Galveston,166,"Member, State Board of Education, District 7",,REP,Matt Robinson,1106,818,231,57
+Galveston,166,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",563,404,106,53
+Galveston,166,State Representative,24,REP,Greg Bonnen,1121,836,228,57
+Galveston,166,State Representative,24,DEM,John Y. Phelps,515,372,95,48
+Galveston,166,State Representative,24,LIB,Dick Illyes,49,27,15,7
+Galveston,166,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,1132,840,237,55
+Galveston,166,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,541,384,103,54
+Galveston,166,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,1116,822,237,57
+Galveston,166,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,554,401,103,50
+Galveston,166,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,1119,823,239,57
+Galveston,166,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,552,401,100,51
+Galveston,166,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,1114,818,239,57
+Galveston,166,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,558,407,99,52
+Galveston,166,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,1133,834,244,55
+Galveston,166,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,540,393,94,53
+Galveston,166,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,1139,838,244,57
+Galveston,166,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,528,383,94,51
+Galveston,166,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,1130,829,244,57
+Galveston,166,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,536,391,94,51
+Galveston,166,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,1131,835,241,55
+Galveston,166,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,539,386,99,54
+Galveston,166,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,1125,829,240,56
+Galveston,166,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,541,391,100,50
+Galveston,166,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,1123,828,238,57
+Galveston,166,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",547,392,102,53
+Galveston,166,"District Judge, 122nd Judicial District",,REP,John Ellisor,1219,889,271,59
+Galveston,166,"District Judge, 212th Judicial District",,REP,Patricia Grady,1221,890,272,59
+Galveston,166,"District Judge, 306th Judicial District",,REP,Anne B. Darring,1216,887,272,57
+Galveston,166,Criminal District Attorney,,REP,Jack Roady,1220,884,271,65
+Galveston,166,County Judge,,REP,Mark Henry,1226,895,271,60
+Galveston,166,"Judge, County Court-at-Law No. 1",,REP,John Grady,1210,878,272,60
+Galveston,166,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,1126,826,245,55
+Galveston,166,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,542,395,95,52
+Galveston,166,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,1224,889,272,63
+Galveston,166,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,1228,894,273,61
+Galveston,166,District Clerk,,REP,John D Kinard,1224,893,273,58
+Galveston,166,County Clerk,,REP,Dwight Sullivan,1221,891,272,58
+Galveston,166,County Treasurer,,REP,Kevin C. Walsh,1215,884,272,59
+Galveston,166,Justice of the Peace Pct. 1,,REP,Greg Rikard,1221,892,266,63
+Galveston,166,Mayor  - League City,,,Sebastian Lofaro,3,3,0,0
+Galveston,166,Mayor  - League City,,,Pat Hallisey,1,1,0,0
+Galveston,166,Council Position 1  - League City,,,Andy Mann,3,3,0,0
+Galveston,166,Council Position 1  - League City,,,Traci Jacobs,0,0,0,0
+Galveston,166,Council Position 2  - League City,,,Hank Dugie,2,2,0,0
+Galveston,166,Council Position 6  - League City,,,Silvio P. Vincenzo,1,1,0,0
+Galveston,166,Council Position 6  - League City,,,Chad Tressler,0,0,0,0
+Galveston,166,Council Position 6  - League City,,,Chris Gross,1,1,0,0
+Galveston,166,Council Position 7  - League City,,,Ange Mertens,2,2,0,0
+Galveston,166,Council Position 7  - League City,,,Nick Long,1,1,0,0
+Galveston,166,League City Proposition A,,,For,3,3,0,0
+Galveston,166,League City Proposition A,,,Against,1,1,0,0
+Galveston,166,League City Proposition B,,,For,3,3,0,0
+Galveston,166,League City Proposition B,,,Against,2,1,0,1
+Galveston,166,League City Proposition C,,,For,4,4,0,0
+Galveston,166,League City Proposition C,,,Against,0,0,0,0
+Galveston,166,League City Proposition D,,,For,4,4,0,0
+Galveston,166,League City Proposition D,,,Against,0,0,0,0
+Galveston,166,League City Proposition E,,,For,4,4,0,0
+Galveston,166,League City Proposition E,,,Against,1,0,0,1
+Galveston,166,League City Proposition F,,,For,5,4,0,1
+Galveston,166,League City Proposition F,,,Against,0,0,0,0
+Galveston,166,League City Proposition G,,,For,4,4,0,0
+Galveston,166,League City Proposition G,,,Against,0,0,0,0
+Galveston,166,League City Proposition H,,,For,1,1,0,0
+Galveston,166,League City Proposition H,,,Against,3,3,0,0
+Galveston,166,League City Proposition I,,,For,4,4,0,0
+Galveston,166,League City Proposition I,,,Against,0,0,0,0
+Galveston,166,League City Proposition J,,,For,3,3,0,0
+Galveston,166,League City Proposition J,,,Against,1,1,0,0
+Galveston,166,League City Proposition K,,,For,4,4,0,0
+Galveston,166,League City Proposition K,,,Against,0,0,0,0
+Galveston,166,League City Proposition L,,,For,4,3,0,1
+Galveston,166,League City Proposition L,,,Against,1,1,0,0
+Galveston,166,League City Proposition M,,,For,4,3,0,1
+Galveston,166,League City Proposition M,,,Against,1,1,0,0
+Galveston,166,League City Proposition N,,,For,2,2,0,0
+Galveston,166,League City Proposition N,,,Against,2,2,0,0
+Galveston,166,League City Proposition O,,,For,4,3,0,1
+Galveston,166,League City Proposition O,,,Against,1,1,0,0
+Galveston,166,Supervisor  - Bayview MUD,,,Linda Elliott,4,3,1,0
+Galveston,166,Supervisor  - Bayview MUD,,,Nicole Loukanis,3,2,1,0
+Galveston,166,Supervisor  - Bayview MUD,,,Troy D Bradfield,6,4,1,1
+Galveston,166,Supervisor  - Bayview MUD,,,Toni Clawson Randall,7,6,0,1
+Galveston,167,Ballots Cast,,,,3256,2430,571,255
+Galveston,167,Straight Party,,REP,Republican,1577,1199,250,128
+Galveston,167,Straight Party,,DEM,Democrat,509,361,102,46
+Galveston,167,Straight Party,,LIB,Libertarian,16,6,5,5
+Galveston,167,U.S. Senate,,REP,Ted Cruz,2191,1677,352,162
+Galveston,167,U.S. Senate,,DEM,Beto O'Rourke,1026,732,206,88
+Galveston,167,U.S. Senate,,LIB,Neal M. Dikeman,24,11,10,3
+Galveston,167,U.S. House,14,REP,Randy Weber,2241,1701,373,167
+Galveston,167,U.S. House,14,DEM,Adrienne Bell,929,671,173,85
+Galveston,167,U.S. House,14,LIB,Don E. Conley III,44,29,15,0
+Galveston,167,Governor,,REP,Greg Abbott,2332,1766,397,169
+Galveston,167,Governor,,DEM,Lupe Valdez,846,615,154,77
+Galveston,167,Governor,,LIB,Mark Jay Tippetts,53,34,14,5
+Galveston,167,Lieutenant Governor,,REP,Dan Patrick,2202,1666,370,166
+Galveston,167,Lieutenant Governor,,DEM,Mike Collier,971,710,178,83
+Galveston,167,Lieutenant Governor,,LIB,Kerry Douglas McKennon,51,31,17,3
+Galveston,167,Attorney General,,REP,Ken Paxton,2162,1635,366,161
+Galveston,167,Attorney General,,DEM,Justin Nelson,983,720,176,87
+Galveston,167,Attorney General,,LIB,Michael Ray Harris,69,47,20,2
+Galveston,167,Comptroller of Public Accounts,,REP,Glenn Hegar,2269,1729,369,171
+Galveston,167,Comptroller of Public Accounts,,DEM,Joi Chevalier,837,605,157,75
+Galveston,167,Comptroller of Public Accounts,,LIB,Ben Sanders,78,51,25,2
+Galveston,167,Commissioner of General Land Office,,REP,George P. Bush,2223,1688,370,165
+Galveston,167,Commissioner of General Land Office,,DEM,Miguel Suazo,865,626,160,79
+Galveston,167,Commissioner of General Land Office,,LIB,Matt Pina,114,81,26,7
+Galveston,167,Commissioner of Agriculture,,REP,Sid Miller,2180,1657,356,167
+Galveston,167,Commissioner of Agriculture,,DEM,Kim Olson,945,686,177,82
+Galveston,167,Commissioner of Agriculture,,LIB,Richard Carpenter,67,44,21,2
+Galveston,167,Railroad Commissioner,,REP,Christi Craddick,2262,1713,376,173
+Galveston,167,Railroad Commissioner,,DEM,Roman McAllen,842,619,151,72
+Galveston,167,Railroad Commissioner,,LIB,Mike Wright,83,53,25,5
+Galveston,167,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,2248,1713,370,165
+Galveston,167,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,936,672,181,83
+Galveston,167,"Justice, Supreme Court, Place 4",,REP,John Devine,2242,1710,365,167
+Galveston,167,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,935,670,184,81
+Galveston,167,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,2262,1722,368,172
+Galveston,167,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,921,660,183,78
+Galveston,167,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,2231,1704,363,164
+Galveston,167,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,876,630,166,80
+Galveston,167,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,63,41,18,4
+Galveston,167,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,2261,1723,369,169
+Galveston,167,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,897,641,177,79
+Galveston,167,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,2366,1798,390,178
+Galveston,167,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,483,356,100,27
+Galveston,167,"Member, State Board of Education, District 7",,REP,Matt Robinson,2220,1689,370,161
+Galveston,167,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",949,683,180,86
+Galveston,167,State Representative,24,REP,Greg Bonnen,2222,1696,364,162
+Galveston,167,State Representative,24,DEM,John Y. Phelps,900,653,169,78
+Galveston,167,State Representative,24,LIB,Dick Illyes,63,37,18,8
+Galveston,167,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,2283,1736,382,165
+Galveston,167,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,876,630,166,80
+Galveston,167,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,2252,1719,370,163
+Galveston,167,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,904,649,177,78
+Galveston,167,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,2237,1708,371,158
+Galveston,167,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,921,661,174,86
+Galveston,167,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,2233,1706,370,157
+Galveston,167,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,925,664,176,85
+Galveston,167,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,2255,1714,385,156
+Galveston,167,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,898,650,161,87
+Galveston,167,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,2266,1725,377,164
+Galveston,167,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,885,637,171,77
+Galveston,167,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,2259,1724,373,162
+Galveston,167,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,889,637,173,79
+Galveston,167,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,2261,1721,378,162
+Galveston,167,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,884,637,168,79
+Galveston,167,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,2238,1709,368,161
+Galveston,167,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,914,651,180,83
+Galveston,167,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,2245,1708,373,164
+Galveston,167,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",904,655,171,78
+Galveston,167,"District Judge, 122nd Judicial District",,REP,John Ellisor,2472,1871,427,174
+Galveston,167,"District Judge, 212th Judicial District",,REP,Patricia Grady,2462,1862,428,172
+Galveston,167,"District Judge, 306th Judicial District",,REP,Anne B. Darring,2457,1858,428,171
+Galveston,167,Criminal District Attorney,,REP,Jack Roady,2471,1865,429,177
+Galveston,167,County Judge,,REP,Mark Henry,2460,1862,425,173
+Galveston,167,"Judge, County Court-at-Law No. 1",,REP,John Grady,2445,1845,427,173
+Galveston,167,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,2269,1730,379,160
+Galveston,167,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,877,629,164,84
+Galveston,167,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,2439,1841,425,173
+Galveston,167,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,2441,1844,425,172
+Galveston,167,District Clerk,,REP,John D Kinard,2448,1845,426,177
+Galveston,167,County Clerk,,REP,Dwight Sullivan,2440,1843,422,175
+Galveston,167,County Treasurer,,REP,Kevin C. Walsh,2441,1844,424,173
+Galveston,167,Justice of the Peace Pct. 1,,REP,Greg Rikard,2438,1841,424,173
+Galveston,167,Mayor  - League City,,,Sebastian Lofaro,657,482,135,40
+Galveston,167,Mayor  - League City,,,Pat Hallisey,1616,1244,248,124
+Galveston,167,Council Position 1  - League City,,,Andy Mann,1163,898,183,82
+Galveston,167,Council Position 1  - League City,,,Traci Jacobs,836,608,166,62
+Galveston,167,Council Position 2  - League City,,,Hank Dugie,1762,1339,311,112
+Galveston,167,Council Position 6  - League City,,,Silvio P. Vincenzo,509,379,104,26
+Galveston,167,Council Position 6  - League City,,,Chad Tressler,859,648,146,65
+Galveston,167,Council Position 6  - League City,,,Chris Gross,616,466,96,54
+Galveston,167,Council Position 7  - League City,,,Ange Mertens,681,496,137,48
+Galveston,167,Council Position 7  - League City,,,Nick Long,1440,1113,224,103
+Galveston,167,League City Proposition A,,,For,1852,1373,301,178
+Galveston,167,League City Proposition A,,,Against,550,418,101,31
+Galveston,167,League City Proposition B,,,For,2213,1670,365,178
+Galveston,167,League City Proposition B,,,Against,353,248,72,33
+Galveston,167,League City Proposition C,,,For,2198,1650,363,185
+Galveston,167,League City Proposition C,,,Against,303,214,60,29
+Galveston,167,League City Proposition D,,,For,2055,1540,325,190
+Galveston,167,League City Proposition D,,,Against,334,241,75,18
+Galveston,167,League City Proposition E,,,For,2301,1712,387,202
+Galveston,167,League City Proposition E,,,Against,184,141,32,11
+Galveston,167,League City Proposition F,,,For,2082,1537,344,201
+Galveston,167,League City Proposition F,,,Against,261,208,47,6
+Galveston,167,League City Proposition G,,,For,2233,1668,365,200
+Galveston,167,League City Proposition G,,,Against,189,140,36,13
+Galveston,167,League City Proposition H,,,For,1391,1052,222,117
+Galveston,167,League City Proposition H,,,Against,850,612,159,79
+Galveston,167,League City Proposition I,,,For,2122,1571,345,206
+Galveston,167,League City Proposition I,,,Against,235,179,48,8
+Galveston,167,League City Proposition J,,,For,2069,1538,337,194
+Galveston,167,League City Proposition J,,,Against,297,225,59,13
+Galveston,167,League City Proposition K,,,For,2099,1560,340,199
+Galveston,167,League City Proposition K,,,Against,225,173,45,7
+Galveston,167,League City Proposition L,,,For,1816,1352,293,171
+Galveston,167,League City Proposition L,,,Against,453,334,87,32
+Galveston,167,League City Proposition M,,,For,2001,1492,323,186
+Galveston,167,League City Proposition M,,,Against,290,210,60,20
+Galveston,167,League City Proposition N,,,For,1872,1400,290,182
+Galveston,167,League City Proposition N,,,Against,417,301,90,26
+Galveston,167,League City Proposition O,,,For,1885,1409,315,161
+Galveston,167,League City Proposition O,,,Against,391,286,68,37
+Galveston,168,Ballots Cast,,,,0,0,0,0
+Galveston,168,Straight Party,,REP,Republican,0,0,0,0
+Galveston,168,Straight Party,,DEM,Democrat,0,0,0,0
+Galveston,168,Straight Party,,LIB,Libertarian,0,0,0,0
+Galveston,168,U.S. Senate,,REP,Ted Cruz,0,0,0,0
+Galveston,168,U.S. Senate,,DEM,Beto O'Rourke,0,0,0,0
+Galveston,168,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Galveston,168,U.S. House,14,REP,Randy Weber,0,0,0,0
+Galveston,168,U.S. House,14,DEM,Adrienne Bell,0,0,0,0
+Galveston,168,U.S. House,14,LIB,Don E. Conley III,0,0,0,0
+Galveston,168,Governor,,REP,Greg Abbott,0,0,0,0
+Galveston,168,Governor,,DEM,Lupe Valdez,0,0,0,0
+Galveston,168,Governor,,LIB,Mark Jay Tippetts,0,0,0,0
+Galveston,168,Lieutenant Governor,,REP,Dan Patrick,0,0,0,0
+Galveston,168,Lieutenant Governor,,DEM,Mike Collier,0,0,0,0
+Galveston,168,Lieutenant Governor,,LIB,Kerry Douglas McKennon,0,0,0,0
+Galveston,168,Attorney General,,REP,Ken Paxton,0,0,0,0
+Galveston,168,Attorney General,,DEM,Justin Nelson,0,0,0,0
+Galveston,168,Attorney General,,LIB,Michael Ray Harris,0,0,0,0
+Galveston,168,Comptroller of Public Accounts,,REP,Glenn Hegar,0,0,0,0
+Galveston,168,Comptroller of Public Accounts,,DEM,Joi Chevalier,0,0,0,0
+Galveston,168,Comptroller of Public Accounts,,LIB,Ben Sanders,0,0,0,0
+Galveston,168,Commissioner of General Land Office,,REP,George P. Bush,0,0,0,0
+Galveston,168,Commissioner of General Land Office,,DEM,Miguel Suazo,0,0,0,0
+Galveston,168,Commissioner of General Land Office,,LIB,Matt Pina,0,0,0,0
+Galveston,168,Commissioner of Agriculture,,REP,Sid Miller,0,0,0,0
+Galveston,168,Commissioner of Agriculture,,DEM,Kim Olson,0,0,0,0
+Galveston,168,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0,0
+Galveston,168,Railroad Commissioner,,REP,Christi Craddick,0,0,0,0
+Galveston,168,Railroad Commissioner,,DEM,Roman McAllen,0,0,0,0
+Galveston,168,Railroad Commissioner,,LIB,Mike Wright,0,0,0,0
+Galveston,168,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,0,0,0,0
+Galveston,168,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,0,0,0,0
+Galveston,168,"Justice, Supreme Court, Place 4",,REP,John Devine,0,0,0,0
+Galveston,168,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,0,0,0,0
+Galveston,168,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,0,0,0,0
+Galveston,168,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,0,0,0,0
+Galveston,168,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,0,0,0,0
+Galveston,168,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,0,0,0,0
+Galveston,168,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,0,0,0,0
+Galveston,168,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,0,0,0,0
+Galveston,168,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0,0,0
+Galveston,168,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,0,0,0,0
+Galveston,168,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,0,0,0,0
+Galveston,168,"Member, State Board of Education, District 7",,REP,Matt Robinson,0,0,0,0
+Galveston,168,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",0,0,0,0
+Galveston,168,State Representative,23,REP,Mayes Middleton,0,0,0,0
+Galveston,168,State Representative,23,DEM,Amanda Jamrok,0,0,0,0
+Galveston,168,State Representative,23,LIB,Lawrence Johnson,0,0,0,0
+Galveston,168,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,0,0,0,0
+Galveston,168,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,0,0,0,0
+Galveston,168,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,0,0,0,0
+Galveston,168,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,0,0,0,0
+Galveston,168,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,0,0,0,0
+Galveston,168,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,0,0,0,0
+Galveston,168,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,0,0,0,0
+Galveston,168,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,0,0,0,0
+Galveston,168,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,0,0,0,0
+Galveston,168,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,0,0,0,0
+Galveston,168,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,0,0,0,0
+Galveston,168,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,0,0,0,0
+Galveston,168,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,0,0,0,0
+Galveston,168,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,0,0,0,0
+Galveston,168,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,0,0,0,0
+Galveston,168,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,0,0,0,0
+Galveston,168,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,0,0,0,0
+Galveston,168,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,0,0,0,0
+Galveston,168,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,0,0,0,0
+Galveston,168,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",0,0,0,0
+Galveston,168,"District Judge, 122nd Judicial District",,REP,John Ellisor,0,0,0,0
+Galveston,168,"District Judge, 212th Judicial District",,REP,Patricia Grady,0,0,0,0
+Galveston,168,"District Judge, 306th Judicial District",,REP,Anne B. Darring,0,0,0,0
+Galveston,168,Criminal District Attorney,,REP,Jack Roady,0,0,0,0
+Galveston,168,County Judge,,REP,Mark Henry,0,0,0,0
+Galveston,168,"Judge, County Court-at-Law No. 1",,REP,John Grady,0,0,0,0
+Galveston,168,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,0,0,0,0
+Galveston,168,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,0,0,0,0
+Galveston,168,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,0,0,0,0
+Galveston,168,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,0,0,0,0
+Galveston,168,District Clerk,,REP,John D Kinard,0,0,0,0
+Galveston,168,County Clerk,,REP,Dwight Sullivan,0,0,0,0
+Galveston,168,County Treasurer,,REP,Kevin C. Walsh,0,0,0,0
+Galveston,168,Justice of the Peace Pct. 3,,DEM,"Billy A. Williams, Jr.",0,0,0,0
+Galveston,168,College of the Mainland Proposition A,,,FOR,0,0,0,0
+Galveston,168,College of the Mainland Proposition A,,,AGAINST,0,0,0,0
+Galveston,169,Ballots Cast,,,,1,1,0,0
+Galveston,169,Straight Party,,REP,Republican,0,0,0,0
+Galveston,169,Straight Party,,DEM,Democrat,0,0,0,0
+Galveston,169,Straight Party,,LIB,Libertarian,0,0,0,0
+Galveston,169,U.S. Senate,,REP,Ted Cruz,1,1,0,0
+Galveston,169,U.S. Senate,,DEM,Beto O'Rourke,0,0,0,0
+Galveston,169,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Galveston,169,U.S. House,14,REP,Randy Weber,1,1,0,0
+Galveston,169,U.S. House,14,DEM,Adrienne Bell,0,0,0,0
+Galveston,169,U.S. House,14,LIB,Don E. Conley III,0,0,0,0
+Galveston,169,Governor,,REP,Greg Abbott,1,1,0,0
+Galveston,169,Governor,,DEM,Lupe Valdez,0,0,0,0
+Galveston,169,Governor,,LIB,Mark Jay Tippetts,0,0,0,0
+Galveston,169,Lieutenant Governor,,REP,Dan Patrick,1,1,0,0
+Galveston,169,Lieutenant Governor,,DEM,Mike Collier,0,0,0,0
+Galveston,169,Lieutenant Governor,,LIB,Kerry Douglas McKennon,0,0,0,0
+Galveston,169,Attorney General,,REP,Ken Paxton,1,1,0,0
+Galveston,169,Attorney General,,DEM,Justin Nelson,0,0,0,0
+Galveston,169,Attorney General,,LIB,Michael Ray Harris,0,0,0,0
+Galveston,169,Comptroller of Public Accounts,,REP,Glenn Hegar,1,1,0,0
+Galveston,169,Comptroller of Public Accounts,,DEM,Joi Chevalier,0,0,0,0
+Galveston,169,Comptroller of Public Accounts,,LIB,Ben Sanders,0,0,0,0
+Galveston,169,Commissioner of General Land Office,,REP,George P. Bush,1,1,0,0
+Galveston,169,Commissioner of General Land Office,,DEM,Miguel Suazo,0,0,0,0
+Galveston,169,Commissioner of General Land Office,,LIB,Matt Pina,0,0,0,0
+Galveston,169,Commissioner of Agriculture,,REP,Sid Miller,1,1,0,0
+Galveston,169,Commissioner of Agriculture,,DEM,Kim Olson,0,0,0,0
+Galveston,169,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0,0
+Galveston,169,Railroad Commissioner,,REP,Christi Craddick,1,1,0,0
+Galveston,169,Railroad Commissioner,,DEM,Roman McAllen,0,0,0,0
+Galveston,169,Railroad Commissioner,,LIB,Mike Wright,0,0,0,0
+Galveston,169,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1,1,0,0
+Galveston,169,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,0,0,0,0
+Galveston,169,"Justice, Supreme Court, Place 4",,REP,John Devine,1,1,0,0
+Galveston,169,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,0,0,0,0
+Galveston,169,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1,1,0,0
+Galveston,169,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,0,0,0,0
+Galveston,169,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1,1,0,0
+Galveston,169,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,0,0,0,0
+Galveston,169,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,0,0,0,0
+Galveston,169,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1,1,0,0
+Galveston,169,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0,0,0
+Galveston,169,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1,1,0,0
+Galveston,169,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,0,0,0,0
+Galveston,169,"Member, State Board of Education, District 7",,REP,Matt Robinson,1,1,0,0
+Galveston,169,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",0,0,0,0
+Galveston,169,State Representative,23,REP,Mayes Middleton,1,1,0,0
+Galveston,169,State Representative,23,DEM,Amanda Jamrok,0,0,0,0
+Galveston,169,State Representative,23,LIB,Lawrence Johnson,0,0,0,0
+Galveston,169,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,1,1,0,0
+Galveston,169,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,0,0,0,0
+Galveston,169,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,1,1,0,0
+Galveston,169,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,0,0,0,0
+Galveston,169,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,1,1,0,0
+Galveston,169,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,0,0,0,0
+Galveston,169,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,1,1,0,0
+Galveston,169,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,0,0,0,0
+Galveston,169,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,1,1,0,0
+Galveston,169,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,0,0,0,0
+Galveston,169,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,1,1,0,0
+Galveston,169,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,0,0,0,0
+Galveston,169,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,1,1,0,0
+Galveston,169,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,0,0,0,0
+Galveston,169,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,1,1,0,0
+Galveston,169,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,0,0,0,0
+Galveston,169,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,1,1,0,0
+Galveston,169,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,0,0,0,0
+Galveston,169,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,1,1,0,0
+Galveston,169,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",0,0,0,0
+Galveston,169,"District Judge, 122nd Judicial District",,REP,John Ellisor,1,1,0,0
+Galveston,169,"District Judge, 212th Judicial District",,REP,Patricia Grady,1,1,0,0
+Galveston,169,"District Judge, 306th Judicial District",,REP,Anne B. Darring,1,1,0,0
+Galveston,169,Criminal District Attorney,,REP,Jack Roady,1,1,0,0
+Galveston,169,County Judge,,REP,Mark Henry,1,1,0,0
+Galveston,169,"Judge, County Court-at-Law No. 1",,REP,John Grady,1,1,0,0
+Galveston,169,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,1,1,0,0
+Galveston,169,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,0,0,0,0
+Galveston,169,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,1,1,0,0
+Galveston,169,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,1,1,0,0
+Galveston,169,District Clerk,,REP,John D Kinard,1,1,0,0
+Galveston,169,County Clerk,,REP,Dwight Sullivan,1,1,0,0
+Galveston,169,County Treasurer,,REP,Kevin C. Walsh,1,1,0,0
+Galveston,169,Justice of the Peace Pct. 3,,DEM,"Billy A. Williams, Jr.",1,1,0,0
+Galveston,169,College of the Mainland Proposition A,,,FOR,1,1,0,0
+Galveston,169,College of the Mainland Proposition A,,,AGAINST,0,0,0,0
+Galveston,170,Ballots Cast,,,,1761,1280,397,84
+Galveston,170,Straight Party,,REP,Republican,817,593,185,39
+Galveston,170,Straight Party,,DEM,Democrat,256,187,47,22
+Galveston,170,Straight Party,,LIB,Libertarian,10,4,4,2
+Galveston,170,U.S. Senate,,REP,Ted Cruz,1177,857,270,50
+Galveston,170,U.S. Senate,,DEM,Beto O'Rourke,566,415,118,33
+Galveston,170,U.S. Senate,,LIB,Neal M. Dikeman,12,5,7,0
+Galveston,170,U.S. House,14,REP,Randy Weber,1199,872,273,54
+Galveston,170,U.S. House,14,DEM,Adrienne Bell,515,382,104,29
+Galveston,170,U.S. House,14,LIB,Don E. Conley III,35,22,13,0
+Galveston,170,Governor,,REP,Greg Abbott,1255,911,292,52
+Galveston,170,Governor,,DEM,Lupe Valdez,465,342,92,31
+Galveston,170,Governor,,LIB,Mark Jay Tippetts,35,24,11,0
+Galveston,170,Lieutenant Governor,,REP,Dan Patrick,1183,857,275,51
+Galveston,170,Lieutenant Governor,,DEM,Mike Collier,529,393,105,31
+Galveston,170,Lieutenant Governor,,LIB,Kerry Douglas McKennon,44,29,14,1
+Galveston,170,Attorney General,,REP,Ken Paxton,1159,842,265,52
+Galveston,170,Attorney General,,DEM,Justin Nelson,541,403,107,31
+Galveston,170,Attorney General,,LIB,Michael Ray Harris,49,28,21,0
+Galveston,170,Comptroller of Public Accounts,,REP,Glenn Hegar,1195,868,273,54
+Galveston,170,Comptroller of Public Accounts,,DEM,Joi Chevalier,477,356,92,29
+Galveston,170,Comptroller of Public Accounts,,LIB,Ben Sanders,61,40,21,0
+Galveston,170,Commissioner of General Land Office,,REP,George P. Bush,1205,875,277,53
+Galveston,170,Commissioner of General Land Office,,DEM,Miguel Suazo,466,342,95,29
+Galveston,170,Commissioner of General Land Office,,LIB,Matt Pina,68,52,15,1
+Galveston,170,Commissioner of Agriculture,,REP,Sid Miller,1151,845,254,52
+Galveston,170,Commissioner of Agriculture,,DEM,Kim Olson,543,396,116,31
+Galveston,170,Commissioner of Agriculture,,LIB,Richard Carpenter,40,26,14,0
+Galveston,170,Railroad Commissioner,,REP,Christi Craddick,1210,874,282,54
+Galveston,170,Railroad Commissioner,,DEM,Roman McAllen,470,355,86,29
+Galveston,170,Railroad Commissioner,,LIB,Mike Wright,54,37,17,0
+Galveston,170,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1207,871,283,53
+Galveston,170,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,530,397,103,30
+Galveston,170,"Justice, Supreme Court, Place 4",,REP,John Devine,1213,877,283,53
+Galveston,170,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,521,388,103,30
+Galveston,170,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1205,873,279,53
+Galveston,170,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,526,390,106,30
+Galveston,170,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1190,862,276,52
+Galveston,170,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,500,372,97,31
+Galveston,170,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,39,28,11,0
+Galveston,170,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1225,887,283,55
+Galveston,170,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,501,373,100,28
+Galveston,170,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1280,929,295,56
+Galveston,170,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,268,194,67,7
+Galveston,170,"Member, State Board of Education, District 7",,REP,Matt Robinson,1191,864,276,51
+Galveston,170,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",537,397,110,30
+Galveston,170,State Representative,24,REP,Greg Bonnen,1207,878,279,50
+Galveston,170,State Representative,24,DEM,John Y. Phelps,495,367,97,31
+Galveston,170,State Representative,24,LIB,Dick Illyes,35,22,11,2
+Galveston,170,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,1223,887,281,55
+Galveston,170,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,501,373,101,27
+Galveston,170,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,1207,877,278,52
+Galveston,170,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,517,384,104,29
+Galveston,170,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,1218,884,283,51
+Galveston,170,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,506,377,99,30
+Galveston,170,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,1210,880,280,50
+Galveston,170,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,512,379,102,31
+Galveston,170,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,1234,889,292,53
+Galveston,170,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,490,370,91,29
+Galveston,170,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,1218,881,284,53
+Galveston,170,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,504,378,97,29
+Galveston,170,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,1229,890,287,52
+Galveston,170,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,489,367,93,29
+Galveston,170,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,1223,883,288,52
+Galveston,170,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,496,373,94,29
+Galveston,170,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,1203,875,277,51
+Galveston,170,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,515,380,105,30
+Galveston,170,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,1204,871,281,52
+Galveston,170,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",515,385,101,29
+Galveston,170,"District Judge, 122nd Judicial District",,REP,John Ellisor,1351,970,322,59
+Galveston,170,"District Judge, 212th Judicial District",,REP,Patricia Grady,1354,971,325,58
+Galveston,170,"District Judge, 306th Judicial District",,REP,Anne B. Darring,1349,968,322,59
+Galveston,170,Criminal District Attorney,,REP,Jack Roady,1351,970,323,58
+Galveston,170,County Judge,,REP,Mark Henry,1345,962,324,59
+Galveston,170,"Judge, County Court-at-Law No. 1",,REP,John Grady,1341,965,319,57
+Galveston,170,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,1206,872,282,52
+Galveston,170,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,513,382,103,28
+Galveston,170,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,1352,971,323,58
+Galveston,170,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,1348,967,323,58
+Galveston,170,District Clerk,,REP,John D Kinard,1351,970,323,58
+Galveston,170,County Clerk,,REP,Dwight Sullivan,1342,965,319,58
+Galveston,170,County Treasurer,,REP,Kevin C. Walsh,1342,963,320,59
+Galveston,170,Justice of the Peace Pct. 1,,REP,Greg Rikard,1341,962,321,58
+Galveston,170,Mayor  - League City,,,Sebastian Lofaro,336,257,69,10
+Galveston,170,Mayor  - League City,,,Pat Hallisey,986,718,221,47
+Galveston,170,Council Position 1  - League City,,,Andy Mann,655,483,134,38
+Galveston,170,Council Position 1  - League City,,,Traci Jacobs,515,372,129,14
+Galveston,170,Council Position 2  - League City,,,Hank Dugie,1064,776,244,44
+Galveston,170,Council Position 6  - League City,,,Silvio P. Vincenzo,243,184,53,6
+Galveston,170,Council Position 6  - League City,,,Chad Tressler,575,416,130,29
+Galveston,170,Council Position 6  - League City,,,Chris Gross,327,246,64,17
+Galveston,170,Council Position 7  - League City,,,Ange Mertens,410,297,99,14
+Galveston,170,Council Position 7  - League City,,,Nick Long,791,588,162,41
+Galveston,170,League City Proposition A,,,For,1040,758,223,59
+Galveston,170,League City Proposition A,,,Against,303,222,68,13
+Galveston,170,League City Proposition B,,,For,1178,860,255,63
+Galveston,170,League City Proposition B,,,Against,234,168,55,11
+Galveston,170,League City Proposition C,,,For,1212,887,262,63
+Galveston,170,League City Proposition C,,,Against,166,123,37,6
+Galveston,170,League City Proposition D,,,For,1135,836,242,57
+Galveston,170,League City Proposition D,,,Against,188,134,42,12
+Galveston,170,League City Proposition E,,,For,1255,917,274,64
+Galveston,170,League City Proposition E,,,Against,106,81,18,7
+Galveston,170,League City Proposition F,,,For,1170,864,240,66
+Galveston,170,League City Proposition F,,,Against,136,97,35,4
+Galveston,170,League City Proposition G,,,For,1245,910,271,64
+Galveston,170,League City Proposition G,,,Against,102,82,13,7
+Galveston,170,League City Proposition H,,,For,810,591,172,47
+Galveston,170,League City Proposition H,,,Against,452,341,90,21
+Galveston,170,League City Proposition I,,,For,1183,872,244,67
+Galveston,170,League City Proposition I,,,Against,137,99,34,4
+Galveston,170,League City Proposition J,,,For,1162,860,238,64
+Galveston,170,League City Proposition J,,,Against,165,113,45,7
+Galveston,170,League City Proposition K,,,For,1173,867,241,65
+Galveston,170,League City Proposition K,,,Against,133,95,31,7
+Galveston,170,League City Proposition L,,,For,1033,767,205,61
+Galveston,170,League City Proposition L,,,Against,239,168,59,12
+Galveston,170,League City Proposition M,,,For,1132,830,238,64
+Galveston,170,League City Proposition M,,,Against,154,117,32,5
+Galveston,170,League City Proposition N,,,For,1034,758,208,68
+Galveston,170,League City Proposition N,,,Against,248,182,62,4
+Galveston,170,League City Proposition O,,,For,1092,799,229,64
+Galveston,170,League City Proposition O,,,Against,187,140,42,5
+Galveston,172,Ballots Cast,,,,292,242,40,10
+Galveston,172,Straight Party,,REP,Republican,158,133,23,2
+Galveston,172,Straight Party,,DEM,Democrat,41,29,8,4
+Galveston,172,Straight Party,,LIB,Libertarian,0,0,0,0
+Galveston,172,U.S. Senate,,REP,Ted Cruz,221,186,30,5
+Galveston,172,U.S. Senate,,DEM,Beto O'Rourke,67,52,10,5
+Galveston,172,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Galveston,172,U.S. House,14,REP,Randy Weber,218,182,32,4
+Galveston,172,U.S. House,14,DEM,Adrienne Bell,69,55,8,6
+Galveston,172,U.S. House,14,LIB,Don E. Conley III,2,2,0,0
+Galveston,172,Governor,,REP,Greg Abbott,234,197,32,5
+Galveston,172,Governor,,DEM,Lupe Valdez,55,42,8,5
+Galveston,172,Governor,,LIB,Mark Jay Tippetts,2,2,0,0
+Galveston,172,Lieutenant Governor,,REP,Dan Patrick,220,184,31,5
+Galveston,172,Lieutenant Governor,,DEM,Mike Collier,65,51,9,5
+Galveston,172,Lieutenant Governor,,LIB,Kerry Douglas McKennon,4,4,0,0
+Galveston,172,Attorney General,,REP,Ken Paxton,216,180,31,5
+Galveston,172,Attorney General,,DEM,Justin Nelson,67,54,8,5
+Galveston,172,Attorney General,,LIB,Michael Ray Harris,3,3,0,0
+Galveston,172,Comptroller of Public Accounts,,REP,Glenn Hegar,220,184,31,5
+Galveston,172,Comptroller of Public Accounts,,DEM,Joi Chevalier,61,48,8,5
+Galveston,172,Comptroller of Public Accounts,,LIB,Ben Sanders,5,5,0,0
+Galveston,172,Commissioner of General Land Office,,REP,George P. Bush,224,188,31,5
+Galveston,172,Commissioner of General Land Office,,DEM,Miguel Suazo,56,43,8,5
+Galveston,172,Commissioner of General Land Office,,LIB,Matt Pina,6,6,0,0
+Galveston,172,Commissioner of Agriculture,,REP,Sid Miller,214,179,30,5
+Galveston,172,Commissioner of Agriculture,,DEM,Kim Olson,70,56,9,5
+Galveston,172,Commissioner of Agriculture,,LIB,Richard Carpenter,1,1,0,0
+Galveston,172,Railroad Commissioner,,REP,Christi Craddick,224,187,32,5
+Galveston,172,Railroad Commissioner,,DEM,Roman McAllen,60,47,8,5
+Galveston,172,Railroad Commissioner,,LIB,Mike Wright,3,3,0,0
+Galveston,172,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,221,185,31,5
+Galveston,172,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,65,51,9,5
+Galveston,172,"Justice, Supreme Court, Place 4",,REP,John Devine,225,189,31,5
+Galveston,172,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,62,48,9,5
+Galveston,172,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,217,182,30,5
+Galveston,172,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,67,53,9,5
+Galveston,172,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,220,185,30,5
+Galveston,172,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,62,48,9,5
+Galveston,172,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,2,2,0,0
+Galveston,172,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,223,188,30,5
+Galveston,172,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,62,48,9,5
+Galveston,172,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,234,198,31,5
+Galveston,172,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,21,19,2,0
+Galveston,172,"Member, State Board of Education, District 7",,REP,Matt Robinson,217,182,30,5
+Galveston,172,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",67,53,9,5
+Galveston,172,State Representative,23,REP,Mayes Middleton,222,187,30,5
+Galveston,172,State Representative,23,DEM,Amanda Jamrok,61,47,9,5
+Galveston,172,State Representative,23,LIB,Lawrence Johnson,4,4,0,0
+Galveston,172,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,222,187,30,5
+Galveston,172,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,63,49,9,5
+Galveston,172,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,217,182,30,5
+Galveston,172,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,66,52,9,5
+Galveston,172,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,221,185,31,5
+Galveston,172,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,63,50,8,5
+Galveston,172,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,216,181,30,5
+Galveston,172,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,68,54,9,5
+Galveston,172,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,221,186,30,5
+Galveston,172,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,63,49,9,5
+Galveston,172,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,220,185,30,5
+Galveston,172,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,65,51,9,5
+Galveston,172,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,222,187,30,5
+Galveston,172,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,63,49,9,5
+Galveston,172,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,224,189,30,5
+Galveston,172,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,61,47,9,5
+Galveston,172,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,213,179,30,4
+Galveston,172,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,71,56,9,6
+Galveston,172,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,218,183,30,5
+Galveston,172,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",67,53,9,5
+Galveston,172,"District Judge, 122nd Judicial District",,REP,John Ellisor,241,204,32,5
+Galveston,172,"District Judge, 212th Judicial District",,REP,Patricia Grady,237,200,32,5
+Galveston,172,"District Judge, 306th Judicial District",,REP,Anne B. Darring,236,200,31,5
+Galveston,172,Criminal District Attorney,,REP,Jack Roady,238,202,31,5
+Galveston,172,County Judge,,REP,Mark Henry,236,200,31,5
+Galveston,172,"Judge, County Court-at-Law No. 1",,REP,John Grady,236,199,32,5
+Galveston,172,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,222,187,30,5
+Galveston,172,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,64,50,9,5
+Galveston,172,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,240,203,32,5
+Galveston,172,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,239,203,31,5
+Galveston,172,District Clerk,,REP,John D Kinard,239,203,31,5
+Galveston,172,County Clerk,,REP,Dwight Sullivan,237,201,31,5
+Galveston,172,County Treasurer,,REP,Kevin C. Walsh,239,202,32,5
+Galveston,172,Justice of the Peace Pct. 1,,REP,Greg Rikard,239,203,31,5
+Galveston,172,College of the Mainland Proposition A,,,FOR,159,135,18,6
+Galveston,172,College of the Mainland Proposition A,,,AGAINST,73,63,7,3
+Galveston,192,Ballots Cast,,,,321,246,60,15
+Galveston,192,Straight Party,,REP,Republican,148,117,24,7
+Galveston,192,Straight Party,,DEM,Democrat,74,54,15,5
+Galveston,192,Straight Party,,LIB,Libertarian,2,1,1,0
+Galveston,192,U.S. Senate,,REP,Ted Cruz,207,164,34,9
+Galveston,192,U.S. Senate,,DEM,Beto O'Rourke,107,77,24,6
+Galveston,192,U.S. Senate,,LIB,Neal M. Dikeman,5,4,1,0
+Galveston,192,U.S. House,14,REP,Randy Weber,210,165,36,9
+Galveston,192,U.S. House,14,DEM,Adrienne Bell,104,76,22,6
+Galveston,192,U.S. House,14,LIB,Don E. Conley III,3,2,1,0
+Galveston,192,Governor,,REP,Greg Abbott,213,168,36,9
+Galveston,192,Governor,,DEM,Lupe Valdez,103,73,24,6
+Galveston,192,Governor,,LIB,Mark Jay Tippetts,4,4,0,0
+Galveston,192,Lieutenant Governor,,REP,Dan Patrick,207,161,36,10
+Galveston,192,Lieutenant Governor,,DEM,Mike Collier,108,80,23,5
+Galveston,192,Lieutenant Governor,,LIB,Kerry Douglas McKennon,5,4,1,0
+Galveston,192,Attorney General,,REP,Ken Paxton,208,164,35,9
+Galveston,192,Attorney General,,DEM,Justin Nelson,106,77,23,6
+Galveston,192,Attorney General,,LIB,Michael Ray Harris,5,4,1,0
+Galveston,192,Comptroller of Public Accounts,,REP,Glenn Hegar,211,166,36,9
+Galveston,192,Comptroller of Public Accounts,,DEM,Joi Chevalier,100,72,22,6
+Galveston,192,Comptroller of Public Accounts,,LIB,Ben Sanders,9,8,1,0
+Galveston,192,Commissioner of General Land Office,,REP,George P. Bush,208,164,35,9
+Galveston,192,Commissioner of General Land Office,,DEM,Miguel Suazo,102,73,23,6
+Galveston,192,Commissioner of General Land Office,,LIB,Matt Pina,10,9,1,0
+Galveston,192,Commissioner of Agriculture,,REP,Sid Miller,208,162,37,9
+Galveston,192,Commissioner of Agriculture,,DEM,Kim Olson,105,79,20,6
+Galveston,192,Commissioner of Agriculture,,LIB,Richard Carpenter,6,4,2,0
+Galveston,192,Railroad Commissioner,,REP,Christi Craddick,206,163,34,9
+Galveston,192,Railroad Commissioner,,DEM,Roman McAllen,103,74,23,6
+Galveston,192,Railroad Commissioner,,LIB,Mike Wright,9,6,3,0
+Galveston,192,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,211,166,36,9
+Galveston,192,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,108,79,23,6
+Galveston,192,"Justice, Supreme Court, Place 4",,REP,John Devine,212,167,36,9
+Galveston,192,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,107,78,23,6
+Galveston,192,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,208,162,37,9
+Galveston,192,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,110,81,23,6
+Galveston,192,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,213,167,37,9
+Galveston,192,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,104,75,23,6
+Galveston,192,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,3,3,0,0
+Galveston,192,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,212,166,37,9
+Galveston,192,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,107,78,23,6
+Galveston,192,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,224,177,37,10
+Galveston,192,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,43,28,13,2
+Galveston,192,"Member, State Board of Education, District 7",,REP,Matt Robinson,207,161,38,8
+Galveston,192,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",111,82,22,7
+Galveston,192,State Representative,24,REP,Greg Bonnen,209,165,36,8
+Galveston,192,State Representative,24,DEM,John Y. Phelps,105,76,22,7
+Galveston,192,State Representative,24,LIB,Dick Illyes,6,4,2,0
+Galveston,192,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,213,167,37,9
+Galveston,192,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,106,77,23,6
+Galveston,192,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,208,163,37,8
+Galveston,192,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,110,80,23,7
+Galveston,192,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,211,166,37,8
+Galveston,192,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,107,78,22,7
+Galveston,192,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,210,165,37,8
+Galveston,192,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,109,79,23,7
+Galveston,192,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,213,168,37,8
+Galveston,192,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,104,75,22,7
+Galveston,192,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,213,168,37,8
+Galveston,192,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,103,74,22,7
+Galveston,192,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,210,165,37,8
+Galveston,192,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,106,77,22,7
+Galveston,192,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,215,170,37,8
+Galveston,192,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,102,73,22,7
+Galveston,192,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,211,165,37,9
+Galveston,192,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,107,79,22,6
+Galveston,192,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,211,166,37,8
+Galveston,192,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",108,78,23,7
+Galveston,192,"District Judge, 122nd Judicial District",,REP,John Ellisor,235,186,40,9
+Galveston,192,"District Judge, 212th Judicial District",,REP,Patricia Grady,233,185,39,9
+Galveston,192,"District Judge, 306th Judicial District",,REP,Anne B. Darring,232,184,39,9
+Galveston,192,Criminal District Attorney,,REP,Jack Roady,234,186,39,9
+Galveston,192,County Judge,,REP,Mark Henry,231,182,40,9
+Galveston,192,"Judge, County Court-at-Law No. 1",,REP,John Grady,231,183,39,9
+Galveston,192,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,209,165,36,8
+Galveston,192,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,109,78,24,7
+Galveston,192,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,231,184,38,9
+Galveston,192,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,235,186,40,9
+Galveston,192,District Clerk,,REP,John D Kinard,232,185,38,9
+Galveston,192,County Clerk,,REP,Dwight Sullivan,232,184,38,10
+Galveston,192,County Treasurer,,REP,Kevin C. Walsh,234,186,38,10
+Galveston,192,College of the Mainland Proposition A,,,FOR,157,121,33,3
+Galveston,192,College of the Mainland Proposition A,,,AGAINST,104,80,16,8
+Galveston,193,Ballots Cast,,,,1505,1114,292,99
+Galveston,193,Straight Party,,REP,Republican,640,485,117,38
+Galveston,193,Straight Party,,DEM,Democrat,243,172,50,21
+Galveston,193,Straight Party,,LIB,Libertarian,12,7,3,2
+Galveston,193,U.S. Senate,,REP,Ted Cruz,972,737,179,56
+Galveston,193,U.S. Senate,,DEM,Beto O'Rourke,507,363,107,37
+Galveston,193,U.S. Senate,,LIB,Neal M. Dikeman,20,13,5,2
+Galveston,193,U.S. House,14,REP,Randy Weber,995,758,182,55
+Galveston,193,U.S. House,14,DEM,Adrienne Bell,467,330,98,39
+Galveston,193,U.S. House,14,LIB,Don E. Conley III,31,20,10,1
+Galveston,193,Governor,,REP,Greg Abbott,1037,777,199,61
+Galveston,193,Governor,,DEM,Lupe Valdez,420,310,79,31
+Galveston,193,Governor,,LIB,Mark Jay Tippetts,37,22,12,3
+Galveston,193,Lieutenant Governor,,REP,Dan Patrick,965,729,181,55
+Galveston,193,Lieutenant Governor,,DEM,Mike Collier,481,345,100,36
+Galveston,193,Lieutenant Governor,,LIB,Kerry Douglas McKennon,43,32,7,4
+Galveston,193,Attorney General,,REP,Ken Paxton,964,725,182,57
+Galveston,193,Attorney General,,DEM,Justin Nelson,469,341,93,35
+Galveston,193,Attorney General,,LIB,Michael Ray Harris,54,40,11,3
+Galveston,193,Comptroller of Public Accounts,,REP,Glenn Hegar,985,747,181,57
+Galveston,193,Comptroller of Public Accounts,,DEM,Joi Chevalier,425,302,89,34
+Galveston,193,Comptroller of Public Accounts,,LIB,Ben Sanders,62,44,15,3
+Galveston,193,Commissioner of General Land Office,,REP,George P. Bush,997,754,187,56
+Galveston,193,Commissioner of General Land Office,,DEM,Miguel Suazo,426,307,87,32
+Galveston,193,Commissioner of General Land Office,,LIB,Matt Pina,62,43,12,7
+Galveston,193,Commissioner of Agriculture,,REP,Sid Miller,946,723,171,52
+Galveston,193,Commissioner of Agriculture,,DEM,Kim Olson,485,343,103,39
+Galveston,193,Commissioner of Agriculture,,LIB,Richard Carpenter,46,32,11,3
+Galveston,193,Railroad Commissioner,,REP,Christi Craddick,997,753,187,57
+Galveston,193,Railroad Commissioner,,DEM,Roman McAllen,426,304,87,35
+Galveston,193,Railroad Commissioner,,LIB,Mike Wright,52,39,11,2
+Galveston,193,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,995,756,185,54
+Galveston,193,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,474,338,98,38
+Galveston,193,"Justice, Supreme Court, Place 4",,REP,John Devine,1000,760,186,54
+Galveston,193,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,468,334,97,37
+Galveston,193,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1005,757,190,58
+Galveston,193,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,463,335,94,34
+Galveston,193,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,981,743,183,55
+Galveston,193,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,446,320,90,36
+Galveston,193,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,48,33,12,3
+Galveston,193,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1018,774,187,57
+Galveston,193,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,451,321,95,35
+Galveston,193,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1071,809,203,59
+Galveston,193,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,240,175,51,14
+Galveston,193,"Member, State Board of Education, District 7",,REP,Matt Robinson,985,747,185,53
+Galveston,193,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",487,349,98,40
+Galveston,193,State Representative,24,REP,Greg Bonnen,979,744,180,55
+Galveston,193,State Representative,24,DEM,John Y. Phelps,447,323,88,36
+Galveston,193,State Representative,24,LIB,Dick Illyes,51,31,17,3
+Galveston,193,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,1015,769,188,58
+Galveston,193,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,450,321,94,35
+Galveston,193,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,999,756,187,56
+Galveston,193,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,464,334,94,36
+Galveston,193,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,991,757,181,53
+Galveston,193,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,470,330,100,40
+Galveston,193,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,992,754,183,55
+Galveston,193,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,468,333,98,37
+Galveston,193,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,1015,766,192,57
+Galveston,193,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,446,319,90,37
+Galveston,193,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,1014,766,191,57
+Galveston,193,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,448,322,91,35
+Galveston,193,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,1013,767,189,57
+Galveston,193,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,449,320,92,37
+Galveston,193,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,1004,761,185,58
+Galveston,193,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,455,324,97,34
+Galveston,193,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,990,751,183,56
+Galveston,193,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,472,335,99,38
+Galveston,193,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,1003,758,187,58
+Galveston,193,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",455,326,95,34
+Galveston,193,"District Judge, 122nd Judicial District",,REP,John Ellisor,1130,842,224,64
+Galveston,193,"District Judge, 212th Judicial District",,REP,Patricia Grady,1128,841,222,65
+Galveston,193,"District Judge, 306th Judicial District",,REP,Anne B. Darring,1126,840,221,65
+Galveston,193,Criminal District Attorney,,REP,Jack Roady,1127,841,220,66
+Galveston,193,County Judge,,REP,Mark Henry,1123,836,222,65
+Galveston,193,"Judge, County Court-at-Law No. 1",,REP,John Grady,1112,827,219,66
+Galveston,193,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,1008,766,186,56
+Galveston,193,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,456,322,96,38
+Galveston,193,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,1114,831,219,64
+Galveston,193,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,1113,829,219,65
+Galveston,193,District Clerk,,REP,John D Kinard,1116,831,219,66
+Galveston,193,County Clerk,,REP,Dwight Sullivan,1116,830,220,66
+Galveston,193,County Treasurer,,REP,Kevin C. Walsh,1112,830,217,65
+Galveston,193,Justice of the Peace Pct. 1,,REP,Greg Rikard,1111,827,218,66
+Galveston,193,Mayor  - League City,,,Sebastian Lofaro,340,251,72,17
+Galveston,193,Mayor  - League City,,,Pat Hallisey,733,556,131,46
+Galveston,193,Council Position 1  - League City,,,Andy Mann,528,400,97,31
+Galveston,193,Council Position 1  - League City,,,Traci Jacobs,414,301,87,26
+Galveston,193,Council Position 2  - League City,,,Hank Dugie,840,624,167,49
+Galveston,193,Council Position 6  - League City,,,Silvio P. Vincenzo,258,182,67,9
+Galveston,193,Council Position 6  - League City,,,Chad Tressler,475,361,85,29
+Galveston,193,Council Position 6  - League City,,,Chris Gross,192,147,29,16
+Galveston,193,Council Position 7  - League City,,,Ange Mertens,368,275,76,17
+Galveston,193,Council Position 7  - League City,,,Nick Long,613,462,110,41
+Galveston,193,League City Proposition A,,,For,877,642,170,65
+Galveston,193,League City Proposition A,,,Against,263,203,52,8
+Galveston,193,League City Proposition B,,,For,1069,802,193,74
+Galveston,193,League City Proposition B,,,Against,156,110,42,4
+Galveston,193,League City Proposition C,,,For,1080,794,213,73
+Galveston,193,League City Proposition C,,,Against,119,92,22,5
+Galveston,193,League City Proposition D,,,For,988,737,180,71
+Galveston,193,League City Proposition D,,,Against,157,111,41,5
+Galveston,193,League City Proposition E,,,For,1112,832,206,74
+Galveston,193,League City Proposition E,,,Against,76,53,20,3
+Galveston,193,League City Proposition F,,,For,1024,758,195,71
+Galveston,193,League City Proposition F,,,Against,111,87,20,4
+Galveston,193,League City Proposition G,,,For,1099,814,206,79
+Galveston,193,League City Proposition G,,,Against,72,55,14,3
+Galveston,193,League City Proposition H,,,For,677,501,121,55
+Galveston,193,League City Proposition H,,,Against,391,289,79,23
+Galveston,193,League City Proposition I,,,For,1039,773,190,76
+Galveston,193,League City Proposition I,,,Against,96,72,21,3
+Galveston,193,League City Proposition J,,,For,1001,747,185,69
+Galveston,193,League City Proposition J,,,Against,139,104,28,7
+Galveston,193,League City Proposition K,,,For,1012,759,181,72
+Galveston,193,League City Proposition K,,,Against,103,73,26,4
+Galveston,193,League City Proposition L,,,For,883,650,167,66
+Galveston,193,League City Proposition L,,,Against,201,155,38,8
+Galveston,193,League City Proposition M,,,For,966,716,182,68
+Galveston,193,League City Proposition M,,,Against,141,104,30,7
+Galveston,193,League City Proposition N,,,For,882,646,163,73
+Galveston,193,League City Proposition N,,,Against,216,166,45,5
+Galveston,193,League City Proposition O,,,For,926,682,171,73
+Galveston,193,League City Proposition O,,,Against,170,131,35,4
+Galveston,197,Ballots Cast,,,,412,307,84,21
+Galveston,197,Straight Party,,REP,Republican,201,162,32,7
+Galveston,197,Straight Party,,DEM,Democrat,75,46,23,6
+Galveston,197,Straight Party,,LIB,Libertarian,0,0,0,0
+Galveston,197,U.S. Senate,,REP,Ted Cruz,273,217,47,9
+Galveston,197,U.S. Senate,,DEM,Beto O'Rourke,130,87,33,10
+Galveston,197,U.S. Senate,,LIB,Neal M. Dikeman,3,1,1,1
+Galveston,197,U.S. House,14,REP,Randy Weber,271,216,46,9
+Galveston,197,U.S. House,14,DEM,Adrienne Bell,126,83,33,10
+Galveston,197,U.S. House,14,LIB,Don E. Conley III,9,5,3,1
+Galveston,197,Governor,,REP,Greg Abbott,283,223,50,10
+Galveston,197,Governor,,DEM,Lupe Valdez,121,80,31,10
+Galveston,197,Governor,,LIB,Mark Jay Tippetts,5,2,2,1
+Galveston,197,Lieutenant Governor,,REP,Dan Patrick,273,218,45,10
+Galveston,197,Lieutenant Governor,,DEM,Mike Collier,125,81,34,10
+Galveston,197,Lieutenant Governor,,LIB,Kerry Douglas McKennon,11,6,4,1
+Galveston,197,Attorney General,,REP,Ken Paxton,270,214,47,9
+Galveston,197,Attorney General,,DEM,Justin Nelson,127,85,32,10
+Galveston,197,Attorney General,,LIB,Michael Ray Harris,10,5,4,1
+Galveston,197,Comptroller of Public Accounts,,REP,Glenn Hegar,277,221,47,9
+Galveston,197,Comptroller of Public Accounts,,DEM,Joi Chevalier,116,75,31,10
+Galveston,197,Comptroller of Public Accounts,,LIB,Ben Sanders,13,8,4,1
+Galveston,197,Commissioner of General Land Office,,REP,George P. Bush,282,220,51,11
+Galveston,197,Commissioner of General Land Office,,DEM,Miguel Suazo,112,75,27,10
+Galveston,197,Commissioner of General Land Office,,LIB,Matt Pina,14,9,5,0
+Galveston,197,Commissioner of Agriculture,,REP,Sid Miller,271,215,48,8
+Galveston,197,Commissioner of Agriculture,,DEM,Kim Olson,129,84,34,11
+Galveston,197,Commissioner of Agriculture,,LIB,Richard Carpenter,8,6,1,1
+Galveston,197,Railroad Commissioner,,REP,Christi Craddick,275,218,48,9
+Galveston,197,Railroad Commissioner,,DEM,Roman McAllen,117,77,30,10
+Galveston,197,Railroad Commissioner,,LIB,Mike Wright,14,9,4,1
+Galveston,197,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,274,217,48,9
+Galveston,197,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,132,87,34,11
+Galveston,197,"Justice, Supreme Court, Place 4",,REP,John Devine,278,219,49,10
+Galveston,197,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,127,84,33,10
+Galveston,197,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,276,217,49,10
+Galveston,197,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,129,86,33,10
+Galveston,197,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,274,217,48,9
+Galveston,197,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,120,80,31,9
+Galveston,197,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,12,7,3,2
+Galveston,197,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,280,219,51,10
+Galveston,197,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,124,83,31,10
+Galveston,197,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,287,225,51,11
+Galveston,197,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,58,44,10,4
+Galveston,197,"Member, State Board of Education, District 7",,REP,Matt Robinson,279,221,49,9
+Galveston,197,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",126,81,34,11
+Galveston,197,State Representative,23,REP,Mayes Middleton,273,214,50,9
+Galveston,197,State Representative,23,DEM,Amanda Jamrok,123,82,31,10
+Galveston,197,State Representative,23,LIB,Lawrence Johnson,9,6,2,1
+Galveston,197,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,281,222,50,9
+Galveston,197,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,123,79,33,11
+Galveston,197,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,279,219,51,9
+Galveston,197,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,125,82,32,11
+Galveston,197,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,279,220,50,9
+Galveston,197,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,125,81,33,11
+Galveston,197,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,278,219,49,10
+Galveston,197,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,126,82,34,10
+Galveston,197,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,281,219,53,9
+Galveston,197,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,123,82,30,11
+Galveston,197,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,281,220,51,10
+Galveston,197,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,123,81,32,10
+Galveston,197,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,281,220,51,10
+Galveston,197,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,123,81,32,10
+Galveston,197,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,279,220,49,10
+Galveston,197,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,125,81,34,10
+Galveston,197,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,276,218,49,9
+Galveston,197,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,128,83,34,11
+Galveston,197,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,278,219,49,10
+Galveston,197,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",126,82,34,10
+Galveston,197,"District Judge, 122nd Judicial District",,REP,John Ellisor,306,238,56,12
+Galveston,197,"District Judge, 212th Judicial District",,REP,Patricia Grady,307,237,57,13
+Galveston,197,"District Judge, 306th Judicial District",,REP,Anne B. Darring,304,235,56,13
+Galveston,197,Criminal District Attorney,,REP,Jack Roady,303,237,53,13
+Galveston,197,County Judge,,REP,Mark Henry,302,234,57,11
+Galveston,197,"Judge, County Court-at-Law No. 1",,REP,John Grady,301,233,55,13
+Galveston,197,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,281,218,52,11
+Galveston,197,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,122,82,30,10
+Galveston,197,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,301,235,55,11
+Galveston,197,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,305,236,56,13
+Galveston,197,District Clerk,,REP,John D Kinard,303,235,55,13
+Galveston,197,County Clerk,,REP,Dwight Sullivan,304,236,55,13
+Galveston,197,County Treasurer,,REP,Kevin C. Walsh,304,236,55,13
+Galveston,197,Justice of the Peace Pct. 1,,REP,Greg Rikard,305,236,56,13
+Galveston,197,College of the Mainland Proposition A,,,FOR,206,145,46,15
+Galveston,197,College of the Mainland Proposition A,,,AGAINST,108,89,14,5
+Galveston,218,Ballots Cast,,,,1942,1364,387,191
+Galveston,218,Straight Party,,REP,Republican,546,395,94,57
+Galveston,218,Straight Party,,DEM,Democrat,557,371,134,52
+Galveston,218,Straight Party,,LIB,Libertarian,9,5,2,2
+Galveston,218,U.S. Senate,,REP,Ted Cruz,848,612,149,87
+Galveston,218,U.S. Senate,,DEM,Beto O'Rourke,1056,728,230,98
+Galveston,218,U.S. Senate,,LIB,Neal M. Dikeman,20,11,5,4
+Galveston,218,U.S. House,14,REP,Randy Weber,884,637,157,90
+Galveston,218,U.S. House,14,DEM,Adrienne Bell,978,680,209,89
+Galveston,218,U.S. House,14,LIB,Don E. Conley III,41,30,11,0
+Galveston,218,Governor,,REP,Greg Abbott,933,663,171,99
+Galveston,218,Governor,,DEM,Lupe Valdez,945,656,205,84
+Galveston,218,Governor,,LIB,Mark Jay Tippetts,44,34,6,4
+Galveston,218,Lieutenant Governor,,REP,Dan Patrick,868,618,155,95
+Galveston,218,Lieutenant Governor,,DEM,Mike Collier,989,689,212,88
+Galveston,218,Lieutenant Governor,,LIB,Kerry Douglas McKennon,48,38,8,2
+Galveston,218,Attorney General,,REP,Ken Paxton,831,595,147,89
+Galveston,218,Attorney General,,DEM,Justin Nelson,1020,704,224,92
+Galveston,218,Attorney General,,LIB,Michael Ray Harris,51,39,9,3
+Galveston,218,Comptroller of Public Accounts,,REP,Glenn Hegar,888,644,152,92
+Galveston,218,Comptroller of Public Accounts,,DEM,Joi Chevalier,925,638,202,85
+Galveston,218,Comptroller of Public Accounts,,LIB,Ben Sanders,69,45,21,3
+Galveston,218,Commissioner of General Land Office,,REP,George P. Bush,931,667,162,102
+Galveston,218,Commissioner of General Land Office,,DEM,Miguel Suazo,912,623,207,82
+Galveston,218,Commissioner of General Land Office,,LIB,Matt Pina,56,43,11,2
+Galveston,218,Commissioner of Agriculture,,REP,Sid Miller,821,599,138,84
+Galveston,218,Commissioner of Agriculture,,DEM,Kim Olson,1015,697,223,95
+Galveston,218,Commissioner of Agriculture,,LIB,Richard Carpenter,52,33,15,4
+Galveston,218,Railroad Commissioner,,REP,Christi Craddick,879,632,152,95
+Galveston,218,Railroad Commissioner,,DEM,Roman McAllen,932,641,207,84
+Galveston,218,Railroad Commissioner,,LIB,Mike Wright,67,49,15,3
+Galveston,218,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,858,623,149,86
+Galveston,218,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,1009,696,223,90
+Galveston,218,"Justice, Supreme Court, Place 4",,REP,John Devine,858,618,153,87
+Galveston,218,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,1010,701,219,90
+Galveston,218,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,865,630,150,85
+Galveston,218,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,1006,692,221,93
+Galveston,218,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,843,612,146,85
+Galveston,218,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,989,681,217,91
+Galveston,218,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,41,30,9,2
+Galveston,218,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,880,635,156,89
+Galveston,218,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,991,685,216,90
+Galveston,218,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,997,711,187,99
+Galveston,218,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,451,335,89,27
+Galveston,218,"Member, State Board of Education, District 7",,REP,Matt Robinson,842,615,145,82
+Galveston,218,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",1024,703,227,94
+Galveston,218,State Representative,23,REP,Mayes Middleton,885,634,160,91
+Galveston,218,State Representative,23,DEM,Amanda Jamrok,971,675,208,88
+Galveston,218,State Representative,23,LIB,Lawrence Johnson,40,32,6,2
+Galveston,218,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,883,643,154,86
+Galveston,218,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,979,673,218,88
+Galveston,218,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,850,621,151,78
+Galveston,218,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,1007,692,221,94
+Galveston,218,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,867,628,157,82
+Galveston,218,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,989,684,215,90
+Galveston,218,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,828,607,143,78
+Galveston,218,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,1031,709,229,93
+Galveston,218,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,878,640,156,82
+Galveston,218,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,979,677,214,88
+Galveston,218,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,872,633,155,84
+Galveston,218,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,980,676,217,87
+Galveston,218,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,873,633,158,82
+Galveston,218,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,977,674,213,90
+Galveston,218,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,868,632,154,82
+Galveston,218,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,983,676,218,89
+Galveston,218,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,854,621,151,82
+Galveston,218,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,998,687,221,90
+Galveston,218,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,861,624,154,83
+Galveston,218,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",991,685,217,89
+Galveston,218,"District Judge, 122nd Judicial District",,REP,John Ellisor,1085,785,202,98
+Galveston,218,"District Judge, 212th Judicial District",,REP,Patricia Grady,1091,786,205,100
+Galveston,218,"District Judge, 306th Judicial District",,REP,Anne B. Darring,1076,779,200,97
+Galveston,218,Criminal District Attorney,,REP,Jack Roady,1085,784,198,103
+Galveston,218,County Judge,,REP,Mark Henry,1046,758,196,92
+Galveston,218,"Judge, County Court-at-Law No. 1",,REP,John Grady,1052,760,196,96
+Galveston,218,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,860,629,148,83
+Galveston,218,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,984,669,221,94
+Galveston,218,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,1059,769,191,99
+Galveston,218,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,1073,776,199,98
+Galveston,218,District Clerk,,REP,John D Kinard,1071,773,198,100
+Galveston,218,County Clerk,,REP,Dwight Sullivan,1066,771,197,98
+Galveston,218,County Treasurer,,REP,Kevin C. Walsh,1059,767,193,99
+Galveston,218,County Commissioner Pct. 2,,REP,Joe Giusti,1107,805,201,101
+Galveston,218,Justice of the Peace Pct. 2,,REP,Mike Nelson,1071,774,198,99
+Galveston,218,Commissioner  - GC Navigation Dist 1,,,"Thomas E. ""Ted"" Farmer, Jr.",638,457,137,44
+Galveston,218,Commissioner  - GC Navigation Dist 1,,,Robert Mihovil,457,316,70,71
+Galveston,219,Ballots Cast,,,,1262,914,290,58
+Galveston,219,Straight Party,,REP,Republican,397,302,82,13
+Galveston,219,Straight Party,,DEM,Democrat,392,252,113,27
+Galveston,219,Straight Party,,LIB,Libertarian,2,2,0,0
+Galveston,219,U.S. Senate,,REP,Ted Cruz,625,477,129,19
+Galveston,219,U.S. Senate,,DEM,Beto O'Rourke,620,425,157,38
+Galveston,219,U.S. Senate,,LIB,Neal M. Dikeman,8,5,2,1
+Galveston,219,U.S. House,14,REP,Randy Weber,621,475,128,18
+Galveston,219,U.S. House,14,DEM,Adrienne Bell,600,412,149,39
+Galveston,219,U.S. House,14,LIB,Don E. Conley III,28,17,11,0
+Galveston,219,Governor,,REP,Greg Abbott,676,512,144,20
+Galveston,219,Governor,,DEM,Lupe Valdez,559,383,139,37
+Galveston,219,Governor,,LIB,Mark Jay Tippetts,16,10,5,1
+Galveston,219,Lieutenant Governor,,REP,Dan Patrick,624,474,130,20
+Galveston,219,Lieutenant Governor,,DEM,Mike Collier,597,411,149,37
+Galveston,219,Lieutenant Governor,,LIB,Kerry Douglas McKennon,26,16,9,1
+Galveston,219,Attorney General,,REP,Ken Paxton,603,458,125,20
+Galveston,219,Attorney General,,DEM,Justin Nelson,610,422,152,36
+Galveston,219,Attorney General,,LIB,Michael Ray Harris,35,22,11,2
+Galveston,219,Comptroller of Public Accounts,,REP,Glenn Hegar,615,471,126,18
+Galveston,219,Comptroller of Public Accounts,,DEM,Joi Chevalier,586,398,151,37
+Galveston,219,Comptroller of Public Accounts,,LIB,Ben Sanders,37,27,8,2
+Galveston,219,Commissioner of General Land Office,,REP,George P. Bush,640,482,136,22
+Galveston,219,Commissioner of General Land Office,,DEM,Miguel Suazo,570,390,144,36
+Galveston,219,Commissioner of General Land Office,,LIB,Matt Pina,35,26,9,0
+Galveston,219,Commissioner of Agriculture,,REP,Sid Miller,590,449,123,18
+Galveston,219,Commissioner of Agriculture,,DEM,Kim Olson,617,423,155,39
+Galveston,219,Commissioner of Agriculture,,LIB,Richard Carpenter,35,26,9,0
+Galveston,219,Railroad Commissioner,,REP,Christi Craddick,617,472,126,19
+Galveston,219,Railroad Commissioner,,DEM,Roman McAllen,584,400,148,36
+Galveston,219,Railroad Commissioner,,LIB,Mike Wright,37,24,12,1
+Galveston,219,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,622,476,129,17
+Galveston,219,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,618,420,158,40
+Galveston,219,"Justice, Supreme Court, Place 4",,REP,John Devine,629,481,130,18
+Galveston,219,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,609,414,157,38
+Galveston,219,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,628,479,130,19
+Galveston,219,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,610,415,157,38
+Galveston,219,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,604,460,127,17
+Galveston,219,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,592,401,152,39
+Galveston,219,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,39,32,6,1
+Galveston,219,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,632,484,131,17
+Galveston,219,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,600,409,152,39
+Galveston,219,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,678,514,144,20
+Galveston,219,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,268,198,61,9
+Galveston,219,"Member, State Board of Education, District 7",,REP,Matt Robinson,621,472,132,17
+Galveston,219,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",616,422,154,40
+Galveston,219,State Representative,23,REP,Mayes Middleton,620,473,130,17
+Galveston,219,State Representative,23,DEM,Amanda Jamrok,591,403,149,39
+Galveston,219,State Representative,23,LIB,Lawrence Johnson,31,23,8,0
+Galveston,219,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,635,490,128,17
+Galveston,219,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,598,403,156,39
+Galveston,219,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,620,474,129,17
+Galveston,219,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,609,416,155,38
+Galveston,219,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,626,476,131,19
+Galveston,219,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,604,415,152,37
+Galveston,219,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,622,474,131,17
+Galveston,219,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,608,416,153,39
+Galveston,219,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,623,477,129,17
+Galveston,219,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,605,412,154,39
+Galveston,219,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,627,480,130,17
+Galveston,219,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,603,411,153,39
+Galveston,219,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,633,485,130,18
+Galveston,219,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,596,406,152,38
+Galveston,219,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,633,483,131,19
+Galveston,219,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,596,409,150,37
+Galveston,219,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,622,477,127,18
+Galveston,219,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,608,415,155,38
+Galveston,219,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,624,480,126,18
+Galveston,219,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",606,412,156,38
+Galveston,219,"District Judge, 122nd Judicial District",,REP,John Ellisor,716,542,150,24
+Galveston,219,"District Judge, 212th Judicial District",,REP,Patricia Grady,713,539,152,22
+Galveston,219,"District Judge, 306th Judicial District",,REP,Anne B. Darring,710,538,150,22
+Galveston,219,Criminal District Attorney,,REP,Jack Roady,709,536,150,23
+Galveston,219,County Judge,,REP,Mark Henry,703,532,150,21
+Galveston,219,"Judge, County Court-at-Law No. 1",,REP,John Grady,704,533,150,21
+Galveston,219,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,615,468,129,18
+Galveston,219,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,612,422,152,38
+Galveston,219,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,713,539,152,22
+Galveston,219,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,716,540,154,22
+Galveston,219,District Clerk,,REP,John D Kinard,713,538,153,22
+Galveston,219,County Clerk,,REP,Dwight Sullivan,712,537,153,22
+Galveston,219,County Treasurer,,REP,Kevin C. Walsh,708,535,151,22
+Galveston,219,County Commissioner Pct. 2,,REP,Joe Giusti,710,539,149,22
+Galveston,219,Justice of the Peace Pct. 3,,DEM,"Billy A. Williams, Jr.",745,518,186,41
+Galveston,219,College of the Mainland Proposition A,,,FOR,685,502,151,32
+Galveston,219,College of the Mainland Proposition A,,,AGAINST,318,233,77,8
+Galveston,219,Trustee Position 4  - SFISD,,,Clay Hertenberger,104,90,14,0
+Galveston,219,Trustee Position 4  - SFISD,,,Donna Hayes,80,52,27,1
+Galveston,219,Trustee Position 4  - SFISD,,,John Rothermel,43,28,14,1
+Galveston,219,Trustee Position 4  - SFISD,,,Jessica Hagewood,103,82,19,2
+Galveston,219,Trustee Position 5  - SFISD,,,James Grassmuck,132,104,27,1
+Galveston,219,Trustee Position 5  - SFISD,,,Sheryl Skufca,66,48,18,0
+Galveston,219,Trustee Position 5  - SFISD,,,Tina Longcoy,49,41,7,1
+Galveston,219,Trustee Position 5  - SFISD,,,Jody Davis,74,50,22,2
+Galveston,219,Trustee Position 6  - SFISD,,,Rusty Norman,283,220,57,6
+Galveston,220,Ballots Cast,,,,3033,2163,731,139
+Galveston,220,Straight Party,,REP,Republican,1208,866,278,64
+Galveston,220,Straight Party,,DEM,Democrat,660,459,169,32
+Galveston,220,Straight Party,,LIB,Libertarian,17,7,2,8
+Galveston,220,U.S. Senate,,REP,Ted Cruz,1780,1287,409,84
+Galveston,220,U.S. Senate,,DEM,Beto O'Rourke,1206,849,304,53
+Galveston,220,U.S. Senate,,LIB,Neal M. Dikeman,25,16,9,0
+Galveston,220,U.S. House,14,REP,Randy Weber,1829,1322,422,85
+Galveston,220,U.S. House,14,DEM,Adrienne Bell,1120,792,276,52
+Galveston,220,U.S. House,14,LIB,Don E. Conley III,51,29,22,0
+Galveston,220,Governor,,REP,Greg Abbott,1913,1357,469,87
+Galveston,220,Governor,,DEM,Lupe Valdez,1048,758,240,50
+Galveston,220,Governor,,LIB,Mark Jay Tippetts,48,32,16,0
+Galveston,220,Lieutenant Governor,,REP,Dan Patrick,1784,1277,425,82
+Galveston,220,Lieutenant Governor,,DEM,Mike Collier,1160,837,270,53
+Galveston,220,Lieutenant Governor,,LIB,Kerry Douglas McKennon,62,35,25,2
+Galveston,220,Attorney General,,REP,Ken Paxton,1757,1269,406,82
+Galveston,220,Attorney General,,DEM,Justin Nelson,1173,830,288,55
+Galveston,220,Attorney General,,LIB,Michael Ray Harris,70,43,27,0
+Galveston,220,Comptroller of Public Accounts,,REP,Glenn Hegar,1832,1313,433,86
+Galveston,220,Comptroller of Public Accounts,,DEM,Joi Chevalier,1059,755,254,50
+Galveston,220,Comptroller of Public Accounts,,LIB,Ben Sanders,87,56,30,1
+Galveston,220,Commissioner of General Land Office,,REP,George P. Bush,1828,1302,440,86
+Galveston,220,Commissioner of General Land Office,,DEM,Miguel Suazo,1062,755,255,52
+Galveston,220,Commissioner of General Land Office,,LIB,Matt Pina,94,71,23,0
+Galveston,220,Commissioner of Agriculture,,REP,Sid Miller,1768,1271,418,79
+Galveston,220,Commissioner of Agriculture,,DEM,Kim Olson,1155,819,278,58
+Galveston,220,Commissioner of Agriculture,,LIB,Richard Carpenter,60,41,18,1
+Galveston,220,Railroad Commissioner,,REP,Christi Craddick,1835,1320,428,87
+Galveston,220,Railroad Commissioner,,DEM,Roman McAllen,1055,748,259,48
+Galveston,220,Railroad Commissioner,,LIB,Mike Wright,90,59,29,2
+Galveston,220,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1821,1306,430,85
+Galveston,220,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,1155,816,287,52
+Galveston,220,"Justice, Supreme Court, Place 4",,REP,John Devine,1830,1312,433,85
+Galveston,220,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,1140,806,282,52
+Galveston,220,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1834,1314,435,85
+Galveston,220,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,1133,803,279,51
+Galveston,220,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1801,1293,423,85
+Galveston,220,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,1107,785,270,52
+Galveston,220,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,59,38,21,0
+Galveston,220,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1853,1326,443,84
+Galveston,220,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,1107,787,267,53
+Galveston,220,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1966,1402,473,91
+Galveston,220,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,519,383,120,16
+Galveston,220,"Member, State Board of Education, District 7",,REP,Matt Robinson,1803,1295,430,78
+Galveston,220,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",1155,818,284,53
+Galveston,220,State Representative,24,REP,Greg Bonnen,1819,1315,426,78
+Galveston,220,State Representative,24,DEM,John Y. Phelps,1102,783,270,49
+Galveston,220,State Representative,24,LIB,Dick Illyes,54,27,18,9
+Galveston,220,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,1839,1322,440,77
+Galveston,220,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,1114,785,273,56
+Galveston,220,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,1817,1306,432,79
+Galveston,220,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,1127,800,277,50
+Galveston,220,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,1823,1314,432,77
+Galveston,220,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,1122,794,277,51
+Galveston,220,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,1816,1306,434,76
+Galveston,220,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,1129,800,276,53
+Galveston,220,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,1844,1325,443,76
+Galveston,220,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,1100,779,268,53
+Galveston,220,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,1842,1318,442,82
+Galveston,220,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,1101,786,267,48
+Galveston,220,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,1838,1320,439,79
+Galveston,220,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,1100,784,267,49
+Galveston,220,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,1837,1323,434,80
+Galveston,220,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,1100,779,273,48
+Galveston,220,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,1812,1309,426,77
+Galveston,220,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,1129,794,283,52
+Galveston,220,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,1820,1305,436,79
+Galveston,220,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",1120,797,271,52
+Galveston,220,"District Judge, 122nd Judicial District",,REP,John Ellisor,2079,1492,503,84
+Galveston,220,"District Judge, 212th Judicial District",,REP,Patricia Grady,2084,1493,506,85
+Galveston,220,"District Judge, 306th Judicial District",,REP,Anne B. Darring,2073,1486,504,83
+Galveston,220,Criminal District Attorney,,REP,Jack Roady,2099,1502,511,86
+Galveston,220,County Judge,,REP,Mark Henry,2072,1480,508,84
+Galveston,220,"Judge, County Court-at-Law No. 1",,REP,John Grady,2049,1470,498,81
+Galveston,220,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,1845,1329,439,77
+Galveston,220,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,1099,781,266,52
+Galveston,220,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,2061,1474,505,82
+Galveston,220,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,2066,1478,506,82
+Galveston,220,District Clerk,,REP,John D Kinard,2064,1475,506,83
+Galveston,220,County Clerk,,REP,Dwight Sullivan,2064,1477,505,82
+Galveston,220,County Treasurer,,REP,Kevin C. Walsh,2056,1467,508,81
+Galveston,220,County Commissioner Pct. 2,,REP,Joe Giusti,2063,1475,505,83
+Galveston,220,Justice of the Peace Pct. 2,,REP,Mike Nelson,2061,1472,506,83
+Galveston,220,College of the Mainland Proposition A,,,FOR,1524,1064,383,77
+Galveston,220,College of the Mainland Proposition A,,,AGAINST,852,632,181,39
+Galveston,220,Mayor  - League City,,,Sebastian Lofaro,554,385,154,15
+Galveston,220,Mayor  - League City,,,Pat Hallisey,912,656,202,54
+Galveston,220,Council Position 1  - League City,,,Andy Mann,671,471,172,28
+Galveston,220,Council Position 1  - League City,,,Traci Jacobs,645,451,160,34
+Galveston,220,Council Position 2  - League City,,,Hank Dugie,1085,753,291,41
+Galveston,220,Council Position 6  - League City,,,Silvio P. Vincenzo,389,264,106,19
+Galveston,220,Council Position 6  - League City,,,Chad Tressler,568,392,150,26
+Galveston,220,Council Position 6  - League City,,,Chris Gross,316,238,70,8
+Galveston,220,Council Position 7  - League City,,,Ange Mertens,546,364,153,29
+Galveston,220,Council Position 7  - League City,,,Nick Long,737,539,171,27
+Galveston,220,League City Proposition A,,,For,1164,802,288,74
+Galveston,220,League City Proposition A,,,Against,444,325,110,9
+Galveston,220,League City Proposition B,,,For,1472,1027,363,82
+Galveston,220,League City Proposition B,,,Against,227,164,57,6
+Galveston,220,League City Proposition C,,,For,1487,1037,369,81
+Galveston,220,League City Proposition C,,,Against,180,131,44,5
+Galveston,220,League City Proposition D,,,For,1330,926,330,74
+Galveston,220,League City Proposition D,,,Against,237,170,57,10
+Galveston,220,League City Proposition E,,,For,1502,1048,372,82
+Galveston,220,League City Proposition E,,,Against,120,88,28,4
+Galveston,220,League City Proposition F,,,For,1360,947,338,75
+Galveston,220,League City Proposition F,,,Against,201,146,48,7
+Galveston,220,League City Proposition G,,,For,1470,1023,366,81
+Galveston,220,League City Proposition G,,,Against,120,94,24,2
+Galveston,220,League City Proposition H,,,For,971,669,250,52
+Galveston,220,League City Proposition H,,,Against,526,380,117,29
+Galveston,220,League City Proposition I,,,For,1363,955,333,75
+Galveston,220,League City Proposition I,,,Against,195,140,50,5
+Galveston,220,League City Proposition J,,,For,1300,909,317,74
+Galveston,220,League City Proposition J,,,Against,241,174,62,5
+Galveston,220,League City Proposition K,,,For,1346,934,337,75
+Galveston,220,League City Proposition K,,,Against,193,145,43,5
+Galveston,220,League City Proposition L,,,For,1180,810,298,72
+Galveston,220,League City Proposition L,,,Against,312,235,68,9
+Galveston,220,League City Proposition M,,,For,1305,915,316,74
+Galveston,220,League City Proposition M,,,Against,206,146,55,5
+Galveston,220,League City Proposition N,,,For,1185,824,296,65
+Galveston,220,League City Proposition N,,,Against,324,232,75,17
+Galveston,220,League City Proposition O,,,For,1315,915,332,68
+Galveston,220,League City Proposition O,,,Against,246,171,62,13
+Galveston,220,Trustee Position 4  - SFISD,,,Clay Hertenberger,49,44,3,2
+Galveston,220,Trustee Position 4  - SFISD,,,Donna Hayes,26,20,6,0
+Galveston,220,Trustee Position 4  - SFISD,,,John Rothermel,28,25,1,2
+Galveston,220,Trustee Position 4  - SFISD,,,Jessica Hagewood,28,25,3,0
+Galveston,220,Trustee Position 5  - SFISD,,,James Grassmuck,45,42,3,0
+Galveston,220,Trustee Position 5  - SFISD,,,Sheryl Skufca,47,42,5,0
+Galveston,220,Trustee Position 5  - SFISD,,,Tina Longcoy,17,12,3,2
+Galveston,220,Trustee Position 5  - SFISD,,,Jody Davis,24,22,2,0
+Galveston,220,Trustee Position 6  - SFISD,,,Rusty Norman,122,106,13,3
+Galveston,221,Ballots Cast,,,,1377,1037,223,117
+Galveston,221,Straight Party,,REP,Republican,685,529,100,56
+Galveston,221,Straight Party,,DEM,Democrat,176,136,25,15
+Galveston,221,Straight Party,,LIB,Libertarian,10,2,0,8
+Galveston,221,U.S. Senate,,REP,Ted Cruz,965,729,155,81
+Galveston,221,U.S. Senate,,DEM,Beto O'Rourke,399,302,62,35
+Galveston,221,U.S. Senate,,LIB,Neal M. Dikeman,6,2,4,0
+Galveston,221,U.S. House,14,REP,Randy Weber,995,749,163,83
+Galveston,221,U.S. House,14,DEM,Adrienne Bell,355,273,51,31
+Galveston,221,U.S. House,14,LIB,Don E. Conley III,15,7,7,1
+Galveston,221,Governor,,REP,Greg Abbott,1019,768,168,83
+Galveston,221,Governor,,DEM,Lupe Valdez,330,251,49,30
+Galveston,221,Governor,,LIB,Mark Jay Tippetts,17,13,4,0
+Galveston,221,Lieutenant Governor,,REP,Dan Patrick,972,740,157,75
+Galveston,221,Lieutenant Governor,,DEM,Mike Collier,372,278,57,37
+Galveston,221,Lieutenant Governor,,LIB,Kerry Douglas McKennon,23,13,7,3
+Galveston,221,Attorney General,,REP,Ken Paxton,932,703,152,77
+Galveston,221,Attorney General,,DEM,Justin Nelson,402,305,61,36
+Galveston,221,Attorney General,,LIB,Michael Ray Harris,28,18,8,2
+Galveston,221,Comptroller of Public Accounts,,REP,Glenn Hegar,996,752,163,81
+Galveston,221,Comptroller of Public Accounts,,DEM,Joi Chevalier,331,251,47,33
+Galveston,221,Comptroller of Public Accounts,,LIB,Ben Sanders,31,21,9,1
+Galveston,221,Commissioner of General Land Office,,REP,George P. Bush,996,751,163,82
+Galveston,221,Commissioner of General Land Office,,DEM,Miguel Suazo,329,246,49,34
+Galveston,221,Commissioner of General Land Office,,LIB,Matt Pina,42,32,9,1
+Galveston,221,Commissioner of Agriculture,,REP,Sid Miller,938,712,149,77
+Galveston,221,Commissioner of Agriculture,,DEM,Kim Olson,384,287,62,35
+Galveston,221,Commissioner of Agriculture,,LIB,Richard Carpenter,32,21,7,4
+Galveston,221,Railroad Commissioner,,REP,Christi Craddick,980,740,161,79
+Galveston,221,Railroad Commissioner,,DEM,Roman McAllen,341,256,50,35
+Galveston,221,Railroad Commissioner,,LIB,Mike Wright,37,26,9,2
+Galveston,221,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,975,736,162,77
+Galveston,221,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,374,284,54,36
+Galveston,221,"Justice, Supreme Court, Place 4",,REP,John Devine,982,743,164,75
+Galveston,221,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,364,273,52,39
+Galveston,221,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,972,734,160,78
+Galveston,221,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,374,283,56,35
+Galveston,221,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,972,734,161,77
+Galveston,221,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,353,266,50,37
+Galveston,221,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,23,17,5,1
+Galveston,221,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,996,753,163,80
+Galveston,221,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,349,263,52,34
+Galveston,221,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1046,793,171,82
+Galveston,221,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,163,122,23,18
+Galveston,221,"Member, State Board of Education, District 7",,REP,Matt Robinson,953,725,160,68
+Galveston,221,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",384,291,57,36
+Galveston,221,State Representative,23,REP,Mayes Middleton,973,739,163,71
+Galveston,221,State Representative,23,DEM,Amanda Jamrok,365,280,52,33
+Galveston,221,State Representative,23,LIB,Lawrence Johnson,23,10,5,8
+Galveston,221,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,994,754,166,74
+Galveston,221,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,346,261,49,36
+Galveston,221,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,967,736,159,72
+Galveston,221,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,368,281,56,31
+Galveston,221,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,968,736,162,70
+Galveston,221,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,368,281,53,34
+Galveston,221,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,969,739,160,70
+Galveston,221,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,364,274,55,35
+Galveston,221,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,983,750,162,71
+Galveston,221,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,351,266,53,32
+Galveston,221,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,989,753,163,73
+Galveston,221,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,343,259,53,31
+Galveston,221,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,994,754,167,73
+Galveston,221,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,337,258,48,31
+Galveston,221,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,994,756,166,72
+Galveston,221,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,337,255,49,33
+Galveston,221,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,971,736,161,74
+Galveston,221,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,359,275,54,30
+Galveston,221,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,966,737,160,69
+Galveston,221,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",366,277,55,34
+Galveston,221,"District Judge, 122nd Judicial District",,REP,John Ellisor,1052,799,179,74
+Galveston,221,"District Judge, 212th Judicial District",,REP,Patricia Grady,1057,801,179,77
+Galveston,221,"District Judge, 306th Judicial District",,REP,Anne B. Darring,1053,801,177,75
+Galveston,221,Criminal District Attorney,,REP,Jack Roady,1054,800,176,78
+Galveston,221,County Judge,,REP,Mark Henry,1025,775,174,76
+Galveston,221,"Judge, County Court-at-Law No. 1",,REP,John Grady,1038,787,177,74
+Galveston,221,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,975,741,163,71
+Galveston,221,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,353,270,50,33
+Galveston,221,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,1044,789,179,76
+Galveston,221,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,1053,797,178,78
+Galveston,221,District Clerk,,REP,John D Kinard,1048,795,179,74
+Galveston,221,County Clerk,,REP,Dwight Sullivan,1041,791,177,73
+Galveston,221,County Treasurer,,REP,Kevin C. Walsh,1043,793,177,73
+Galveston,221,County Commissioner Pct. 2,,REP,Joe Giusti,1050,798,178,74
+Galveston,221,Justice of the Peace Pct. 2,,REP,Mike Nelson,1040,788,179,73
+Galveston,221,Commissioner  - GC Navigation Dist 1,,,"Thomas E. ""Ted"" Farmer, Jr.",0,0,0,0
+Galveston,221,Commissioner  - GC Navigation Dist 1,,,Robert Mihovil,2,0,0,2
+Galveston,223,Ballots Cast,,,,1703,1102,468,133
+Galveston,223,Straight Party,,REP,Republican,440,284,120,36
+Galveston,223,Straight Party,,DEM,Democrat,520,319,155,46
+Galveston,223,Straight Party,,LIB,Libertarian,9,3,4,2
+Galveston,223,U.S. Senate,,REP,Ted Cruz,766,513,200,53
+Galveston,223,U.S. Senate,,DEM,Beto O'Rourke,905,571,255,79
+Galveston,223,U.S. Senate,,LIB,Neal M. Dikeman,18,8,10,0
+Galveston,223,U.S. House,14,REP,Randy Weber,788,529,205,54
+Galveston,223,U.S. House,14,DEM,Adrienne Bell,840,527,239,74
+Galveston,223,U.S. House,14,LIB,Don E. Conley III,47,28,18,1
+Galveston,223,Governor,,REP,Greg Abbott,850,555,235,60
+Galveston,223,Governor,,DEM,Lupe Valdez,804,514,220,70
+Galveston,223,Governor,,LIB,Mark Jay Tippetts,35,23,10,2
+Galveston,223,Lieutenant Governor,,REP,Dan Patrick,767,502,211,54
+Galveston,223,Lieutenant Governor,,DEM,Mike Collier,856,547,234,75
+Galveston,223,Lieutenant Governor,,LIB,Kerry Douglas McKennon,49,33,13,3
+Galveston,223,Attorney General,,REP,Ken Paxton,735,486,198,51
+Galveston,223,Attorney General,,DEM,Justin Nelson,880,561,241,78
+Galveston,223,Attorney General,,LIB,Michael Ray Harris,51,33,16,2
+Galveston,223,Comptroller of Public Accounts,,REP,Glenn Hegar,758,509,197,52
+Galveston,223,Comptroller of Public Accounts,,DEM,Joi Chevalier,808,502,231,75
+Galveston,223,Comptroller of Public Accounts,,LIB,Ben Sanders,77,50,26,1
+Galveston,223,Commissioner of General Land Office,,REP,George P. Bush,835,563,216,56
+Galveston,223,Commissioner of General Land Office,,DEM,Miguel Suazo,780,487,223,70
+Galveston,223,Commissioner of General Land Office,,LIB,Matt Pina,48,29,18,1
+Galveston,223,Commissioner of Agriculture,,REP,Sid Miller,735,495,192,48
+Galveston,223,Commissioner of Agriculture,,DEM,Kim Olson,872,546,244,82
+Galveston,223,Commissioner of Agriculture,,LIB,Richard Carpenter,42,24,17,1
+Galveston,223,Railroad Commissioner,,REP,Christi Craddick,776,517,208,51
+Galveston,223,Railroad Commissioner,,DEM,Roman McAllen,810,504,228,78
+Galveston,223,Railroad Commissioner,,LIB,Mike Wright,61,42,18,1
+Galveston,223,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,760,502,207,51
+Galveston,223,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,883,562,244,77
+Galveston,223,"Justice, Supreme Court, Place 4",,REP,John Devine,771,514,206,51
+Galveston,223,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,867,548,244,75
+Galveston,223,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,760,503,209,48
+Galveston,223,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,876,557,241,78
+Galveston,223,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,748,501,197,50
+Galveston,223,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,846,532,242,72
+Galveston,223,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,52,34,13,5
+Galveston,223,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,767,514,204,49
+Galveston,223,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,866,545,243,78
+Galveston,223,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,878,589,227,62
+Galveston,223,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,357,226,108,23
+Galveston,223,"Member, State Board of Education, District 7",,REP,Matt Robinson,751,505,200,46
+Galveston,223,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",883,558,246,79
+Galveston,223,State Representative,23,REP,Mayes Middleton,792,529,213,50
+Galveston,223,State Representative,23,DEM,Amanda Jamrok,837,530,233,74
+Galveston,223,State Representative,23,LIB,Lawrence Johnson,40,25,13,2
+Galveston,223,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,776,516,211,49
+Galveston,223,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,852,539,238,75
+Galveston,223,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,761,504,209,48
+Galveston,223,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,871,552,243,76
+Galveston,223,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,772,518,208,46
+Galveston,223,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,856,539,240,77
+Galveston,223,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,744,494,205,45
+Galveston,223,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,888,565,245,78
+Galveston,223,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,774,517,210,47
+Galveston,223,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,846,535,236,75
+Galveston,223,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,779,515,213,51
+Galveston,223,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,841,532,236,73
+Galveston,223,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,771,509,212,50
+Galveston,223,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,845,538,235,72
+Galveston,223,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,770,510,209,51
+Galveston,223,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,849,537,239,73
+Galveston,223,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,754,502,205,47
+Galveston,223,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,859,543,242,74
+Galveston,223,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,763,507,208,48
+Galveston,223,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",854,538,240,76
+Galveston,223,"District Judge, 122nd Judicial District",,REP,John Ellisor,980,649,267,64
+Galveston,223,"District Judge, 212th Judicial District",,REP,Patricia Grady,967,636,266,65
+Galveston,223,"District Judge, 306th Judicial District",,REP,Anne B. Darring,954,627,263,64
+Galveston,223,Criminal District Attorney,,REP,Jack Roady,981,650,265,66
+Galveston,223,County Judge,,REP,Mark Henry,933,611,262,60
+Galveston,223,"Judge, County Court-at-Law No. 1",,REP,John Grady,937,622,256,59
+Galveston,223,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,770,512,211,47
+Galveston,223,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,850,540,234,76
+Galveston,223,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,939,621,258,60
+Galveston,223,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,964,636,266,62
+Galveston,223,District Clerk,,REP,John D Kinard,942,619,263,60
+Galveston,223,County Clerk,,REP,Dwight Sullivan,951,625,260,66
+Galveston,223,County Treasurer,,REP,Kevin C. Walsh,944,620,259,65
+Galveston,223,County Commissioner Pct. 2,,REP,Joe Giusti,988,651,274,63
+Galveston,223,Justice of the Peace Pct. 2,,REP,Mike Nelson,948,621,265,62
+Galveston,223,Commissioner  - GC Navigation Dist 1,,,"Thomas E. ""Ted"" Farmer, Jr.",655,447,171,37
+Galveston,223,Commissioner  - GC Navigation Dist 1,,,Robert Mihovil,323,221,73,29
+Galveston,224,Ballots Cast,,,,1882,1249,422,211
+Galveston,224,Straight Party,,REP,Republican,589,392,142,55
+Galveston,224,Straight Party,,DEM,Democrat,540,354,110,76
+Galveston,224,Straight Party,,LIB,Libertarian,11,2,3,6
+Galveston,224,U.S. Senate,,REP,Ted Cruz,889,595,213,81
+Galveston,224,U.S. Senate,,DEM,Beto O'Rourke,965,637,200,128
+Galveston,224,U.S. Senate,,LIB,Neal M. Dikeman,14,6,6,2
+Galveston,224,U.S. House,14,REP,Randy Weber,928,627,219,82
+Galveston,224,U.S. House,14,DEM,Adrienne Bell,892,585,183,124
+Galveston,224,U.S. House,14,LIB,Don E. Conley III,43,25,15,3
+Galveston,224,Governor,,REP,Greg Abbott,982,652,237,93
+Galveston,224,Governor,,DEM,Lupe Valdez,829,551,168,110
+Galveston,224,Governor,,LIB,Mark Jay Tippetts,46,29,13,4
+Galveston,224,Lieutenant Governor,,REP,Dan Patrick,910,614,217,79
+Galveston,224,Lieutenant Governor,,DEM,Mike Collier,904,599,185,120
+Galveston,224,Lieutenant Governor,,LIB,Kerry Douglas McKennon,37,18,13,6
+Galveston,224,Attorney General,,REP,Ken Paxton,878,589,209,80
+Galveston,224,Attorney General,,DEM,Justin Nelson,924,612,191,121
+Galveston,224,Attorney General,,LIB,Michael Ray Harris,51,31,15,5
+Galveston,224,Comptroller of Public Accounts,,REP,Glenn Hegar,919,621,216,82
+Galveston,224,Comptroller of Public Accounts,,DEM,Joi Chevalier,838,553,170,115
+Galveston,224,Comptroller of Public Accounts,,LIB,Ben Sanders,80,48,24,8
+Galveston,224,Commissioner of General Land Office,,REP,George P. Bush,971,664,221,86
+Galveston,224,Commissioner of General Land Office,,DEM,Miguel Suazo,821,537,170,114
+Galveston,224,Commissioner of General Land Office,,LIB,Matt Pina,59,31,22,6
+Galveston,224,Commissioner of Agriculture,,REP,Sid Miller,883,599,205,79
+Galveston,224,Commissioner of Agriculture,,DEM,Kim Olson,910,597,193,120
+Galveston,224,Commissioner of Agriculture,,LIB,Richard Carpenter,48,28,14,6
+Galveston,224,Railroad Commissioner,,REP,Christi Craddick,930,629,217,84
+Galveston,224,Railroad Commissioner,,DEM,Roman McAllen,847,558,175,114
+Galveston,224,Railroad Commissioner,,LIB,Mike Wright,56,33,17,6
+Galveston,224,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,924,622,219,83
+Galveston,224,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,911,600,189,122
+Galveston,224,"Justice, Supreme Court, Place 4",,REP,John Devine,930,630,217,83
+Galveston,224,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,895,586,188,121
+Galveston,224,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,944,632,225,87
+Galveston,224,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,888,588,183,117
+Galveston,224,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,917,621,215,81
+Galveston,224,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,876,577,181,118
+Galveston,224,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,41,22,15,4
+Galveston,224,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,954,640,226,88
+Galveston,224,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,873,575,183,115
+Galveston,224,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1042,704,250,88
+Galveston,224,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,398,270,92,36
+Galveston,224,"Member, State Board of Education, District 7",,REP,Matt Robinson,897,613,212,72
+Galveston,224,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",926,606,195,125
+Galveston,224,State Representative,23,REP,Mayes Middleton,936,631,228,77
+Galveston,224,State Representative,23,DEM,Amanda Jamrok,869,570,180,119
+Galveston,224,State Representative,23,LIB,Lawrence Johnson,49,30,11,8
+Galveston,224,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,944,637,225,82
+Galveston,224,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,876,575,182,119
+Galveston,224,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,927,622,226,79
+Galveston,224,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,894,592,183,119
+Galveston,224,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,935,633,228,74
+Galveston,224,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,881,579,182,120
+Galveston,224,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,909,614,221,74
+Galveston,224,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,902,597,187,118
+Galveston,224,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,934,634,223,77
+Galveston,224,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,879,576,185,118
+Galveston,224,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,937,641,223,73
+Galveston,224,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,872,571,181,120
+Galveston,224,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,941,643,223,75
+Galveston,224,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,871,569,182,120
+Galveston,224,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,932,631,224,77
+Galveston,224,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,881,581,180,120
+Galveston,224,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,920,626,218,76
+Galveston,224,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,894,587,187,120
+Galveston,224,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,919,622,220,77
+Galveston,224,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",899,591,188,120
+Galveston,224,"District Judge, 122nd Judicial District",,REP,John Ellisor,1142,772,273,97
+Galveston,224,"District Judge, 212th Judicial District",,REP,Patricia Grady,1136,768,272,96
+Galveston,224,"District Judge, 306th Judicial District",,REP,Anne B. Darring,1128,760,272,96
+Galveston,224,Criminal District Attorney,,REP,Jack Roady,1132,761,276,95
+Galveston,224,County Judge,,REP,Mark Henry,1083,722,269,92
+Galveston,224,"Judge, County Court-at-Law No. 1",,REP,John Grady,1108,749,268,91
+Galveston,224,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,937,639,225,73
+Galveston,224,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,880,576,180,124
+Galveston,224,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,1114,756,262,96
+Galveston,224,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,1121,762,265,94
+Galveston,224,District Clerk,,REP,John D Kinard,1118,757,267,94
+Galveston,224,County Clerk,,REP,Dwight Sullivan,1126,763,268,95
+Galveston,224,County Treasurer,,REP,Kevin C. Walsh,1117,754,265,98
+Galveston,224,County Commissioner Pct. 2,,REP,Joe Giusti,1143,775,267,101
+Galveston,224,Justice of the Peace Pct. 2,,REP,Mike Nelson,1107,754,261,92
+Galveston,224,Commissioner  - GC Navigation Dist 1,,,"Thomas E. ""Ted"" Farmer, Jr.",644,420,165,59
+Galveston,224,Commissioner  - GC Navigation Dist 1,,,Robert Mihovil,388,269,70,49
+Galveston,225,Ballots Cast,,,,1868,1430,302,136
+Galveston,225,Straight Party,,REP,Republican,1064,836,167,61
+Galveston,225,Straight Party,,DEM,Democrat,227,151,40,36
+Galveston,225,Straight Party,,LIB,Libertarian,12,3,2,7
+Galveston,225,U.S. Senate,,REP,Ted Cruz,1415,1121,213,81
+Galveston,225,U.S. Senate,,DEM,Beto O'Rourke,434,298,81,55
+Galveston,225,U.S. Senate,,LIB,Neal M. Dikeman,13,6,7,0
+Galveston,225,U.S. House,14,REP,Randy Weber,1422,1120,220,82
+Galveston,225,U.S. House,14,DEM,Adrienne Bell,397,272,74,51
+Galveston,225,U.S. House,14,LIB,Don E. Conley III,30,21,7,2
+Galveston,225,Governor,,REP,Greg Abbott,1493,1169,238,86
+Galveston,225,Governor,,DEM,Lupe Valdez,347,237,60,50
+Galveston,225,Governor,,LIB,Mark Jay Tippetts,20,17,3,0
+Galveston,225,Lieutenant Governor,,REP,Dan Patrick,1434,1126,224,84
+Galveston,225,Lieutenant Governor,,DEM,Mike Collier,401,278,72,51
+Galveston,225,Lieutenant Governor,,LIB,Kerry Douglas McKennon,21,15,5,1
+Galveston,225,Attorney General,,REP,Ken Paxton,1395,1093,219,83
+Galveston,225,Attorney General,,DEM,Justin Nelson,429,300,76,53
+Galveston,225,Attorney General,,LIB,Michael Ray Harris,26,20,6,0
+Galveston,225,Comptroller of Public Accounts,,REP,Glenn Hegar,1444,1128,230,86
+Galveston,225,Comptroller of Public Accounts,,DEM,Joi Chevalier,358,246,62,50
+Galveston,225,Comptroller of Public Accounts,,LIB,Ben Sanders,33,28,5,0
+Galveston,225,Commissioner of General Land Office,,REP,George P. Bush,1448,1133,229,86
+Galveston,225,Commissioner of General Land Office,,DEM,Miguel Suazo,349,236,63,50
+Galveston,225,Commissioner of General Land Office,,LIB,Matt Pina,52,44,8,0
+Galveston,225,Commissioner of Agriculture,,REP,Sid Miller,1388,1088,220,80
+Galveston,225,Commissioner of Agriculture,,DEM,Kim Olson,412,284,73,55
+Galveston,225,Commissioner of Agriculture,,LIB,Richard Carpenter,34,28,5,1
+Galveston,225,Railroad Commissioner,,REP,Christi Craddick,1439,1125,231,83
+Galveston,225,Railroad Commissioner,,DEM,Roman McAllen,356,240,63,53
+Galveston,225,Railroad Commissioner,,LIB,Mike Wright,40,34,6,0
+Galveston,225,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1427,1123,224,80
+Galveston,225,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,400,275,71,54
+Galveston,225,"Justice, Supreme Court, Place 4",,REP,John Devine,1431,1125,225,81
+Galveston,225,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,396,272,72,52
+Galveston,225,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1442,1131,228,83
+Galveston,225,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,389,269,69,51
+Galveston,225,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1413,1109,224,80
+Galveston,225,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,387,267,66,54
+Galveston,225,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,28,22,5,1
+Galveston,225,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1449,1138,229,82
+Galveston,225,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,379,260,66,53
+Galveston,225,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1491,1167,240,84
+Galveston,225,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,173,127,29,17
+Galveston,225,"Member, State Board of Education, District 7",,REP,Matt Robinson,1417,1122,221,74
+Galveston,225,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",402,276,74,52
+Galveston,225,State Representative,24,REP,Greg Bonnen,1420,1122,223,75
+Galveston,225,State Representative,24,DEM,John Y. Phelps,378,263,63,52
+Galveston,225,State Representative,24,LIB,Dick Illyes,34,19,9,6
+Galveston,225,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,1437,1131,228,78
+Galveston,225,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,380,260,66,54
+Galveston,225,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,1418,1119,225,74
+Galveston,225,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,394,273,70,51
+Galveston,225,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,1423,1125,225,73
+Galveston,225,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,386,265,69,52
+Galveston,225,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,1413,1116,224,73
+Galveston,225,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,399,275,70,54
+Galveston,225,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,1434,1131,229,74
+Galveston,225,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,377,256,66,55
+Galveston,225,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,1422,1125,223,74
+Galveston,225,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,385,263,71,51
+Galveston,225,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,1432,1130,227,75
+Galveston,225,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,375,258,66,51
+Galveston,225,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,1427,1129,225,73
+Galveston,225,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,375,256,67,52
+Galveston,225,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,1418,1121,224,73
+Galveston,225,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,388,265,68,55
+Galveston,225,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,1415,1119,221,75
+Galveston,225,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",390,266,72,52
+Galveston,225,"District Judge, 122nd Judicial District",,REP,John Ellisor,1509,1187,242,80
+Galveston,225,"District Judge, 212th Judicial District",,REP,Patricia Grady,1508,1186,243,79
+Galveston,225,"District Judge, 306th Judicial District",,REP,Anne B. Darring,1502,1179,243,80
+Galveston,225,Criminal District Attorney,,REP,Jack Roady,1510,1184,243,83
+Galveston,225,County Judge,,REP,Mark Henry,1503,1174,243,86
+Galveston,225,"Judge, County Court-at-Law No. 1",,REP,John Grady,1500,1177,243,80
+Galveston,225,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,1424,1125,226,73
+Galveston,225,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,379,263,65,51
+Galveston,225,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,1499,1175,242,82
+Galveston,225,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,1505,1180,243,82
+Galveston,225,District Clerk,,REP,John D Kinard,1499,1175,241,83
+Galveston,225,County Clerk,,REP,Dwight Sullivan,1502,1177,242,83
+Galveston,225,County Treasurer,,REP,Kevin C. Walsh,1494,1174,241,79
+Galveston,225,County Commissioner Pct. 2,,REP,Joe Giusti,1521,1196,242,83
+Galveston,225,Justice of the Peace Pct. 2,,REP,Mike Nelson,1510,1185,243,82
+Galveston,225,College of the Mainland Proposition A,,,FOR,816,610,132,74
+Galveston,225,College of the Mainland Proposition A,,,AGAINST,709,560,108,41
+Galveston,226,Ballots Cast,,,,1322,964,277,81
+Galveston,226,Straight Party,,REP,Republican,570,435,111,24
+Galveston,226,Straight Party,,DEM,Democrat,259,169,54,36
+Galveston,226,Straight Party,,LIB,Libertarian,8,2,5,1
+Galveston,226,U.S. Senate,,REP,Ted Cruz,874,657,183,34
+Galveston,226,U.S. Senate,,DEM,Beto O'Rourke,424,292,86,46
+Galveston,226,U.S. Senate,,LIB,Neal M. Dikeman,12,7,5,0
+Galveston,226,U.S. House,14,REP,Randy Weber,873,659,177,37
+Galveston,226,U.S. House,14,DEM,Adrienne Bell,408,282,82,44
+Galveston,226,U.S. House,14,LIB,Don E. Conley III,22,12,10,0
+Galveston,226,Governor,,REP,Greg Abbott,927,690,196,41
+Galveston,226,Governor,,DEM,Lupe Valdez,368,257,71,40
+Galveston,226,Governor,,LIB,Mark Jay Tippetts,16,9,7,0
+Galveston,226,Lieutenant Governor,,REP,Dan Patrick,876,655,184,37
+Galveston,226,Lieutenant Governor,,DEM,Mike Collier,407,285,78,44
+Galveston,226,Lieutenant Governor,,LIB,Kerry Douglas McKennon,25,15,10,0
+Galveston,226,Attorney General,,REP,Ken Paxton,843,636,171,36
+Galveston,226,Attorney General,,DEM,Justin Nelson,424,296,83,45
+Galveston,226,Attorney General,,LIB,Michael Ray Harris,33,18,15,0
+Galveston,226,Comptroller of Public Accounts,,REP,Glenn Hegar,859,649,172,38
+Galveston,226,Comptroller of Public Accounts,,DEM,Joi Chevalier,390,272,75,43
+Galveston,226,Comptroller of Public Accounts,,LIB,Ben Sanders,47,27,20,0
+Galveston,226,Commissioner of General Land Office,,REP,George P. Bush,867,652,176,39
+Galveston,226,Commissioner of General Land Office,,DEM,Miguel Suazo,382,267,74,41
+Galveston,226,Commissioner of General Land Office,,LIB,Matt Pina,51,34,17,0
+Galveston,226,Commissioner of Agriculture,,REP,Sid Miller,846,644,167,35
+Galveston,226,Commissioner of Agriculture,,DEM,Kim Olson,417,286,86,45
+Galveston,226,Commissioner of Agriculture,,LIB,Richard Carpenter,30,17,13,0
+Galveston,226,Railroad Commissioner,,REP,Christi Craddick,867,651,177,39
+Galveston,226,Railroad Commissioner,,DEM,Roman McAllen,396,276,79,41
+Galveston,226,Railroad Commissioner,,LIB,Mike Wright,35,22,13,0
+Galveston,226,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,866,648,181,37
+Galveston,226,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,422,294,85,43
+Galveston,226,"Justice, Supreme Court, Place 4",,REP,John Devine,875,653,186,36
+Galveston,226,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,406,286,76,44
+Galveston,226,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,867,654,178,35
+Galveston,226,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,418,286,87,45
+Galveston,226,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,851,643,172,36
+Galveston,226,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,403,281,78,44
+Galveston,226,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,32,16,16,0
+Galveston,226,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,872,655,180,37
+Galveston,226,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,412,284,85,43
+Galveston,226,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,917,693,188,36
+Galveston,226,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,171,119,38,14
+Galveston,226,"Member, State Board of Education, District 7",,REP,Matt Robinson,876,657,184,35
+Galveston,226,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",412,287,80,45
+Galveston,226,State Representative,24,REP,Greg Bonnen,875,657,179,39
+Galveston,226,State Representative,24,DEM,John Y. Phelps,393,277,75,41
+Galveston,226,State Representative,24,LIB,Dick Illyes,25,13,12,0
+Galveston,226,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,867,650,182,35
+Galveston,226,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,416,288,83,45
+Galveston,226,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,859,648,178,33
+Galveston,226,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,421,290,85,46
+Galveston,226,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,860,648,178,34
+Galveston,226,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,418,288,86,44
+Galveston,226,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,865,650,179,36
+Galveston,226,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,418,288,87,43
+Galveston,226,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,872,653,183,36
+Galveston,226,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,407,284,81,42
+Galveston,226,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,864,646,184,34
+Galveston,226,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,411,285,81,45
+Galveston,226,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,865,647,183,35
+Galveston,226,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,412,286,81,45
+Galveston,226,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,871,652,184,35
+Galveston,226,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,405,282,79,44
+Galveston,226,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,855,642,177,36
+Galveston,226,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,418,289,86,43
+Galveston,226,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,862,646,182,34
+Galveston,226,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",416,289,81,46
+Galveston,226,"District Judge, 122nd Judicial District",,REP,John Ellisor,959,711,207,41
+Galveston,226,"District Judge, 212th Judicial District",,REP,Patricia Grady,963,714,209,40
+Galveston,226,"District Judge, 306th Judicial District",,REP,Anne B. Darring,954,708,207,39
+Galveston,226,Criminal District Attorney,,REP,Jack Roady,968,717,208,43
+Galveston,226,County Judge,,REP,Mark Henry,961,708,211,42
+Galveston,226,"Judge, County Court-at-Law No. 1",,REP,John Grady,953,705,209,39
+Galveston,226,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,868,655,178,35
+Galveston,226,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,410,283,84,43
+Galveston,226,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,951,703,207,41
+Galveston,226,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,957,710,208,39
+Galveston,226,District Clerk,,REP,John D Kinard,955,709,206,40
+Galveston,226,County Clerk,,REP,Dwight Sullivan,957,709,209,39
+Galveston,226,County Treasurer,,REP,Kevin C. Walsh,951,707,205,39
+Galveston,226,County Commissioner Pct. 2,,REP,Joe Giusti,966,715,209,42
+Galveston,226,Justice of the Peace Pct. 2,,REP,Mike Nelson,982,723,214,45
+Galveston,226,College of the Mainland Proposition A,,,FOR,723,508,170,45
+Galveston,226,College of the Mainland Proposition A,,,AGAINST,316,237,59,20
+Galveston,226,Trustee Position 4  - SFISD,,,Clay Hertenberger,50,39,11,0
+Galveston,226,Trustee Position 4  - SFISD,,,Donna Hayes,10,8,2,0
+Galveston,226,Trustee Position 4  - SFISD,,,John Rothermel,29,23,5,1
+Galveston,226,Trustee Position 4  - SFISD,,,Jessica Hagewood,25,18,7,0
+Galveston,226,Trustee Position 5  - SFISD,,,James Grassmuck,39,28,11,0
+Galveston,226,Trustee Position 5  - SFISD,,,Sheryl Skufca,47,37,9,1
+Galveston,226,Trustee Position 5  - SFISD,,,Tina Longcoy,9,7,2,0
+Galveston,226,Trustee Position 5  - SFISD,,,Jody Davis,17,14,3,0
+Galveston,226,Trustee Position 6  - SFISD,,,Rusty Norman,100,77,22,1
+Galveston,226,Director  - Flamingo Isles MUD,,,Joe B. Dillard,27,26,1,0
+Galveston,226,Director  - Flamingo Isles MUD,,,Michael Vigneault,28,24,1,3
+Galveston,226,Director  - Flamingo Isles MUD,,,David Dunn,27,26,1,0
+Galveston,226,Director  - Flamingo Isles MUD,,,Rea Berry,24,24,0,0
+Galveston,226,Director  - Flamingo Isles MUD,,,Mac DeLaup,38,34,2,2
+Galveston,226,Director  - Flamingo Isles MUD,,,Michael Andries,47,42,2,3
+Galveston,227,Ballots Cast,,,,1722,1309,280,133
+Galveston,227,Straight Party,,REP,Republican,867,661,146,60
+Galveston,227,Straight Party,,DEM,Democrat,164,119,22,23
+Galveston,227,Straight Party,,LIB,Libertarian,8,3,3,2
+Galveston,227,U.S. Senate,,REP,Ted Cruz,1371,1066,220,85
+Galveston,227,U.S. Senate,,DEM,Beto O'Rourke,332,232,53,47
+Galveston,227,U.S. Senate,,LIB,Neal M. Dikeman,10,5,4,1
+Galveston,227,U.S. House,14,REP,Randy Weber,1351,1043,223,85
+Galveston,227,U.S. House,14,DEM,Adrienne Bell,318,226,46,46
+Galveston,227,U.S. House,14,LIB,Don E. Conley III,29,22,6,1
+Galveston,227,Governor,,REP,Greg Abbott,1413,1087,231,95
+Galveston,227,Governor,,DEM,Lupe Valdez,271,198,36,37
+Galveston,227,Governor,,LIB,Mark Jay Tippetts,25,14,11,0
+Galveston,227,Lieutenant Governor,,REP,Dan Patrick,1346,1048,216,82
+Galveston,227,Lieutenant Governor,,DEM,Mike Collier,334,235,52,47
+Galveston,227,Lieutenant Governor,,LIB,Kerry Douglas McKennon,27,17,8,2
+Galveston,227,Attorney General,,REP,Ken Paxton,1309,1019,210,80
+Galveston,227,Attorney General,,DEM,Justin Nelson,353,247,56,50
+Galveston,227,Attorney General,,LIB,Michael Ray Harris,41,28,11,2
+Galveston,227,Comptroller of Public Accounts,,REP,Glenn Hegar,1330,1031,214,85
+Galveston,227,Comptroller of Public Accounts,,DEM,Joi Chevalier,296,214,42,40
+Galveston,227,Comptroller of Public Accounts,,LIB,Ben Sanders,58,37,16,5
+Galveston,227,Commissioner of General Land Office,,REP,George P. Bush,1349,1046,215,88
+Galveston,227,Commissioner of General Land Office,,DEM,Miguel Suazo,293,207,44,42
+Galveston,227,Commissioner of General Land Office,,LIB,Matt Pina,57,39,15,3
+Galveston,227,Commissioner of Agriculture,,REP,Sid Miller,1313,1020,212,81
+Galveston,227,Commissioner of Agriculture,,DEM,Kim Olson,346,244,55,47
+Galveston,227,Commissioner of Agriculture,,LIB,Richard Carpenter,28,18,6,4
+Galveston,227,Railroad Commissioner,,REP,Christi Craddick,1333,1033,221,79
+Galveston,227,Railroad Commissioner,,DEM,Roman McAllen,308,222,41,45
+Galveston,227,Railroad Commissioner,,LIB,Mike Wright,46,28,12,6
+Galveston,227,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1345,1043,221,81
+Galveston,227,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,331,236,48,47
+Galveston,227,"Justice, Supreme Court, Place 4",,REP,John Devine,1342,1044,216,82
+Galveston,227,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,331,232,53,46
+Galveston,227,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1345,1041,220,84
+Galveston,227,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,327,234,50,43
+Galveston,227,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1326,1033,215,78
+Galveston,227,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,314,221,47,46
+Galveston,227,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,34,19,10,5
+Galveston,227,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1355,1048,224,83
+Galveston,227,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,312,224,44,44
+Galveston,227,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1412,1091,229,92
+Galveston,227,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,146,100,30,16
+Galveston,227,"Member, State Board of Education, District 7",,REP,Matt Robinson,1334,1038,217,79
+Galveston,227,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",337,236,52,49
+Galveston,227,State Representative,24,REP,Greg Bonnen,1349,1046,220,83
+Galveston,227,State Representative,24,DEM,John Y. Phelps,313,222,45,46
+Galveston,227,State Representative,24,LIB,Dick Illyes,31,18,9,4
+Galveston,227,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,1352,1046,221,85
+Galveston,227,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,311,223,45,43
+Galveston,227,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,1333,1035,216,82
+Galveston,227,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,329,235,50,44
+Galveston,227,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,1334,1035,217,82
+Galveston,227,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,326,233,49,44
+Galveston,227,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,1328,1030,217,81
+Galveston,227,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,333,239,48,46
+Galveston,227,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,1342,1039,222,81
+Galveston,227,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,317,228,44,45
+Galveston,227,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,1338,1037,219,82
+Galveston,227,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,322,230,48,44
+Galveston,227,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,1343,1043,218,82
+Galveston,227,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,316,223,48,45
+Galveston,227,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,1349,1040,224,85
+Galveston,227,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,310,226,43,41
+Galveston,227,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,1334,1034,218,82
+Galveston,227,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,327,233,50,44
+Galveston,227,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,1340,1039,217,84
+Galveston,227,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",318,227,49,42
+Galveston,227,"District Judge, 122nd Judicial District",,REP,John Ellisor,1428,1098,240,90
+Galveston,227,"District Judge, 212th Judicial District",,REP,Patricia Grady,1431,1099,241,91
+Galveston,227,"District Judge, 306th Judicial District",,REP,Anne B. Darring,1424,1092,243,89
+Galveston,227,Criminal District Attorney,,REP,Jack Roady,1440,1102,241,97
+Galveston,227,County Judge,,REP,Mark Henry,1400,1073,234,93
+Galveston,227,"Judge, County Court-at-Law No. 1",,REP,John Grady,1424,1094,240,90
+Galveston,227,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,1349,1050,221,78
+Galveston,227,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,316,223,45,48
+Galveston,227,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,1426,1096,239,91
+Galveston,227,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,1420,1091,238,91
+Galveston,227,District Clerk,,REP,John D Kinard,1429,1099,239,91
+Galveston,227,County Clerk,,REP,Dwight Sullivan,1427,1094,238,95
+Galveston,227,County Treasurer,,REP,Kevin C. Walsh,1423,1095,237,91
+Galveston,227,County Commissioner Pct. 2,,REP,Joe Giusti,1439,1105,239,95
+Galveston,227,Justice of the Peace Pct. 2,,REP,Mike Nelson,1439,1104,241,94
+Galveston,227,College of the Mainland Proposition A,,,FOR,789,583,136,70
+Galveston,227,College of the Mainland Proposition A,,,AGAINST,637,493,90,54
+Galveston,227,Trustee Position 4  - SFISD,,,Clay Hertenberger,421,321,73,27
+Galveston,227,Trustee Position 4  - SFISD,,,Donna Hayes,142,109,23,10
+Galveston,227,Trustee Position 4  - SFISD,,,John Rothermel,371,270,55,46
+Galveston,227,Trustee Position 4  - SFISD,,,Jessica Hagewood,322,255,50,17
+Galveston,227,Trustee Position 5  - SFISD,,,James Grassmuck,434,332,66,36
+Galveston,227,Trustee Position 5  - SFISD,,,Sheryl Skufca,379,288,53,38
+Galveston,227,Trustee Position 5  - SFISD,,,Tina Longcoy,199,154,32,13
+Galveston,227,Trustee Position 5  - SFISD,,,Jody Davis,238,183,43,12
+Galveston,227,Trustee Position 6  - SFISD,,,Rusty Norman,1073,815,178,80
+Galveston,228,Ballots Cast,,,,1926,1494,314,118
+Galveston,228,Straight Party,,REP,Republican,1019,797,159,63
+Galveston,228,Straight Party,,DEM,Democrat,154,109,27,18
+Galveston,228,Straight Party,,LIB,Libertarian,6,2,3,1
+Galveston,228,U.S. Senate,,REP,Ted Cruz,1594,1256,252,86
+Galveston,228,U.S. Senate,,DEM,Beto O'Rourke,307,220,56,31
+Galveston,228,U.S. Senate,,LIB,Neal M. Dikeman,16,11,5,0
+Galveston,228,U.S. House,14,REP,Randy Weber,1588,1256,250,82
+Galveston,228,U.S. House,14,DEM,Adrienne Bell,298,209,53,36
+Galveston,228,U.S. House,14,LIB,Don E. Conley III,30,23,7,0
+Galveston,228,Governor,,REP,Greg Abbott,1630,1281,264,85
+Galveston,228,Governor,,DEM,Lupe Valdez,259,191,36,32
+Galveston,228,Governor,,LIB,Mark Jay Tippetts,30,17,12,1
+Galveston,228,Lieutenant Governor,,REP,Dan Patrick,1573,1245,245,83
+Galveston,228,Lieutenant Governor,,DEM,Mike Collier,313,224,55,34
+Galveston,228,Lieutenant Governor,,LIB,Kerry Douglas McKennon,29,15,13,1
+Galveston,228,Attorney General,,REP,Ken Paxton,1517,1204,237,76
+Galveston,228,Attorney General,,DEM,Justin Nelson,349,246,63,40
+Galveston,228,Attorney General,,LIB,Michael Ray Harris,42,29,12,1
+Galveston,228,Comptroller of Public Accounts,,REP,Glenn Hegar,1577,1246,253,78
+Galveston,228,Comptroller of Public Accounts,,DEM,Joi Chevalier,279,195,47,37
+Galveston,228,Comptroller of Public Accounts,,LIB,Ben Sanders,50,35,12,3
+Galveston,228,Commissioner of General Land Office,,REP,George P. Bush,1573,1240,252,81
+Galveston,228,Commissioner of General Land Office,,DEM,Miguel Suazo,267,188,44,35
+Galveston,228,Commissioner of General Land Office,,LIB,Matt Pina,70,53,16,1
+Galveston,228,Commissioner of Agriculture,,REP,Sid Miller,1533,1211,242,80
+Galveston,228,Commissioner of Agriculture,,DEM,Kim Olson,328,229,62,37
+Galveston,228,Commissioner of Agriculture,,LIB,Richard Carpenter,44,35,9,0
+Galveston,228,Railroad Commissioner,,REP,Christi Craddick,1560,1235,246,79
+Galveston,228,Railroad Commissioner,,DEM,Roman McAllen,287,200,52,35
+Galveston,228,Railroad Commissioner,,LIB,Mike Wright,54,39,13,2
+Galveston,228,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1587,1250,256,81
+Galveston,228,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,317,224,57,36
+Galveston,228,"Justice, Supreme Court, Place 4",,REP,John Devine,1597,1260,256,81
+Galveston,228,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,306,213,57,36
+Galveston,228,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1591,1252,257,82
+Galveston,228,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,310,219,56,35
+Galveston,228,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1563,1237,245,81
+Galveston,228,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,295,205,56,34
+Galveston,228,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,42,30,11,1
+Galveston,228,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1600,1263,256,81
+Galveston,228,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,298,208,56,34
+Galveston,228,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1628,1278,265,85
+Galveston,228,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,163,122,29,12
+Galveston,228,"Member, State Board of Education, District 7",,REP,Matt Robinson,1589,1256,253,80
+Galveston,228,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",309,215,59,35
+Galveston,228,State Representative,24,REP,Greg Bonnen,1580,1252,247,81
+Galveston,228,State Representative,24,DEM,John Y. Phelps,292,204,52,36
+Galveston,228,State Representative,24,LIB,Dick Illyes,37,23,14,0
+Galveston,228,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,1585,1250,254,81
+Galveston,228,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,311,217,59,35
+Galveston,228,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,1583,1250,254,79
+Galveston,228,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,312,217,59,36
+Galveston,228,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,1593,1255,258,80
+Galveston,228,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,303,213,54,36
+Galveston,228,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,1578,1244,254,80
+Galveston,228,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,319,224,59,36
+Galveston,228,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,1586,1249,259,78
+Galveston,228,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,306,216,54,36
+Galveston,228,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,1590,1256,255,79
+Galveston,228,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,303,210,58,35
+Galveston,228,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,1590,1256,254,80
+Galveston,228,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,299,207,58,34
+Galveston,228,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,1595,1259,256,80
+Galveston,228,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,292,203,55,34
+Galveston,228,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,1579,1250,251,78
+Galveston,228,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,312,216,60,36
+Galveston,228,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,1588,1254,255,79
+Galveston,228,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",303,211,56,36
+Galveston,228,"District Judge, 122nd Judicial District",,REP,John Ellisor,1663,1297,277,89
+Galveston,228,"District Judge, 212th Judicial District",,REP,Patricia Grady,1658,1291,278,89
+Galveston,228,"District Judge, 306th Judicial District",,REP,Anne B. Darring,1660,1293,278,89
+Galveston,228,Criminal District Attorney,,REP,Jack Roady,1661,1294,277,90
+Galveston,228,County Judge,,REP,Mark Henry,1650,1285,277,88
+Galveston,228,"Judge, County Court-at-Law No. 1",,REP,John Grady,1658,1291,276,91
+Galveston,228,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,1586,1256,253,77
+Galveston,228,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,305,209,58,38
+Galveston,228,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,1660,1293,277,90
+Galveston,228,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,1657,1290,277,90
+Galveston,228,District Clerk,,REP,John D Kinard,1661,1293,278,90
+Galveston,228,County Clerk,,REP,Dwight Sullivan,1661,1293,276,92
+Galveston,228,County Treasurer,,REP,Kevin C. Walsh,1657,1289,277,91
+Galveston,228,County Commissioner Pct. 2,,REP,Joe Giusti,1669,1302,276,91
+Galveston,228,Justice of the Peace Pct. 2,,REP,Mike Nelson,1681,1306,279,96
+Galveston,228,College of the Mainland Proposition A,,,FOR,825,620,154,51
+Galveston,228,College of the Mainland Proposition A,,,AGAINST,762,605,109,48
+Galveston,228,Trustee Position 4  - SFISD,,,Clay Hertenberger,505,383,93,29
+Galveston,228,Trustee Position 4  - SFISD,,,Donna Hayes,162,134,24,4
+Galveston,228,Trustee Position 4  - SFISD,,,John Rothermel,353,292,38,23
+Galveston,228,Trustee Position 4  - SFISD,,,Jessica Hagewood,327,239,68,20
+Galveston,228,Trustee Position 5  - SFISD,,,James Grassmuck,464,361,74,29
+Galveston,228,Trustee Position 5  - SFISD,,,Sheryl Skufca,429,336,72,21
+Galveston,228,Trustee Position 5  - SFISD,,,Tina Longcoy,190,139,38,13
+Galveston,228,Trustee Position 5  - SFISD,,,Jody Davis,249,197,39,13
+Galveston,228,Trustee Position 6  - SFISD,,,Rusty Norman,1148,898,199,51
+Galveston,232,Ballots Cast,,,,1069,762,222,85
+Galveston,232,Straight Party,,REP,Republican,349,255,69,25
+Galveston,232,Straight Party,,DEM,Democrat,337,236,74,27
+Galveston,232,Straight Party,,LIB,Libertarian,4,2,1,1
+Galveston,232,U.S. Senate,,REP,Ted Cruz,521,377,103,41
+Galveston,232,U.S. Senate,,DEM,Beto O'Rourke,528,376,109,43
+Galveston,232,U.S. Senate,,LIB,Neal M. Dikeman,15,5,9,1
+Galveston,232,U.S. House,14,REP,Randy Weber,531,383,104,44
+Galveston,232,U.S. House,14,DEM,Adrienne Bell,511,361,110,40
+Galveston,232,U.S. House,14,LIB,Don E. Conley III,18,11,7,0
+Galveston,232,Governor,,REP,Greg Abbott,558,407,106,45
+Galveston,232,Governor,,DEM,Lupe Valdez,490,344,108,38
+Galveston,232,Governor,,LIB,Mark Jay Tippetts,14,8,5,1
+Galveston,232,Lieutenant Governor,,REP,Dan Patrick,523,382,98,43
+Galveston,232,Lieutenant Governor,,DEM,Mike Collier,514,361,113,40
+Galveston,232,Lieutenant Governor,,LIB,Kerry Douglas McKennon,18,9,9,0
+Galveston,232,Attorney General,,REP,Ken Paxton,499,359,100,40
+Galveston,232,Attorney General,,DEM,Justin Nelson,532,378,110,44
+Galveston,232,Attorney General,,LIB,Michael Ray Harris,23,14,9,0
+Galveston,232,Comptroller of Public Accounts,,REP,Glenn Hegar,512,373,98,41
+Galveston,232,Comptroller of Public Accounts,,DEM,Joi Chevalier,505,359,107,39
+Galveston,232,Comptroller of Public Accounts,,LIB,Ben Sanders,32,17,13,2
+Galveston,232,Commissioner of General Land Office,,REP,George P. Bush,523,379,101,43
+Galveston,232,Commissioner of General Land Office,,DEM,Miguel Suazo,498,352,108,38
+Galveston,232,Commissioner of General Land Office,,LIB,Matt Pina,31,18,11,2
+Galveston,232,Commissioner of Agriculture,,REP,Sid Miller,497,361,99,37
+Galveston,232,Commissioner of Agriculture,,DEM,Kim Olson,535,380,114,41
+Galveston,232,Commissioner of Agriculture,,LIB,Richard Carpenter,19,8,7,4
+Galveston,232,Railroad Commissioner,,REP,Christi Craddick,506,367,101,38
+Galveston,232,Railroad Commissioner,,DEM,Roman McAllen,515,367,108,40
+Galveston,232,Railroad Commissioner,,LIB,Mike Wright,30,16,10,4
+Galveston,232,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,511,370,103,38
+Galveston,232,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,529,375,112,42
+Galveston,232,"Justice, Supreme Court, Place 4",,REP,John Devine,515,374,100,41
+Galveston,232,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,519,366,114,39
+Galveston,232,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,510,370,101,39
+Galveston,232,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,526,373,112,41
+Galveston,232,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,506,370,98,38
+Galveston,232,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,520,367,111,42
+Galveston,232,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,18,10,7,1
+Galveston,232,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,520,378,101,41
+Galveston,232,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,516,365,111,40
+Galveston,232,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,580,414,117,49
+Galveston,232,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,196,136,49,11
+Galveston,232,"Member, State Board of Education, District 7",,REP,Matt Robinson,508,371,99,38
+Galveston,232,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",532,375,115,42
+Galveston,232,State Representative,23,REP,Mayes Middleton,520,379,100,41
+Galveston,232,State Representative,23,DEM,Amanda Jamrok,509,361,108,40
+Galveston,232,State Representative,23,LIB,Lawrence Johnson,23,12,9,2
+Galveston,232,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,519,379,102,38
+Galveston,232,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,520,365,111,44
+Galveston,232,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,508,370,103,35
+Galveston,232,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,528,372,111,45
+Galveston,232,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,514,376,100,38
+Galveston,232,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,522,367,114,41
+Galveston,232,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,511,370,103,38
+Galveston,232,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,524,371,111,42
+Galveston,232,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,517,376,102,39
+Galveston,232,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,520,369,111,40
+Galveston,232,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,508,370,100,38
+Galveston,232,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,527,372,114,41
+Galveston,232,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,519,377,101,41
+Galveston,232,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,514,363,113,38
+Galveston,232,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,511,371,101,39
+Galveston,232,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,522,370,112,40
+Galveston,232,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,502,367,99,36
+Galveston,232,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,534,375,115,44
+Galveston,232,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,504,370,99,35
+Galveston,232,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",535,375,115,45
+Galveston,232,"District Judge, 122nd Judicial District",,REP,John Ellisor,617,434,134,49
+Galveston,232,"District Judge, 212th Judicial District",,REP,Patricia Grady,614,434,133,47
+Galveston,232,"District Judge, 306th Judicial District",,REP,Anne B. Darring,616,436,133,47
+Galveston,232,Criminal District Attorney,,REP,Jack Roady,612,433,131,48
+Galveston,232,County Judge,,REP,Mark Henry,614,434,133,47
+Galveston,232,"Judge, County Court-at-Law No. 1",,REP,John Grady,603,426,129,48
+Galveston,232,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,513,371,100,42
+Galveston,232,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,528,373,114,41
+Galveston,232,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,611,435,126,50
+Galveston,232,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,611,432,130,49
+Galveston,232,District Clerk,,REP,John D Kinard,611,432,129,50
+Galveston,232,County Clerk,,REP,Dwight Sullivan,609,429,130,50
+Galveston,232,County Treasurer,,REP,Kevin C. Walsh,608,433,126,49
+Galveston,232,County Commissioner Pct. 2,,REP,Joe Giusti,615,438,128,49
+Galveston,232,Justice of the Peace Pct. 2,,REP,Mike Nelson,618,437,131,50
+Galveston,232,College of the Mainland Proposition A,,,FOR,601,427,117,57
+Galveston,232,College of the Mainland Proposition A,,,AGAINST,245,171,53,21
+Galveston,232-3,Ballots Cast,,,,274,227,30,17
+Galveston,232-3,Straight Party,,REP,Republican,168,143,17,8
+Galveston,232-3,Straight Party,,DEM,Democrat,19,14,3,2
+Galveston,232-3,Straight Party,,LIB,Libertarian,3,1,0,2
+Galveston,232-3,U.S. Senate,,REP,Ted Cruz,237,201,24,12
+Galveston,232-3,U.S. Senate,,DEM,Beto O'Rourke,35,24,6,5
+Galveston,232-3,U.S. Senate,,LIB,Neal M. Dikeman,2,2,0,0
+Galveston,232-3,U.S. House,14,REP,Randy Weber,238,202,25,11
+Galveston,232-3,U.S. House,14,DEM,Adrienne Bell,30,21,5,4
+Galveston,232-3,U.S. House,14,LIB,Don E. Conley III,2,2,0,0
+Galveston,232-3,Governor,,REP,Greg Abbott,240,202,24,14
+Galveston,232-3,Governor,,DEM,Lupe Valdez,32,23,6,3
+Galveston,232-3,Governor,,LIB,Mark Jay Tippetts,2,2,0,0
+Galveston,232-3,Lieutenant Governor,,REP,Dan Patrick,232,196,24,12
+Galveston,232-3,Lieutenant Governor,,DEM,Mike Collier,35,26,4,5
+Galveston,232-3,Lieutenant Governor,,LIB,Kerry Douglas McKennon,6,4,2,0
+Galveston,232-3,Attorney General,,REP,Ken Paxton,230,196,24,10
+Galveston,232-3,Attorney General,,DEM,Justin Nelson,34,25,4,5
+Galveston,232-3,Attorney General,,LIB,Michael Ray Harris,5,3,2,0
+Galveston,232-3,Comptroller of Public Accounts,,REP,Glenn Hegar,236,202,24,10
+Galveston,232-3,Comptroller of Public Accounts,,DEM,Joi Chevalier,29,20,5,4
+Galveston,232-3,Comptroller of Public Accounts,,LIB,Ben Sanders,4,2,1,1
+Galveston,232-3,Commissioner of General Land Office,,REP,George P. Bush,234,196,25,13
+Galveston,232-3,Commissioner of General Land Office,,DEM,Miguel Suazo,26,18,4,4
+Galveston,232-3,Commissioner of General Land Office,,LIB,Matt Pina,11,10,1,0
+Galveston,232-3,Commissioner of Agriculture,,REP,Sid Miller,233,200,24,9
+Galveston,232-3,Commissioner of Agriculture,,DEM,Kim Olson,34,23,6,5
+Galveston,232-3,Commissioner of Agriculture,,LIB,Richard Carpenter,1,1,0,0
+Galveston,232-3,Railroad Commissioner,,REP,Christi Craddick,235,202,23,10
+Galveston,232-3,Railroad Commissioner,,DEM,Roman McAllen,27,18,5,4
+Galveston,232-3,Railroad Commissioner,,LIB,Mike Wright,5,4,1,0
+Galveston,232-3,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,234,201,24,9
+Galveston,232-3,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,34,23,6,5
+Galveston,232-3,"Justice, Supreme Court, Place 4",,REP,John Devine,235,201,24,10
+Galveston,232-3,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,32,22,6,4
+Galveston,232-3,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,232,199,24,9
+Galveston,232-3,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,34,23,6,5
+Galveston,232-3,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,232,198,24,10
+Galveston,232-3,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,33,23,6,4
+Galveston,232-3,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,2,2,0,0
+Galveston,232-3,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,234,200,24,10
+Galveston,232-3,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,32,22,6,4
+Galveston,232-3,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,236,202,24,10
+Galveston,232-3,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,15,8,4,3
+Galveston,232-3,"Member, State Board of Education, District 7",,REP,Matt Robinson,239,205,24,10
+Galveston,232-3,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",27,18,6,3
+Galveston,232-3,State Representative,23,REP,Mayes Middleton,238,202,24,12
+Galveston,232-3,State Representative,23,DEM,Amanda Jamrok,30,21,6,3
+Galveston,232-3,State Representative,23,LIB,Lawrence Johnson,5,3,0,2
+Galveston,232-3,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,236,203,24,9
+Galveston,232-3,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,31,20,6,5
+Galveston,232-3,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,231,198,24,9
+Galveston,232-3,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,34,25,6,3
+Galveston,232-3,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,232,200,24,8
+Galveston,232-3,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,34,23,6,5
+Galveston,232-3,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,232,199,24,9
+Galveston,232-3,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,33,24,6,3
+Galveston,232-3,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,232,201,24,7
+Galveston,232-3,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,34,22,6,6
+Galveston,232-3,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,234,201,24,9
+Galveston,232-3,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,31,22,6,3
+Galveston,232-3,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,233,201,24,8
+Galveston,232-3,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,32,22,6,4
+Galveston,232-3,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,235,202,24,9
+Galveston,232-3,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,30,21,6,3
+Galveston,232-3,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,234,201,24,9
+Galveston,232-3,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,31,22,6,3
+Galveston,232-3,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,234,201,24,9
+Galveston,232-3,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",32,22,6,4
+Galveston,232-3,"District Judge, 122nd Judicial District",,REP,John Ellisor,240,205,26,9
+Galveston,232-3,"District Judge, 212th Judicial District",,REP,Patricia Grady,239,205,25,9
+Galveston,232-3,"District Judge, 306th Judicial District",,REP,Anne B. Darring,240,205,26,9
+Galveston,232-3,Criminal District Attorney,,REP,Jack Roady,239,204,25,10
+Galveston,232-3,County Judge,,REP,Mark Henry,239,204,25,10
+Galveston,232-3,"Judge, County Court-at-Law No. 1",,REP,John Grady,237,203,25,9
+Galveston,232-3,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,232,200,24,8
+Galveston,232-3,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,31,21,6,4
+Galveston,232-3,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,238,203,26,9
+Galveston,232-3,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,241,205,27,9
+Galveston,232-3,District Clerk,,REP,John D Kinard,239,203,26,10
+Galveston,232-3,County Clerk,,REP,Dwight Sullivan,238,203,26,9
+Galveston,232-3,County Treasurer,,REP,Kevin C. Walsh,239,203,26,10
+Galveston,232-3,County Commissioner Pct. 2,,REP,Joe Giusti,239,204,26,9
+Galveston,232-3,Justice of the Peace Pct. 2,,REP,Mike Nelson,242,206,26,10
+Galveston,232-3,College of the Mainland Proposition A,,,FOR,106,94,7,5
+Galveston,232-3,College of the Mainland Proposition A,,,AGAINST,131,104,17,10
+Galveston,258,Ballots Cast,,,,1260,926,270,64
+Galveston,258,Straight Party,,REP,Republican,671,482,151,38
+Galveston,258,Straight Party,,DEM,Democrat,105,77,19,9
+Galveston,258,Straight Party,,LIB,Libertarian,5,3,0,2
+Galveston,258,U.S. Senate,,REP,Ted Cruz,1049,775,226,48
+Galveston,258,U.S. Senate,,DEM,Beto O'Rourke,199,143,41,15
+Galveston,258,U.S. Senate,,LIB,Neal M. Dikeman,6,4,2,0
+Galveston,258,U.S. House,14,REP,Randy Weber,1049,773,227,49
+Galveston,258,U.S. House,14,DEM,Adrienne Bell,191,138,38,15
+Galveston,258,U.S. House,14,LIB,Don E. Conley III,12,10,2,0
+Galveston,258,Governor,,REP,Greg Abbott,1068,782,237,49
+Galveston,258,Governor,,DEM,Lupe Valdez,171,127,30,14
+Galveston,258,Governor,,LIB,Mark Jay Tippetts,14,11,3,0
+Galveston,258,Lieutenant Governor,,REP,Dan Patrick,1040,762,229,49
+Galveston,258,Lieutenant Governor,,DEM,Mike Collier,193,143,36,14
+Galveston,258,Lieutenant Governor,,LIB,Kerry Douglas McKennon,17,13,4,0
+Galveston,258,Attorney General,,REP,Ken Paxton,1006,744,216,46
+Galveston,258,Attorney General,,DEM,Justin Nelson,211,151,43,17
+Galveston,258,Attorney General,,LIB,Michael Ray Harris,24,18,5,1
+Galveston,258,Comptroller of Public Accounts,,REP,Glenn Hegar,1022,749,226,47
+Galveston,258,Comptroller of Public Accounts,,DEM,Joi Chevalier,183,140,30,13
+Galveston,258,Comptroller of Public Accounts,,LIB,Ben Sanders,28,18,8,2
+Galveston,258,Commissioner of General Land Office,,REP,George P. Bush,1023,751,226,46
+Galveston,258,Commissioner of General Land Office,,DEM,Miguel Suazo,180,135,30,15
+Galveston,258,Commissioner of General Land Office,,LIB,Matt Pina,36,27,8,1
+Galveston,258,Commissioner of Agriculture,,REP,Sid Miller,994,737,212,45
+Galveston,258,Commissioner of Agriculture,,DEM,Kim Olson,217,158,44,15
+Galveston,258,Commissioner of Agriculture,,LIB,Richard Carpenter,23,16,6,1
+Galveston,258,Railroad Commissioner,,REP,Christi Craddick,1018,748,221,49
+Galveston,258,Railroad Commissioner,,DEM,Roman McAllen,192,143,37,12
+Galveston,258,Railroad Commissioner,,LIB,Mike Wright,26,20,5,1
+Galveston,258,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1038,771,222,45
+Galveston,258,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,193,139,40,14
+Galveston,258,"Justice, Supreme Court, Place 4",,REP,John Devine,1039,775,220,44
+Galveston,258,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,192,137,40,15
+Galveston,258,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1033,765,222,46
+Galveston,258,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,199,145,39,15
+Galveston,258,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1017,754,219,44
+Galveston,258,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,192,137,41,14
+Galveston,258,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,26,21,3,2
+Galveston,258,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1041,774,222,45
+Galveston,258,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,192,137,41,14
+Galveston,258,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1064,785,231,48
+Galveston,258,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,95,70,22,3
+Galveston,258,"Member, State Board of Education, District 7",,REP,Matt Robinson,1026,765,219,42
+Galveston,258,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",205,146,44,15
+Galveston,258,State Representative,24,REP,Greg Bonnen,1029,766,221,42
+Galveston,258,State Representative,24,DEM,John Y. Phelps,190,136,39,15
+Galveston,258,State Representative,24,LIB,Dick Illyes,14,9,3,2
+Galveston,258,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,1040,770,226,44
+Galveston,258,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,192,140,37,15
+Galveston,258,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,1030,766,222,42
+Galveston,258,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,196,141,39,16
+Galveston,258,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,1030,766,224,40
+Galveston,258,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,196,143,37,16
+Galveston,258,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,1011,753,218,40
+Galveston,258,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,211,152,43,16
+Galveston,258,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,1034,766,224,44
+Galveston,258,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,194,141,39,14
+Galveston,258,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,1026,764,220,42
+Galveston,258,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,197,142,41,14
+Galveston,258,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,1036,770,223,43
+Galveston,258,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,186,135,37,14
+Galveston,258,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,1034,771,220,43
+Galveston,258,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,188,135,39,14
+Galveston,258,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,1023,761,221,41
+Galveston,258,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,200,146,39,15
+Galveston,258,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,1030,768,220,42
+Galveston,258,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",194,139,40,15
+Galveston,258,"District Judge, 122nd Judicial District",,REP,John Ellisor,1084,806,234,44
+Galveston,258,"District Judge, 212th Judicial District",,REP,Patricia Grady,1086,807,235,44
+Galveston,258,"District Judge, 306th Judicial District",,REP,Anne B. Darring,1081,802,235,44
+Galveston,258,Criminal District Attorney,,REP,Jack Roady,1085,802,239,44
+Galveston,258,County Judge,,REP,Mark Henry,1078,796,234,48
+Galveston,258,"Judge, County Court-at-Law No. 1",,REP,John Grady,1082,800,237,45
+Galveston,258,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,1032,766,224,42
+Galveston,258,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,194,140,38,16
+Galveston,258,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,1077,798,234,45
+Galveston,258,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,1082,799,236,47
+Galveston,258,District Clerk,,REP,John D Kinard,1081,799,236,46
+Galveston,258,County Clerk,,REP,Dwight Sullivan,1079,797,236,46
+Galveston,258,County Treasurer,,REP,Kevin C. Walsh,1076,797,234,45
+Galveston,258,County Commissioner Pct. 2,,REP,Joe Giusti,1087,803,238,46
+Galveston,258,Justice of the Peace Pct. 2,,REP,Mike Nelson,1114,822,245,47
+Galveston,258,College of the Mainland Proposition A,,,FOR,522,364,131,27
+Galveston,258,College of the Mainland Proposition A,,,AGAINST,475,365,89,21
+Galveston,258,Trustee Position 4  - SFISD,,,Clay Hertenberger,360,256,92,12
+Galveston,258,Trustee Position 4  - SFISD,,,Donna Hayes,97,70,23,4
+Galveston,258,Trustee Position 4  - SFISD,,,John Rothermel,236,166,54,16
+Galveston,258,Trustee Position 4  - SFISD,,,Jessica Hagewood,195,157,31,7
+Galveston,258,Trustee Position 5  - SFISD,,,James Grassmuck,331,242,74,15
+Galveston,258,Trustee Position 5  - SFISD,,,Sheryl Skufca,259,199,57,3
+Galveston,258,Trustee Position 5  - SFISD,,,Tina Longcoy,142,103,31,8
+Galveston,258,Trustee Position 5  - SFISD,,,Jody Davis,150,103,35,12
+Galveston,258,Trustee Position 6  - SFISD,,,Rusty Norman,774,566,181,27
+Galveston,263,Ballots Cast,,,,4122,3154,781,187
+Galveston,263,Straight Party,,REP,Republican,1820,1409,334,77
+Galveston,263,Straight Party,,DEM,Democrat,664,515,113,36
+Galveston,263,Straight Party,,LIB,Libertarian,13,7,5,1
+Galveston,263,U.S. Senate,,REP,Ted Cruz,2687,2078,499,110
+Galveston,263,U.S. Senate,,DEM,Beto O'Rourke,1381,1044,265,72
+Galveston,263,U.S. Senate,,LIB,Neal M. Dikeman,32,21,10,1
+Galveston,263,U.S. House,14,REP,Randy Weber,2760,2130,518,112
+Galveston,263,U.S. House,14,DEM,Adrienne Bell,1259,955,233,71
+Galveston,263,U.S. House,14,LIB,Don E. Conley III,65,42,23,0
+Galveston,263,Governor,,REP,Greg Abbott,2890,2207,571,112
+Galveston,263,Governor,,DEM,Lupe Valdez,1130,879,182,69
+Galveston,263,Governor,,LIB,Mark Jay Tippetts,78,55,20,3
+Galveston,263,Lieutenant Governor,,REP,Dan Patrick,2705,2082,513,110
+Galveston,263,Lieutenant Governor,,DEM,Mike Collier,1272,965,234,73
+Galveston,263,Lieutenant Governor,,LIB,Kerry Douglas McKennon,112,85,26,1
+Galveston,263,Attorney General,,REP,Ken Paxton,2644,2043,496,105
+Galveston,263,Attorney General,,DEM,Justin Nelson,1314,994,246,74
+Galveston,263,Attorney General,,LIB,Michael Ray Harris,114,85,25,4
+Galveston,263,Comptroller of Public Accounts,,REP,Glenn Hegar,2747,2119,517,111
+Galveston,263,Comptroller of Public Accounts,,DEM,Joi Chevalier,1125,864,196,65
+Galveston,263,Comptroller of Public Accounts,,LIB,Ben Sanders,173,120,49,4
+Galveston,263,Commissioner of General Land Office,,REP,George P. Bush,2757,2108,536,113
+Galveston,263,Commissioner of General Land Office,,DEM,Miguel Suazo,1156,893,195,68
+Galveston,263,Commissioner of General Land Office,,LIB,Matt Pina,149,114,34,1
+Galveston,263,Commissioner of Agriculture,,REP,Sid Miller,2640,2048,489,103
+Galveston,263,Commissioner of Agriculture,,DEM,Kim Olson,1284,974,235,75
+Galveston,263,Commissioner of Agriculture,,LIB,Richard Carpenter,111,76,33,2
+Galveston,263,Railroad Commissioner,,REP,Christi Craddick,2761,2130,523,108
+Galveston,263,Railroad Commissioner,,DEM,Roman McAllen,1138,868,202,68
+Galveston,263,Railroad Commissioner,,LIB,Mike Wright,132,97,33,2
+Galveston,263,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,2763,2129,529,105
+Galveston,263,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,1272,968,234,70
+Galveston,263,"Justice, Supreme Court, Place 4",,REP,John Devine,2780,2144,532,104
+Galveston,263,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,1248,950,228,70
+Galveston,263,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,2762,2130,523,109
+Galveston,263,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,1269,964,239,66
+Galveston,263,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,2712,2105,506,101
+Galveston,263,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,1217,926,221,70
+Galveston,263,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,99,67,29,3
+Galveston,263,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,2807,2163,539,105
+Galveston,263,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,1216,929,219,68
+Galveston,263,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,2967,2294,566,107
+Galveston,263,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,658,511,120,27
+Galveston,263,"Member, State Board of Education, District 7",,REP,Matt Robinson,2722,2107,517,98
+Galveston,263,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",1305,989,240,76
+Galveston,263,State Representative,24,REP,Greg Bonnen,2756,2126,524,106
+Galveston,263,State Representative,24,DEM,John Y. Phelps,1195,917,210,68
+Galveston,263,State Representative,24,LIB,Dick Illyes,94,66,27,1
+Galveston,263,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,2816,2165,544,107
+Galveston,263,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,1198,922,211,65
+Galveston,263,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,2752,2123,524,105
+Galveston,263,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,1258,961,230,67
+Galveston,263,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,2753,2125,526,102
+Galveston,263,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,1256,959,229,68
+Galveston,263,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,2774,2147,528,99
+Galveston,263,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,1235,938,227,70
+Galveston,263,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,2795,2158,534,103
+Galveston,263,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,1211,923,220,68
+Galveston,263,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,2797,2153,542,102
+Galveston,263,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,1208,929,212,67
+Galveston,263,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,2783,2147,532,104
+Galveston,263,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,1213,931,217,65
+Galveston,263,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,2787,2150,534,103
+Galveston,263,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,1215,929,219,67
+Galveston,263,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,2744,2112,527,105
+Galveston,263,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,1258,966,224,68
+Galveston,263,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,2747,2121,522,104
+Galveston,263,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",1250,957,228,65
+Galveston,263,"District Judge, 122nd Judicial District",,REP,John Ellisor,3108,2385,614,109
+Galveston,263,"District Judge, 212th Judicial District",,REP,Patricia Grady,3114,2390,615,109
+Galveston,263,"District Judge, 306th Judicial District",,REP,Anne B. Darring,3109,2387,613,109
+Galveston,263,Criminal District Attorney,,REP,Jack Roady,3101,2380,610,111
+Galveston,263,County Judge,,REP,Mark Henry,3088,2367,610,111
+Galveston,263,"Judge, County Court-at-Law No. 1",,REP,John Grady,3075,2360,605,110
+Galveston,263,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,2784,2143,537,104
+Galveston,263,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,1217,934,216,67
+Galveston,263,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,3078,2360,608,110
+Galveston,263,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,3092,2374,606,112
+Galveston,263,District Clerk,,REP,John D Kinard,3089,2372,608,109
+Galveston,263,County Clerk,,REP,Dwight Sullivan,3084,2367,605,112
+Galveston,263,County Treasurer,,REP,Kevin C. Walsh,3074,2356,606,112
+Galveston,263,County Commissioner Pct. 2,,REP,Joe Giusti,3078,2362,606,110
+Galveston,263,Mayor  - League City,,,Sebastian Lofaro,1092,857,206,29
+Galveston,263,Mayor  - League City,,,Pat Hallisey,2035,1561,368,106
+Galveston,263,Council Position 1  - League City,,,Andy Mann,1481,1150,269,62
+Galveston,263,Council Position 1  - League City,,,Traci Jacobs,1233,931,244,58
+Galveston,263,Council Position 2  - League City,,,Hank Dugie,2310,1769,463,78
+Galveston,263,Council Position 6  - League City,,,Silvio P. Vincenzo,691,540,117,34
+Galveston,263,Council Position 6  - League City,,,Chad Tressler,1238,934,251,53
+Galveston,263,Council Position 6  - League City,,,Chris Gross,747,568,147,32
+Galveston,263,Council Position 7  - League City,,,Ange Mertens,1043,808,192,43
+Galveston,263,Council Position 7  - League City,,,Nick Long,1712,1307,330,75
+Galveston,263,League City Proposition A,,,For,2404,1818,444,142
+Galveston,263,League City Proposition A,,,Against,744,586,143,15
+Galveston,263,League City Proposition B,,,For,2894,2232,521,141
+Galveston,263,League City Proposition B,,,Against,469,350,103,16
+Galveston,263,League City Proposition C,,,For,2890,2225,526,139
+Galveston,263,League City Proposition C,,,Against,357,272,71,14
+Galveston,263,League City Proposition D,,,For,2680,2067,476,137
+Galveston,263,League City Proposition D,,,Against,422,303,101,18
+Galveston,263,League City Proposition E,,,For,3021,2330,550,141
+Galveston,263,League City Proposition E,,,Against,205,150,39,16
+Galveston,263,League City Proposition F,,,For,2786,2147,495,144
+Galveston,263,League City Proposition F,,,Against,290,216,63,11
+Galveston,263,League City Proposition G,,,For,2946,2275,530,141
+Galveston,263,League City Proposition G,,,Against,215,162,40,13
+Galveston,263,League City Proposition H,,,For,1863,1425,348,90
+Galveston,263,League City Proposition H,,,Against,1053,816,182,55
+Galveston,263,League City Proposition I,,,For,2820,2171,506,143
+Galveston,263,League City Proposition I,,,Against,274,199,60,15
+Galveston,263,League City Proposition J,,,For,2659,2044,477,138
+Galveston,263,League City Proposition J,,,Against,424,322,83,19
+Galveston,263,League City Proposition K,,,For,2744,2123,480,141
+Galveston,263,League City Proposition K,,,Against,287,206,67,14
+Galveston,263,League City Proposition L,,,For,2338,1802,416,120
+Galveston,263,League City Proposition L,,,Against,600,455,116,29
+Galveston,263,League City Proposition M,,,For,2643,2033,472,138
+Galveston,263,League City Proposition M,,,Against,359,277,69,13
+Galveston,263,League City Proposition N,,,For,2377,1826,413,138
+Galveston,263,League City Proposition N,,,Against,604,472,116,16
+Galveston,263,League City Proposition O,,,For,2429,1894,417,118
+Galveston,263,League City Proposition O,,,Against,540,395,113,32
+Galveston,274,Ballots Cast,,,,567,444,88,35
+Galveston,274,Straight Party,,REP,Republican,285,235,37,13
+Galveston,274,Straight Party,,DEM,Democrat,65,51,8,6
+Galveston,274,Straight Party,,LIB,Libertarian,2,0,1,1
+Galveston,274,U.S. Senate,,REP,Ted Cruz,411,323,64,24
+Galveston,274,U.S. Senate,,DEM,Beto O'Rourke,151,117,23,11
+Galveston,274,U.S. Senate,,LIB,Neal M. Dikeman,3,2,1,0
+Galveston,274,U.S. House,14,REP,Randy Weber,425,336,65,24
+Galveston,274,U.S. House,14,DEM,Adrienne Bell,131,102,19,10
+Galveston,274,U.S. House,14,LIB,Don E. Conley III,9,5,3,1
+Galveston,274,Governor,,REP,Greg Abbott,434,339,70,25
+Galveston,274,Governor,,DEM,Lupe Valdez,120,97,13,10
+Galveston,274,Governor,,LIB,Mark Jay Tippetts,10,6,4,0
+Galveston,274,Lieutenant Governor,,REP,Dan Patrick,415,330,63,22
+Galveston,274,Lieutenant Governor,,DEM,Mike Collier,136,105,18,13
+Galveston,274,Lieutenant Governor,,LIB,Kerry Douglas McKennon,13,8,5,0
+Galveston,274,Attorney General,,REP,Ken Paxton,404,322,62,20
+Galveston,274,Attorney General,,DEM,Justin Nelson,146,114,19,13
+Galveston,274,Attorney General,,LIB,Michael Ray Harris,12,6,5,1
+Galveston,274,Comptroller of Public Accounts,,REP,Glenn Hegar,435,344,67,24
+Galveston,274,Comptroller of Public Accounts,,DEM,Joi Chevalier,117,91,16,10
+Galveston,274,Comptroller of Public Accounts,,LIB,Ben Sanders,7,4,2,1
+Galveston,274,Commissioner of General Land Office,,REP,George P. Bush,413,321,66,26
+Galveston,274,Commissioner of General Land Office,,DEM,Miguel Suazo,119,95,16,8
+Galveston,274,Commissioner of General Land Office,,LIB,Matt Pina,30,25,4,1
+Galveston,274,Commissioner of Agriculture,,REP,Sid Miller,406,323,60,23
+Galveston,274,Commissioner of Agriculture,,DEM,Kim Olson,139,108,20,11
+Galveston,274,Commissioner of Agriculture,,LIB,Richard Carpenter,12,8,3,1
+Galveston,274,Railroad Commissioner,,REP,Christi Craddick,428,343,63,22
+Galveston,274,Railroad Commissioner,,DEM,Roman McAllen,118,91,16,11
+Galveston,274,Railroad Commissioner,,LIB,Mike Wright,11,5,4,2
+Galveston,274,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,424,336,65,23
+Galveston,274,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,128,100,17,11
+Galveston,274,"Justice, Supreme Court, Place 4",,REP,John Devine,430,341,66,23
+Galveston,274,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,123,96,16,11
+Galveston,274,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,427,338,66,23
+Galveston,274,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,126,99,16,11
+Galveston,274,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,423,338,64,21
+Galveston,274,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,126,96,18,12
+Galveston,274,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,8,4,2,2
+Galveston,274,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,435,345,65,25
+Galveston,274,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,120,93,17,10
+Galveston,274,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,445,349,70,26
+Galveston,274,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,63,47,11,5
+Galveston,274,"Member, State Board of Education, District 7",,REP,Matt Robinson,421,333,67,21
+Galveston,274,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",133,106,15,12
+Galveston,274,State Representative,23,REP,Mayes Middleton,421,332,67,22
+Galveston,274,State Representative,23,DEM,Amanda Jamrok,124,99,15,10
+Galveston,274,State Representative,23,LIB,Lawrence Johnson,12,8,3,1
+Galveston,274,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,428,339,66,23
+Galveston,274,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,122,98,15,9
+Galveston,274,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,424,338,66,20
+Galveston,274,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,127,100,15,12
+Galveston,274,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,423,338,66,19
+Galveston,274,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,131,101,16,14
+Galveston,274,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,424,340,64,20
+Galveston,274,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,129,99,18,12
+Galveston,274,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,428,340,66,22
+Galveston,274,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,124,98,15,11
+Galveston,274,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,428,340,66,22
+Galveston,274,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,122,96,16,10
+Galveston,274,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,425,338,67,20
+Galveston,274,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,125,97,15,13
+Galveston,274,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,427,340,67,20
+Galveston,274,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,122,96,14,12
+Galveston,274,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,426,338,66,22
+Galveston,274,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,125,99,15,11
+Galveston,274,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,424,337,67,20
+Galveston,274,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",127,100,15,12
+Galveston,274,"District Judge, 122nd Judicial District",,REP,John Ellisor,449,354,72,23
+Galveston,274,"District Judge, 212th Judicial District",,REP,Patricia Grady,449,356,71,22
+Galveston,274,"District Judge, 306th Judicial District",,REP,Anne B. Darring,447,354,71,22
+Galveston,274,Criminal District Attorney,,REP,Jack Roady,451,356,71,24
+Galveston,274,County Judge,,REP,Mark Henry,445,353,70,22
+Galveston,274,"Judge, County Court-at-Law No. 1",,REP,John Grady,441,350,69,22
+Galveston,274,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,420,336,63,21
+Galveston,274,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,129,100,18,11
+Galveston,274,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,446,354,70,22
+Galveston,274,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,448,354,72,22
+Galveston,274,District Clerk,,REP,John D Kinard,447,355,69,23
+Galveston,274,County Clerk,,REP,Dwight Sullivan,445,355,69,21
+Galveston,274,County Treasurer,,REP,Kevin C. Walsh,445,353,70,22
+Galveston,274,County Commissioner Pct. 2,,REP,Joe Giusti,446,353,71,22
+Galveston,274,Justice of the Peace Pct. 2,,REP,Mike Nelson,446,352,71,23
+Galveston,275,Ballots Cast,,,,273,199,28,46
+Galveston,275,Straight Party,,REP,Republican,139,104,14,21
+Galveston,275,Straight Party,,DEM,Democrat,36,22,3,11
+Galveston,275,Straight Party,,LIB,Libertarian,0,0,0,0
+Galveston,275,U.S. Senate,,REP,Ted Cruz,187,145,19,23
+Galveston,275,U.S. Senate,,DEM,Beto O'Rourke,82,50,9,23
+Galveston,275,U.S. Senate,,LIB,Neal M. Dikeman,2,2,0,0
+Galveston,275,U.S. House,14,REP,Randy Weber,194,151,19,24
+Galveston,275,U.S. House,14,DEM,Adrienne Bell,72,44,7,21
+Galveston,275,U.S. House,14,LIB,Don E. Conley III,7,4,2,1
+Galveston,275,Governor,,REP,Greg Abbott,202,155,20,27
+Galveston,275,Governor,,DEM,Lupe Valdez,66,40,8,18
+Galveston,275,Governor,,LIB,Mark Jay Tippetts,5,4,0,1
+Galveston,275,Lieutenant Governor,,REP,Dan Patrick,184,140,20,24
+Galveston,275,Lieutenant Governor,,DEM,Mike Collier,76,50,6,20
+Galveston,275,Lieutenant Governor,,LIB,Kerry Douglas McKennon,13,9,2,2
+Galveston,275,Attorney General,,REP,Ken Paxton,180,136,20,24
+Galveston,275,Attorney General,,DEM,Justin Nelson,85,58,7,20
+Galveston,275,Attorney General,,LIB,Michael Ray Harris,7,4,1,2
+Galveston,275,Comptroller of Public Accounts,,REP,Glenn Hegar,198,151,22,25
+Galveston,275,Comptroller of Public Accounts,,DEM,Joi Chevalier,63,39,4,20
+Galveston,275,Comptroller of Public Accounts,,LIB,Ben Sanders,11,8,2,1
+Galveston,275,Commissioner of General Land Office,,REP,George P. Bush,199,149,23,27
+Galveston,275,Commissioner of General Land Office,,DEM,Miguel Suazo,64,42,4,18
+Galveston,275,Commissioner of General Land Office,,LIB,Matt Pina,8,6,1,1
+Galveston,275,Commissioner of Agriculture,,REP,Sid Miller,185,140,21,24
+Galveston,275,Commissioner of Agriculture,,DEM,Kim Olson,79,52,5,22
+Galveston,275,Commissioner of Agriculture,,LIB,Richard Carpenter,7,5,2,0
+Galveston,275,Railroad Commissioner,,REP,Christi Craddick,194,147,21,26
+Galveston,275,Railroad Commissioner,,DEM,Roman McAllen,66,43,5,18
+Galveston,275,Railroad Commissioner,,LIB,Mike Wright,9,6,2,1
+Galveston,275,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,192,148,20,24
+Galveston,275,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,77,48,8,21
+Galveston,275,"Justice, Supreme Court, Place 4",,REP,John Devine,193,149,20,24
+Galveston,275,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,77,48,8,21
+Galveston,275,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,193,148,19,26
+Galveston,275,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,77,49,9,19
+Galveston,275,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,191,146,20,25
+Galveston,275,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,70,46,6,18
+Galveston,275,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,9,5,2,2
+Galveston,275,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,196,152,21,23
+Galveston,275,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,72,44,7,21
+Galveston,275,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,203,152,25,26
+Galveston,275,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,34,27,1,6
+Galveston,275,"Member, State Board of Education, District 7",,REP,Matt Robinson,187,144,20,23
+Galveston,275,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",81,52,8,21
+Galveston,275,State Representative,23,REP,Mayes Middleton,192,147,21,24
+Galveston,275,State Representative,23,DEM,Amanda Jamrok,73,49,6,18
+Galveston,275,State Representative,23,LIB,Lawrence Johnson,4,3,1,0
+Galveston,275,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,196,153,18,25
+Galveston,275,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,72,43,10,19
+Galveston,275,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,193,148,19,26
+Galveston,275,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,75,48,9,18
+Galveston,275,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,190,147,20,23
+Galveston,275,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,78,49,8,21
+Galveston,275,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,186,144,19,23
+Galveston,275,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,82,52,9,21
+Galveston,275,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,191,146,20,25
+Galveston,275,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,76,49,8,19
+Galveston,275,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,194,147,22,25
+Galveston,275,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,71,46,6,19
+Galveston,275,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,193,145,21,27
+Galveston,275,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,71,47,7,17
+Galveston,275,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,191,146,20,25
+Galveston,275,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,73,46,8,19
+Galveston,275,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,192,147,20,25
+Galveston,275,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,73,46,8,19
+Galveston,275,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,192,146,22,24
+Galveston,275,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",74,48,6,20
+Galveston,275,"District Judge, 122nd Judicial District",,REP,John Ellisor,210,155,26,29
+Galveston,275,"District Judge, 212th Judicial District",,REP,Patricia Grady,213,158,26,29
+Galveston,275,"District Judge, 306th Judicial District",,REP,Anne B. Darring,212,157,26,29
+Galveston,275,Criminal District Attorney,,REP,Jack Roady,213,158,26,29
+Galveston,275,County Judge,,REP,Mark Henry,211,156,26,29
+Galveston,275,"Judge, County Court-at-Law No. 1",,REP,John Grady,212,158,25,29
+Galveston,275,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,195,148,22,25
+Galveston,275,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,72,47,6,19
+Galveston,275,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,210,156,26,28
+Galveston,275,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,211,156,26,29
+Galveston,275,District Clerk,,REP,John D Kinard,209,155,26,28
+Galveston,275,County Clerk,,REP,Dwight Sullivan,207,153,26,28
+Galveston,275,County Treasurer,,REP,Kevin C. Walsh,212,157,26,29
+Galveston,275,County Commissioner Pct. 2,,REP,Joe Giusti,213,158,26,29
+Galveston,275,Justice of the Peace Pct. 2,,REP,Mike Nelson,210,155,26,29
+Galveston,275,College of the Mainland Proposition A,,,FOR,0,0,0,0
+Galveston,275,College of the Mainland Proposition A,,,AGAINST,0,0,0,0
+Galveston,276,Ballots Cast,,,,1322,886,292,144
+Galveston,276,Straight Party,,REP,Republican,441,304,87,50
+Galveston,276,Straight Party,,DEM,Democrat,302,192,66,44
+Galveston,276,Straight Party,,LIB,Libertarian,5,0,2,3
+Galveston,276,U.S. Senate,,REP,Ted Cruz,688,473,145,70
+Galveston,276,U.S. Senate,,DEM,Beto O'Rourke,618,404,140,74
+Galveston,276,U.S. Senate,,LIB,Neal M. Dikeman,9,6,3,0
+Galveston,276,U.S. House,14,REP,Randy Weber,731,510,149,72
+Galveston,276,U.S. House,14,DEM,Adrienne Bell,553,359,125,69
+Galveston,276,U.S. House,14,LIB,Don E. Conley III,23,10,13,0
+Galveston,276,Governor,,REP,Greg Abbott,760,525,162,73
+Galveston,276,Governor,,DEM,Lupe Valdez,521,336,117,68
+Galveston,276,Governor,,LIB,Mark Jay Tippetts,35,22,11,2
+Galveston,276,Lieutenant Governor,,REP,Dan Patrick,708,483,155,70
+Galveston,276,Lieutenant Governor,,DEM,Mike Collier,566,377,120,69
+Galveston,276,Lieutenant Governor,,LIB,Kerry Douglas McKennon,29,14,12,3
+Galveston,276,Attorney General,,REP,Ken Paxton,683,466,145,72
+Galveston,276,Attorney General,,DEM,Justin Nelson,586,392,125,69
+Galveston,276,Attorney General,,LIB,Michael Ray Harris,30,14,16,0
+Galveston,276,Comptroller of Public Accounts,,REP,Glenn Hegar,709,491,146,72
+Galveston,276,Comptroller of Public Accounts,,DEM,Joi Chevalier,513,335,113,65
+Galveston,276,Comptroller of Public Accounts,,LIB,Ben Sanders,52,31,20,1
+Galveston,276,Commissioner of General Land Office,,REP,George P. Bush,745,512,158,75
+Galveston,276,Commissioner of General Land Office,,DEM,Miguel Suazo,504,339,108,57
+Galveston,276,Commissioner of General Land Office,,LIB,Matt Pina,42,19,18,5
+Galveston,276,Commissioner of Agriculture,,REP,Sid Miller,684,477,138,69
+Galveston,276,Commissioner of Agriculture,,DEM,Kim Olson,564,371,127,66
+Galveston,276,Commissioner of Agriculture,,LIB,Richard Carpenter,33,16,16,1
+Galveston,276,Railroad Commissioner,,REP,Christi Craddick,708,489,149,70
+Galveston,276,Railroad Commissioner,,DEM,Roman McAllen,528,352,111,65
+Galveston,276,Railroad Commissioner,,LIB,Mike Wright,38,17,21,0
+Galveston,276,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,709,490,154,65
+Galveston,276,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,554,363,124,67
+Galveston,276,"Justice, Supreme Court, Place 4",,REP,John Devine,711,490,152,69
+Galveston,276,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,554,362,126,66
+Galveston,276,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,713,491,154,68
+Galveston,276,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,558,365,127,66
+Galveston,276,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,699,485,144,70
+Galveston,276,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,541,354,124,63
+Galveston,276,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,32,16,15,1
+Galveston,276,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,716,492,156,68
+Galveston,276,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,545,357,123,65
+Galveston,276,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,770,528,169,73
+Galveston,276,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,260,177,65,18
+Galveston,276,"Member, State Board of Education, District 7",,REP,Matt Robinson,689,478,149,62
+Galveston,276,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",571,374,130,67
+Galveston,276,State Representative,23,REP,Mayes Middleton,711,500,147,64
+Galveston,276,State Representative,23,DEM,Amanda Jamrok,538,352,121,65
+Galveston,276,State Representative,23,LIB,Lawrence Johnson,41,17,19,5
+Galveston,276,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,723,495,160,68
+Galveston,276,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,535,353,118,64
+Galveston,276,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,701,483,156,62
+Galveston,276,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,556,366,122,68
+Galveston,276,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,704,489,149,66
+Galveston,276,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,550,358,126,66
+Galveston,276,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,692,477,153,62
+Galveston,276,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,569,376,124,69
+Galveston,276,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,721,501,156,64
+Galveston,276,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,536,347,121,68
+Galveston,276,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,703,482,157,64
+Galveston,276,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,550,364,120,66
+Galveston,276,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,711,493,155,63
+Galveston,276,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,542,353,122,67
+Galveston,276,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,711,492,156,63
+Galveston,276,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,540,352,121,67
+Galveston,276,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,697,486,149,62
+Galveston,276,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,554,359,127,68
+Galveston,276,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,702,484,154,64
+Galveston,276,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",550,358,124,68
+Galveston,276,"District Judge, 122nd Judicial District",,REP,John Ellisor,847,580,194,73
+Galveston,276,"District Judge, 212th Judicial District",,REP,Patricia Grady,844,574,196,74
+Galveston,276,"District Judge, 306th Judicial District",,REP,Anne B. Darring,832,566,193,73
+Galveston,276,Criminal District Attorney,,REP,Jack Roady,833,566,191,76
+Galveston,276,County Judge,,REP,Mark Henry,813,553,187,73
+Galveston,276,"Judge, County Court-at-Law No. 1",,REP,John Grady,819,560,188,71
+Galveston,276,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,708,487,158,63
+Galveston,276,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,550,359,122,69
+Galveston,276,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,824,563,190,71
+Galveston,276,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,834,571,192,71
+Galveston,276,District Clerk,,REP,John D Kinard,838,570,193,75
+Galveston,276,County Clerk,,REP,Dwight Sullivan,835,568,192,75
+Galveston,276,County Treasurer,,REP,Kevin C. Walsh,828,566,187,75
+Galveston,276,County Commissioner Pct. 2,,REP,Joe Giusti,850,583,191,76
+Galveston,276,Justice of the Peace Pct. 2,,REP,Mike Nelson,829,565,191,73
+Galveston,276,Commissioner  - GC Navigation Dist 1,,,"Thomas E. ""Ted"" Farmer, Jr.",311,224,60,27
+Galveston,276,Commissioner  - GC Navigation Dist 1,,,Robert Mihovil,127,81,27,19
+Galveston,277,Ballots Cast,,,,1386,1078,226,82
+Galveston,277,Straight Party,,REP,Republican,731,576,103,52
+Galveston,277,Straight Party,,DEM,Democrat,99,73,19,7
+Galveston,277,Straight Party,,LIB,Libertarian,2,1,1,0
+Galveston,277,U.S. Senate,,REP,Ted Cruz,1140,893,182,65
+Galveston,277,U.S. Senate,,DEM,Beto O'Rourke,231,174,40,17
+Galveston,277,U.S. Senate,,LIB,Neal M. Dikeman,5,5,0,0
+Galveston,277,U.S. House,14,REP,Randy Weber,1129,888,177,64
+Galveston,277,U.S. House,14,DEM,Adrienne Bell,217,161,39,17
+Galveston,277,U.S. House,14,LIB,Don E. Conley III,16,11,4,1
+Galveston,277,Governor,,REP,Greg Abbott,1169,914,189,66
+Galveston,277,Governor,,DEM,Lupe Valdez,191,144,32,15
+Galveston,277,Governor,,LIB,Mark Jay Tippetts,13,10,2,1
+Galveston,277,Lieutenant Governor,,REP,Dan Patrick,1125,883,177,65
+Galveston,277,Lieutenant Governor,,DEM,Mike Collier,222,170,36,16
+Galveston,277,Lieutenant Governor,,LIB,Kerry Douglas McKennon,14,8,5,1
+Galveston,277,Attorney General,,REP,Ken Paxton,1089,857,169,63
+Galveston,277,Attorney General,,DEM,Justin Nelson,234,175,42,17
+Galveston,277,Attorney General,,LIB,Michael Ray Harris,26,18,7,1
+Galveston,277,Comptroller of Public Accounts,,REP,Glenn Hegar,1107,876,168,63
+Galveston,277,Comptroller of Public Accounts,,DEM,Joi Chevalier,198,145,36,17
+Galveston,277,Comptroller of Public Accounts,,LIB,Ben Sanders,33,24,8,1
+Galveston,277,Commissioner of General Land Office,,REP,George P. Bush,1111,875,173,63
+Galveston,277,Commissioner of General Land Office,,DEM,Miguel Suazo,206,153,38,15
+Galveston,277,Commissioner of General Land Office,,LIB,Matt Pina,38,28,7,3
+Galveston,277,Commissioner of Agriculture,,REP,Sid Miller,1088,861,167,60
+Galveston,277,Commissioner of Agriculture,,DEM,Kim Olson,235,172,43,20
+Galveston,277,Commissioner of Agriculture,,LIB,Richard Carpenter,21,16,4,1
+Galveston,277,Railroad Commissioner,,REP,Christi Craddick,1114,879,173,62
+Galveston,277,Railroad Commissioner,,DEM,Roman McAllen,201,147,36,18
+Galveston,277,Railroad Commissioner,,LIB,Mike Wright,30,21,8,1
+Galveston,277,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1120,878,180,62
+Galveston,277,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,222,168,37,17
+Galveston,277,"Justice, Supreme Court, Place 4",,REP,John Devine,1117,881,174,62
+Galveston,277,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,223,163,42,18
+Galveston,277,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1122,879,176,67
+Galveston,277,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,217,164,40,13
+Galveston,277,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1109,870,176,63
+Galveston,277,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,215,162,36,17
+Galveston,277,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,20,17,3,0
+Galveston,277,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1132,889,179,64
+Galveston,277,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,207,154,37,16
+Galveston,277,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1169,911,189,69
+Galveston,277,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,111,91,16,4
+Galveston,277,"Member, State Board of Education, District 7",,REP,Matt Robinson,1109,872,174,63
+Galveston,277,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",227,168,42,17
+Galveston,277,State Representative,24,REP,Greg Bonnen,1118,878,179,61
+Galveston,277,State Representative,24,DEM,John Y. Phelps,212,159,35,18
+Galveston,277,State Representative,24,LIB,Dick Illyes,14,7,6,1
+Galveston,277,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,1121,878,179,64
+Galveston,277,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,209,155,38,16
+Galveston,277,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,1109,868,178,63
+Galveston,277,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,219,163,39,17
+Galveston,277,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,1113,871,178,64
+Galveston,277,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,215,161,38,16
+Galveston,277,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,1113,873,177,63
+Galveston,277,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,218,161,40,17
+Galveston,277,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,1117,876,177,64
+Galveston,277,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,214,159,38,17
+Galveston,277,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,1116,878,174,64
+Galveston,277,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,210,155,40,15
+Galveston,277,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,1115,877,175,63
+Galveston,277,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,208,154,38,16
+Galveston,277,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,1107,873,171,63
+Galveston,277,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,217,159,41,17
+Galveston,277,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,1110,873,173,64
+Galveston,277,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,216,161,39,16
+Galveston,277,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,1102,866,172,64
+Galveston,277,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",223,166,41,16
+Galveston,277,"District Judge, 122nd Judicial District",,REP,John Ellisor,1179,921,187,71
+Galveston,277,"District Judge, 212th Judicial District",,REP,Patricia Grady,1186,929,186,71
+Galveston,277,"District Judge, 306th Judicial District",,REP,Anne B. Darring,1183,925,187,71
+Galveston,277,Criminal District Attorney,,REP,Jack Roady,1196,934,191,71
+Galveston,277,County Judge,,REP,Mark Henry,1163,903,189,71
+Galveston,277,"Judge, County Court-at-Law No. 1",,REP,John Grady,1179,919,190,70
+Galveston,277,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,1119,880,175,64
+Galveston,277,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,212,155,39,18
+Galveston,277,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,1178,919,188,71
+Galveston,277,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,1177,919,188,70
+Galveston,277,District Clerk,,REP,John D Kinard,1178,919,189,70
+Galveston,277,County Clerk,,REP,Dwight Sullivan,1169,911,187,71
+Galveston,277,County Treasurer,,REP,Kevin C. Walsh,1168,910,188,70
+Galveston,277,County Commissioner Pct. 2,,REP,Joe Giusti,1195,932,193,70
+Galveston,277,Justice of the Peace Pct. 2,,REP,Mike Nelson,1216,948,196,72
+Galveston,277,College of the Mainland Proposition A,,,FOR,588,456,109,23
+Galveston,277,College of the Mainland Proposition A,,,AGAINST,518,402,77,39
+Galveston,277,Trustee Position 4  - SFISD,,,Clay Hertenberger,294,212,61,21
+Galveston,277,Trustee Position 4  - SFISD,,,Donna Hayes,103,76,21,6
+Galveston,277,Trustee Position 4  - SFISD,,,John Rothermel,351,283,49,19
+Galveston,277,Trustee Position 4  - SFISD,,,Jessica Hagewood,258,211,36,11
+Galveston,277,Trustee Position 5  - SFISD,,,James Grassmuck,332,256,57,19
+Galveston,277,Trustee Position 5  - SFISD,,,Sheryl Skufca,331,261,51,19
+Galveston,277,Trustee Position 5  - SFISD,,,Tina Longcoy,149,120,23,6
+Galveston,277,Trustee Position 5  - SFISD,,,Jody Davis,161,119,32,10
+Galveston,277,Trustee Position 6  - SFISD,,,Rusty Norman,845,662,146,37
+Galveston,278,Ballots Cast,,,,1546,1168,289,89
+Galveston,278,Straight Party,,REP,Republican,787,594,162,31
+Galveston,278,Straight Party,,DEM,Democrat,127,76,23,28
+Galveston,278,Straight Party,,LIB,Libertarian,1,0,1,0
+Galveston,278,U.S. Senate,,REP,Ted Cruz,1243,966,229,48
+Galveston,278,U.S. Senate,,DEM,Beto O'Rourke,279,186,52,41
+Galveston,278,U.S. Senate,,LIB,Neal M. Dikeman,11,8,3,0
+Galveston,278,U.S. House,14,REP,Randy Weber,1245,964,232,49
+Galveston,278,U.S. House,14,DEM,Adrienne Bell,263,179,44,40
+Galveston,278,U.S. House,14,LIB,Don E. Conley III,17,12,5,0
+Galveston,278,Governor,,REP,Greg Abbott,1298,996,248,54
+Galveston,278,Governor,,DEM,Lupe Valdez,219,152,32,35
+Galveston,278,Governor,,LIB,Mark Jay Tippetts,17,11,6,0
+Galveston,278,Lieutenant Governor,,REP,Dan Patrick,1236,955,233,48
+Galveston,278,Lieutenant Governor,,DEM,Mike Collier,277,187,49,41
+Galveston,278,Lieutenant Governor,,LIB,Kerry Douglas McKennon,20,17,3,0
+Galveston,278,Attorney General,,REP,Ken Paxton,1207,938,222,47
+Galveston,278,Attorney General,,DEM,Justin Nelson,301,205,54,42
+Galveston,278,Attorney General,,LIB,Michael Ray Harris,21,13,8,0
+Galveston,278,Comptroller of Public Accounts,,REP,Glenn Hegar,1219,945,228,46
+Galveston,278,Comptroller of Public Accounts,,DEM,Joi Chevalier,259,171,47,41
+Galveston,278,Comptroller of Public Accounts,,LIB,Ben Sanders,35,27,7,1
+Galveston,278,Commissioner of General Land Office,,REP,George P. Bush,1216,936,233,47
+Galveston,278,Commissioner of General Land Office,,DEM,Miguel Suazo,259,176,43,40
+Galveston,278,Commissioner of General Land Office,,LIB,Matt Pina,49,42,7,0
+Galveston,278,Commissioner of Agriculture,,REP,Sid Miller,1196,931,219,46
+Galveston,278,Commissioner of Agriculture,,DEM,Kim Olson,299,205,51,43
+Galveston,278,Commissioner of Agriculture,,LIB,Richard Carpenter,24,15,9,0
+Galveston,278,Railroad Commissioner,,REP,Christi Craddick,1223,945,232,46
+Galveston,278,Railroad Commissioner,,DEM,Roman McAllen,257,175,40,42
+Galveston,278,Railroad Commissioner,,LIB,Mike Wright,38,28,9,1
+Galveston,278,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1233,955,231,47
+Galveston,278,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,277,188,49,40
+Galveston,278,"Justice, Supreme Court, Place 4",,REP,John Devine,1237,961,229,47
+Galveston,278,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,268,178,48,42
+Galveston,278,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1234,954,233,47
+Galveston,278,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,269,182,45,42
+Galveston,278,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1229,953,230,46
+Galveston,278,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,256,171,43,42
+Galveston,278,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,23,16,6,1
+Galveston,278,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1248,968,232,48
+Galveston,278,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,259,173,45,41
+Galveston,278,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1282,984,242,56
+Galveston,278,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,131,94,25,12
+Galveston,278,"Member, State Board of Education, District 7",,REP,Matt Robinson,1229,956,228,45
+Galveston,278,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",280,186,51,43
+Galveston,278,State Representative,24,REP,Greg Bonnen,1236,956,232,48
+Galveston,278,State Representative,24,DEM,John Y. Phelps,259,175,44,40
+Galveston,278,State Representative,24,LIB,Dick Illyes,19,14,5,0
+Galveston,278,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,1236,959,231,46
+Galveston,278,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,270,180,48,42
+Galveston,278,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,1223,950,226,47
+Galveston,278,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,282,189,52,41
+Galveston,278,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,1233,958,229,46
+Galveston,278,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,268,179,47,42
+Galveston,278,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,1218,948,224,46
+Galveston,278,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,283,188,53,42
+Galveston,278,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,1228,950,232,46
+Galveston,278,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,273,184,46,43
+Galveston,278,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,1231,956,229,46
+Galveston,278,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,268,180,47,41
+Galveston,278,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,1234,954,233,47
+Galveston,278,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,266,181,44,41
+Galveston,278,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,1233,954,233,46
+Galveston,278,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,264,179,43,42
+Galveston,278,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,1225,948,230,47
+Galveston,278,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,276,186,48,42
+Galveston,278,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,1220,944,230,46
+Galveston,278,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",278,188,48,42
+Galveston,278,"District Judge, 122nd Judicial District",,REP,John Ellisor,1312,1013,246,53
+Galveston,278,"District Judge, 212th Judicial District",,REP,Patricia Grady,1308,1007,246,55
+Galveston,278,"District Judge, 306th Judicial District",,REP,Anne B. Darring,1312,1011,247,54
+Galveston,278,Criminal District Attorney,,REP,Jack Roady,1313,1009,248,56
+Galveston,278,County Judge,,REP,Mark Henry,1293,994,244,55
+Galveston,278,"Judge, County Court-at-Law No. 1",,REP,John Grady,1302,1002,245,55
+Galveston,278,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,1221,946,229,46
+Galveston,278,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,282,188,52,42
+Galveston,278,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,1312,1008,248,56
+Galveston,278,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,1313,1010,247,56
+Galveston,278,District Clerk,,REP,John D Kinard,1311,1009,245,57
+Galveston,278,County Clerk,,REP,Dwight Sullivan,1311,1011,244,56
+Galveston,278,County Treasurer,,REP,Kevin C. Walsh,1305,1009,243,53
+Galveston,278,County Commissioner Pct. 2,,REP,Joe Giusti,1320,1018,245,57
+Galveston,278,Justice of the Peace Pct. 2,,REP,Mike Nelson,1330,1021,251,58
+Galveston,278,College of the Mainland Proposition A,,,FOR,650,485,120,45
+Galveston,278,College of the Mainland Proposition A,,,AGAINST,595,461,102,32
+Galveston,278,Trustee Position 4  - SFISD,,,Clay Hertenberger,392,296,73,23
+Galveston,278,Trustee Position 4  - SFISD,,,Donna Hayes,119,91,20,8
+Galveston,278,Trustee Position 4  - SFISD,,,John Rothermel,303,225,53,25
+Galveston,278,Trustee Position 4  - SFISD,,,Jessica Hagewood,275,216,44,15
+Galveston,278,Trustee Position 5  - SFISD,,,James Grassmuck,382,300,54,28
+Galveston,278,Trustee Position 5  - SFISD,,,Sheryl Skufca,318,235,64,19
+Galveston,278,Trustee Position 5  - SFISD,,,Tina Longcoy,213,162,40,11
+Galveston,278,Trustee Position 5  - SFISD,,,Jody Davis,180,134,37,9
+Galveston,278,Trustee Position 6  - SFISD,,,Rusty Norman,948,722,167,59
+Galveston,279,Ballots Cast,,,,690,511,137,42
+Galveston,279,Straight Party,,REP,Republican,364,267,74,23
+Galveston,279,Straight Party,,DEM,Democrat,61,37,15,9
+Galveston,279,Straight Party,,LIB,Libertarian,0,0,0,0
+Galveston,279,U.S. Senate,,REP,Ted Cruz,569,426,112,31
+Galveston,279,U.S. Senate,,DEM,Beto O'Rourke,108,74,24,10
+Galveston,279,U.S. Senate,,LIB,Neal M. Dikeman,7,6,0,1
+Galveston,279,U.S. House,14,REP,Randy Weber,559,422,109,28
+Galveston,279,U.S. House,14,DEM,Adrienne Bell,110,74,23,13
+Galveston,279,U.S. House,14,LIB,Don E. Conley III,13,8,4,1
+Galveston,279,Governor,,REP,Greg Abbott,581,436,115,30
+Galveston,279,Governor,,DEM,Lupe Valdez,96,64,21,11
+Galveston,279,Governor,,LIB,Mark Jay Tippetts,9,7,1,1
+Galveston,279,Lieutenant Governor,,REP,Dan Patrick,559,420,111,28
+Galveston,279,Lieutenant Governor,,DEM,Mike Collier,110,76,21,13
+Galveston,279,Lieutenant Governor,,LIB,Kerry Douglas McKennon,16,10,5,1
+Galveston,279,Attorney General,,REP,Ken Paxton,550,412,111,27
+Galveston,279,Attorney General,,DEM,Justin Nelson,115,81,21,13
+Galveston,279,Attorney General,,LIB,Michael Ray Harris,20,13,5,2
+Galveston,279,Comptroller of Public Accounts,,REP,Glenn Hegar,551,415,108,28
+Galveston,279,Comptroller of Public Accounts,,DEM,Joi Chevalier,101,66,22,13
+Galveston,279,Comptroller of Public Accounts,,LIB,Ben Sanders,25,18,6,1
+Galveston,279,Commissioner of General Land Office,,REP,George P. Bush,546,411,105,30
+Galveston,279,Commissioner of General Land Office,,DEM,Miguel Suazo,109,76,22,11
+Galveston,279,Commissioner of General Land Office,,LIB,Matt Pina,27,17,9,1
+Galveston,279,Commissioner of Agriculture,,REP,Sid Miller,550,416,108,26
+Galveston,279,Commissioner of Agriculture,,DEM,Kim Olson,109,73,23,13
+Galveston,279,Commissioner of Agriculture,,LIB,Richard Carpenter,19,11,5,3
+Galveston,279,Railroad Commissioner,,REP,Christi Craddick,551,417,106,28
+Galveston,279,Railroad Commissioner,,DEM,Roman McAllen,102,69,22,11
+Galveston,279,Railroad Commissioner,,LIB,Mike Wright,27,16,8,3
+Galveston,279,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,562,424,111,27
+Galveston,279,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,118,78,25,15
+Galveston,279,"Justice, Supreme Court, Place 4",,REP,John Devine,564,423,112,29
+Galveston,279,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,113,76,24,13
+Galveston,279,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,564,424,111,29
+Galveston,279,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,114,76,25,13
+Galveston,279,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,559,419,111,29
+Galveston,279,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,106,73,22,11
+Galveston,279,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,14,9,3,2
+Galveston,279,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,566,423,114,29
+Galveston,279,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,111,77,21,13
+Galveston,279,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,569,426,113,30
+Galveston,279,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,65,51,11,3
+Galveston,279,"Member, State Board of Education, District 7",,REP,Matt Robinson,562,423,112,27
+Galveston,279,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",113,75,24,14
+Galveston,279,State Representative,24,REP,Greg Bonnen,552,416,110,26
+Galveston,279,State Representative,24,DEM,John Y. Phelps,110,73,24,13
+Galveston,279,State Representative,24,LIB,Dick Illyes,16,12,3,1
+Galveston,279,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,564,426,111,27
+Galveston,279,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,112,73,25,14
+Galveston,279,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,560,424,111,25
+Galveston,279,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,116,76,25,15
+Galveston,279,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,566,426,114,26
+Galveston,279,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,111,75,22,14
+Galveston,279,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,564,427,111,26
+Galveston,279,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,112,74,24,14
+Galveston,279,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,572,430,115,27
+Galveston,279,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,106,72,21,13
+Galveston,279,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,560,421,112,27
+Galveston,279,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,110,76,21,13
+Galveston,279,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,563,423,114,26
+Galveston,279,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,107,73,20,14
+Galveston,279,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,566,425,114,27
+Galveston,279,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,105,71,20,14
+Galveston,279,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,561,423,113,25
+Galveston,279,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,111,74,21,16
+Galveston,279,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,562,424,113,25
+Galveston,279,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",108,72,21,15
+Galveston,279,"District Judge, 122nd Judicial District",,REP,John Ellisor,582,437,119,26
+Galveston,279,"District Judge, 212th Judicial District",,REP,Patricia Grady,584,440,118,26
+Galveston,279,"District Judge, 306th Judicial District",,REP,Anne B. Darring,585,441,118,26
+Galveston,279,Criminal District Attorney,,REP,Jack Roady,585,439,119,27
+Galveston,279,County Judge,,REP,Mark Henry,585,436,118,31
+Galveston,279,"Judge, County Court-at-Law No. 1",,REP,John Grady,580,436,116,28
+Galveston,279,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,566,426,112,28
+Galveston,279,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,108,74,22,12
+Galveston,279,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,587,440,118,29
+Galveston,279,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,587,438,120,29
+Galveston,279,District Clerk,,REP,John D Kinard,582,436,118,28
+Galveston,279,County Clerk,,REP,Dwight Sullivan,585,437,119,29
+Galveston,279,County Treasurer,,REP,Kevin C. Walsh,583,437,117,29
+Galveston,279,County Commissioner Pct. 2,,REP,Joe Giusti,587,440,119,28
+Galveston,279,Justice of the Peace Pct. 2,,REP,Mike Nelson,595,445,119,31
+Galveston,279,College of the Mainland Proposition A,,,FOR,256,192,52,12
+Galveston,279,College of the Mainland Proposition A,,,AGAINST,291,218,50,23
+Galveston,279,Trustee Position 4  - SFISD,,,Clay Hertenberger,191,148,34,9
+Galveston,279,Trustee Position 4  - SFISD,,,Donna Hayes,57,43,10,4
+Galveston,279,Trustee Position 4  - SFISD,,,John Rothermel,111,85,18,8
+Galveston,279,Trustee Position 4  - SFISD,,,Jessica Hagewood,115,82,28,5
+Galveston,279,Trustee Position 5  - SFISD,,,James Grassmuck,173,132,32,9
+Galveston,279,Trustee Position 5  - SFISD,,,Sheryl Skufca,139,103,29,7
+Galveston,279,Trustee Position 5  - SFISD,,,Tina Longcoy,71,56,10,5
+Galveston,279,Trustee Position 5  - SFISD,,,Jody Davis,89,68,17,4
+Galveston,279,Trustee Position 6  - SFISD,,,Rusty Norman,406,304,81,21
+Galveston,280,Ballots Cast,,,,265,177,74,14
+Galveston,280,Straight Party,,REP,Republican,86,60,23,3
+Galveston,280,Straight Party,,DEM,Democrat,68,44,21,3
+Galveston,280,Straight Party,,LIB,Libertarian,2,0,0,2
+Galveston,280,U.S. Senate,,REP,Ted Cruz,141,98,35,8
+Galveston,280,U.S. Senate,,DEM,Beto O'Rourke,120,76,38,6
+Galveston,280,U.S. Senate,,LIB,Neal M. Dikeman,1,1,0,0
+Galveston,280,U.S. House,14,REP,Randy Weber,150,103,39,8
+Galveston,280,U.S. House,14,DEM,Adrienne Bell,110,71,33,6
+Galveston,280,U.S. House,14,LIB,Don E. Conley III,1,0,1,0
+Galveston,280,Governor,,REP,Greg Abbott,156,106,42,8
+Galveston,280,Governor,,DEM,Lupe Valdez,101,68,27,6
+Galveston,280,Governor,,LIB,Mark Jay Tippetts,5,2,3,0
+Galveston,280,Lieutenant Governor,,REP,Dan Patrick,142,96,38,8
+Galveston,280,Lieutenant Governor,,DEM,Mike Collier,115,76,33,6
+Galveston,280,Lieutenant Governor,,LIB,Kerry Douglas McKennon,4,3,1,0
+Galveston,280,Attorney General,,REP,Ken Paxton,141,96,37,8
+Galveston,280,Attorney General,,DEM,Justin Nelson,114,75,33,6
+Galveston,280,Attorney General,,LIB,Michael Ray Harris,4,3,1,0
+Galveston,280,Comptroller of Public Accounts,,REP,Glenn Hegar,146,97,41,8
+Galveston,280,Comptroller of Public Accounts,,DEM,Joi Chevalier,102,68,28,6
+Galveston,280,Comptroller of Public Accounts,,LIB,Ben Sanders,9,6,3,0
+Galveston,280,Commissioner of General Land Office,,REP,George P. Bush,149,102,41,6
+Galveston,280,Commissioner of General Land Office,,DEM,Miguel Suazo,108,70,30,8
+Galveston,280,Commissioner of General Land Office,,LIB,Matt Pina,4,3,1,0
+Galveston,280,Commissioner of Agriculture,,REP,Sid Miller,145,97,40,8
+Galveston,280,Commissioner of Agriculture,,DEM,Kim Olson,109,72,31,6
+Galveston,280,Commissioner of Agriculture,,LIB,Richard Carpenter,3,2,1,0
+Galveston,280,Railroad Commissioner,,REP,Christi Craddick,152,103,42,7
+Galveston,280,Railroad Commissioner,,DEM,Roman McAllen,104,70,28,6
+Galveston,280,Railroad Commissioner,,LIB,Mike Wright,3,1,2,0
+Galveston,280,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,147,99,41,7
+Galveston,280,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,111,73,32,6
+Galveston,280,"Justice, Supreme Court, Place 4",,REP,John Devine,145,97,41,7
+Galveston,280,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,113,75,32,6
+Galveston,280,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,144,97,40,7
+Galveston,280,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,113,74,33,6
+Galveston,280,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,145,97,40,8
+Galveston,280,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,111,74,31,6
+Galveston,280,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,3,1,2,0
+Galveston,280,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,149,99,42,8
+Galveston,280,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,108,72,30,6
+Galveston,280,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,163,109,45,9
+Galveston,280,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,55,39,14,2
+Galveston,280,"Member, State Board of Education, District 7",,REP,Matt Robinson,146,100,41,5
+Galveston,280,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",111,73,32,6
+Galveston,280,State Representative,24,REP,Greg Bonnen,146,101,40,5
+Galveston,280,State Representative,24,DEM,John Y. Phelps,109,72,31,6
+Galveston,280,State Representative,24,LIB,Dick Illyes,5,1,2,2
+Galveston,280,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,144,98,41,5
+Galveston,280,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,112,73,31,8
+Galveston,280,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,143,97,41,5
+Galveston,280,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,111,74,31,6
+Galveston,280,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,143,97,41,5
+Galveston,280,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,111,74,31,6
+Galveston,280,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,143,97,41,5
+Galveston,280,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,111,74,31,6
+Galveston,280,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,145,99,41,5
+Galveston,280,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,108,72,31,5
+Galveston,280,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,145,99,41,5
+Galveston,280,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,110,72,31,7
+Galveston,280,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,146,100,41,5
+Galveston,280,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,108,71,31,6
+Galveston,280,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,145,99,41,5
+Galveston,280,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,109,72,31,6
+Galveston,280,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,142,96,42,4
+Galveston,280,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,112,75,30,7
+Galveston,280,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,144,97,41,6
+Galveston,280,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",111,74,31,6
+Galveston,280,"District Judge, 122nd Judicial District",,REP,John Ellisor,171,118,49,4
+Galveston,280,"District Judge, 212th Judicial District",,REP,Patricia Grady,174,119,50,5
+Galveston,280,"District Judge, 306th Judicial District",,REP,Anne B. Darring,174,118,50,6
+Galveston,280,Criminal District Attorney,,REP,Jack Roady,175,119,49,7
+Galveston,280,County Judge,,REP,Mark Henry,174,118,50,6
+Galveston,280,"Judge, County Court-at-Law No. 1",,REP,John Grady,169,116,48,5
+Galveston,280,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,143,99,39,5
+Galveston,280,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,114,75,33,6
+Galveston,280,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,168,115,48,5
+Galveston,280,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,172,118,49,5
+Galveston,280,District Clerk,,REP,John D Kinard,173,118,49,6
+Galveston,280,County Clerk,,REP,Dwight Sullivan,177,120,50,7
+Galveston,280,County Treasurer,,REP,Kevin C. Walsh,172,118,48,6
+Galveston,280,County Commissioner Pct. 2,,REP,Joe Giusti,176,122,49,5
+Galveston,280,Justice of the Peace Pct. 2,,REP,Mike Nelson,171,117,49,5
+Galveston,280,College of the Mainland Proposition A,,,FOR,125,86,36,3
+Galveston,280,College of the Mainland Proposition A,,,AGAINST,87,58,20,9
+Galveston,281,Ballots Cast,,,,115,94,12,9
+Galveston,281,Straight Party,,REP,Republican,62,52,4,6
+Galveston,281,Straight Party,,DEM,Democrat,9,6,2,1
+Galveston,281,Straight Party,,LIB,Libertarian,0,0,0,0
+Galveston,281,U.S. Senate,,REP,Ted Cruz,87,70,9,8
+Galveston,281,U.S. Senate,,DEM,Beto O'Rourke,27,24,2,1
+Galveston,281,U.S. Senate,,LIB,Neal M. Dikeman,1,0,1,0
+Galveston,281,U.S. House,14,REP,Randy Weber,85,69,9,7
+Galveston,281,U.S. House,14,DEM,Adrienne Bell,30,25,3,2
+Galveston,281,U.S. House,14,LIB,Don E. Conley III,0,0,0,0
+Galveston,281,Governor,,REP,Greg Abbott,92,75,9,8
+Galveston,281,Governor,,DEM,Lupe Valdez,22,18,3,1
+Galveston,281,Governor,,LIB,Mark Jay Tippetts,1,1,0,0
+Galveston,281,Lieutenant Governor,,REP,Dan Patrick,82,69,7,6
+Galveston,281,Lieutenant Governor,,DEM,Mike Collier,30,23,4,3
+Galveston,281,Lieutenant Governor,,LIB,Kerry Douglas McKennon,2,1,1,0
+Galveston,281,Attorney General,,REP,Ken Paxton,77,64,7,6
+Galveston,281,Attorney General,,DEM,Justin Nelson,34,27,4,3
+Galveston,281,Attorney General,,LIB,Michael Ray Harris,2,1,1,0
+Galveston,281,Comptroller of Public Accounts,,REP,Glenn Hegar,84,71,7,6
+Galveston,281,Comptroller of Public Accounts,,DEM,Joi Chevalier,28,22,3,3
+Galveston,281,Comptroller of Public Accounts,,LIB,Ben Sanders,3,1,2,0
+Galveston,281,Commissioner of General Land Office,,REP,George P. Bush,86,70,8,8
+Galveston,281,Commissioner of General Land Office,,DEM,Miguel Suazo,23,20,2,1
+Galveston,281,Commissioner of General Land Office,,LIB,Matt Pina,5,3,2,0
+Galveston,281,Commissioner of Agriculture,,REP,Sid Miller,78,65,6,7
+Galveston,281,Commissioner of Agriculture,,DEM,Kim Olson,35,28,5,2
+Galveston,281,Commissioner of Agriculture,,LIB,Richard Carpenter,1,0,1,0
+Galveston,281,Railroad Commissioner,,REP,Christi Craddick,84,69,9,6
+Galveston,281,Railroad Commissioner,,DEM,Roman McAllen,28,23,2,3
+Galveston,281,Railroad Commissioner,,LIB,Mike Wright,3,2,1,0
+Galveston,281,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,84,68,10,6
+Galveston,281,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,30,25,2,3
+Galveston,281,"Justice, Supreme Court, Place 4",,REP,John Devine,83,68,8,7
+Galveston,281,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,30,24,4,2
+Galveston,281,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,83,68,9,6
+Galveston,281,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,30,24,3,3
+Galveston,281,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,84,70,7,7
+Galveston,281,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,29,23,4,2
+Galveston,281,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,1,0,1,0
+Galveston,281,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,83,67,9,7
+Galveston,281,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,30,25,3,2
+Galveston,281,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,89,74,8,7
+Galveston,281,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,16,14,2,0
+Galveston,281,"Member, State Board of Education, District 7",,REP,Matt Robinson,82,66,9,7
+Galveston,281,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",31,26,3,2
+Galveston,281,State Representative,24,REP,Greg Bonnen,87,72,9,6
+Galveston,281,State Representative,24,DEM,John Y. Phelps,28,22,3,3
+Galveston,281,State Representative,24,LIB,Dick Illyes,0,0,0,0
+Galveston,281,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,87,73,8,6
+Galveston,281,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,26,20,4,2
+Galveston,281,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,83,68,9,6
+Galveston,281,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,30,24,3,3
+Galveston,281,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,84,68,9,7
+Galveston,281,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,29,24,3,2
+Galveston,281,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,83,69,8,6
+Galveston,281,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,31,24,4,3
+Galveston,281,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,87,71,9,7
+Galveston,281,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,27,22,3,2
+Galveston,281,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,85,70,9,6
+Galveston,281,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,28,22,3,3
+Galveston,281,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,84,69,9,6
+Galveston,281,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,30,24,3,3
+Galveston,281,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,84,69,8,7
+Galveston,281,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,30,24,4,2
+Galveston,281,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,84,68,9,7
+Galveston,281,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,29,24,3,2
+Galveston,281,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,86,70,9,7
+Galveston,281,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",28,23,3,2
+Galveston,281,"District Judge, 122nd Judicial District",,REP,John Ellisor,92,77,9,6
+Galveston,281,"District Judge, 212th Judicial District",,REP,Patricia Grady,93,78,9,6
+Galveston,281,"District Judge, 306th Judicial District",,REP,Anne B. Darring,91,76,9,6
+Galveston,281,Criminal District Attorney,,REP,Jack Roady,92,77,9,6
+Galveston,281,County Judge,,REP,Mark Henry,90,73,9,8
+Galveston,281,"Judge, County Court-at-Law No. 1",,REP,John Grady,91,75,9,7
+Galveston,281,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,83,68,9,6
+Galveston,281,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,31,25,3,3
+Galveston,281,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,89,74,9,6
+Galveston,281,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,92,76,9,7
+Galveston,281,District Clerk,,REP,John D Kinard,90,75,9,6
+Galveston,281,County Clerk,,REP,Dwight Sullivan,90,74,9,7
+Galveston,281,County Treasurer,,REP,Kevin C. Walsh,90,75,9,6
+Galveston,281,County Commissioner Pct. 2,,REP,Joe Giusti,92,75,9,8
+Galveston,281,Justice of the Peace Pct. 2,,REP,Mike Nelson,91,75,9,7
+Galveston,281,College of the Mainland Proposition A,,,FOR,58,46,6,6
+Galveston,281,College of the Mainland Proposition A,,,AGAINST,28,24,4,0
+Galveston,283,Ballots Cast,,,,1877,1367,425,85
+Galveston,283,Straight Party,,REP,Republican,769,555,184,30
+Galveston,283,Straight Party,,DEM,Democrat,379,278,80,21
+Galveston,283,Straight Party,,LIB,Libertarian,11,4,5,2
+Galveston,283,U.S. Senate,,REP,Ted Cruz,1129,833,257,39
+Galveston,283,U.S. Senate,,DEM,Beto O'Rourke,723,515,164,44
+Galveston,283,U.S. Senate,,LIB,Neal M. Dikeman,12,8,2,2
+Galveston,283,U.S. House,14,REP,Randy Weber,1150,845,267,38
+Galveston,283,U.S. House,14,DEM,Adrienne Bell,674,486,146,42
+Galveston,283,U.S. House,14,LIB,Don E. Conley III,32,22,9,1
+Galveston,283,Governor,,REP,Greg Abbott,1197,875,280,42
+Galveston,283,Governor,,DEM,Lupe Valdez,628,455,131,42
+Galveston,283,Governor,,LIB,Mark Jay Tippetts,38,25,12,1
+Galveston,283,Lieutenant Governor,,REP,Dan Patrick,1110,817,256,37
+Galveston,283,Lieutenant Governor,,DEM,Mike Collier,706,508,153,45
+Galveston,283,Lieutenant Governor,,LIB,Kerry Douglas McKennon,37,24,12,1
+Galveston,283,Attorney General,,REP,Ken Paxton,1097,807,254,36
+Galveston,283,Attorney General,,DEM,Justin Nelson,705,511,148,46
+Galveston,283,Attorney General,,LIB,Michael Ray Harris,43,26,16,1
+Galveston,283,Comptroller of Public Accounts,,REP,Glenn Hegar,1137,839,258,40
+Galveston,283,Comptroller of Public Accounts,,DEM,Joi Chevalier,632,460,133,39
+Galveston,283,Comptroller of Public Accounts,,LIB,Ben Sanders,64,40,21,3
+Galveston,283,Commissioner of General Land Office,,REP,George P. Bush,1135,834,264,37
+Galveston,283,Commissioner of General Land Office,,DEM,Miguel Suazo,637,464,131,42
+Galveston,283,Commissioner of General Land Office,,LIB,Matt Pina,68,46,19,3
+Galveston,283,Commissioner of Agriculture,,REP,Sid Miller,1090,803,251,36
+Galveston,283,Commissioner of Agriculture,,DEM,Kim Olson,700,508,150,42
+Galveston,283,Commissioner of Agriculture,,LIB,Richard Carpenter,41,24,13,4
+Galveston,283,Railroad Commissioner,,REP,Christi Craddick,1142,840,260,42
+Galveston,283,Railroad Commissioner,,DEM,Roman McAllen,622,453,131,38
+Galveston,283,Railroad Commissioner,,LIB,Mike Wright,66,43,21,2
+Galveston,283,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1150,842,267,41
+Galveston,283,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,686,499,147,40
+Galveston,283,"Justice, Supreme Court, Place 4",,REP,John Devine,1159,852,268,39
+Galveston,283,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,677,489,146,42
+Galveston,283,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1168,860,267,41
+Galveston,283,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,666,476,149,41
+Galveston,283,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1127,831,258,38
+Galveston,283,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,666,483,141,42
+Galveston,283,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,43,23,18,2
+Galveston,283,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1164,853,271,40
+Galveston,283,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,661,477,143,41
+Galveston,283,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1235,908,287,40
+Galveston,283,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,338,243,75,20
+Galveston,283,"Member, State Board of Education, District 7",,REP,Matt Robinson,1133,835,261,37
+Galveston,283,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",693,500,153,40
+Galveston,283,State Representative,24,REP,Greg Bonnen,1139,841,263,35
+Galveston,283,State Representative,24,DEM,John Y. Phelps,662,481,142,39
+Galveston,283,State Representative,24,LIB,Dick Illyes,37,23,10,4
+Galveston,283,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,1174,861,274,39
+Galveston,283,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,655,475,139,41
+Galveston,283,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,1143,840,265,38
+Galveston,283,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,679,491,149,39
+Galveston,283,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,1147,846,264,37
+Galveston,283,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,680,489,150,41
+Galveston,283,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,1138,838,263,37
+Galveston,283,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,687,497,148,42
+Galveston,283,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,1162,855,270,37
+Galveston,283,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,663,479,142,42
+Galveston,283,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,1165,855,271,39
+Galveston,283,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,652,477,137,38
+Galveston,283,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,1149,845,265,39
+Galveston,283,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,670,487,143,40
+Galveston,283,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,1155,850,266,39
+Galveston,283,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,662,480,144,38
+Galveston,283,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,1136,834,262,40
+Galveston,283,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,683,496,148,39
+Galveston,283,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,1149,844,266,39
+Galveston,283,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",667,485,144,38
+Galveston,283,"District Judge, 122nd Judicial District",,REP,John Ellisor,1328,976,310,42
+Galveston,283,"District Judge, 212th Judicial District",,REP,Patricia Grady,1326,975,311,40
+Galveston,283,"District Judge, 306th Judicial District",,REP,Anne B. Darring,1324,971,312,41
+Galveston,283,Criminal District Attorney,,REP,Jack Roady,1315,965,308,42
+Galveston,283,County Judge,,REP,Mark Henry,1315,965,308,42
+Galveston,283,"Judge, County Court-at-Law No. 1",,REP,John Grady,1300,955,305,40
+Galveston,283,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,1147,840,268,39
+Galveston,283,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,665,488,140,37
+Galveston,283,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,1313,964,307,42
+Galveston,283,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,1317,965,310,42
+Galveston,283,District Clerk,,REP,John D Kinard,1317,964,308,45
+Galveston,283,County Clerk,,REP,Dwight Sullivan,1320,969,309,42
+Galveston,283,County Treasurer,,REP,Kevin C. Walsh,1316,965,309,42
+Galveston,283,County Commissioner Pct. 2,,REP,Joe Giusti,1316,967,306,43
+Galveston,283,Justice of the Peace Pct. 2,,REP,Mike Nelson,1315,965,308,42
+Galveston,283,College of the Mainland Proposition A,,,FOR,998,728,227,43
+Galveston,283,College of the Mainland Proposition A,,,AGAINST,490,358,107,25
+Galveston,283,Mayor  - League City,,,Sebastian Lofaro,288,206,73,9
+Galveston,283,Mayor  - League City,,,Pat Hallisey,489,363,110,16
+Galveston,283,Council Position 1  - League City,,,Andy Mann,344,251,82,11
+Galveston,283,Council Position 1  - League City,,,Traci Jacobs,356,258,85,13
+Galveston,283,Council Position 2  - League City,,,Hank Dugie,574,416,146,12
+Galveston,283,Council Position 6  - League City,,,Silvio P. Vincenzo,211,153,53,5
+Galveston,283,Council Position 6  - League City,,,Chad Tressler,287,200,77,10
+Galveston,283,Council Position 6  - League City,,,Chris Gross,185,140,37,8
+Galveston,283,Council Position 7  - League City,,,Ange Mertens,313,227,74,12
+Galveston,283,Council Position 7  - League City,,,Nick Long,366,269,87,10
+Galveston,283,League City Proposition A,,,For,634,456,155,23
+Galveston,283,League City Proposition A,,,Against,222,164,49,9
+Galveston,283,League City Proposition B,,,For,783,566,190,27
+Galveston,283,League City Proposition B,,,Against,118,90,25,3
+Galveston,283,League City Proposition C,,,For,784,566,193,25
+Galveston,283,League City Proposition C,,,Against,103,79,19,5
+Galveston,283,League City Proposition D,,,For,711,512,171,28
+Galveston,283,League City Proposition D,,,Against,135,102,30,3
+Galveston,283,League City Proposition E,,,For,802,591,186,25
+Galveston,283,League City Proposition E,,,Against,68,45,18,5
+Galveston,283,League City Proposition F,,,For,749,542,179,28
+Galveston,283,League City Proposition F,,,Against,86,66,17,3
+Galveston,283,League City Proposition G,,,For,787,575,184,28
+Galveston,283,League City Proposition G,,,Against,68,52,13,3
+Galveston,283,League City Proposition H,,,For,523,377,128,18
+Galveston,283,League City Proposition H,,,Against,272,206,54,12
+Galveston,283,League City Proposition I,,,For,745,546,171,28
+Galveston,283,League City Proposition I,,,Against,97,71,22,4
+Galveston,283,League City Proposition J,,,For,711,517,166,28
+Galveston,283,League City Proposition J,,,Against,117,85,28,4
+Galveston,283,League City Proposition K,,,For,748,546,174,28
+Galveston,283,League City Proposition K,,,Against,87,65,19,3
+Galveston,283,League City Proposition L,,,For,642,473,148,21
+Galveston,283,League City Proposition L,,,Against,168,121,40,7
+Galveston,283,League City Proposition M,,,For,710,523,166,21
+Galveston,283,League City Proposition M,,,Against,105,77,21,7
+Galveston,283,League City Proposition N,,,For,650,469,157,24
+Galveston,283,League City Proposition N,,,Against,165,129,32,4
+Galveston,283,League City Proposition O,,,For,713,516,174,23
+Galveston,283,League City Proposition O,,,Against,123,98,19,6
+Galveston,283,Trustee Position 4  - SFISD,,,Clay Hertenberger,36,24,10,2
+Galveston,283,Trustee Position 4  - SFISD,,,Donna Hayes,22,21,1,0
+Galveston,283,Trustee Position 4  - SFISD,,,John Rothermel,16,12,3,1
+Galveston,283,Trustee Position 4  - SFISD,,,Jessica Hagewood,23,14,6,3
+Galveston,283,Trustee Position 5  - SFISD,,,James Grassmuck,35,24,9,2
+Galveston,283,Trustee Position 5  - SFISD,,,Sheryl Skufca,28,19,5,4
+Galveston,283,Trustee Position 5  - SFISD,,,Tina Longcoy,13,10,2,1
+Galveston,283,Trustee Position 5  - SFISD,,,Jody Davis,22,17,5,0
+Galveston,283,Trustee Position 6  - SFISD,,,Rusty Norman,82,62,17,3
+Galveston,301,Ballots Cast,,,,679,496,151,32
+Galveston,301,Straight Party,,REP,Republican,173,128,34,11
+Galveston,301,Straight Party,,DEM,Democrat,276,194,65,17
+Galveston,301,Straight Party,,LIB,Libertarian,2,1,1,0
+Galveston,301,U.S. Senate,,REP,Ted Cruz,255,189,53,13
+Galveston,301,U.S. Senate,,DEM,Beto O'Rourke,417,304,94,19
+Galveston,301,U.S. Senate,,LIB,Neal M. Dikeman,1,0,1,0
+Galveston,301,U.S. House,14,REP,Randy Weber,252,185,54,13
+Galveston,301,U.S. House,14,DEM,Adrienne Bell,412,301,92,19
+Galveston,301,U.S. House,14,LIB,Don E. Conley III,10,6,4,0
+Galveston,301,Governor,,REP,Greg Abbott,278,201,65,12
+Galveston,301,Governor,,DEM,Lupe Valdez,385,284,81,20
+Galveston,301,Governor,,LIB,Mark Jay Tippetts,8,5,3,0
+Galveston,301,Lieutenant Governor,,REP,Dan Patrick,254,189,52,13
+Galveston,301,Lieutenant Governor,,DEM,Mike Collier,406,293,94,19
+Galveston,301,Lieutenant Governor,,LIB,Kerry Douglas McKennon,13,10,3,0
+Galveston,301,Attorney General,,REP,Ken Paxton,246,181,52,13
+Galveston,301,Attorney General,,DEM,Justin Nelson,415,303,94,18
+Galveston,301,Attorney General,,LIB,Michael Ray Harris,10,8,2,0
+Galveston,301,Comptroller of Public Accounts,,REP,Glenn Hegar,251,186,53,12
+Galveston,301,Comptroller of Public Accounts,,DEM,Joi Chevalier,401,293,89,19
+Galveston,301,Comptroller of Public Accounts,,LIB,Ben Sanders,17,10,7,0
+Galveston,301,Commissioner of General Land Office,,REP,George P. Bush,266,196,56,14
+Galveston,301,Commissioner of General Land Office,,DEM,Miguel Suazo,394,290,86,18
+Galveston,301,Commissioner of General Land Office,,LIB,Matt Pina,13,5,8,0
+Galveston,301,Commissioner of Agriculture,,REP,Sid Miller,249,184,52,13
+Galveston,301,Commissioner of Agriculture,,DEM,Kim Olson,409,296,94,19
+Galveston,301,Commissioner of Agriculture,,LIB,Richard Carpenter,14,11,3,0
+Galveston,301,Railroad Commissioner,,REP,Christi Craddick,255,191,51,13
+Galveston,301,Railroad Commissioner,,DEM,Roman McAllen,398,287,92,19
+Galveston,301,Railroad Commissioner,,LIB,Mike Wright,16,11,5,0
+Galveston,301,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,252,185,54,13
+Galveston,301,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,418,304,95,19
+Galveston,301,"Justice, Supreme Court, Place 4",,REP,John Devine,254,188,53,13
+Galveston,301,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,415,301,95,19
+Galveston,301,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,254,187,54,13
+Galveston,301,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,415,302,94,19
+Galveston,301,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,251,184,53,14
+Galveston,301,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,405,297,90,18
+Galveston,301,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,10,5,5,0
+Galveston,301,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,250,184,54,12
+Galveston,301,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,418,304,94,20
+Galveston,301,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,295,218,63,14
+Galveston,301,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,170,130,37,3
+Galveston,301,"Member, State Board of Education, District 7",,REP,Matt Robinson,256,188,55,13
+Galveston,301,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",412,301,92,19
+Galveston,301,State Representative,23,REP,Mayes Middleton,256,187,56,13
+Galveston,301,State Representative,23,DEM,Amanda Jamrok,403,295,89,19
+Galveston,301,State Representative,23,LIB,Lawrence Johnson,13,9,4,0
+Galveston,301,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,254,189,52,13
+Galveston,301,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,413,299,95,19
+Galveston,301,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,253,187,53,13
+Galveston,301,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,413,300,94,19
+Galveston,301,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,255,189,53,13
+Galveston,301,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,411,298,94,19
+Galveston,301,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,252,186,53,13
+Galveston,301,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,415,302,94,19
+Galveston,301,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,258,191,53,14
+Galveston,301,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,410,298,94,18
+Galveston,301,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,256,189,54,13
+Galveston,301,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,411,299,93,19
+Galveston,301,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,257,189,55,13
+Galveston,301,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,409,298,92,19
+Galveston,301,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,259,190,55,14
+Galveston,301,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,406,296,92,18
+Galveston,301,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,254,188,53,13
+Galveston,301,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,412,299,94,19
+Galveston,301,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,257,189,55,13
+Galveston,301,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",406,295,92,19
+Galveston,301,"District Judge, 122nd Judicial District",,REP,John Ellisor,328,238,76,14
+Galveston,301,"District Judge, 212th Judicial District",,REP,Patricia Grady,328,238,76,14
+Galveston,301,"District Judge, 306th Judicial District",,REP,Anne B. Darring,323,235,74,14
+Galveston,301,Criminal District Attorney,,REP,Jack Roady,323,233,76,14
+Galveston,301,County Judge,,REP,Mark Henry,319,230,76,13
+Galveston,301,"Judge, County Court-at-Law No. 1",,REP,John Grady,320,232,75,13
+Galveston,301,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,258,192,53,13
+Galveston,301,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,405,292,94,19
+Galveston,301,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,324,233,78,13
+Galveston,301,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,322,231,78,13
+Galveston,301,District Clerk,,REP,John D Kinard,324,232,78,14
+Galveston,301,County Clerk,,REP,Dwight Sullivan,326,234,78,14
+Galveston,301,County Treasurer,,REP,Kevin C. Walsh,326,236,77,13
+Galveston,301,Justice of the Peace Pct. 2,,REP,Mike Nelson,324,233,78,13
+Galveston,301,College of the Mainland Proposition A,,,FOR,431,314,98,19
+Galveston,301,College of the Mainland Proposition A,,,AGAINST,131,106,20,5
+Galveston,306,Ballots Cast,,,,2730,1849,654,227
+Galveston,306,Straight Party,,REP,Republican,630,428,143,59
+Galveston,306,Straight Party,,DEM,Democrat,900,619,210,71
+Galveston,306,Straight Party,,LIB,Libertarian,17,2,7,8
+Galveston,306,U.S. Senate,,REP,Ted Cruz,975,649,234,92
+Galveston,306,U.S. Senate,,DEM,Beto O'Rourke,1719,1179,407,133
+Galveston,306,U.S. Senate,,LIB,Neal M. Dikeman,18,11,6,1
+Galveston,306,U.S. House,14,REP,Randy Weber,1028,684,253,91
+Galveston,306,U.S. House,14,DEM,Adrienne Bell,1586,1101,355,130
+Galveston,306,U.S. House,14,LIB,Don E. Conley III,64,33,28,3
+Galveston,306,Governor,,REP,Greg Abbott,1086,713,276,97
+Galveston,306,Governor,,DEM,Lupe Valdez,1528,1066,340,122
+Galveston,306,Governor,,LIB,Mark Jay Tippetts,77,42,29,6
+Galveston,306,Lieutenant Governor,,REP,Dan Patrick,999,661,238,100
+Galveston,306,Lieutenant Governor,,DEM,Mike Collier,1591,1109,363,119
+Galveston,306,Lieutenant Governor,,LIB,Kerry Douglas McKennon,91,49,38,4
+Galveston,306,Attorney General,,REP,Ken Paxton,963,638,231,94
+Galveston,306,Attorney General,,DEM,Justin Nelson,1625,1124,374,127
+Galveston,306,Attorney General,,LIB,Michael Ray Harris,90,56,32,2
+Galveston,306,Comptroller of Public Accounts,,REP,Glenn Hegar,1031,692,242,97
+Galveston,306,Comptroller of Public Accounts,,DEM,Joi Chevalier,1496,1041,339,116
+Galveston,306,Comptroller of Public Accounts,,LIB,Ben Sanders,128,71,50,7
+Galveston,306,Commissioner of General Land Office,,REP,George P. Bush,1061,703,260,98
+Galveston,306,Commissioner of General Land Office,,DEM,Miguel Suazo,1485,1034,337,114
+Galveston,306,Commissioner of General Land Office,,LIB,Matt Pina,120,71,40,9
+Galveston,306,Commissioner of Agriculture,,REP,Sid Miller,986,662,240,84
+Galveston,306,Commissioner of Agriculture,,DEM,Kim Olson,1582,1094,364,124
+Galveston,306,Commissioner of Agriculture,,LIB,Richard Carpenter,89,51,29,9
+Galveston,306,Railroad Commissioner,,REP,Christi Craddick,1014,682,238,94
+Galveston,306,Railroad Commissioner,,DEM,Roman McAllen,1521,1059,347,115
+Galveston,306,Railroad Commissioner,,LIB,Mike Wright,112,56,47,9
+Galveston,306,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1013,674,249,90
+Galveston,306,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,1630,1127,377,126
+Galveston,306,"Justice, Supreme Court, Place 4",,REP,John Devine,1016,678,248,90
+Galveston,306,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,1620,1118,378,124
+Galveston,306,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1023,682,249,92
+Galveston,306,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,1618,1116,378,124
+Galveston,306,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,992,665,238,89
+Galveston,306,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,1567,1090,354,123
+Galveston,306,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,86,44,38,4
+Galveston,306,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1040,697,253,90
+Galveston,306,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,1590,1096,371,123
+Galveston,306,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1179,788,292,99
+Galveston,306,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,811,573,187,51
+Galveston,306,"Member, State Board of Education, District 7",,REP,Matt Robinson,999,668,248,83
+Galveston,306,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",1626,1129,376,121
+Galveston,306,State Representative,23,REP,Mayes Middleton,1029,688,259,82
+Galveston,306,State Representative,23,DEM,Amanda Jamrok,1545,1082,346,117
+Galveston,306,State Representative,23,LIB,Lawrence Johnson,81,42,29,10
+Galveston,306,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,1036,692,253,91
+Galveston,306,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,1579,1095,367,117
+Galveston,306,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,1008,678,248,82
+Galveston,306,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,1599,1109,372,118
+Galveston,306,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,997,673,243,81
+Galveston,306,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,1605,1110,377,118
+Galveston,306,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,1003,679,244,80
+Galveston,306,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,1595,1106,375,114
+Galveston,306,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,1035,691,258,86
+Galveston,306,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,1568,1091,362,115
+Galveston,306,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,1022,687,253,82
+Galveston,306,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,1576,1095,367,114
+Galveston,306,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,1016,684,250,82
+Galveston,306,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,1580,1095,367,118
+Galveston,306,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,1024,688,255,81
+Galveston,306,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,1570,1091,363,116
+Galveston,306,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,1001,670,249,82
+Galveston,306,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,1592,1109,368,115
+Galveston,306,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,1005,672,251,82
+Galveston,306,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",1589,1107,366,116
+Galveston,306,"District Judge, 122nd Judicial District",,REP,John Ellisor,1378,937,335,106
+Galveston,306,"District Judge, 212th Judicial District",,REP,Patricia Grady,1359,926,331,102
+Galveston,306,"District Judge, 306th Judicial District",,REP,Anne B. Darring,1353,917,334,102
+Galveston,306,Criminal District Attorney,,REP,Jack Roady,1371,925,334,112
+Galveston,306,County Judge,,REP,Mark Henry,1347,903,330,114
+Galveston,306,"Judge, County Court-at-Law No. 1",,REP,John Grady,1323,901,320,102
+Galveston,306,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,1020,684,251,85
+Galveston,306,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,1572,1096,363,113
+Galveston,306,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,1330,904,321,105
+Galveston,306,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,1352,917,325,110
+Galveston,306,District Clerk,,REP,John D Kinard,1336,898,327,111
+Galveston,306,County Clerk,,REP,Dwight Sullivan,1332,907,321,104
+Galveston,306,County Treasurer,,REP,Kevin C. Walsh,1341,913,322,106
+Galveston,306,Justice of the Peace Pct. 2,,REP,Mike Nelson,1337,905,328,104
+Galveston,306,Commissioner  - GC Navigation Dist 1,,,"Thomas E. ""Ted"" Farmer, Jr.",724,490,192,42
+Galveston,306,Commissioner  - GC Navigation Dist 1,,,Robert Mihovil,699,491,139,69
+Galveston,306-1,Ballots Cast,,,,1,1,0,0
+Galveston,306-1,Straight Party,,REP,Republican,0,0,0,0
+Galveston,306-1,Straight Party,,DEM,Democrat,1,1,0,0
+Galveston,306-1,Straight Party,,LIB,Libertarian,0,0,0,0
+Galveston,306-1,U.S. Senate,,REP,Ted Cruz,0,0,0,0
+Galveston,306-1,U.S. Senate,,DEM,Beto O'Rourke,1,1,0,0
+Galveston,306-1,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Galveston,306-1,U.S. House,14,REP,Randy Weber,0,0,0,0
+Galveston,306-1,U.S. House,14,DEM,Adrienne Bell,1,1,0,0
+Galveston,306-1,U.S. House,14,LIB,Don E. Conley III,0,0,0,0
+Galveston,306-1,Governor,,REP,Greg Abbott,0,0,0,0
+Galveston,306-1,Governor,,DEM,Lupe Valdez,1,1,0,0
+Galveston,306-1,Governor,,LIB,Mark Jay Tippetts,0,0,0,0
+Galveston,306-1,Lieutenant Governor,,REP,Dan Patrick,0,0,0,0
+Galveston,306-1,Lieutenant Governor,,DEM,Mike Collier,1,1,0,0
+Galveston,306-1,Lieutenant Governor,,LIB,Kerry Douglas McKennon,0,0,0,0
+Galveston,306-1,Attorney General,,REP,Ken Paxton,0,0,0,0
+Galveston,306-1,Attorney General,,DEM,Justin Nelson,1,1,0,0
+Galveston,306-1,Attorney General,,LIB,Michael Ray Harris,0,0,0,0
+Galveston,306-1,Comptroller of Public Accounts,,REP,Glenn Hegar,0,0,0,0
+Galveston,306-1,Comptroller of Public Accounts,,DEM,Joi Chevalier,1,1,0,0
+Galveston,306-1,Comptroller of Public Accounts,,LIB,Ben Sanders,0,0,0,0
+Galveston,306-1,Commissioner of General Land Office,,REP,George P. Bush,0,0,0,0
+Galveston,306-1,Commissioner of General Land Office,,DEM,Miguel Suazo,1,1,0,0
+Galveston,306-1,Commissioner of General Land Office,,LIB,Matt Pina,0,0,0,0
+Galveston,306-1,Commissioner of Agriculture,,REP,Sid Miller,0,0,0,0
+Galveston,306-1,Commissioner of Agriculture,,DEM,Kim Olson,1,1,0,0
+Galveston,306-1,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0,0
+Galveston,306-1,Railroad Commissioner,,REP,Christi Craddick,0,0,0,0
+Galveston,306-1,Railroad Commissioner,,DEM,Roman McAllen,1,1,0,0
+Galveston,306-1,Railroad Commissioner,,LIB,Mike Wright,0,0,0,0
+Galveston,306-1,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,0,0,0,0
+Galveston,306-1,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,1,1,0,0
+Galveston,306-1,"Justice, Supreme Court, Place 4",,REP,John Devine,0,0,0,0
+Galveston,306-1,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,1,1,0,0
+Galveston,306-1,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,0,0,0,0
+Galveston,306-1,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,1,1,0,0
+Galveston,306-1,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,0,0,0,0
+Galveston,306-1,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,1,1,0,0
+Galveston,306-1,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,0,0,0,0
+Galveston,306-1,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,0,0,0,0
+Galveston,306-1,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,1,1,0,0
+Galveston,306-1,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,0,0,0,0
+Galveston,306-1,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,0,0,0,0
+Galveston,306-1,"Member, State Board of Education, District 7",,REP,Matt Robinson,0,0,0,0
+Galveston,306-1,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",1,1,0,0
+Galveston,306-1,State Representative,23,REP,Mayes Middleton,0,0,0,0
+Galveston,306-1,State Representative,23,DEM,Amanda Jamrok,1,1,0,0
+Galveston,306-1,State Representative,23,LIB,Lawrence Johnson,0,0,0,0
+Galveston,306-1,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,0,0,0,0
+Galveston,306-1,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,1,1,0,0
+Galveston,306-1,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,0,0,0,0
+Galveston,306-1,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,1,1,0,0
+Galveston,306-1,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,0,0,0,0
+Galveston,306-1,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,1,1,0,0
+Galveston,306-1,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,0,0,0,0
+Galveston,306-1,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,1,1,0,0
+Galveston,306-1,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,0,0,0,0
+Galveston,306-1,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,1,1,0,0
+Galveston,306-1,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,0,0,0,0
+Galveston,306-1,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,1,1,0,0
+Galveston,306-1,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,0,0,0,0
+Galveston,306-1,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,1,1,0,0
+Galveston,306-1,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,0,0,0,0
+Galveston,306-1,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,1,1,0,0
+Galveston,306-1,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,0,0,0,0
+Galveston,306-1,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,1,1,0,0
+Galveston,306-1,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,0,0,0,0
+Galveston,306-1,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",1,1,0,0
+Galveston,306-1,"District Judge, 122nd Judicial District",,REP,John Ellisor,0,0,0,0
+Galveston,306-1,"District Judge, 212th Judicial District",,REP,Patricia Grady,0,0,0,0
+Galveston,306-1,"District Judge, 306th Judicial District",,REP,Anne B. Darring,0,0,0,0
+Galveston,306-1,Criminal District Attorney,,REP,Jack Roady,0,0,0,0
+Galveston,306-1,County Judge,,REP,Mark Henry,0,0,0,0
+Galveston,306-1,"Judge, County Court-at-Law No. 1",,REP,John Grady,0,0,0,0
+Galveston,306-1,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,0,0,0,0
+Galveston,306-1,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,1,1,0,0
+Galveston,306-1,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,0,0,0,0
+Galveston,306-1,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,0,0,0,0
+Galveston,306-1,District Clerk,,REP,John D Kinard,0,0,0,0
+Galveston,306-1,County Clerk,,REP,Dwight Sullivan,0,0,0,0
+Galveston,306-1,County Treasurer,,REP,Kevin C. Walsh,0,0,0,0
+Galveston,306-1,Justice of the Peace Pct. 3,,DEM,"Billy A. Williams, Jr.",1,1,0,0
+Galveston,306-1,Commissioner  - GC Navigation Dist 1,,,"Thomas E. ""Ted"" Farmer, Jr.",0,0,0,0
+Galveston,306-1,Commissioner  - GC Navigation Dist 1,,,Robert Mihovil,0,0,0,0
+Galveston,309,Ballots Cast,,,,65,42,19,4
+Galveston,309,Straight Party,,REP,Republican,27,19,7,1
+Galveston,309,Straight Party,,DEM,Democrat,13,8,5,0
+Galveston,309,Straight Party,,LIB,Libertarian,3,2,1,0
+Galveston,309,U.S. Senate,,REP,Ted Cruz,39,25,10,4
+Galveston,309,U.S. Senate,,DEM,Beto O'Rourke,24,16,8,0
+Galveston,309,U.S. Senate,,LIB,Neal M. Dikeman,1,0,1,0
+Galveston,309,U.S. House,14,REP,Randy Weber,40,25,11,4
+Galveston,309,U.S. House,14,DEM,Adrienne Bell,24,16,8,0
+Galveston,309,U.S. House,14,LIB,Don E. Conley III,1,1,0,0
+Galveston,309,Governor,,REP,Greg Abbott,39,25,11,3
+Galveston,309,Governor,,DEM,Lupe Valdez,23,16,7,0
+Galveston,309,Governor,,LIB,Mark Jay Tippetts,3,1,1,1
+Galveston,309,Lieutenant Governor,,REP,Dan Patrick,37,24,9,4
+Galveston,309,Lieutenant Governor,,DEM,Mike Collier,24,16,8,0
+Galveston,309,Lieutenant Governor,,LIB,Kerry Douglas McKennon,4,2,2,0
+Galveston,309,Attorney General,,REP,Ken Paxton,37,23,11,3
+Galveston,309,Attorney General,,DEM,Justin Nelson,24,17,7,0
+Galveston,309,Attorney General,,LIB,Michael Ray Harris,4,2,1,1
+Galveston,309,Comptroller of Public Accounts,,REP,Glenn Hegar,41,26,11,4
+Galveston,309,Comptroller of Public Accounts,,DEM,Joi Chevalier,21,14,7,0
+Galveston,309,Comptroller of Public Accounts,,LIB,Ben Sanders,3,2,1,0
+Galveston,309,Commissioner of General Land Office,,REP,George P. Bush,39,26,10,3
+Galveston,309,Commissioner of General Land Office,,DEM,Miguel Suazo,22,15,7,0
+Galveston,309,Commissioner of General Land Office,,LIB,Matt Pina,4,1,2,1
+Galveston,309,Commissioner of Agriculture,,REP,Sid Miller,38,25,10,3
+Galveston,309,Commissioner of Agriculture,,DEM,Kim Olson,24,16,8,0
+Galveston,309,Commissioner of Agriculture,,LIB,Richard Carpenter,3,1,1,1
+Galveston,309,Railroad Commissioner,,REP,Christi Craddick,39,27,9,3
+Galveston,309,Railroad Commissioner,,DEM,Roman McAllen,20,13,7,0
+Galveston,309,Railroad Commissioner,,LIB,Mike Wright,5,1,3,1
+Galveston,309,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,41,27,10,4
+Galveston,309,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,23,15,8,0
+Galveston,309,"Justice, Supreme Court, Place 4",,REP,John Devine,39,25,11,3
+Galveston,309,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,25,17,7,1
+Galveston,309,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,38,25,10,3
+Galveston,309,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,26,17,8,1
+Galveston,309,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,38,25,10,3
+Galveston,309,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,22,15,7,0
+Galveston,309,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,5,2,2,1
+Galveston,309,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,41,26,11,4
+Galveston,309,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,23,16,7,0
+Galveston,309,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,40,27,11,2
+Galveston,309,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,16,8,6,2
+Galveston,309,"Member, State Board of Education, District 7",,REP,Matt Robinson,40,25,11,4
+Galveston,309,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",25,17,8,0
+Galveston,309,State Representative,23,REP,Mayes Middleton,43,27,12,4
+Galveston,309,State Representative,23,DEM,Amanda Jamrok,21,15,6,0
+Galveston,309,State Representative,23,LIB,Lawrence Johnson,1,0,1,0
+Galveston,309,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,37,24,10,3
+Galveston,309,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,26,17,8,1
+Galveston,309,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,41,27,11,3
+Galveston,309,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,22,14,7,1
+Galveston,309,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,42,27,12,3
+Galveston,309,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,21,14,6,1
+Galveston,309,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,39,26,10,3
+Galveston,309,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,24,15,8,1
+Galveston,309,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,39,26,10,3
+Galveston,309,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,24,15,8,1
+Galveston,309,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,38,25,10,3
+Galveston,309,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,25,16,8,1
+Galveston,309,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,39,25,11,3
+Galveston,309,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,23,15,7,1
+Galveston,309,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,40,26,11,3
+Galveston,309,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,22,14,7,1
+Galveston,309,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,39,25,11,3
+Galveston,309,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,22,14,7,1
+Galveston,309,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,39,25,11,3
+Galveston,309,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",23,15,7,1
+Galveston,309,"District Judge, 122nd Judicial District",,REP,John Ellisor,48,31,13,4
+Galveston,309,"District Judge, 212th Judicial District",,REP,Patricia Grady,48,31,13,4
+Galveston,309,"District Judge, 306th Judicial District",,REP,Anne B. Darring,48,31,13,4
+Galveston,309,Criminal District Attorney,,REP,Jack Roady,47,32,13,2
+Galveston,309,County Judge,,REP,Mark Henry,46,31,13,2
+Galveston,309,"Judge, County Court-at-Law No. 1",,REP,John Grady,46,30,12,4
+Galveston,309,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,40,25,11,4
+Galveston,309,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,24,17,7,0
+Galveston,309,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,47,30,13,4
+Galveston,309,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,46,30,12,4
+Galveston,309,District Clerk,,REP,John D Kinard,46,30,12,4
+Galveston,309,County Clerk,,REP,Dwight Sullivan,46,30,12,4
+Galveston,309,County Treasurer,,REP,Kevin C. Walsh,42,28,12,2
+Galveston,309,Justice of the Peace Pct. 3,,DEM,"Billy A. Williams, Jr.",32,22,9,1
+Galveston,309,Commissioner  - GC Navigation Dist 1,,,"Thomas E. ""Ted"" Farmer, Jr.",25,16,7,2
+Galveston,309,Commissioner  - GC Navigation Dist 1,,,Robert Mihovil,10,5,3,2
+Galveston,311,Ballots Cast,,,,492,252,191,49
+Galveston,311,Straight Party,,REP,Republican,53,28,23,2
+Galveston,311,Straight Party,,DEM,Democrat,311,152,122,37
+Galveston,311,Straight Party,,LIB,Libertarian,1,0,1,0
+Galveston,311,U.S. Senate,,REP,Ted Cruz,75,41,30,4
+Galveston,311,U.S. Senate,,DEM,Beto O'Rourke,404,203,156,45
+Galveston,311,U.S. Senate,,LIB,Neal M. Dikeman,4,2,2,0
+Galveston,311,U.S. House,14,REP,Randy Weber,78,45,29,4
+Galveston,311,U.S. House,14,DEM,Adrienne Bell,399,200,154,45
+Galveston,311,U.S. House,14,LIB,Don E. Conley III,4,1,3,0
+Galveston,311,Governor,,REP,Greg Abbott,93,50,38,5
+Galveston,311,Governor,,DEM,Lupe Valdez,381,191,146,44
+Galveston,311,Governor,,LIB,Mark Jay Tippetts,9,6,3,0
+Galveston,311,Lieutenant Governor,,REP,Dan Patrick,85,47,34,4
+Galveston,311,Lieutenant Governor,,DEM,Mike Collier,389,199,145,45
+Galveston,311,Lieutenant Governor,,LIB,Kerry Douglas McKennon,7,2,5,0
+Galveston,311,Attorney General,,REP,Ken Paxton,78,46,28,4
+Galveston,311,Attorney General,,DEM,Justin Nelson,391,198,148,45
+Galveston,311,Attorney General,,LIB,Michael Ray Harris,13,4,9,0
+Galveston,311,Comptroller of Public Accounts,,REP,Glenn Hegar,78,45,29,4
+Galveston,311,Comptroller of Public Accounts,,DEM,Joi Chevalier,382,195,142,45
+Galveston,311,Comptroller of Public Accounts,,LIB,Ben Sanders,19,5,14,0
+Galveston,311,Commissioner of General Land Office,,REP,George P. Bush,83,48,31,4
+Galveston,311,Commissioner of General Land Office,,DEM,Miguel Suazo,384,192,147,45
+Galveston,311,Commissioner of General Land Office,,LIB,Matt Pina,13,6,7,0
+Galveston,311,Commissioner of Agriculture,,REP,Sid Miller,77,43,30,4
+Galveston,311,Commissioner of Agriculture,,DEM,Kim Olson,395,199,151,45
+Galveston,311,Commissioner of Agriculture,,LIB,Richard Carpenter,8,4,4,0
+Galveston,311,Railroad Commissioner,,REP,Christi Craddick,81,45,32,4
+Galveston,311,Railroad Commissioner,,DEM,Roman McAllen,391,198,148,45
+Galveston,311,Railroad Commissioner,,LIB,Mike Wright,9,3,6,0
+Galveston,311,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,78,41,33,4
+Galveston,311,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,399,202,152,45
+Galveston,311,"Justice, Supreme Court, Place 4",,REP,John Devine,80,45,31,4
+Galveston,311,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,396,198,154,44
+Galveston,311,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,78,43,31,4
+Galveston,311,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,398,201,153,44
+Galveston,311,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,75,41,30,4
+Galveston,311,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,396,199,152,45
+Galveston,311,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,8,5,3,0
+Galveston,311,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,80,42,34,4
+Galveston,311,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,399,202,153,44
+Galveston,311,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,109,56,48,5
+Galveston,311,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,125,69,50,6
+Galveston,311,"Member, State Board of Education, District 7",,REP,Matt Robinson,75,43,29,3
+Galveston,311,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",403,203,157,43
+Galveston,311,State Representative,23,REP,Mayes Middleton,86,50,33,3
+Galveston,311,State Representative,23,DEM,Amanda Jamrok,386,194,149,43
+Galveston,311,State Representative,23,LIB,Lawrence Johnson,6,2,4,0
+Galveston,311,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,75,41,31,3
+Galveston,311,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,402,203,155,44
+Galveston,311,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,80,44,33,3
+Galveston,311,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,396,200,153,43
+Galveston,311,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,83,45,34,4
+Galveston,311,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,393,199,152,42
+Galveston,311,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,76,42,30,4
+Galveston,311,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,401,202,156,43
+Galveston,311,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,77,42,32,3
+Galveston,311,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,397,201,153,43
+Galveston,311,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,79,43,33,3
+Galveston,311,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,396,200,153,43
+Galveston,311,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,82,46,33,3
+Galveston,311,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,395,199,153,43
+Galveston,311,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,78,42,33,3
+Galveston,311,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,396,201,152,43
+Galveston,311,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,79,44,31,4
+Galveston,311,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,398,200,155,43
+Galveston,311,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,78,44,31,3
+Galveston,311,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",400,200,156,44
+Galveston,311,"District Judge, 122nd Judicial District",,REP,John Ellisor,142,70,64,8
+Galveston,311,"District Judge, 212th Judicial District",,REP,Patricia Grady,139,69,63,7
+Galveston,311,"District Judge, 306th Judicial District",,REP,Anne B. Darring,139,68,64,7
+Galveston,311,Criminal District Attorney,,REP,Jack Roady,143,71,63,9
+Galveston,311,County Judge,,REP,Mark Henry,143,70,65,8
+Galveston,311,"Judge, County Court-at-Law No. 1",,REP,John Grady,134,69,58,7
+Galveston,311,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,77,45,29,3
+Galveston,311,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,400,199,157,44
+Galveston,311,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,134,68,58,8
+Galveston,311,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,137,72,58,7
+Galveston,311,District Clerk,,REP,John D Kinard,138,71,59,8
+Galveston,311,County Clerk,,REP,Dwight Sullivan,139,73,58,8
+Galveston,311,County Treasurer,,REP,Kevin C. Walsh,135,69,58,8
+Galveston,311,Justice of the Peace Pct. 3,,DEM,"Billy A. Williams, Jr.",423,215,164,44
+Galveston,311,Commissioner  - GC Navigation Dist 1,,,"Thomas E. ""Ted"" Farmer, Jr.",101,44,53,4
+Galveston,311,Commissioner  - GC Navigation Dist 1,,,Robert Mihovil,64,34,19,11
+Galveston,312,Ballots Cast,,,,40,27,13,0
+Galveston,312,Straight Party,,REP,Republican,5,3,2,0
+Galveston,312,Straight Party,,DEM,Democrat,24,16,8,0
+Galveston,312,Straight Party,,LIB,Libertarian,0,0,0,0
+Galveston,312,U.S. Senate,,REP,Ted Cruz,7,4,3,0
+Galveston,312,U.S. Senate,,DEM,Beto O'Rourke,31,21,10,0
+Galveston,312,U.S. Senate,,LIB,Neal M. Dikeman,1,1,0,0
+Galveston,312,U.S. House,14,REP,Randy Weber,5,3,2,0
+Galveston,312,U.S. House,14,DEM,Adrienne Bell,33,22,11,0
+Galveston,312,U.S. House,14,LIB,Don E. Conley III,0,0,0,0
+Galveston,312,Governor,,REP,Greg Abbott,8,4,4,0
+Galveston,312,Governor,,DEM,Lupe Valdez,31,22,9,0
+Galveston,312,Governor,,LIB,Mark Jay Tippetts,0,0,0,0
+Galveston,312,Lieutenant Governor,,REP,Dan Patrick,6,3,3,0
+Galveston,312,Lieutenant Governor,,DEM,Mike Collier,32,22,10,0
+Galveston,312,Lieutenant Governor,,LIB,Kerry Douglas McKennon,1,1,0,0
+Galveston,312,Attorney General,,REP,Ken Paxton,5,3,2,0
+Galveston,312,Attorney General,,DEM,Justin Nelson,33,22,11,0
+Galveston,312,Attorney General,,LIB,Michael Ray Harris,1,1,0,0
+Galveston,312,Comptroller of Public Accounts,,REP,Glenn Hegar,5,3,2,0
+Galveston,312,Comptroller of Public Accounts,,DEM,Joi Chevalier,33,22,11,0
+Galveston,312,Comptroller of Public Accounts,,LIB,Ben Sanders,1,1,0,0
+Galveston,312,Commissioner of General Land Office,,REP,George P. Bush,6,3,3,0
+Galveston,312,Commissioner of General Land Office,,DEM,Miguel Suazo,33,23,10,0
+Galveston,312,Commissioner of General Land Office,,LIB,Matt Pina,0,0,0,0
+Galveston,312,Commissioner of Agriculture,,REP,Sid Miller,5,3,2,0
+Galveston,312,Commissioner of Agriculture,,DEM,Kim Olson,34,23,11,0
+Galveston,312,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0,0
+Galveston,312,Railroad Commissioner,,REP,Christi Craddick,6,4,2,0
+Galveston,312,Railroad Commissioner,,DEM,Roman McAllen,32,21,11,0
+Galveston,312,Railroad Commissioner,,LIB,Mike Wright,1,1,0,0
+Galveston,312,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,5,3,2,0
+Galveston,312,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,34,23,11,0
+Galveston,312,"Justice, Supreme Court, Place 4",,REP,John Devine,5,3,2,0
+Galveston,312,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,34,23,11,0
+Galveston,312,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,6,4,2,0
+Galveston,312,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,33,22,11,0
+Galveston,312,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,5,3,2,0
+Galveston,312,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,34,23,11,0
+Galveston,312,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,0,0,0,0
+Galveston,312,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,5,3,2,0
+Galveston,312,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,34,23,11,0
+Galveston,312,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,9,6,3,0
+Galveston,312,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,8,7,1,0
+Galveston,312,"Member, State Board of Education, District 7",,REP,Matt Robinson,5,3,2,0
+Galveston,312,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",34,23,11,0
+Galveston,312,State Representative,23,REP,Mayes Middleton,5,3,2,0
+Galveston,312,State Representative,23,DEM,Amanda Jamrok,33,23,10,0
+Galveston,312,State Representative,23,LIB,Lawrence Johnson,1,0,1,0
+Galveston,312,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,7,4,3,0
+Galveston,312,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,32,22,10,0
+Galveston,312,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,5,3,2,0
+Galveston,312,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,34,23,11,0
+Galveston,312,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,6,4,2,0
+Galveston,312,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,33,22,11,0
+Galveston,312,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,5,3,2,0
+Galveston,312,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,34,23,11,0
+Galveston,312,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,6,3,3,0
+Galveston,312,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,33,23,10,0
+Galveston,312,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,6,4,2,0
+Galveston,312,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,33,22,11,0
+Galveston,312,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,5,3,2,0
+Galveston,312,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,34,23,11,0
+Galveston,312,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,5,3,2,0
+Galveston,312,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,34,23,11,0
+Galveston,312,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,5,3,2,0
+Galveston,312,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,34,23,11,0
+Galveston,312,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,5,3,2,0
+Galveston,312,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",34,23,11,0
+Galveston,312,"District Judge, 122nd Judicial District",,REP,John Ellisor,9,5,4,0
+Galveston,312,"District Judge, 212th Judicial District",,REP,Patricia Grady,10,6,4,0
+Galveston,312,"District Judge, 306th Judicial District",,REP,Anne B. Darring,10,6,4,0
+Galveston,312,Criminal District Attorney,,REP,Jack Roady,8,4,4,0
+Galveston,312,County Judge,,REP,Mark Henry,10,6,4,0
+Galveston,312,"Judge, County Court-at-Law No. 1",,REP,John Grady,8,4,4,0
+Galveston,312,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,6,4,2,0
+Galveston,312,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,33,22,11,0
+Galveston,312,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,8,4,4,0
+Galveston,312,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,9,5,4,0
+Galveston,312,District Clerk,,REP,John D Kinard,8,4,4,0
+Galveston,312,County Clerk,,REP,Dwight Sullivan,9,5,4,0
+Galveston,312,County Treasurer,,REP,Kevin C. Walsh,8,4,4,0
+Galveston,312,Justice of the Peace Pct. 3,,DEM,"Billy A. Williams, Jr.",35,24,11,0
+Galveston,312,College of the Mainland Proposition A,,,FOR,21,16,5,0
+Galveston,312,College of the Mainland Proposition A,,,AGAINST,6,3,3,0
+Galveston,314,Ballots Cast,,,,2008,1301,490,217
+Galveston,314,Straight Party,,REP,Republican,286,195,70,21
+Galveston,314,Straight Party,,DEM,Democrat,986,605,254,127
+Galveston,314,Straight Party,,LIB,Libertarian,18,5,4,9
+Galveston,314,U.S. Senate,,REP,Ted Cruz,459,309,115,35
+Galveston,314,U.S. Senate,,DEM,Beto O'Rourke,1512,967,364,181
+Galveston,314,U.S. Senate,,LIB,Neal M. Dikeman,17,10,7,0
+Galveston,314,U.S. House,14,REP,Randy Weber,463,318,112,33
+Galveston,314,U.S. House,14,DEM,Adrienne Bell,1466,933,352,181
+Galveston,314,U.S. House,14,LIB,Don E. Conley III,44,25,18,1
+Galveston,314,Governor,,REP,Greg Abbott,523,354,130,39
+Galveston,314,Governor,,DEM,Lupe Valdez,1401,892,336,173
+Galveston,314,Governor,,LIB,Mark Jay Tippetts,55,30,21,4
+Galveston,314,Lieutenant Governor,,REP,Dan Patrick,473,319,120,34
+Galveston,314,Lieutenant Governor,,DEM,Mike Collier,1439,920,340,179
+Galveston,314,Lieutenant Governor,,LIB,Kerry Douglas McKennon,59,35,22,2
+Galveston,314,Attorney General,,REP,Ken Paxton,449,303,116,30
+Galveston,314,Attorney General,,DEM,Justin Nelson,1469,942,347,180
+Galveston,314,Attorney General,,LIB,Michael Ray Harris,54,32,17,5
+Galveston,314,Comptroller of Public Accounts,,REP,Glenn Hegar,460,316,112,32
+Galveston,314,Comptroller of Public Accounts,,DEM,Joi Chevalier,1410,895,339,176
+Galveston,314,Comptroller of Public Accounts,,LIB,Ben Sanders,96,58,31,7
+Galveston,314,Commissioner of General Land Office,,REP,George P. Bush,490,331,121,38
+Galveston,314,Commissioner of General Land Office,,DEM,Miguel Suazo,1401,893,337,171
+Galveston,314,Commissioner of General Land Office,,LIB,Matt Pina,80,47,26,7
+Galveston,314,Commissioner of Agriculture,,REP,Sid Miller,447,301,113,33
+Galveston,314,Commissioner of Agriculture,,DEM,Kim Olson,1461,933,350,178
+Galveston,314,Commissioner of Agriculture,,LIB,Richard Carpenter,55,35,17,3
+Galveston,314,Railroad Commissioner,,REP,Christi Craddick,468,325,111,32
+Galveston,314,Railroad Commissioner,,DEM,Roman McAllen,1429,907,344,178
+Galveston,314,Railroad Commissioner,,LIB,Mike Wright,72,42,26,4
+Galveston,314,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,477,321,124,32
+Galveston,314,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,1490,949,359,182
+Galveston,314,"Justice, Supreme Court, Place 4",,REP,John Devine,479,327,122,30
+Galveston,314,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,1479,939,359,181
+Galveston,314,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,485,333,121,31
+Galveston,314,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,1478,934,360,184
+Galveston,314,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,456,318,108,30
+Galveston,314,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,1455,921,352,182
+Galveston,314,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,59,34,21,4
+Galveston,314,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,485,333,119,33
+Galveston,314,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,1476,935,359,182
+Galveston,314,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,579,392,138,49
+Galveston,314,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,547,364,136,47
+Galveston,314,"Member, State Board of Education, District 7",,REP,Matt Robinson,456,312,114,30
+Galveston,314,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",1487,942,365,180
+Galveston,314,State Representative,23,REP,Mayes Middleton,472,322,123,27
+Galveston,314,State Representative,23,DEM,Amanda Jamrok,1445,922,345,178
+Galveston,314,State Representative,23,LIB,Lawrence Johnson,55,30,16,9
+Galveston,314,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,489,332,122,35
+Galveston,314,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,1463,925,358,180
+Galveston,314,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,464,321,117,26
+Galveston,314,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,1477,936,362,179
+Galveston,314,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,477,329,120,28
+Galveston,314,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,1466,928,360,178
+Galveston,314,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,460,318,112,30
+Galveston,314,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,1491,946,366,179
+Galveston,314,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,487,335,123,29
+Galveston,314,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,1457,924,356,177
+Galveston,314,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,470,319,123,28
+Galveston,314,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,1467,932,358,177
+Galveston,314,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,478,324,124,30
+Galveston,314,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,1462,928,355,179
+Galveston,314,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,471,328,114,29
+Galveston,314,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,1463,921,364,178
+Galveston,314,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,466,321,117,28
+Galveston,314,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,1472,928,364,180
+Galveston,314,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,460,316,115,29
+Galveston,314,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",1476,932,364,180
+Galveston,314,"District Judge, 122nd Judicial District",,REP,John Ellisor,690,457,182,51
+Galveston,314,"District Judge, 212th Judicial District",,REP,Patricia Grady,676,446,179,51
+Galveston,314,"District Judge, 306th Judicial District",,REP,Anne B. Darring,666,439,174,53
+Galveston,314,Criminal District Attorney,,REP,Jack Roady,679,445,181,53
+Galveston,314,County Judge,,REP,Mark Henry,661,429,177,55
+Galveston,314,"Judge, County Court-at-Law No. 1",,REP,John Grady,644,422,170,52
+Galveston,314,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,467,321,120,26
+Galveston,314,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,1456,920,358,178
+Galveston,314,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,662,432,173,57
+Galveston,314,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,668,438,175,55
+Galveston,314,District Clerk,,REP,John D Kinard,659,429,178,52
+Galveston,314,County Clerk,,REP,Dwight Sullivan,664,429,180,55
+Galveston,314,County Treasurer,,REP,Kevin C. Walsh,654,426,175,53
+Galveston,314,Justice of the Peace Pct. 3,,DEM,"Billy A. Williams, Jr.",1543,977,385,181
+Galveston,314,Commissioner  - GC Navigation Dist 1,,,"Thomas E. ""Ted"" Farmer, Jr.",409,250,119,40
+Galveston,314,Commissioner  - GC Navigation Dist 1,,,Robert Mihovil,386,271,72,43
+Galveston,315,Ballots Cast,,,,1985,1277,503,205
+Galveston,315,Straight Party,,REP,Republican,401,285,89,27
+Galveston,315,Straight Party,,DEM,Democrat,803,489,210,104
+Galveston,315,Straight Party,,LIB,Libertarian,10,4,1,5
+Galveston,315,U.S. Senate,,REP,Ted Cruz,626,429,153,44
+Galveston,315,U.S. Senate,,DEM,Beto O'Rourke,1327,832,339,156
+Galveston,315,U.S. Senate,,LIB,Neal M. Dikeman,13,8,4,1
+Galveston,315,U.S. House,14,REP,Randy Weber,654,445,166,43
+Galveston,315,U.S. House,14,DEM,Adrienne Bell,1264,788,319,157
+Galveston,315,U.S. House,14,LIB,Don E. Conley III,42,31,10,1
+Galveston,315,Governor,,REP,Greg Abbott,708,475,189,44
+Galveston,315,Governor,,DEM,Lupe Valdez,1220,768,296,156
+Galveston,315,Governor,,LIB,Mark Jay Tippetts,40,27,11,2
+Galveston,315,Lieutenant Governor,,REP,Dan Patrick,637,433,162,42
+Galveston,315,Lieutenant Governor,,DEM,Mike Collier,1272,796,317,159
+Galveston,315,Lieutenant Governor,,LIB,Kerry Douglas McKennon,47,34,13,0
+Galveston,315,Attorney General,,REP,Ken Paxton,601,411,151,39
+Galveston,315,Attorney General,,DEM,Justin Nelson,1285,803,322,160
+Galveston,315,Attorney General,,LIB,Michael Ray Harris,62,42,19,1
+Galveston,315,Comptroller of Public Accounts,,REP,Glenn Hegar,627,431,154,42
+Galveston,315,Comptroller of Public Accounts,,DEM,Joi Chevalier,1211,751,304,156
+Galveston,315,Comptroller of Public Accounts,,LIB,Ben Sanders,96,61,31,4
+Galveston,315,Commissioner of General Land Office,,REP,George P. Bush,674,459,169,46
+Galveston,315,Commissioner of General Land Office,,DEM,Miguel Suazo,1208,749,303,156
+Galveston,315,Commissioner of General Land Office,,LIB,Matt Pina,72,50,20,2
+Galveston,315,Commissioner of Agriculture,,REP,Sid Miller,599,413,146,40
+Galveston,315,Commissioner of Agriculture,,DEM,Kim Olson,1275,793,321,161
+Galveston,315,Commissioner of Agriculture,,LIB,Richard Carpenter,68,42,24,2
+Galveston,315,Railroad Commissioner,,REP,Christi Craddick,627,426,153,48
+Galveston,315,Railroad Commissioner,,DEM,Roman McAllen,1230,768,308,154
+Galveston,315,Railroad Commissioner,,LIB,Mike Wright,87,56,29,2
+Galveston,315,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,634,432,162,40
+Galveston,315,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,1300,814,328,158
+Galveston,315,"Justice, Supreme Court, Place 4",,REP,John Devine,650,440,168,42
+Galveston,315,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,1273,799,321,153
+Galveston,315,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,650,439,168,43
+Galveston,315,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,1281,803,321,157
+Galveston,315,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,624,428,156,40
+Galveston,315,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,1245,774,314,157
+Galveston,315,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,66,42,20,4
+Galveston,315,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,657,440,174,43
+Galveston,315,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,1272,800,315,157
+Galveston,315,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,770,517,205,48
+Galveston,315,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,507,335,125,47
+Galveston,315,"Member, State Board of Education, District 7",,REP,Matt Robinson,631,432,162,37
+Galveston,315,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",1297,809,328,160
+Galveston,315,State Representative,23,REP,Mayes Middleton,645,438,167,40
+Galveston,315,State Representative,23,DEM,Amanda Jamrok,1241,774,311,156
+Galveston,315,State Representative,23,LIB,Lawrence Johnson,63,45,13,5
+Galveston,315,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,648,437,167,44
+Galveston,315,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,1272,799,321,152
+Galveston,315,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,638,438,162,38
+Galveston,315,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,1288,802,325,161
+Galveston,315,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,647,440,170,37
+Galveston,315,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,1276,798,317,161
+Galveston,315,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,621,428,154,39
+Galveston,315,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,1299,808,332,159
+Galveston,315,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,649,443,166,40
+Galveston,315,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,1270,794,318,158
+Galveston,315,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,651,442,170,39
+Galveston,315,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,1268,793,316,159
+Galveston,315,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,649,442,166,41
+Galveston,315,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,1267,794,316,157
+Galveston,315,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,649,444,164,41
+Galveston,315,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,1268,790,320,158
+Galveston,315,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,625,431,156,38
+Galveston,315,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,1294,807,327,160
+Galveston,315,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,631,434,159,38
+Galveston,315,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",1292,804,325,163
+Galveston,315,"District Judge, 122nd Judicial District",,REP,John Ellisor,861,560,241,60
+Galveston,315,"District Judge, 212th Judicial District",,REP,Patricia Grady,869,572,239,58
+Galveston,315,"District Judge, 306th Judicial District",,REP,Anne B. Darring,863,568,238,57
+Galveston,315,Criminal District Attorney,,REP,Jack Roady,869,569,239,61
+Galveston,315,County Judge,,REP,Mark Henry,854,553,239,62
+Galveston,315,"Judge, County Court-at-Law No. 1",,REP,John Grady,834,549,228,57
+Galveston,315,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,634,436,160,38
+Galveston,315,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,1283,799,327,157
+Galveston,315,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,843,557,230,56
+Galveston,315,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,858,565,231,62
+Galveston,315,District Clerk,,REP,John D Kinard,844,558,229,57
+Galveston,315,County Clerk,,REP,Dwight Sullivan,850,559,232,59
+Galveston,315,County Treasurer,,REP,Kevin C. Walsh,851,558,233,60
+Galveston,315,Justice of the Peace Pct. 2,,REP,Mike Nelson,856,565,232,59
+Galveston,315,Commissioner  - GC Navigation Dist 1,,,"Thomas E. ""Ted"" Farmer, Jr.",545,356,149,40
+Galveston,315,Commissioner  - GC Navigation Dist 1,,,Robert Mihovil,415,273,92,50
+Galveston,316,Ballots Cast,,,,1119,735,306,78
+Galveston,316,Straight Party,,REP,Republican,212,145,56,11
+Galveston,316,Straight Party,,DEM,Democrat,551,354,151,46
+Galveston,316,Straight Party,,LIB,Libertarian,3,0,3,0
+Galveston,316,U.S. Senate,,REP,Ted Cruz,316,221,78,17
+Galveston,316,U.S. Senate,,DEM,Beto O'Rourke,779,502,217,60
+Galveston,316,U.S. Senate,,LIB,Neal M. Dikeman,10,5,5,0
+Galveston,316,U.S. House,14,REP,Randy Weber,310,216,78,16
+Galveston,316,U.S. House,14,DEM,Adrienne Bell,755,490,205,60
+Galveston,316,U.S. House,14,LIB,Don E. Conley III,25,14,11,0
+Galveston,316,Governor,,REP,Greg Abbott,357,249,87,21
+Galveston,316,Governor,,DEM,Lupe Valdez,718,465,198,55
+Galveston,316,Governor,,LIB,Mark Jay Tippetts,22,10,11,1
+Galveston,316,Lieutenant Governor,,REP,Dan Patrick,324,222,85,17
+Galveston,316,Lieutenant Governor,,DEM,Mike Collier,736,478,199,59
+Galveston,316,Lieutenant Governor,,LIB,Kerry Douglas McKennon,38,21,16,1
+Galveston,316,Attorney General,,REP,Ken Paxton,306,213,76,17
+Galveston,316,Attorney General,,DEM,Justin Nelson,755,488,208,59
+Galveston,316,Attorney General,,LIB,Michael Ray Harris,33,20,12,1
+Galveston,316,Comptroller of Public Accounts,,REP,Glenn Hegar,311,214,80,17
+Galveston,316,Comptroller of Public Accounts,,DEM,Joi Chevalier,720,466,195,59
+Galveston,316,Comptroller of Public Accounts,,LIB,Ben Sanders,59,35,23,1
+Galveston,316,Commissioner of General Land Office,,REP,George P. Bush,321,222,81,18
+Galveston,316,Commissioner of General Land Office,,DEM,Miguel Suazo,738,474,205,59
+Galveston,316,Commissioner of General Land Office,,LIB,Matt Pina,41,27,13,1
+Galveston,316,Commissioner of Agriculture,,REP,Sid Miller,301,210,74,17
+Galveston,316,Commissioner of Agriculture,,DEM,Kim Olson,761,492,208,61
+Galveston,316,Commissioner of Agriculture,,LIB,Richard Carpenter,37,21,16,0
+Galveston,316,Railroad Commissioner,,REP,Christi Craddick,310,215,77,18
+Galveston,316,Railroad Commissioner,,DEM,Roman McAllen,744,481,203,60
+Galveston,316,Railroad Commissioner,,LIB,Mike Wright,39,23,16,0
+Galveston,316,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,322,223,82,17
+Galveston,316,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,768,494,213,61
+Galveston,316,"Justice, Supreme Court, Place 4",,REP,John Devine,331,231,83,17
+Galveston,316,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,760,488,212,60
+Galveston,316,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,325,226,82,17
+Galveston,316,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,762,490,211,61
+Galveston,316,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,306,214,74,18
+Galveston,316,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,758,489,210,59
+Galveston,316,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,32,16,15,1
+Galveston,316,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,328,230,81,17
+Galveston,316,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,763,488,214,61
+Galveston,316,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,391,273,99,19
+Galveston,316,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,260,159,85,16
+Galveston,316,"Member, State Board of Education, District 7",,REP,Matt Robinson,322,221,84,17
+Galveston,316,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",768,498,209,61
+Galveston,316,State Representative,23,REP,Mayes Middleton,335,236,82,17
+Galveston,316,State Representative,23,DEM,Amanda Jamrok,740,478,202,60
+Galveston,316,State Representative,23,LIB,Lawrence Johnson,26,11,14,1
+Galveston,316,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,325,226,82,17
+Galveston,316,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,763,492,210,61
+Galveston,316,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,324,225,82,17
+Galveston,316,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,763,491,212,60
+Galveston,316,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,333,234,82,17
+Galveston,316,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,754,481,212,61
+Galveston,316,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,312,218,78,16
+Galveston,316,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,774,498,214,62
+Galveston,316,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,334,231,85,18
+Galveston,316,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,750,483,207,60
+Galveston,316,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,328,231,79,18
+Galveston,316,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,761,487,214,60
+Galveston,316,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,335,235,82,18
+Galveston,316,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,753,481,212,60
+Galveston,316,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,332,233,81,18
+Galveston,316,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,752,482,210,60
+Galveston,316,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,330,228,85,17
+Galveston,316,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,756,487,208,61
+Galveston,316,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,325,226,82,17
+Galveston,316,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",762,490,211,61
+Galveston,316,"District Judge, 122nd Judicial District",,REP,John Ellisor,467,309,133,25
+Galveston,316,"District Judge, 212th Judicial District",,REP,Patricia Grady,463,309,129,25
+Galveston,316,"District Judge, 306th Judicial District",,REP,Anne B. Darring,456,304,128,24
+Galveston,316,Criminal District Attorney,,REP,Jack Roady,461,308,127,26
+Galveston,316,County Judge,,REP,Mark Henry,446,298,124,24
+Galveston,316,"Judge, County Court-at-Law No. 1",,REP,John Grady,449,305,121,23
+Galveston,316,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,330,232,81,17
+Galveston,316,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,753,482,211,60
+Galveston,316,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,450,302,126,22
+Galveston,316,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,458,309,127,22
+Galveston,316,District Clerk,,REP,John D Kinard,448,303,124,21
+Galveston,316,County Clerk,,REP,Dwight Sullivan,448,300,124,24
+Galveston,316,County Treasurer,,REP,Kevin C. Walsh,445,300,122,23
+Galveston,316,Justice of the Peace Pct. 3,,DEM,"Billy A. Williams, Jr.",846,549,231,66
+Galveston,316,Commissioner  - GC Navigation Dist 1,,,"Thomas E. ""Ted"" Farmer, Jr.",280,181,85,14
+Galveston,316,Commissioner  - GC Navigation Dist 1,,,Robert Mihovil,172,115,42,15
+Galveston,330,Ballots Cast,,,,1255,814,343,98
+Galveston,330,Straight Party,,REP,Republican,285,186,75,24
+Galveston,330,Straight Party,,DEM,Democrat,606,379,182,45
+Galveston,330,Straight Party,,LIB,Libertarian,9,5,3,1
+Galveston,330,U.S. Senate,,REP,Ted Cruz,410,278,97,35
+Galveston,330,U.S. Senate,,DEM,Beto O'Rourke,817,520,236,61
+Galveston,330,U.S. Senate,,LIB,Neal M. Dikeman,14,6,7,1
+Galveston,330,U.S. House,14,REP,Randy Weber,409,276,99,34
+Galveston,330,U.S. House,14,DEM,Adrienne Bell,808,516,229,63
+Galveston,330,U.S. House,14,LIB,Don E. Conley III,24,14,10,0
+Galveston,330,Governor,,REP,Greg Abbott,456,302,117,37
+Galveston,330,Governor,,DEM,Lupe Valdez,763,492,213,58
+Galveston,330,Governor,,LIB,Mark Jay Tippetts,24,12,10,2
+Galveston,330,Lieutenant Governor,,REP,Dan Patrick,416,272,109,35
+Galveston,330,Lieutenant Governor,,DEM,Mike Collier,813,528,223,62
+Galveston,330,Lieutenant Governor,,LIB,Kerry Douglas McKennon,16,8,7,1
+Galveston,330,Attorney General,,REP,Ken Paxton,394,264,96,34
+Galveston,330,Attorney General,,DEM,Justin Nelson,817,527,228,62
+Galveston,330,Attorney General,,LIB,Michael Ray Harris,31,16,13,2
+Galveston,330,Comptroller of Public Accounts,,REP,Glenn Hegar,406,278,95,33
+Galveston,330,Comptroller of Public Accounts,,DEM,Joi Chevalier,796,508,225,63
+Galveston,330,Comptroller of Public Accounts,,LIB,Ben Sanders,39,21,17,1
+Galveston,330,Commissioner of General Land Office,,REP,George P. Bush,414,272,107,35
+Galveston,330,Commissioner of General Land Office,,DEM,Miguel Suazo,793,513,221,59
+Galveston,330,Commissioner of General Land Office,,LIB,Matt Pina,33,20,10,3
+Galveston,330,Commissioner of Agriculture,,REP,Sid Miller,393,268,94,31
+Galveston,330,Commissioner of Agriculture,,DEM,Kim Olson,817,525,229,63
+Galveston,330,Commissioner of Agriculture,,LIB,Richard Carpenter,29,12,15,2
+Galveston,330,Railroad Commissioner,,REP,Christi Craddick,406,272,101,33
+Galveston,330,Railroad Commissioner,,DEM,Roman McAllen,796,513,222,61
+Galveston,330,Railroad Commissioner,,LIB,Mike Wright,35,19,14,2
+Galveston,330,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,412,278,99,35
+Galveston,330,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,821,529,232,60
+Galveston,330,"Justice, Supreme Court, Place 4",,REP,John Devine,415,281,100,34
+Galveston,330,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,814,525,229,60
+Galveston,330,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,405,276,97,32
+Galveston,330,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,825,528,235,62
+Galveston,330,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,398,271,94,33
+Galveston,330,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,813,525,228,60
+Galveston,330,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,23,9,12,2
+Galveston,330,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,415,285,98,32
+Galveston,330,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,815,520,233,62
+Galveston,330,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,461,304,120,37
+Galveston,330,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,261,186,64,11
+Galveston,330,"Member, State Board of Education, District 7",,REP,Matt Robinson,407,275,100,32
+Galveston,330,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",823,529,232,62
+Galveston,330,State Representative,23,REP,Mayes Middleton,411,275,101,35
+Galveston,330,State Representative,23,DEM,Amanda Jamrok,806,520,225,61
+Galveston,330,State Representative,23,LIB,Lawrence Johnson,23,12,9,2
+Galveston,330,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,407,275,101,31
+Galveston,330,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,818,527,230,61
+Galveston,330,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,407,276,98,33
+Galveston,330,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,823,529,233,61
+Galveston,330,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,413,281,99,33
+Galveston,330,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,817,523,233,61
+Galveston,330,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,410,276,101,33
+Galveston,330,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,821,528,232,61
+Galveston,330,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,415,281,103,31
+Galveston,330,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,813,523,229,61
+Galveston,330,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,413,280,100,33
+Galveston,330,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,815,524,231,60
+Galveston,330,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,410,276,101,33
+Galveston,330,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,817,527,230,60
+Galveston,330,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,414,283,99,32
+Galveston,330,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,814,521,232,61
+Galveston,330,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,402,272,98,32
+Galveston,330,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,827,532,234,61
+Galveston,330,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,409,278,100,31
+Galveston,330,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",820,526,232,62
+Galveston,330,"District Judge, 122nd Judicial District",,REP,John Ellisor,519,347,134,38
+Galveston,330,"District Judge, 212th Judicial District",,REP,Patricia Grady,521,347,134,40
+Galveston,330,"District Judge, 306th Judicial District",,REP,Anne B. Darring,517,345,133,39
+Galveston,330,Criminal District Attorney,,REP,Jack Roady,514,342,131,41
+Galveston,330,County Judge,,REP,Mark Henry,501,331,132,38
+Galveston,330,"Judge, County Court-at-Law No. 1",,REP,John Grady,502,332,131,39
+Galveston,330,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,403,273,98,32
+Galveston,330,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,821,527,232,62
+Galveston,330,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,507,335,131,41
+Galveston,330,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,508,337,132,39
+Galveston,330,District Clerk,,REP,John D Kinard,508,340,130,38
+Galveston,330,County Clerk,,REP,Dwight Sullivan,513,340,132,41
+Galveston,330,County Treasurer,,REP,Kevin C. Walsh,505,338,127,40
+Galveston,330,Justice of the Peace Pct. 3,,DEM,"Billy A. Williams, Jr.",885,570,253,62
+Galveston,330,College of the Mainland Proposition A,,,FOR,735,480,187,68
+Galveston,330,College of the Mainland Proposition A,,,AGAINST,234,144,66,24
+Galveston,330-1,Ballots Cast,,,,0,0,0,0
+Galveston,330-1,Straight Party,,REP,Republican,0,0,0,0
+Galveston,330-1,Straight Party,,DEM,Democrat,0,0,0,0
+Galveston,330-1,Straight Party,,LIB,Libertarian,0,0,0,0
+Galveston,330-1,U.S. Senate,,REP,Ted Cruz,0,0,0,0
+Galveston,330-1,U.S. Senate,,DEM,Beto O'Rourke,0,0,0,0
+Galveston,330-1,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Galveston,330-1,U.S. House,14,REP,Randy Weber,0,0,0,0
+Galveston,330-1,U.S. House,14,DEM,Adrienne Bell,0,0,0,0
+Galveston,330-1,U.S. House,14,LIB,Don E. Conley III,0,0,0,0
+Galveston,330-1,Governor,,REP,Greg Abbott,0,0,0,0
+Galveston,330-1,Governor,,DEM,Lupe Valdez,0,0,0,0
+Galveston,330-1,Governor,,LIB,Mark Jay Tippetts,0,0,0,0
+Galveston,330-1,Lieutenant Governor,,REP,Dan Patrick,0,0,0,0
+Galveston,330-1,Lieutenant Governor,,DEM,Mike Collier,0,0,0,0
+Galveston,330-1,Lieutenant Governor,,LIB,Kerry Douglas McKennon,0,0,0,0
+Galveston,330-1,Attorney General,,REP,Ken Paxton,0,0,0,0
+Galveston,330-1,Attorney General,,DEM,Justin Nelson,0,0,0,0
+Galveston,330-1,Attorney General,,LIB,Michael Ray Harris,0,0,0,0
+Galveston,330-1,Comptroller of Public Accounts,,REP,Glenn Hegar,0,0,0,0
+Galveston,330-1,Comptroller of Public Accounts,,DEM,Joi Chevalier,0,0,0,0
+Galveston,330-1,Comptroller of Public Accounts,,LIB,Ben Sanders,0,0,0,0
+Galveston,330-1,Commissioner of General Land Office,,REP,George P. Bush,0,0,0,0
+Galveston,330-1,Commissioner of General Land Office,,DEM,Miguel Suazo,0,0,0,0
+Galveston,330-1,Commissioner of General Land Office,,LIB,Matt Pina,0,0,0,0
+Galveston,330-1,Commissioner of Agriculture,,REP,Sid Miller,0,0,0,0
+Galveston,330-1,Commissioner of Agriculture,,DEM,Kim Olson,0,0,0,0
+Galveston,330-1,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0,0
+Galveston,330-1,Railroad Commissioner,,REP,Christi Craddick,0,0,0,0
+Galveston,330-1,Railroad Commissioner,,DEM,Roman McAllen,0,0,0,0
+Galveston,330-1,Railroad Commissioner,,LIB,Mike Wright,0,0,0,0
+Galveston,330-1,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,0,0,0,0
+Galveston,330-1,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,0,0,0,0
+Galveston,330-1,"Justice, Supreme Court, Place 4",,REP,John Devine,0,0,0,0
+Galveston,330-1,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,0,0,0,0
+Galveston,330-1,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,0,0,0,0
+Galveston,330-1,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,0,0,0,0
+Galveston,330-1,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,0,0,0,0
+Galveston,330-1,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,0,0,0,0
+Galveston,330-1,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,0,0,0,0
+Galveston,330-1,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,0,0,0,0
+Galveston,330-1,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0,0,0
+Galveston,330-1,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,0,0,0,0
+Galveston,330-1,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,0,0,0,0
+Galveston,330-1,"Member, State Board of Education, District 7",,REP,Matt Robinson,0,0,0,0
+Galveston,330-1,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",0,0,0,0
+Galveston,330-1,State Representative,24,REP,Greg Bonnen,0,0,0,0
+Galveston,330-1,State Representative,24,DEM,John Y. Phelps,0,0,0,0
+Galveston,330-1,State Representative,24,LIB,Dick Illyes,0,0,0,0
+Galveston,330-1,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,0,0,0,0
+Galveston,330-1,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,0,0,0,0
+Galveston,330-1,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,0,0,0,0
+Galveston,330-1,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,0,0,0,0
+Galveston,330-1,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,0,0,0,0
+Galveston,330-1,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,0,0,0,0
+Galveston,330-1,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,0,0,0,0
+Galveston,330-1,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,0,0,0,0
+Galveston,330-1,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,0,0,0,0
+Galveston,330-1,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,0,0,0,0
+Galveston,330-1,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,0,0,0,0
+Galveston,330-1,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,0,0,0,0
+Galveston,330-1,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,0,0,0,0
+Galveston,330-1,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,0,0,0,0
+Galveston,330-1,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,0,0,0,0
+Galveston,330-1,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,0,0,0,0
+Galveston,330-1,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,0,0,0,0
+Galveston,330-1,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,0,0,0,0
+Galveston,330-1,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,0,0,0,0
+Galveston,330-1,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",0,0,0,0
+Galveston,330-1,"District Judge, 122nd Judicial District",,REP,John Ellisor,0,0,0,0
+Galveston,330-1,"District Judge, 212th Judicial District",,REP,Patricia Grady,0,0,0,0
+Galveston,330-1,"District Judge, 306th Judicial District",,REP,Anne B. Darring,0,0,0,0
+Galveston,330-1,Criminal District Attorney,,REP,Jack Roady,0,0,0,0
+Galveston,330-1,County Judge,,REP,Mark Henry,0,0,0,0
+Galveston,330-1,"Judge, County Court-at-Law No. 1",,REP,John Grady,0,0,0,0
+Galveston,330-1,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,0,0,0,0
+Galveston,330-1,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,0,0,0,0
+Galveston,330-1,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,0,0,0,0
+Galveston,330-1,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,0,0,0,0
+Galveston,330-1,District Clerk,,REP,John D Kinard,0,0,0,0
+Galveston,330-1,County Clerk,,REP,Dwight Sullivan,0,0,0,0
+Galveston,330-1,County Treasurer,,REP,Kevin C. Walsh,0,0,0,0
+Galveston,330-1,Justice of the Peace Pct. 3,,DEM,"Billy A. Williams, Jr.",0,0,0,0
+Galveston,330-1,College of the Mainland Proposition A,,,FOR,0,0,0,0
+Galveston,330-1,College of the Mainland Proposition A,,,AGAINST,0,0,0,0
+Galveston,331,Ballots Cast,,,,1216,798,281,137
+Galveston,331,Straight Party,,REP,Republican,162,115,28,19
+Galveston,331,Straight Party,,DEM,Democrat,721,461,180,80
+Galveston,331,Straight Party,,LIB,Libertarian,4,2,1,1
+Galveston,331,U.S. Senate,,REP,Ted Cruz,241,165,43,33
+Galveston,331,U.S. Senate,,DEM,Beto O'Rourke,957,622,232,103
+Galveston,331,U.S. Senate,,LIB,Neal M. Dikeman,7,3,3,1
+Galveston,331,U.S. House,14,REP,Randy Weber,239,165,44,30
+Galveston,331,U.S. House,14,DEM,Adrienne Bell,955,617,232,106
+Galveston,331,U.S. House,14,LIB,Don E. Conley III,9,6,3,0
+Galveston,331,Governor,,REP,Greg Abbott,281,189,57,35
+Galveston,331,Governor,,DEM,Lupe Valdez,910,587,221,102
+Galveston,331,Governor,,LIB,Mark Jay Tippetts,17,15,2,0
+Galveston,331,Lieutenant Governor,,REP,Dan Patrick,244,168,46,30
+Galveston,331,Lieutenant Governor,,DEM,Mike Collier,939,607,226,106
+Galveston,331,Lieutenant Governor,,LIB,Kerry Douglas McKennon,22,14,7,1
+Galveston,331,Attorney General,,REP,Ken Paxton,227,158,40,29
+Galveston,331,Attorney General,,DEM,Justin Nelson,947,611,229,107
+Galveston,331,Attorney General,,LIB,Michael Ray Harris,27,17,10,0
+Galveston,331,Comptroller of Public Accounts,,REP,Glenn Hegar,238,162,45,31
+Galveston,331,Comptroller of Public Accounts,,DEM,Joi Chevalier,937,605,227,105
+Galveston,331,Comptroller of Public Accounts,,LIB,Ben Sanders,23,18,5,0
+Galveston,331,Commissioner of General Land Office,,REP,George P. Bush,242,168,43,31
+Galveston,331,Commissioner of General Land Office,,DEM,Miguel Suazo,930,598,227,105
+Galveston,331,Commissioner of General Land Office,,LIB,Matt Pina,27,19,8,0
+Galveston,331,Commissioner of Agriculture,,REP,Sid Miller,226,157,39,30
+Galveston,331,Commissioner of Agriculture,,DEM,Kim Olson,953,616,232,105
+Galveston,331,Commissioner of Agriculture,,LIB,Richard Carpenter,21,13,7,1
+Galveston,331,Railroad Commissioner,,REP,Christi Craddick,235,164,42,29
+Galveston,331,Railroad Commissioner,,DEM,Roman McAllen,936,605,226,105
+Galveston,331,Railroad Commissioner,,LIB,Mike Wright,27,16,10,1
+Galveston,331,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,244,164,47,33
+Galveston,331,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,957,622,232,103
+Galveston,331,"Justice, Supreme Court, Place 4",,REP,John Devine,247,167,49,31
+Galveston,331,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,952,618,229,105
+Galveston,331,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,242,163,47,32
+Galveston,331,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,958,624,231,103
+Galveston,331,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,239,166,43,30
+Galveston,331,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,947,612,230,105
+Galveston,331,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,16,11,4,1
+Galveston,331,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,243,167,45,31
+Galveston,331,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,957,620,232,105
+Galveston,331,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,300,206,56,38
+Galveston,331,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,263,182,59,22
+Galveston,331,"Member, State Board of Education, District 7",,REP,Matt Robinson,239,165,44,30
+Galveston,331,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",956,619,233,104
+Galveston,331,State Representative,23,REP,Mayes Middleton,238,164,45,29
+Galveston,331,State Representative,23,DEM,Amanda Jamrok,941,611,228,102
+Galveston,331,State Representative,23,LIB,Lawrence Johnson,24,15,5,4
+Galveston,331,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,241,165,44,32
+Galveston,331,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,954,619,232,103
+Galveston,331,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,237,163,44,30
+Galveston,331,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,958,621,233,104
+Galveston,331,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,238,163,44,31
+Galveston,331,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,957,621,233,103
+Galveston,331,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,233,161,42,30
+Galveston,331,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,963,624,235,104
+Galveston,331,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,247,169,46,32
+Galveston,331,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,948,613,231,104
+Galveston,331,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,244,168,46,30
+Galveston,331,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,952,616,231,105
+Galveston,331,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,245,168,45,32
+Galveston,331,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,949,615,232,102
+Galveston,331,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,250,169,48,33
+Galveston,331,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,943,614,227,102
+Galveston,331,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,232,161,41,30
+Galveston,331,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,964,623,236,105
+Galveston,331,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,242,166,46,30
+Galveston,331,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",953,617,231,105
+Galveston,331,"District Judge, 122nd Judicial District",,REP,John Ellisor,349,236,73,40
+Galveston,331,"District Judge, 212th Judicial District",,REP,Patricia Grady,357,243,74,40
+Galveston,331,"District Judge, 306th Judicial District",,REP,Anne B. Darring,351,238,73,40
+Galveston,331,Criminal District Attorney,,REP,Jack Roady,349,237,71,41
+Galveston,331,County Judge,,REP,Mark Henry,348,241,71,36
+Galveston,331,"Judge, County Court-at-Law No. 1",,REP,John Grady,336,227,71,38
+Galveston,331,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,232,157,46,29
+Galveston,331,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,955,625,228,102
+Galveston,331,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,346,235,72,39
+Galveston,331,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,342,234,70,38
+Galveston,331,District Clerk,,REP,John D Kinard,336,230,69,37
+Galveston,331,County Clerk,,REP,Dwight Sullivan,344,231,73,40
+Galveston,331,County Treasurer,,REP,Kevin C. Walsh,338,229,71,38
+Galveston,331,Justice of the Peace Pct. 3,,DEM,"Billy A. Williams, Jr.",996,645,243,108
+Galveston,331,College of the Mainland Proposition A,,,FOR,773,495,187,91
+Galveston,331,College of the Mainland Proposition A,,,AGAINST,175,116,32,27
+Galveston,331-1,Ballots Cast,,,,187,135,33,19
+Galveston,331-1,Straight Party,,REP,Republican,50,37,7,6
+Galveston,331-1,Straight Party,,DEM,Democrat,74,53,12,9
+Galveston,331-1,Straight Party,,LIB,Libertarian,0,0,0,0
+Galveston,331-1,U.S. Senate,,REP,Ted Cruz,76,56,13,7
+Galveston,331-1,U.S. Senate,,DEM,Beto O'Rourke,109,77,20,12
+Galveston,331-1,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Galveston,331-1,U.S. House,14,REP,Randy Weber,77,58,12,7
+Galveston,331-1,U.S. House,14,DEM,Adrienne Bell,106,74,20,12
+Galveston,331-1,U.S. House,14,LIB,Don E. Conley III,2,1,1,0
+Galveston,331-1,Governor,,REP,Greg Abbott,86,63,15,8
+Galveston,331-1,Governor,,DEM,Lupe Valdez,99,70,18,11
+Galveston,331-1,Governor,,LIB,Mark Jay Tippetts,0,0,0,0
+Galveston,331-1,Lieutenant Governor,,REP,Dan Patrick,78,57,14,7
+Galveston,331-1,Lieutenant Governor,,DEM,Mike Collier,107,76,19,12
+Galveston,331-1,Lieutenant Governor,,LIB,Kerry Douglas McKennon,1,1,0,0
+Galveston,331-1,Attorney General,,REP,Ken Paxton,75,55,13,7
+Galveston,331-1,Attorney General,,DEM,Justin Nelson,110,78,20,12
+Galveston,331-1,Attorney General,,LIB,Michael Ray Harris,1,1,0,0
+Galveston,331-1,Comptroller of Public Accounts,,REP,Glenn Hegar,73,53,13,7
+Galveston,331-1,Comptroller of Public Accounts,,DEM,Joi Chevalier,107,76,19,12
+Galveston,331-1,Comptroller of Public Accounts,,LIB,Ben Sanders,4,3,1,0
+Galveston,331-1,Commissioner of General Land Office,,REP,George P. Bush,75,55,14,6
+Galveston,331-1,Commissioner of General Land Office,,DEM,Miguel Suazo,102,72,18,12
+Galveston,331-1,Commissioner of General Land Office,,LIB,Matt Pina,8,6,1,1
+Galveston,331-1,Commissioner of Agriculture,,REP,Sid Miller,69,51,11,7
+Galveston,331-1,Commissioner of Agriculture,,DEM,Kim Olson,111,79,20,12
+Galveston,331-1,Commissioner of Agriculture,,LIB,Richard Carpenter,4,2,2,0
+Galveston,331-1,Railroad Commissioner,,REP,Christi Craddick,76,57,13,6
+Galveston,331-1,Railroad Commissioner,,DEM,Roman McAllen,106,76,18,12
+Galveston,331-1,Railroad Commissioner,,LIB,Mike Wright,4,1,2,1
+Galveston,331-1,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,74,54,13,7
+Galveston,331-1,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,113,81,20,12
+Galveston,331-1,"Justice, Supreme Court, Place 4",,REP,John Devine,72,52,13,7
+Galveston,331-1,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,114,82,20,12
+Galveston,331-1,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,74,54,13,7
+Galveston,331-1,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,112,80,20,12
+Galveston,331-1,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,74,55,12,7
+Galveston,331-1,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,111,79,20,12
+Galveston,331-1,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,2,1,1,0
+Galveston,331-1,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,75,55,13,7
+Galveston,331-1,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,111,79,20,12
+Galveston,331-1,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,88,66,15,7
+Galveston,331-1,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,32,24,4,4
+Galveston,331-1,"Member, State Board of Education, District 7",,REP,Matt Robinson,76,56,13,7
+Galveston,331-1,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",108,76,20,12
+Galveston,331-1,State Representative,23,REP,Mayes Middleton,79,59,13,7
+Galveston,331-1,State Representative,23,DEM,Amanda Jamrok,101,71,18,12
+Galveston,331-1,State Representative,23,LIB,Lawrence Johnson,4,3,1,0
+Galveston,331-1,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,76,54,15,7
+Galveston,331-1,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,108,78,18,12
+Galveston,331-1,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,77,56,14,7
+Galveston,331-1,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,109,78,19,12
+Galveston,331-1,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,76,55,14,7
+Galveston,331-1,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,110,79,19,12
+Galveston,331-1,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,74,55,12,7
+Galveston,331-1,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,111,78,21,12
+Galveston,331-1,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,76,54,15,7
+Galveston,331-1,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,108,78,18,12
+Galveston,331-1,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,75,54,14,7
+Galveston,331-1,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,110,80,18,12
+Galveston,331-1,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,74,53,14,7
+Galveston,331-1,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,112,81,19,12
+Galveston,331-1,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,74,54,13,7
+Galveston,331-1,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,111,79,20,12
+Galveston,331-1,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,73,53,13,7
+Galveston,331-1,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,112,80,20,12
+Galveston,331-1,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,74,54,13,7
+Galveston,331-1,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",112,80,20,12
+Galveston,331-1,"District Judge, 122nd Judicial District",,REP,John Ellisor,97,72,18,7
+Galveston,331-1,"District Judge, 212th Judicial District",,REP,Patricia Grady,96,72,17,7
+Galveston,331-1,"District Judge, 306th Judicial District",,REP,Anne B. Darring,95,71,17,7
+Galveston,331-1,Criminal District Attorney,,REP,Jack Roady,94,70,17,7
+Galveston,331-1,County Judge,,REP,Mark Henry,95,72,17,6
+Galveston,331-1,"Judge, County Court-at-Law No. 1",,REP,John Grady,89,68,15,6
+Galveston,331-1,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,74,54,14,6
+Galveston,331-1,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,110,80,18,12
+Galveston,331-1,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,92,70,16,6
+Galveston,331-1,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,91,69,16,6
+Galveston,331-1,District Clerk,,REP,John D Kinard,92,70,16,6
+Galveston,331-1,County Clerk,,REP,Dwight Sullivan,92,70,16,6
+Galveston,331-1,County Treasurer,,REP,Kevin C. Walsh,90,68,16,6
+Galveston,331-1,Justice of the Peace Pct. 2,,REP,Mike Nelson,88,66,16,6
+Galveston,331-1,College of the Mainland Proposition A,,,FOR,106,86,13,7
+Galveston,331-1,College of the Mainland Proposition A,,,AGAINST,44,29,10,5
+Galveston,334,Ballots Cast,,,,607,346,180,81
+Galveston,334,Straight Party,,REP,Republican,78,45,28,5
+Galveston,334,Straight Party,,DEM,Democrat,410,229,125,56
+Galveston,334,Straight Party,,LIB,Libertarian,2,0,0,2
+Galveston,334,U.S. Senate,,REP,Ted Cruz,100,63,31,6
+Galveston,334,U.S. Senate,,DEM,Beto O'Rourke,498,277,148,73
+Galveston,334,U.S. Senate,,LIB,Neal M. Dikeman,4,3,0,1
+Galveston,334,U.S. House,14,REP,Randy Weber,100,61,33,6
+Galveston,334,U.S. House,14,DEM,Adrienne Bell,496,280,143,73
+Galveston,334,U.S. House,14,LIB,Don E. Conley III,6,3,2,1
+Galveston,334,Governor,,REP,Greg Abbott,116,74,36,6
+Galveston,334,Governor,,DEM,Lupe Valdez,486,270,143,73
+Galveston,334,Governor,,LIB,Mark Jay Tippetts,2,1,0,1
+Galveston,334,Lieutenant Governor,,REP,Dan Patrick,102,61,35,6
+Galveston,334,Lieutenant Governor,,DEM,Mike Collier,495,279,143,73
+Galveston,334,Lieutenant Governor,,LIB,Kerry Douglas McKennon,6,3,2,1
+Galveston,334,Attorney General,,REP,Ken Paxton,97,59,32,6
+Galveston,334,Attorney General,,DEM,Justin Nelson,499,280,147,72
+Galveston,334,Attorney General,,LIB,Michael Ray Harris,7,5,1,1
+Galveston,334,Comptroller of Public Accounts,,REP,Glenn Hegar,98,60,32,6
+Galveston,334,Comptroller of Public Accounts,,DEM,Joi Chevalier,488,273,142,73
+Galveston,334,Comptroller of Public Accounts,,LIB,Ben Sanders,17,10,6,1
+Galveston,334,Commissioner of General Land Office,,REP,George P. Bush,103,65,32,6
+Galveston,334,Commissioner of General Land Office,,DEM,Miguel Suazo,491,275,143,73
+Galveston,334,Commissioner of General Land Office,,LIB,Matt Pina,10,4,5,1
+Galveston,334,Commissioner of Agriculture,,REP,Sid Miller,98,60,32,6
+Galveston,334,Commissioner of Agriculture,,DEM,Kim Olson,497,279,145,73
+Galveston,334,Commissioner of Agriculture,,LIB,Richard Carpenter,9,5,3,1
+Galveston,334,Railroad Commissioner,,REP,Christi Craddick,98,60,32,6
+Galveston,334,Railroad Commissioner,,DEM,Roman McAllen,496,279,144,73
+Galveston,334,Railroad Commissioner,,LIB,Mike Wright,10,5,4,1
+Galveston,334,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,102,61,34,7
+Galveston,334,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,501,283,146,72
+Galveston,334,"Justice, Supreme Court, Place 4",,REP,John Devine,102,61,35,6
+Galveston,334,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,501,284,145,72
+Galveston,334,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,102,61,35,6
+Galveston,334,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,502,284,145,73
+Galveston,334,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,98,59,33,6
+Galveston,334,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,499,281,145,73
+Galveston,334,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,6,3,2,1
+Galveston,334,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,104,64,34,6
+Galveston,334,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,499,280,146,73
+Galveston,334,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,120,76,37,7
+Galveston,334,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,123,73,32,18
+Galveston,334,"Member, State Board of Education, District 7",,REP,Matt Robinson,97,58,34,5
+Galveston,334,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",504,285,146,73
+Galveston,334,State Representative,24,REP,Greg Bonnen,98,61,32,5
+Galveston,334,State Representative,24,DEM,John Y. Phelps,497,281,143,73
+Galveston,334,State Representative,24,LIB,Dick Illyes,10,3,5,2
+Galveston,334,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,100,61,34,5
+Galveston,334,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,501,282,146,73
+Galveston,334,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,103,62,35,6
+Galveston,334,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,498,281,145,72
+Galveston,334,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,100,61,34,5
+Galveston,334,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,500,281,146,73
+Galveston,334,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,98,59,34,5
+Galveston,334,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,502,283,146,73
+Galveston,334,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,102,62,35,5
+Galveston,334,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,497,279,145,73
+Galveston,334,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,102,62,35,5
+Galveston,334,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,498,280,145,73
+Galveston,334,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,100,61,34,5
+Galveston,334,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,500,281,146,73
+Galveston,334,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,102,62,35,5
+Galveston,334,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,499,281,145,73
+Galveston,334,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,103,63,35,5
+Galveston,334,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,498,280,145,73
+Galveston,334,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,100,61,34,5
+Galveston,334,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",502,282,146,74
+Galveston,334,"District Judge, 122nd Judicial District",,REP,John Ellisor,146,88,46,12
+Galveston,334,"District Judge, 212th Judicial District",,REP,Patricia Grady,144,87,46,11
+Galveston,334,"District Judge, 306th Judicial District",,REP,Anne B. Darring,146,89,46,11
+Galveston,334,Criminal District Attorney,,REP,Jack Roady,144,86,45,13
+Galveston,334,County Judge,,REP,Mark Henry,146,88,47,11
+Galveston,334,"Judge, County Court-at-Law No. 1",,REP,John Grady,140,84,46,10
+Galveston,334,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,104,64,35,5
+Galveston,334,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,495,278,145,72
+Galveston,334,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,141,87,44,10
+Galveston,334,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,143,87,45,11
+Galveston,334,District Clerk,,REP,John D Kinard,142,87,44,11
+Galveston,334,County Clerk,,REP,Dwight Sullivan,147,88,47,12
+Galveston,334,County Treasurer,,REP,Kevin C. Walsh,141,86,45,10
+Galveston,334,Justice of the Peace Pct. 3,,DEM,"Billy A. Williams, Jr.",512,289,149,74
+Galveston,334,College of the Mainland Proposition A,,,FOR,400,228,118,54
+Galveston,334,College of the Mainland Proposition A,,,AGAINST,59,34,15,10
+Galveston,336,Ballots Cast,,,,2128,1389,475,264
+Galveston,336,Straight Party,,REP,Republican,155,97,38,20
+Galveston,336,Straight Party,,DEM,Democrat,1481,969,320,192
+Galveston,336,Straight Party,,LIB,Libertarian,5,2,2,1
+Galveston,336,U.S. Senate,,REP,Ted Cruz,225,139,57,29
+Galveston,336,U.S. Senate,,DEM,Beto O'Rourke,1873,1230,410,233
+Galveston,336,U.S. Senate,,LIB,Neal M. Dikeman,13,8,4,1
+Galveston,336,U.S. House,14,REP,Randy Weber,224,141,56,27
+Galveston,336,U.S. House,14,DEM,Adrienne Bell,1876,1233,410,233
+Galveston,336,U.S. House,14,LIB,Don E. Conley III,10,4,5,1
+Galveston,336,Governor,,REP,Greg Abbott,280,173,72,35
+Galveston,336,Governor,,DEM,Lupe Valdez,1807,1194,388,225
+Galveston,336,Governor,,LIB,Mark Jay Tippetts,23,11,11,1
+Galveston,336,Lieutenant Governor,,REP,Dan Patrick,243,147,63,33
+Galveston,336,Lieutenant Governor,,DEM,Mike Collier,1847,1216,401,230
+Galveston,336,Lieutenant Governor,,LIB,Kerry Douglas McKennon,17,10,7,0
+Galveston,336,Attorney General,,REP,Ken Paxton,228,141,59,28
+Galveston,336,Attorney General,,DEM,Justin Nelson,1865,1226,406,233
+Galveston,336,Attorney General,,LIB,Michael Ray Harris,18,11,6,1
+Galveston,336,Comptroller of Public Accounts,,REP,Glenn Hegar,219,134,58,27
+Galveston,336,Comptroller of Public Accounts,,DEM,Joi Chevalier,1855,1219,402,234
+Galveston,336,Comptroller of Public Accounts,,LIB,Ben Sanders,27,19,8,0
+Galveston,336,Commissioner of General Land Office,,REP,George P. Bush,231,141,61,29
+Galveston,336,Commissioner of General Land Office,,DEM,Miguel Suazo,1843,1212,401,230
+Galveston,336,Commissioner of General Land Office,,LIB,Matt Pina,29,19,10,0
+Galveston,336,Commissioner of Agriculture,,REP,Sid Miller,217,136,54,27
+Galveston,336,Commissioner of Agriculture,,DEM,Kim Olson,1871,1227,412,232
+Galveston,336,Commissioner of Agriculture,,LIB,Richard Carpenter,15,11,4,0
+Galveston,336,Railroad Commissioner,,REP,Christi Craddick,219,134,58,27
+Galveston,336,Railroad Commissioner,,DEM,Roman McAllen,1866,1226,407,233
+Galveston,336,Railroad Commissioner,,LIB,Mike Wright,25,18,7,0
+Galveston,336,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,226,138,61,27
+Galveston,336,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,1878,1237,408,233
+Galveston,336,"Justice, Supreme Court, Place 4",,REP,John Devine,230,143,60,27
+Galveston,336,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,1869,1230,409,230
+Galveston,336,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,227,140,59,28
+Galveston,336,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,1874,1233,409,232
+Galveston,336,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,220,137,56,27
+Galveston,336,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,1873,1235,406,232
+Galveston,336,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,12,5,7,0
+Galveston,336,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,228,141,60,27
+Galveston,336,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,1875,1234,409,232
+Galveston,336,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,314,196,83,35
+Galveston,336,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,497,341,126,30
+Galveston,336,"Member, State Board of Education, District 7",,REP,Matt Robinson,225,140,59,26
+Galveston,336,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",1877,1238,408,231
+Galveston,336,State Representative,23,REP,Mayes Middleton,231,146,58,27
+Galveston,336,State Representative,23,DEM,Amanda Jamrok,1856,1221,404,231
+Galveston,336,State Representative,23,LIB,Lawrence Johnson,21,12,8,1
+Galveston,336,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,224,141,57,26
+Galveston,336,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,1878,1236,409,233
+Galveston,336,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,229,143,59,27
+Galveston,336,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,1869,1232,407,230
+Galveston,336,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,228,142,60,26
+Galveston,336,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,1870,1232,407,231
+Galveston,336,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,221,140,56,25
+Galveston,336,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,1880,1237,410,233
+Galveston,336,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,233,144,61,28
+Galveston,336,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,1865,1231,404,230
+Galveston,336,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,231,148,58,25
+Galveston,336,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,1865,1224,409,232
+Galveston,336,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,230,144,61,25
+Galveston,336,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,1866,1228,406,232
+Galveston,336,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,230,144,60,26
+Galveston,336,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,1866,1228,407,231
+Galveston,336,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,229,144,58,27
+Galveston,336,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,1868,1229,408,231
+Galveston,336,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,226,144,56,26
+Galveston,336,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",1870,1228,411,231
+Galveston,336,"District Judge, 122nd Judicial District",,REP,John Ellisor,402,256,103,43
+Galveston,336,"District Judge, 212th Judicial District",,REP,Patricia Grady,398,253,104,41
+Galveston,336,"District Judge, 306th Judicial District",,REP,Anne B. Darring,389,247,102,40
+Galveston,336,Criminal District Attorney,,REP,Jack Roady,397,247,104,46
+Galveston,336,County Judge,,REP,Mark Henry,397,243,108,46
+Galveston,336,"Judge, County Court-at-Law No. 1",,REP,John Grady,377,235,103,39
+Galveston,336,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,222,141,56,25
+Galveston,336,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,1878,1232,412,234
+Galveston,336,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,393,248,104,41
+Galveston,336,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,389,240,104,45
+Galveston,336,District Clerk,,REP,John D Kinard,382,239,101,42
+Galveston,336,County Clerk,,REP,Dwight Sullivan,396,246,105,45
+Galveston,336,County Treasurer,,REP,Kevin C. Walsh,381,237,102,42
+Galveston,336,Justice of the Peace Pct. 3,,DEM,"Billy A. Williams, Jr.",1907,1250,421,236
+Galveston,336,College of the Mainland Proposition A,,,FOR,1400,908,321,171
+Galveston,336,College of the Mainland Proposition A,,,AGAINST,283,183,68,32
+Galveston,336,Galveston County MUD No. 66 Proposition A,,,FOR,25,11,12,2
+Galveston,336,Galveston County MUD No. 66 Proposition A,,,AGAINST,26,16,9,1
+Galveston,336,Galveston County MUD No. 66 Proposition B,,,FOR,34,16,15,3
+Galveston,336,Galveston County MUD No. 66 Proposition B,,,AGAINST,20,13,6,1
+Galveston,338,Ballots Cast,,,,1800,1228,409,163
+Galveston,338,Straight Party,,REP,Republican,430,299,75,56
+Galveston,338,Straight Party,,DEM,Democrat,813,543,198,72
+Galveston,338,Straight Party,,LIB,Libertarian,9,4,5,0
+Galveston,338,U.S. Senate,,REP,Ted Cruz,625,432,122,71
+Galveston,338,U.S. Senate,,DEM,Beto O'Rourke,1145,777,277,91
+Galveston,338,U.S. Senate,,LIB,Neal M. Dikeman,14,8,6,0
+Galveston,338,U.S. House,14,REP,Randy Weber,634,444,122,68
+Galveston,338,U.S. House,14,DEM,Adrienne Bell,1129,761,275,93
+Galveston,338,U.S. House,14,LIB,Don E. Conley III,21,13,8,0
+Galveston,338,Governor,,REP,Greg Abbott,692,473,147,72
+Galveston,338,Governor,,DEM,Lupe Valdez,1065,725,252,88
+Galveston,338,Governor,,LIB,Mark Jay Tippetts,29,21,7,1
+Galveston,338,Lieutenant Governor,,REP,Dan Patrick,635,439,127,69
+Galveston,338,Lieutenant Governor,,DEM,Mike Collier,1119,757,269,93
+Galveston,338,Lieutenant Governor,,LIB,Kerry Douglas McKennon,25,17,8,0
+Galveston,338,Attorney General,,REP,Ken Paxton,605,414,127,64
+Galveston,338,Attorney General,,DEM,Justin Nelson,1147,776,274,97
+Galveston,338,Attorney General,,LIB,Michael Ray Harris,27,20,6,1
+Galveston,338,Comptroller of Public Accounts,,REP,Glenn Hegar,618,429,122,67
+Galveston,338,Comptroller of Public Accounts,,DEM,Joi Chevalier,1104,747,266,91
+Galveston,338,Comptroller of Public Accounts,,LIB,Ben Sanders,52,34,15,3
+Galveston,338,Commissioner of General Land Office,,REP,George P. Bush,640,441,129,70
+Galveston,338,Commissioner of General Land Office,,DEM,Miguel Suazo,1086,734,262,90
+Galveston,338,Commissioner of General Land Office,,LIB,Matt Pina,48,34,13,1
+Galveston,338,Commissioner of Agriculture,,REP,Sid Miller,604,421,116,67
+Galveston,338,Commissioner of Agriculture,,DEM,Kim Olson,1138,770,277,91
+Galveston,338,Commissioner of Agriculture,,LIB,Richard Carpenter,29,17,11,1
+Galveston,338,Railroad Commissioner,,REP,Christi Craddick,620,431,123,66
+Galveston,338,Railroad Commissioner,,DEM,Roman McAllen,1116,757,267,92
+Galveston,338,Railroad Commissioner,,LIB,Mike Wright,37,25,12,0
+Galveston,338,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,614,432,117,65
+Galveston,338,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,1152,775,283,94
+Galveston,338,"Justice, Supreme Court, Place 4",,REP,John Devine,625,432,126,67
+Galveston,338,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,1140,773,276,91
+Galveston,338,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,636,445,122,69
+Galveston,338,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,1132,763,279,90
+Galveston,338,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,614,430,116,68
+Galveston,338,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,1123,755,276,92
+Galveston,338,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,30,21,9,0
+Galveston,338,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,630,435,124,71
+Galveston,338,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,1135,769,278,88
+Galveston,338,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,731,510,148,73
+Galveston,338,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,391,259,105,27
+Galveston,338,"Member, State Board of Education, District 7",,REP,Matt Robinson,621,434,120,67
+Galveston,338,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",1147,774,280,93
+Galveston,338,State Representative,23,REP,Mayes Middleton,642,449,126,67
+Galveston,338,State Representative,23,DEM,Amanda Jamrok,1109,747,270,92
+Galveston,338,State Representative,23,LIB,Lawrence Johnson,30,20,8,2
+Galveston,338,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,639,441,128,70
+Galveston,338,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,1129,766,274,89
+Galveston,338,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,625,437,120,68
+Galveston,338,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,1140,770,278,92
+Galveston,338,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,629,439,124,66
+Galveston,338,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,1136,766,277,93
+Galveston,338,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,614,428,121,65
+Galveston,338,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,1152,778,281,93
+Galveston,338,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,633,441,127,65
+Galveston,338,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,1132,765,274,93
+Galveston,338,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,622,433,124,65
+Galveston,338,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,1137,768,275,94
+Galveston,338,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,635,440,125,70
+Galveston,338,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,1124,760,275,89
+Galveston,338,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,631,439,125,67
+Galveston,338,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,1130,762,275,93
+Galveston,338,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,620,433,122,65
+Galveston,338,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,1139,769,277,93
+Galveston,338,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,623,429,125,69
+Galveston,338,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",1136,771,275,90
+Galveston,338,"District Judge, 122nd Judicial District",,REP,John Ellisor,826,563,182,81
+Galveston,338,"District Judge, 212th Judicial District",,REP,Patricia Grady,817,553,184,80
+Galveston,338,"District Judge, 306th Judicial District",,REP,Anne B. Darring,809,547,181,81
+Galveston,338,Criminal District Attorney,,REP,Jack Roady,807,547,178,82
+Galveston,338,County Judge,,REP,Mark Henry,804,542,182,80
+Galveston,338,"Judge, County Court-at-Law No. 1",,REP,John Grady,796,537,179,80
+Galveston,338,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,623,432,123,68
+Galveston,338,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,1141,771,279,91
+Galveston,338,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,811,547,181,83
+Galveston,338,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,813,549,183,81
+Galveston,338,District Clerk,,REP,John D Kinard,810,549,181,80
+Galveston,338,County Clerk,,REP,Dwight Sullivan,818,554,183,81
+Galveston,338,County Treasurer,,REP,Kevin C. Walsh,811,546,185,80
+Galveston,338,Justice of the Peace Pct. 2,,REP,Mike Nelson,813,551,182,80
+Galveston,338,College of the Mainland Proposition A,,,FOR,1151,780,275,96
+Galveston,338,College of the Mainland Proposition A,,,AGAINST,317,212,55,50
+Galveston,338,Galveston County MUD No. 66 Proposition A,,,FOR,42,33,9,0
+Galveston,338,Galveston County MUD No. 66 Proposition A,,,AGAINST,67,42,22,3
+Galveston,338,Galveston County MUD No. 66 Proposition B,,,FOR,53,39,14,0
+Galveston,338,Galveston County MUD No. 66 Proposition B,,,AGAINST,56,35,18,3
+Galveston,340,Ballots Cast,,,,299,200,75,24
+Galveston,340,Straight Party,,REP,Republican,20,12,8,0
+Galveston,340,Straight Party,,DEM,Democrat,209,137,53,19
+Galveston,340,Straight Party,,LIB,Libertarian,0,0,0,0
+Galveston,340,U.S. Senate,,REP,Ted Cruz,29,17,10,2
+Galveston,340,U.S. Senate,,DEM,Beto O'Rourke,265,179,65,21
+Galveston,340,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Galveston,340,U.S. House,14,REP,Randy Weber,29,18,10,1
+Galveston,340,U.S. House,14,DEM,Adrienne Bell,261,176,63,22
+Galveston,340,U.S. House,14,LIB,Don E. Conley III,2,1,1,0
+Galveston,340,Governor,,REP,Greg Abbott,34,22,10,2
+Galveston,340,Governor,,DEM,Lupe Valdez,253,170,62,21
+Galveston,340,Governor,,LIB,Mark Jay Tippetts,4,3,1,0
+Galveston,340,Lieutenant Governor,,REP,Dan Patrick,33,19,12,2
+Galveston,340,Lieutenant Governor,,DEM,Mike Collier,256,174,61,21
+Galveston,340,Lieutenant Governor,,LIB,Kerry Douglas McKennon,2,2,0,0
+Galveston,340,Attorney General,,REP,Ken Paxton,31,20,9,2
+Galveston,340,Attorney General,,DEM,Justin Nelson,257,173,63,21
+Galveston,340,Attorney General,,LIB,Michael Ray Harris,3,2,1,0
+Galveston,340,Comptroller of Public Accounts,,REP,Glenn Hegar,27,16,9,2
+Galveston,340,Comptroller of Public Accounts,,DEM,Joi Chevalier,254,174,59,21
+Galveston,340,Comptroller of Public Accounts,,LIB,Ben Sanders,9,4,5,0
+Galveston,340,Commissioner of General Land Office,,REP,George P. Bush,33,21,10,2
+Galveston,340,Commissioner of General Land Office,,DEM,Miguel Suazo,258,174,62,22
+Galveston,340,Commissioner of General Land Office,,LIB,Matt Pina,1,0,1,0
+Galveston,340,Commissioner of Agriculture,,REP,Sid Miller,26,15,9,2
+Galveston,340,Commissioner of Agriculture,,DEM,Kim Olson,262,177,63,22
+Galveston,340,Commissioner of Agriculture,,LIB,Richard Carpenter,3,2,1,0
+Galveston,340,Railroad Commissioner,,REP,Christi Craddick,30,19,10,1
+Galveston,340,Railroad Commissioner,,DEM,Roman McAllen,259,175,62,22
+Galveston,340,Railroad Commissioner,,LIB,Mike Wright,2,0,1,1
+Galveston,340,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,28,16,10,2
+Galveston,340,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,263,178,63,22
+Galveston,340,"Justice, Supreme Court, Place 4",,REP,John Devine,29,16,11,2
+Galveston,340,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,263,179,62,22
+Galveston,340,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,29,17,10,2
+Galveston,340,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,261,177,62,22
+Galveston,340,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,27,16,10,1
+Galveston,340,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,261,177,62,22
+Galveston,340,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,3,2,0,1
+Galveston,340,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,32,18,12,2
+Galveston,340,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,259,176,61,22
+Galveston,340,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,44,30,12,2
+Galveston,340,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,70,44,17,9
+Galveston,340,"Member, State Board of Education, District 7",,REP,Matt Robinson,31,18,11,2
+Galveston,340,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",259,175,62,22
+Galveston,340,State Representative,24,REP,Greg Bonnen,28,17,10,1
+Galveston,340,State Representative,24,DEM,John Y. Phelps,262,177,63,22
+Galveston,340,State Representative,24,LIB,Dick Illyes,1,1,0,0
+Galveston,340,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,26,15,9,2
+Galveston,340,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,265,179,64,22
+Galveston,340,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,30,17,11,2
+Galveston,340,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,261,177,62,22
+Galveston,340,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,31,18,11,2
+Galveston,340,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,260,176,62,22
+Galveston,340,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,27,15,11,1
+Galveston,340,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,263,178,62,23
+Galveston,340,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,29,17,10,2
+Galveston,340,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,261,176,63,22
+Galveston,340,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,29,19,9,1
+Galveston,340,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,259,173,63,23
+Galveston,340,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,29,18,10,1
+Galveston,340,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,260,175,62,23
+Galveston,340,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,30,19,10,1
+Galveston,340,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,259,175,62,22
+Galveston,340,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,30,17,11,2
+Galveston,340,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,260,177,61,22
+Galveston,340,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,28,16,10,2
+Galveston,340,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",261,177,62,22
+Galveston,340,"District Judge, 122nd Judicial District",,REP,John Ellisor,48,32,13,3
+Galveston,340,"District Judge, 212th Judicial District",,REP,Patricia Grady,50,33,13,4
+Galveston,340,"District Judge, 306th Judicial District",,REP,Anne B. Darring,47,31,13,3
+Galveston,340,Criminal District Attorney,,REP,Jack Roady,48,32,13,3
+Galveston,340,County Judge,,REP,Mark Henry,52,35,13,4
+Galveston,340,"Judge, County Court-at-Law No. 1",,REP,John Grady,48,32,13,3
+Galveston,340,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,27,17,9,1
+Galveston,340,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,261,176,62,23
+Galveston,340,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,49,32,13,4
+Galveston,340,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,50,32,14,4
+Galveston,340,District Clerk,,REP,John D Kinard,48,32,13,3
+Galveston,340,County Clerk,,REP,Dwight Sullivan,50,32,13,5
+Galveston,340,County Treasurer,,REP,Kevin C. Walsh,53,34,14,5
+Galveston,340,College of the Mainland Proposition A,,,FOR,177,122,37,18
+Galveston,340,College of the Mainland Proposition A,,,AGAINST,29,23,5,1
+Galveston,340,Mayor  - League City,,,Sebastian Lofaro,1,1,0,0
+Galveston,340,Mayor  - League City,,,Pat Hallisey,1,1,0,0
+Galveston,340,Council Position 1  - League City,,,Andy Mann,1,1,0,0
+Galveston,340,Council Position 1  - League City,,,Traci Jacobs,1,1,0,0
+Galveston,340,Council Position 2  - League City,,,Hank Dugie,2,2,0,0
+Galveston,340,Council Position 6  - League City,,,Silvio P. Vincenzo,0,0,0,0
+Galveston,340,Council Position 6  - League City,,,Chad Tressler,1,1,0,0
+Galveston,340,Council Position 6  - League City,,,Chris Gross,1,1,0,0
+Galveston,340,Council Position 7  - League City,,,Ange Mertens,1,1,0,0
+Galveston,340,Council Position 7  - League City,,,Nick Long,1,1,0,0
+Galveston,340,League City Proposition A,,,For,1,1,0,0
+Galveston,340,League City Proposition A,,,Against,1,1,0,0
+Galveston,340,League City Proposition B,,,For,1,1,0,0
+Galveston,340,League City Proposition B,,,Against,1,1,0,0
+Galveston,340,League City Proposition C,,,For,2,2,0,0
+Galveston,340,League City Proposition C,,,Against,0,0,0,0
+Galveston,340,League City Proposition D,,,For,2,2,0,0
+Galveston,340,League City Proposition D,,,Against,0,0,0,0
+Galveston,340,League City Proposition E,,,For,2,2,0,0
+Galveston,340,League City Proposition E,,,Against,0,0,0,0
+Galveston,340,League City Proposition F,,,For,2,2,0,0
+Galveston,340,League City Proposition F,,,Against,0,0,0,0
+Galveston,340,League City Proposition G,,,For,2,2,0,0
+Galveston,340,League City Proposition G,,,Against,0,0,0,0
+Galveston,340,League City Proposition H,,,For,2,2,0,0
+Galveston,340,League City Proposition H,,,Against,0,0,0,0
+Galveston,340,League City Proposition I,,,For,2,2,0,0
+Galveston,340,League City Proposition I,,,Against,0,0,0,0
+Galveston,340,League City Proposition J,,,For,2,2,0,0
+Galveston,340,League City Proposition J,,,Against,0,0,0,0
+Galveston,340,League City Proposition K,,,For,2,2,0,0
+Galveston,340,League City Proposition K,,,Against,0,0,0,0
+Galveston,340,League City Proposition L,,,For,2,2,0,0
+Galveston,340,League City Proposition L,,,Against,0,0,0,0
+Galveston,340,League City Proposition M,,,For,2,2,0,0
+Galveston,340,League City Proposition M,,,Against,0,0,0,0
+Galveston,340,League City Proposition N,,,For,1,1,0,0
+Galveston,340,League City Proposition N,,,Against,1,1,0,0
+Galveston,340,League City Proposition O,,,For,2,2,0,0
+Galveston,340,League City Proposition O,,,Against,0,0,0,0
+Galveston,341,Ballots Cast,,,,565,384,153,28
+Galveston,341,Straight Party,,REP,Republican,176,126,43,7
+Galveston,341,Straight Party,,DEM,Democrat,198,124,58,16
+Galveston,341,Straight Party,,LIB,Libertarian,6,2,4,0
+Galveston,341,U.S. Senate,,REP,Ted Cruz,263,182,72,9
+Galveston,341,U.S. Senate,,DEM,Beto O'Rourke,293,197,77,19
+Galveston,341,U.S. Senate,,LIB,Neal M. Dikeman,5,4,1,0
+Galveston,341,U.S. House,14,REP,Randy Weber,259,180,71,8
+Galveston,341,U.S. House,14,DEM,Adrienne Bell,287,190,78,19
+Galveston,341,U.S. House,14,LIB,Don E. Conley III,8,7,1,0
+Galveston,341,Governor,,REP,Greg Abbott,280,190,79,11
+Galveston,341,Governor,,DEM,Lupe Valdez,268,186,66,16
+Galveston,341,Governor,,LIB,Mark Jay Tippetts,9,6,3,0
+Galveston,341,Lieutenant Governor,,REP,Dan Patrick,265,182,74,9
+Galveston,341,Lieutenant Governor,,DEM,Mike Collier,278,189,70,19
+Galveston,341,Lieutenant Governor,,LIB,Kerry Douglas McKennon,12,10,2,0
+Galveston,341,Attorney General,,REP,Ken Paxton,252,173,70,9
+Galveston,341,Attorney General,,DEM,Justin Nelson,283,189,75,19
+Galveston,341,Attorney General,,LIB,Michael Ray Harris,20,17,3,0
+Galveston,341,Comptroller of Public Accounts,,REP,Glenn Hegar,255,176,70,9
+Galveston,341,Comptroller of Public Accounts,,DEM,Joi Chevalier,272,182,72,18
+Galveston,341,Comptroller of Public Accounts,,LIB,Ben Sanders,27,22,5,0
+Galveston,341,Commissioner of General Land Office,,REP,George P. Bush,262,182,71,9
+Galveston,341,Commissioner of General Land Office,,DEM,Miguel Suazo,272,181,72,19
+Galveston,341,Commissioner of General Land Office,,LIB,Matt Pina,20,16,4,0
+Galveston,341,Commissioner of Agriculture,,REP,Sid Miller,255,176,71,8
+Galveston,341,Commissioner of Agriculture,,DEM,Kim Olson,283,189,75,19
+Galveston,341,Commissioner of Agriculture,,LIB,Richard Carpenter,15,12,3,0
+Galveston,341,Railroad Commissioner,,REP,Christi Craddick,258,179,70,9
+Galveston,341,Railroad Commissioner,,DEM,Roman McAllen,279,186,75,18
+Galveston,341,Railroad Commissioner,,LIB,Mike Wright,16,13,3,0
+Galveston,341,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,262,183,71,8
+Galveston,341,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,294,196,79,19
+Galveston,341,"Justice, Supreme Court, Place 4",,REP,John Devine,265,185,72,8
+Galveston,341,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,291,195,77,19
+Galveston,341,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,262,183,71,8
+Galveston,341,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,294,197,78,19
+Galveston,341,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,255,176,71,8
+Galveston,341,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,282,189,74,19
+Galveston,341,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,18,14,4,0
+Galveston,341,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,273,189,75,9
+Galveston,341,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,281,189,74,18
+Galveston,341,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,287,201,78,8
+Galveston,341,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,117,82,29,6
+Galveston,341,"Member, State Board of Education, District 7",,REP,Matt Robinson,263,184,71,8
+Galveston,341,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",290,194,77,19
+Galveston,341,State Representative,24,REP,Greg Bonnen,257,180,69,8
+Galveston,341,State Representative,24,DEM,John Y. Phelps,288,193,76,19
+Galveston,341,State Representative,24,LIB,Dick Illyes,9,6,3,0
+Galveston,341,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,269,187,73,9
+Galveston,341,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,285,191,76,18
+Galveston,341,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,268,187,72,9
+Galveston,341,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,286,191,77,18
+Galveston,341,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,272,192,72,8
+Galveston,341,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,281,186,76,19
+Galveston,341,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,264,184,72,8
+Galveston,341,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,288,194,75,19
+Galveston,341,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,273,189,76,8
+Galveston,341,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,282,189,74,19
+Galveston,341,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,272,190,73,9
+Galveston,341,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,279,186,75,18
+Galveston,341,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,279,194,76,9
+Galveston,341,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,271,181,72,18
+Galveston,341,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,268,186,73,9
+Galveston,341,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,283,190,75,18
+Galveston,341,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,268,187,72,9
+Galveston,341,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,284,188,78,18
+Galveston,341,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,267,186,72,9
+Galveston,341,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",285,190,77,18
+Galveston,341,"District Judge, 122nd Judicial District",,REP,John Ellisor,320,221,90,9
+Galveston,341,"District Judge, 212th Judicial District",,REP,Patricia Grady,315,216,90,9
+Galveston,341,"District Judge, 306th Judicial District",,REP,Anne B. Darring,317,216,92,9
+Galveston,341,Criminal District Attorney,,REP,Jack Roady,312,213,90,9
+Galveston,341,County Judge,,REP,Mark Henry,313,215,89,9
+Galveston,341,"Judge, County Court-at-Law No. 1",,REP,John Grady,314,216,89,9
+Galveston,341,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,266,184,74,8
+Galveston,341,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,283,188,76,19
+Galveston,341,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,316,216,91,9
+Galveston,341,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,319,218,91,10
+Galveston,341,District Clerk,,REP,John D Kinard,316,216,91,9
+Galveston,341,County Clerk,,REP,Dwight Sullivan,318,218,90,10
+Galveston,341,County Treasurer,,REP,Kevin C. Walsh,310,212,89,9
+Galveston,341,College of the Mainland Proposition A,,,FOR,296,192,89,15
+Galveston,341,College of the Mainland Proposition A,,,AGAINST,131,102,24,5
+Galveston,343,Ballots Cast,,,,830,533,251,46
+Galveston,343,Straight Party,,REP,Republican,220,140,66,14
+Galveston,343,Straight Party,,DEM,Democrat,368,229,117,22
+Galveston,343,Straight Party,,LIB,Libertarian,2,0,2,0
+Galveston,343,U.S. Senate,,REP,Ted Cruz,310,201,91,18
+Galveston,343,U.S. Senate,,DEM,Beto O'Rourke,504,321,155,28
+Galveston,343,U.S. Senate,,LIB,Neal M. Dikeman,5,2,3,0
+Galveston,343,U.S. House,14,REP,Randy Weber,310,201,92,17
+Galveston,343,U.S. House,14,DEM,Adrienne Bell,495,314,153,28
+Galveston,343,U.S. House,14,LIB,Don E. Conley III,9,6,3,0
+Galveston,343,Governor,,REP,Greg Abbott,336,215,102,19
+Galveston,343,Governor,,DEM,Lupe Valdez,473,306,141,26
+Galveston,343,Governor,,LIB,Mark Jay Tippetts,11,6,4,1
+Galveston,343,Lieutenant Governor,,REP,Dan Patrick,320,209,93,18
+Galveston,343,Lieutenant Governor,,DEM,Mike Collier,481,305,149,27
+Galveston,343,Lieutenant Governor,,LIB,Kerry Douglas McKennon,17,9,7,1
+Galveston,343,Attorney General,,REP,Ken Paxton,301,196,89,16
+Galveston,343,Attorney General,,DEM,Justin Nelson,494,313,152,29
+Galveston,343,Attorney General,,LIB,Michael Ray Harris,20,13,7,0
+Galveston,343,Comptroller of Public Accounts,,REP,Glenn Hegar,310,201,91,18
+Galveston,343,Comptroller of Public Accounts,,DEM,Joi Chevalier,481,306,147,28
+Galveston,343,Comptroller of Public Accounts,,LIB,Ben Sanders,24,14,10,0
+Galveston,343,Commissioner of General Land Office,,REP,George P. Bush,319,204,97,18
+Galveston,343,Commissioner of General Land Office,,DEM,Miguel Suazo,478,304,146,28
+Galveston,343,Commissioner of General Land Office,,LIB,Matt Pina,18,12,6,0
+Galveston,343,Commissioner of Agriculture,,REP,Sid Miller,300,194,88,18
+Galveston,343,Commissioner of Agriculture,,DEM,Kim Olson,505,321,156,28
+Galveston,343,Commissioner of Agriculture,,LIB,Richard Carpenter,14,9,5,0
+Galveston,343,Railroad Commissioner,,REP,Christi Craddick,311,205,89,17
+Galveston,343,Railroad Commissioner,,DEM,Roman McAllen,484,309,147,28
+Galveston,343,Railroad Commissioner,,LIB,Mike Wright,23,10,13,0
+Galveston,343,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,314,204,93,17
+Galveston,343,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,503,319,156,28
+Galveston,343,"Justice, Supreme Court, Place 4",,REP,John Devine,317,205,94,18
+Galveston,343,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,498,315,155,28
+Galveston,343,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,323,210,95,18
+Galveston,343,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,492,310,154,28
+Galveston,343,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,307,202,86,19
+Galveston,343,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,496,313,156,27
+Galveston,343,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,17,9,8,0
+Galveston,343,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,321,208,94,19
+Galveston,343,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,493,312,154,27
+Galveston,343,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,356,234,105,17
+Galveston,343,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,175,116,48,11
+Galveston,343,"Member, State Board of Education, District 7",,REP,Matt Robinson,318,207,93,18
+Galveston,343,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",498,314,156,28
+Galveston,343,State Representative,23,REP,Mayes Middleton,321,208,95,18
+Galveston,343,State Representative,23,DEM,Amanda Jamrok,481,304,150,27
+Galveston,343,State Representative,23,LIB,Lawrence Johnson,17,11,5,1
+Galveston,343,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,319,206,96,17
+Galveston,343,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,496,314,153,29
+Galveston,343,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,321,206,98,17
+Galveston,343,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,495,315,151,29
+Galveston,343,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,321,206,97,18
+Galveston,343,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,494,314,152,28
+Galveston,343,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,310,202,91,17
+Galveston,343,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,503,317,158,28
+Galveston,343,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,318,206,94,18
+Galveston,343,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,498,315,155,28
+Galveston,343,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,323,205,99,19
+Galveston,343,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,489,313,149,27
+Galveston,343,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,317,207,93,17
+Galveston,343,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,494,311,154,29
+Galveston,343,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,315,204,94,17
+Galveston,343,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,496,315,152,29
+Galveston,343,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,309,201,91,17
+Galveston,343,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,503,318,156,29
+Galveston,343,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,315,206,91,18
+Galveston,343,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",496,313,155,28
+Galveston,343,"District Judge, 122nd Judicial District",,REP,John Ellisor,388,248,121,19
+Galveston,343,"District Judge, 212th Judicial District",,REP,Patricia Grady,390,248,123,19
+Galveston,343,"District Judge, 306th Judicial District",,REP,Anne B. Darring,388,246,123,19
+Galveston,343,Criminal District Attorney,,REP,Jack Roady,387,248,120,19
+Galveston,343,County Judge,,REP,Mark Henry,380,241,120,19
+Galveston,343,"Judge, County Court-at-Law No. 1",,REP,John Grady,383,244,120,19
+Galveston,343,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,304,198,88,18
+Galveston,343,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,504,320,157,27
+Galveston,343,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,387,245,123,19
+Galveston,343,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,384,245,120,19
+Galveston,343,District Clerk,,REP,John D Kinard,382,243,120,19
+Galveston,343,County Clerk,,REP,Dwight Sullivan,385,246,120,19
+Galveston,343,County Treasurer,,REP,Kevin C. Walsh,380,243,118,19
+Galveston,343,Justice of the Peace Pct. 1,,REP,Greg Rikard,382,243,120,19
+Galveston,343,College of the Mainland Proposition A,,,FOR,510,328,150,32
+Galveston,343,College of the Mainland Proposition A,,,AGAINST,141,94,38,9
+Galveston,345,Ballots Cast,,,,346,214,106,26
+Galveston,345,Straight Party,,REP,Republican,31,16,14,1
+Galveston,345,Straight Party,,DEM,Democrat,248,155,75,18
+Galveston,345,Straight Party,,LIB,Libertarian,2,1,1,0
+Galveston,345,U.S. Senate,,REP,Ted Cruz,39,23,14,2
+Galveston,345,U.S. Senate,,DEM,Beto O'Rourke,293,184,87,22
+Galveston,345,U.S. Senate,,LIB,Neal M. Dikeman,3,1,2,0
+Galveston,345,U.S. House,14,REP,Randy Weber,37,21,14,2
+Galveston,345,U.S. House,14,DEM,Adrienne Bell,295,186,86,23
+Galveston,345,U.S. House,14,LIB,Don E. Conley III,8,4,4,0
+Galveston,345,Governor,,REP,Greg Abbott,45,27,16,2
+Galveston,345,Governor,,DEM,Lupe Valdez,291,183,86,22
+Galveston,345,Governor,,LIB,Mark Jay Tippetts,4,1,2,1
+Galveston,345,Lieutenant Governor,,REP,Dan Patrick,43,23,18,2
+Galveston,345,Lieutenant Governor,,DEM,Mike Collier,292,185,85,22
+Galveston,345,Lieutenant Governor,,LIB,Kerry Douglas McKennon,7,4,2,1
+Galveston,345,Attorney General,,REP,Ken Paxton,38,22,14,2
+Galveston,345,Attorney General,,DEM,Justin Nelson,294,185,87,22
+Galveston,345,Attorney General,,LIB,Michael Ray Harris,9,5,4,0
+Galveston,345,Comptroller of Public Accounts,,REP,Glenn Hegar,40,24,14,2
+Galveston,345,Comptroller of Public Accounts,,DEM,Joi Chevalier,289,181,87,21
+Galveston,345,Comptroller of Public Accounts,,LIB,Ben Sanders,11,6,4,1
+Galveston,345,Commissioner of General Land Office,,REP,George P. Bush,45,30,13,2
+Galveston,345,Commissioner of General Land Office,,DEM,Miguel Suazo,285,176,86,23
+Galveston,345,Commissioner of General Land Office,,LIB,Matt Pina,11,6,5,0
+Galveston,345,Commissioner of Agriculture,,REP,Sid Miller,41,24,15,2
+Galveston,345,Commissioner of Agriculture,,DEM,Kim Olson,295,185,87,23
+Galveston,345,Commissioner of Agriculture,,LIB,Richard Carpenter,6,3,3,0
+Galveston,345,Railroad Commissioner,,REP,Christi Craddick,45,26,17,2
+Galveston,345,Railroad Commissioner,,DEM,Roman McAllen,288,181,85,22
+Galveston,345,Railroad Commissioner,,LIB,Mike Wright,8,5,3,0
+Galveston,345,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,42,24,16,2
+Galveston,345,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,300,188,89,23
+Galveston,345,"Justice, Supreme Court, Place 4",,REP,John Devine,41,22,17,2
+Galveston,345,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,300,190,88,22
+Galveston,345,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,46,26,18,2
+Galveston,345,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,296,186,87,23
+Galveston,345,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,42,25,15,2
+Galveston,345,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,292,182,87,23
+Galveston,345,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,9,5,3,1
+Galveston,345,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,45,25,18,2
+Galveston,345,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,297,187,87,23
+Galveston,345,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,56,32,21,3
+Galveston,345,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,82,49,27,6
+Galveston,345,"Member, State Board of Education, District 7",,REP,Matt Robinson,40,22,16,2
+Galveston,345,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",302,190,89,23
+Galveston,345,State Representative,23,REP,Mayes Middleton,39,20,17,2
+Galveston,345,State Representative,23,DEM,Amanda Jamrok,292,184,86,22
+Galveston,345,State Representative,23,LIB,Lawrence Johnson,10,7,2,1
+Galveston,345,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,42,23,17,2
+Galveston,345,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,300,189,88,23
+Galveston,345,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,44,26,16,2
+Galveston,345,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,297,184,89,24
+Galveston,345,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,44,25,17,2
+Galveston,345,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,297,185,88,24
+Galveston,345,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,39,21,16,2
+Galveston,345,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,302,189,89,24
+Galveston,345,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,41,22,17,2
+Galveston,345,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,299,188,87,24
+Galveston,345,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,42,23,17,2
+Galveston,345,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,296,186,87,23
+Galveston,345,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,42,23,17,2
+Galveston,345,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,297,186,87,24
+Galveston,345,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,41,22,17,2
+Galveston,345,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,298,187,87,24
+Galveston,345,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,41,23,16,2
+Galveston,345,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,299,187,88,24
+Galveston,345,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,41,22,17,2
+Galveston,345,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",297,187,86,24
+Galveston,345,"District Judge, 122nd Judicial District",,REP,John Ellisor,72,45,23,4
+Galveston,345,"District Judge, 212th Judicial District",,REP,Patricia Grady,73,45,24,4
+Galveston,345,"District Judge, 306th Judicial District",,REP,Anne B. Darring,77,48,24,5
+Galveston,345,Criminal District Attorney,,REP,Jack Roady,69,43,22,4
+Galveston,345,County Judge,,REP,Mark Henry,67,43,20,4
+Galveston,345,"Judge, County Court-at-Law No. 1",,REP,John Grady,69,42,22,5
+Galveston,345,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,43,24,17,2
+Galveston,345,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,294,185,87,22
+Galveston,345,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,69,42,21,6
+Galveston,345,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,66,41,21,4
+Galveston,345,District Clerk,,REP,John D Kinard,68,42,22,4
+Galveston,345,County Clerk,,REP,Dwight Sullivan,68,42,21,5
+Galveston,345,County Treasurer,,REP,Kevin C. Walsh,68,42,21,5
+Galveston,345,Justice of the Peace Pct. 3,,DEM,"Billy A. Williams, Jr.",304,191,91,22
+Galveston,345,College of the Mainland Proposition A,,,FOR,217,137,60,20
+Galveston,345,College of the Mainland Proposition A,,,AGAINST,36,23,12,1
+Galveston,347,Ballots Cast,,,,558,357,131,70
+Galveston,347,Straight Party,,REP,Republican,100,56,29,15
+Galveston,347,Straight Party,,DEM,Democrat,310,203,72,35
+Galveston,347,Straight Party,,LIB,Libertarian,5,2,0,3
+Galveston,347,U.S. Senate,,REP,Ted Cruz,144,89,35,20
+Galveston,347,U.S. Senate,,DEM,Beto O'Rourke,408,265,95,48
+Galveston,347,U.S. Senate,,LIB,Neal M. Dikeman,3,1,0,2
+Galveston,347,U.S. House,14,REP,Randy Weber,140,86,35,19
+Galveston,347,U.S. House,14,DEM,Adrienne Bell,406,263,92,51
+Galveston,347,U.S. House,14,LIB,Don E. Conley III,9,6,3,0
+Galveston,347,Governor,,REP,Greg Abbott,160,98,42,20
+Galveston,347,Governor,,DEM,Lupe Valdez,385,253,84,48
+Galveston,347,Governor,,LIB,Mark Jay Tippetts,9,4,4,1
+Galveston,347,Lieutenant Governor,,REP,Dan Patrick,145,89,36,20
+Galveston,347,Lieutenant Governor,,DEM,Mike Collier,400,259,92,49
+Galveston,347,Lieutenant Governor,,LIB,Kerry Douglas McKennon,9,5,3,1
+Galveston,347,Attorney General,,REP,Ken Paxton,137,84,34,19
+Galveston,347,Attorney General,,DEM,Justin Nelson,405,264,91,50
+Galveston,347,Attorney General,,LIB,Michael Ray Harris,12,6,5,1
+Galveston,347,Comptroller of Public Accounts,,REP,Glenn Hegar,140,87,34,19
+Galveston,347,Comptroller of Public Accounts,,DEM,Joi Chevalier,397,257,92,48
+Galveston,347,Comptroller of Public Accounts,,LIB,Ben Sanders,17,11,3,3
+Galveston,347,Commissioner of General Land Office,,REP,George P. Bush,139,87,35,17
+Galveston,347,Commissioner of General Land Office,,DEM,Miguel Suazo,401,258,90,53
+Galveston,347,Commissioner of General Land Office,,LIB,Matt Pina,13,9,4,0
+Galveston,347,Commissioner of Agriculture,,REP,Sid Miller,136,81,36,19
+Galveston,347,Commissioner of Agriculture,,DEM,Kim Olson,407,264,92,51
+Galveston,347,Commissioner of Agriculture,,LIB,Richard Carpenter,8,7,1,0
+Galveston,347,Railroad Commissioner,,REP,Christi Craddick,135,84,34,17
+Galveston,347,Railroad Commissioner,,DEM,Roman McAllen,402,261,92,49
+Galveston,347,Railroad Commissioner,,LIB,Mike Wright,13,7,3,3
+Galveston,347,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,139,88,34,17
+Galveston,347,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,410,264,95,51
+Galveston,347,"Justice, Supreme Court, Place 4",,REP,John Devine,144,92,35,17
+Galveston,347,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,403,259,94,50
+Galveston,347,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,138,85,34,19
+Galveston,347,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,412,267,95,50
+Galveston,347,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,136,85,33,18
+Galveston,347,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,402,260,93,49
+Galveston,347,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,12,8,2,2
+Galveston,347,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,147,94,34,19
+Galveston,347,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,403,258,95,50
+Galveston,347,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,159,96,43,20
+Galveston,347,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,117,75,30,12
+Galveston,347,"Member, State Board of Education, District 7",,REP,Matt Robinson,143,88,35,20
+Galveston,347,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",401,262,93,46
+Galveston,347,State Representative,23,REP,Mayes Middleton,146,92,36,18
+Galveston,347,State Representative,23,DEM,Amanda Jamrok,394,253,93,48
+Galveston,347,State Representative,23,LIB,Lawrence Johnson,11,9,0,2
+Galveston,347,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,143,91,35,17
+Galveston,347,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,405,260,94,51
+Galveston,347,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,139,88,33,18
+Galveston,347,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,408,263,96,49
+Galveston,347,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,146,93,35,18
+Galveston,347,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,400,257,94,49
+Galveston,347,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,143,90,36,17
+Galveston,347,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,404,260,93,51
+Galveston,347,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,147,92,36,19
+Galveston,347,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,398,257,93,48
+Galveston,347,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,147,91,38,18
+Galveston,347,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,400,260,91,49
+Galveston,347,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,143,89,36,18
+Galveston,347,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,404,261,93,50
+Galveston,347,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,144,90,36,18
+Galveston,347,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,402,260,93,49
+Galveston,347,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,142,89,34,19
+Galveston,347,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,404,261,95,48
+Galveston,347,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,144,90,35,19
+Galveston,347,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",403,260,94,49
+Galveston,347,"District Judge, 122nd Judicial District",,REP,John Ellisor,204,122,53,29
+Galveston,347,"District Judge, 212th Judicial District",,REP,Patricia Grady,200,118,53,29
+Galveston,347,"District Judge, 306th Judicial District",,REP,Anne B. Darring,201,118,54,29
+Galveston,347,Criminal District Attorney,,REP,Jack Roady,200,118,51,31
+Galveston,347,County Judge,,REP,Mark Henry,203,122,51,30
+Galveston,347,"Judge, County Court-at-Law No. 1",,REP,John Grady,193,117,48,28
+Galveston,347,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,146,89,37,20
+Galveston,347,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,400,260,92,48
+Galveston,347,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,198,118,49,31
+Galveston,347,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,194,118,48,28
+Galveston,347,District Clerk,,REP,John D Kinard,198,119,50,29
+Galveston,347,County Clerk,,REP,Dwight Sullivan,193,117,48,28
+Galveston,347,County Treasurer,,REP,Kevin C. Walsh,194,118,48,28
+Galveston,347,Justice of the Peace Pct. 1,,REP,Greg Rikard,195,116,49,30
+Galveston,347,College of the Mainland Proposition A,,,FOR,350,218,86,46
+Galveston,347,College of the Mainland Proposition A,,,AGAINST,72,46,15,11
+Galveston,389,Ballots Cast,,,,307,224,62,21
+Galveston,389,Straight Party,,REP,Republican,70,51,14,5
+Galveston,389,Straight Party,,DEM,Democrat,147,105,32,10
+Galveston,389,Straight Party,,LIB,Libertarian,0,0,0,0
+Galveston,389,U.S. Senate,,REP,Ted Cruz,97,70,20,7
+Galveston,389,U.S. Senate,,DEM,Beto O'Rourke,206,151,41,14
+Galveston,389,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Galveston,389,U.S. House,14,REP,Randy Weber,104,77,19,8
+Galveston,389,U.S. House,14,DEM,Adrienne Bell,192,137,42,13
+Galveston,389,U.S. House,14,LIB,Don E. Conley III,1,1,0,0
+Galveston,389,Governor,,REP,Greg Abbott,110,80,22,8
+Galveston,389,Governor,,DEM,Lupe Valdez,190,139,38,13
+Galveston,389,Governor,,LIB,Mark Jay Tippetts,3,2,1,0
+Galveston,389,Lieutenant Governor,,REP,Dan Patrick,93,67,19,7
+Galveston,389,Lieutenant Governor,,DEM,Mike Collier,203,149,40,14
+Galveston,389,Lieutenant Governor,,LIB,Kerry Douglas McKennon,2,0,2,0
+Galveston,389,Attorney General,,REP,Ken Paxton,96,68,20,8
+Galveston,389,Attorney General,,DEM,Justin Nelson,199,147,39,13
+Galveston,389,Attorney General,,LIB,Michael Ray Harris,3,1,2,0
+Galveston,389,Comptroller of Public Accounts,,REP,Glenn Hegar,98,72,19,7
+Galveston,389,Comptroller of Public Accounts,,DEM,Joi Chevalier,195,141,40,14
+Galveston,389,Comptroller of Public Accounts,,LIB,Ben Sanders,4,2,2,0
+Galveston,389,Commissioner of General Land Office,,REP,George P. Bush,105,75,22,8
+Galveston,389,Commissioner of General Land Office,,DEM,Miguel Suazo,190,140,37,13
+Galveston,389,Commissioner of General Land Office,,LIB,Matt Pina,3,1,2,0
+Galveston,389,Commissioner of Agriculture,,REP,Sid Miller,97,71,19,7
+Galveston,389,Commissioner of Agriculture,,DEM,Kim Olson,196,142,40,14
+Galveston,389,Commissioner of Agriculture,,LIB,Richard Carpenter,3,2,1,0
+Galveston,389,Railroad Commissioner,,REP,Christi Craddick,102,74,21,7
+Galveston,389,Railroad Commissioner,,DEM,Roman McAllen,191,140,37,14
+Galveston,389,Railroad Commissioner,,LIB,Mike Wright,5,2,3,0
+Galveston,389,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,97,71,19,7
+Galveston,389,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,203,147,42,14
+Galveston,389,"Justice, Supreme Court, Place 4",,REP,John Devine,98,72,19,7
+Galveston,389,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,201,145,42,14
+Galveston,389,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,98,72,19,7
+Galveston,389,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,203,147,42,14
+Galveston,389,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,101,75,19,7
+Galveston,389,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,197,141,42,14
+Galveston,389,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,1,1,0,0
+Galveston,389,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,100,74,19,7
+Galveston,389,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,198,142,42,14
+Galveston,389,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,113,81,24,8
+Galveston,389,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,61,47,9,5
+Galveston,389,"Member, State Board of Education, District 7",,REP,Matt Robinson,98,72,19,7
+Galveston,389,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",200,144,42,14
+Galveston,389,State Representative,24,REP,Greg Bonnen,97,72,18,7
+Galveston,389,State Representative,24,DEM,John Y. Phelps,200,144,42,14
+Galveston,389,State Representative,24,LIB,Dick Illyes,2,1,1,0
+Galveston,389,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,102,75,20,7
+Galveston,389,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,196,141,41,14
+Galveston,389,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,100,73,20,7
+Galveston,389,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,198,143,41,14
+Galveston,389,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,97,71,19,7
+Galveston,389,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,200,144,42,14
+Galveston,389,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,97,70,20,7
+Galveston,389,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,200,145,41,14
+Galveston,389,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,99,72,20,7
+Galveston,389,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,199,145,40,14
+Galveston,389,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,101,74,19,8
+Galveston,389,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,198,143,42,13
+Galveston,389,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,101,74,20,7
+Galveston,389,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,196,142,40,14
+Galveston,389,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,100,72,21,7
+Galveston,389,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,197,144,39,14
+Galveston,389,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,103,75,20,8
+Galveston,389,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,195,142,40,13
+Galveston,389,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,101,75,19,7
+Galveston,389,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",197,142,41,14
+Galveston,389,"District Judge, 122nd Judicial District",,REP,John Ellisor,121,86,25,10
+Galveston,389,"District Judge, 212th Judicial District",,REP,Patricia Grady,118,84,25,9
+Galveston,389,"District Judge, 306th Judicial District",,REP,Anne B. Darring,120,84,26,10
+Galveston,389,Criminal District Attorney,,REP,Jack Roady,118,83,25,10
+Galveston,389,County Judge,,REP,Mark Henry,123,86,27,10
+Galveston,389,"Judge, County Court-at-Law No. 1",,REP,John Grady,115,81,24,10
+Galveston,389,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,97,72,17,8
+Galveston,389,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,200,144,44,12
+Galveston,389,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,117,82,25,10
+Galveston,389,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,118,83,25,10
+Galveston,389,District Clerk,,REP,John D Kinard,117,81,25,11
+Galveston,389,County Clerk,,REP,Dwight Sullivan,117,82,25,10
+Galveston,389,County Treasurer,,REP,Kevin C. Walsh,118,83,25,10
+Galveston,389,College of the Mainland Proposition A,,,FOR,149,114,25,10
+Galveston,389,College of the Mainland Proposition A,,,AGAINST,65,47,13,5
+Galveston,391,Ballots Cast,,,,56,36,16,4
+Galveston,391,Straight Party,,REP,Republican,22,14,6,2
+Galveston,391,Straight Party,,DEM,Democrat,14,12,2,0
+Galveston,391,Straight Party,,LIB,Libertarian,0,0,0,0
+Galveston,391,U.S. Senate,,REP,Ted Cruz,27,16,9,2
+Galveston,391,U.S. Senate,,DEM,Beto O'Rourke,27,19,6,2
+Galveston,391,U.S. Senate,,LIB,Neal M. Dikeman,1,0,1,0
+Galveston,391,U.S. House,14,REP,Randy Weber,28,16,10,2
+Galveston,391,U.S. House,14,DEM,Adrienne Bell,25,17,6,2
+Galveston,391,U.S. House,14,LIB,Don E. Conley III,0,0,0,0
+Galveston,391,Governor,,REP,Greg Abbott,31,18,11,2
+Galveston,391,Governor,,DEM,Lupe Valdez,22,15,5,2
+Galveston,391,Governor,,LIB,Mark Jay Tippetts,0,0,0,0
+Galveston,391,Lieutenant Governor,,REP,Dan Patrick,27,16,9,2
+Galveston,391,Lieutenant Governor,,DEM,Mike Collier,24,16,6,2
+Galveston,391,Lieutenant Governor,,LIB,Kerry Douglas McKennon,1,0,1,0
+Galveston,391,Attorney General,,REP,Ken Paxton,28,16,10,2
+Galveston,391,Attorney General,,DEM,Justin Nelson,25,17,6,2
+Galveston,391,Attorney General,,LIB,Michael Ray Harris,0,0,0,0
+Galveston,391,Comptroller of Public Accounts,,REP,Glenn Hegar,28,16,10,2
+Galveston,391,Comptroller of Public Accounts,,DEM,Joi Chevalier,26,18,6,2
+Galveston,391,Comptroller of Public Accounts,,LIB,Ben Sanders,0,0,0,0
+Galveston,391,Commissioner of General Land Office,,REP,George P. Bush,28,16,10,2
+Galveston,391,Commissioner of General Land Office,,DEM,Miguel Suazo,25,18,5,2
+Galveston,391,Commissioner of General Land Office,,LIB,Matt Pina,1,0,1,0
+Galveston,391,Commissioner of Agriculture,,REP,Sid Miller,28,16,10,2
+Galveston,391,Commissioner of Agriculture,,DEM,Kim Olson,26,18,6,2
+Galveston,391,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0,0
+Galveston,391,Railroad Commissioner,,REP,Christi Craddick,29,16,11,2
+Galveston,391,Railroad Commissioner,,DEM,Roman McAllen,25,18,5,2
+Galveston,391,Railroad Commissioner,,LIB,Mike Wright,0,0,0,0
+Galveston,391,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,27,15,9,3
+Galveston,391,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,25,18,6,1
+Galveston,391,"Justice, Supreme Court, Place 4",,REP,John Devine,27,15,10,2
+Galveston,391,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,25,18,5,2
+Galveston,391,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,26,15,9,2
+Galveston,391,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,26,18,6,2
+Galveston,391,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,27,15,10,2
+Galveston,391,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,24,17,5,2
+Galveston,391,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,3,2,1,0
+Galveston,391,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,28,15,11,2
+Galveston,391,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,25,18,5,2
+Galveston,391,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,28,15,11,2
+Galveston,391,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,14,11,3,0
+Galveston,391,"Member, State Board of Education, District 7",,REP,Matt Robinson,28,16,10,2
+Galveston,391,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",26,18,6,2
+Galveston,391,State Representative,24,REP,Greg Bonnen,27,15,10,2
+Galveston,391,State Representative,24,DEM,John Y. Phelps,25,18,5,2
+Galveston,391,State Representative,24,LIB,Dick Illyes,3,2,1,0
+Galveston,391,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,27,15,10,2
+Galveston,391,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,25,18,5,2
+Galveston,391,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,28,16,10,2
+Galveston,391,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,26,18,6,2
+Galveston,391,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,27,16,9,2
+Galveston,391,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,25,17,6,2
+Galveston,391,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,26,15,9,2
+Galveston,391,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,27,19,6,2
+Galveston,391,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,27,15,9,3
+Galveston,391,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,26,19,6,1
+Galveston,391,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,26,15,9,2
+Galveston,391,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,27,19,6,2
+Galveston,391,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,26,15,9,2
+Galveston,391,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,26,18,6,2
+Galveston,391,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,26,15,9,2
+Galveston,391,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,27,19,6,2
+Galveston,391,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,27,16,9,2
+Galveston,391,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,26,18,6,2
+Galveston,391,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,27,16,9,2
+Galveston,391,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",26,18,6,2
+Galveston,391,"District Judge, 122nd Judicial District",,REP,John Ellisor,31,17,12,2
+Galveston,391,"District Judge, 212th Judicial District",,REP,Patricia Grady,30,16,12,2
+Galveston,391,"District Judge, 306th Judicial District",,REP,Anne B. Darring,30,16,12,2
+Galveston,391,Criminal District Attorney,,REP,Jack Roady,31,17,12,2
+Galveston,391,County Judge,,REP,Mark Henry,30,16,12,2
+Galveston,391,"Judge, County Court-at-Law No. 1",,REP,John Grady,30,16,12,2
+Galveston,391,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,28,16,10,2
+Galveston,391,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,27,19,6,2
+Galveston,391,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,31,16,13,2
+Galveston,391,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,31,17,12,2
+Galveston,391,District Clerk,,REP,John D Kinard,31,16,12,3
+Galveston,391,County Clerk,,REP,Dwight Sullivan,30,16,12,2
+Galveston,391,County Treasurer,,REP,Kevin C. Walsh,30,16,12,2
+Galveston,391,College of the Mainland Proposition A,,,FOR,30,19,8,3
+Galveston,391,College of the Mainland Proposition A,,,AGAINST,15,9,5,1
+Galveston,394,Ballots Cast,,,,23,18,4,1
+Galveston,394,Straight Party,,REP,Republican,5,4,1,0
+Galveston,394,Straight Party,,DEM,Democrat,12,10,2,0
+Galveston,394,Straight Party,,LIB,Libertarian,1,0,0,1
+Galveston,394,U.S. Senate,,REP,Ted Cruz,7,6,1,0
+Galveston,394,U.S. Senate,,DEM,Beto O'Rourke,15,11,3,1
+Galveston,394,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Galveston,394,U.S. House,14,REP,Randy Weber,7,6,1,0
+Galveston,394,U.S. House,14,DEM,Adrienne Bell,15,11,3,1
+Galveston,394,U.S. House,14,LIB,Don E. Conley III,0,0,0,0
+Galveston,394,Governor,,REP,Greg Abbott,8,6,2,0
+Galveston,394,Governor,,DEM,Lupe Valdez,14,11,2,1
+Galveston,394,Governor,,LIB,Mark Jay Tippetts,0,0,0,0
+Galveston,394,Lieutenant Governor,,REP,Dan Patrick,7,6,1,0
+Galveston,394,Lieutenant Governor,,DEM,Mike Collier,15,11,3,1
+Galveston,394,Lieutenant Governor,,LIB,Kerry Douglas McKennon,0,0,0,0
+Galveston,394,Attorney General,,REP,Ken Paxton,8,6,2,0
+Galveston,394,Attorney General,,DEM,Justin Nelson,14,11,2,1
+Galveston,394,Attorney General,,LIB,Michael Ray Harris,0,0,0,0
+Galveston,394,Comptroller of Public Accounts,,REP,Glenn Hegar,8,6,2,0
+Galveston,394,Comptroller of Public Accounts,,DEM,Joi Chevalier,14,11,2,1
+Galveston,394,Comptroller of Public Accounts,,LIB,Ben Sanders,0,0,0,0
+Galveston,394,Commissioner of General Land Office,,REP,George P. Bush,8,6,2,0
+Galveston,394,Commissioner of General Land Office,,DEM,Miguel Suazo,14,11,2,1
+Galveston,394,Commissioner of General Land Office,,LIB,Matt Pina,0,0,0,0
+Galveston,394,Commissioner of Agriculture,,REP,Sid Miller,7,6,1,0
+Galveston,394,Commissioner of Agriculture,,DEM,Kim Olson,15,11,3,1
+Galveston,394,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0,0
+Galveston,394,Railroad Commissioner,,REP,Christi Craddick,8,6,2,0
+Galveston,394,Railroad Commissioner,,DEM,Roman McAllen,14,11,2,1
+Galveston,394,Railroad Commissioner,,LIB,Mike Wright,0,0,0,0
+Galveston,394,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,7,6,1,0
+Galveston,394,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,15,11,3,1
+Galveston,394,"Justice, Supreme Court, Place 4",,REP,John Devine,8,6,2,0
+Galveston,394,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,14,11,2,1
+Galveston,394,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,7,6,1,0
+Galveston,394,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,15,11,3,1
+Galveston,394,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,8,6,2,0
+Galveston,394,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,14,11,2,1
+Galveston,394,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,0,0,0,0
+Galveston,394,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,8,6,2,0
+Galveston,394,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,14,11,2,1
+Galveston,394,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,9,7,2,0
+Galveston,394,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,4,3,0,1
+Galveston,394,"Member, State Board of Education, District 7",,REP,Matt Robinson,7,6,1,0
+Galveston,394,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",14,11,3,0
+Galveston,394,State Representative,23,REP,Mayes Middleton,7,6,1,0
+Galveston,394,State Representative,23,DEM,Amanda Jamrok,14,11,3,0
+Galveston,394,State Representative,23,LIB,Lawrence Johnson,1,0,0,1
+Galveston,394,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,8,6,2,0
+Galveston,394,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,14,11,2,1
+Galveston,394,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,7,6,1,0
+Galveston,394,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,14,11,3,0
+Galveston,394,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,7,6,1,0
+Galveston,394,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,14,11,3,0
+Galveston,394,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,7,6,1,0
+Galveston,394,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,15,11,3,1
+Galveston,394,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,8,6,2,0
+Galveston,394,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,13,11,2,0
+Galveston,394,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,7,6,1,0
+Galveston,394,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,14,11,3,0
+Galveston,394,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,7,6,1,0
+Galveston,394,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,14,11,3,0
+Galveston,394,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,8,6,2,0
+Galveston,394,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,13,11,2,0
+Galveston,394,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,7,6,1,0
+Galveston,394,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,14,11,3,0
+Galveston,394,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,7,6,1,0
+Galveston,394,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",15,11,3,1
+Galveston,394,"District Judge, 122nd Judicial District",,REP,John Ellisor,9,7,2,0
+Galveston,394,"District Judge, 212th Judicial District",,REP,Patricia Grady,9,7,2,0
+Galveston,394,"District Judge, 306th Judicial District",,REP,Anne B. Darring,9,7,2,0
+Galveston,394,Criminal District Attorney,,REP,Jack Roady,10,7,2,1
+Galveston,394,County Judge,,REP,Mark Henry,9,7,2,0
+Galveston,394,"Judge, County Court-at-Law No. 1",,REP,John Grady,9,7,2,0
+Galveston,394,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,8,7,1,0
+Galveston,394,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,14,11,3,0
+Galveston,394,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,9,7,2,0
+Galveston,394,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,10,7,2,1
+Galveston,394,District Clerk,,REP,John D Kinard,9,7,2,0
+Galveston,394,County Clerk,,REP,Dwight Sullivan,9,7,2,0
+Galveston,394,County Treasurer,,REP,Kevin C. Walsh,9,7,2,0
+Galveston,394,Justice of the Peace Pct. 1,,REP,Greg Rikard,9,7,2,0
+Galveston,394,College of the Mainland Proposition A,,,FOR,14,10,3,1
+Galveston,394,College of the Mainland Proposition A,,,AGAINST,4,4,0,0
+Galveston,398,Ballots Cast,,,,247,185,44,18
+Galveston,398,Straight Party,,REP,Republican,80,62,12,6
+Galveston,398,Straight Party,,DEM,Democrat,109,78,20,11
+Galveston,398,Straight Party,,LIB,Libertarian,0,0,0,0
+Galveston,398,U.S. Senate,,REP,Ted Cruz,101,80,15,6
+Galveston,398,U.S. Senate,,DEM,Beto O'Rourke,141,102,27,12
+Galveston,398,U.S. Senate,,LIB,Neal M. Dikeman,2,2,0,0
+Galveston,398,U.S. House,14,REP,Randy Weber,105,83,16,6
+Galveston,398,U.S. House,14,DEM,Adrienne Bell,140,100,28,12
+Galveston,398,U.S. House,14,LIB,Don E. Conley III,1,1,0,0
+Galveston,398,Governor,,REP,Greg Abbott,109,86,17,6
+Galveston,398,Governor,,DEM,Lupe Valdez,134,95,27,12
+Galveston,398,Governor,,LIB,Mark Jay Tippetts,1,1,0,0
+Galveston,398,Lieutenant Governor,,REP,Dan Patrick,104,82,16,6
+Galveston,398,Lieutenant Governor,,DEM,Mike Collier,141,102,27,12
+Galveston,398,Lieutenant Governor,,LIB,Kerry Douglas McKennon,2,1,1,0
+Galveston,398,Attorney General,,REP,Ken Paxton,103,81,16,6
+Galveston,398,Attorney General,,DEM,Justin Nelson,142,103,27,12
+Galveston,398,Attorney General,,LIB,Michael Ray Harris,0,0,0,0
+Galveston,398,Comptroller of Public Accounts,,REP,Glenn Hegar,100,79,15,6
+Galveston,398,Comptroller of Public Accounts,,DEM,Joi Chevalier,135,98,25,12
+Galveston,398,Comptroller of Public Accounts,,LIB,Ben Sanders,10,7,3,0
+Galveston,398,Commissioner of General Land Office,,REP,George P. Bush,103,82,15,6
+Galveston,398,Commissioner of General Land Office,,DEM,Miguel Suazo,138,98,28,12
+Galveston,398,Commissioner of General Land Office,,LIB,Matt Pina,5,4,1,0
+Galveston,398,Commissioner of Agriculture,,REP,Sid Miller,98,78,14,6
+Galveston,398,Commissioner of Agriculture,,DEM,Kim Olson,144,103,29,12
+Galveston,398,Commissioner of Agriculture,,LIB,Richard Carpenter,3,3,0,0
+Galveston,398,Railroad Commissioner,,REP,Christi Craddick,100,79,15,6
+Galveston,398,Railroad Commissioner,,DEM,Roman McAllen,138,98,28,12
+Galveston,398,Railroad Commissioner,,LIB,Mike Wright,7,6,1,0
+Galveston,398,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,99,79,14,6
+Galveston,398,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,146,105,29,12
+Galveston,398,"Justice, Supreme Court, Place 4",,REP,John Devine,101,80,15,6
+Galveston,398,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,144,104,28,12
+Galveston,398,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,101,80,15,6
+Galveston,398,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,144,104,28,12
+Galveston,398,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,100,79,15,6
+Galveston,398,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,142,104,26,12
+Galveston,398,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,3,1,2,0
+Galveston,398,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,103,82,15,6
+Galveston,398,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,142,102,28,12
+Galveston,398,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,111,87,17,7
+Galveston,398,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,43,31,12,0
+Galveston,398,"Member, State Board of Education, District 7",,REP,Matt Robinson,102,80,16,6
+Galveston,398,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",145,105,28,12
+Galveston,398,State Representative,24,REP,Greg Bonnen,101,80,15,6
+Galveston,398,State Representative,24,DEM,John Y. Phelps,144,103,29,12
+Galveston,398,State Representative,24,LIB,Dick Illyes,1,1,0,0
+Galveston,398,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,100,80,14,6
+Galveston,398,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,146,105,29,12
+Galveston,398,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,99,79,14,6
+Galveston,398,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,147,106,29,12
+Galveston,398,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,103,82,15,6
+Galveston,398,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,143,103,28,12
+Galveston,398,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,101,81,14,6
+Galveston,398,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,146,104,30,12
+Galveston,398,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,101,79,16,6
+Galveston,398,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,145,106,27,12
+Galveston,398,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,102,81,15,6
+Galveston,398,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,143,103,28,12
+Galveston,398,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,102,81,15,6
+Galveston,398,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,143,103,28,12
+Galveston,398,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,101,81,14,6
+Galveston,398,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,143,103,28,12
+Galveston,398,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,100,80,14,6
+Galveston,398,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,145,104,29,12
+Galveston,398,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,100,81,13,6
+Galveston,398,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",145,103,30,12
+Galveston,398,"District Judge, 122nd Judicial District",,REP,John Ellisor,127,99,21,7
+Galveston,398,"District Judge, 212th Judicial District",,REP,Patricia Grady,127,98,22,7
+Galveston,398,"District Judge, 306th Judicial District",,REP,Anne B. Darring,126,97,22,7
+Galveston,398,Criminal District Attorney,,REP,Jack Roady,125,96,22,7
+Galveston,398,County Judge,,REP,Mark Henry,125,97,21,7
+Galveston,398,"Judge, County Court-at-Law No. 1",,REP,John Grady,124,96,21,7
+Galveston,398,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,101,79,16,6
+Galveston,398,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,146,106,28,12
+Galveston,398,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,125,97,21,7
+Galveston,398,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,125,97,22,6
+Galveston,398,District Clerk,,REP,John D Kinard,122,95,20,7
+Galveston,398,County Clerk,,REP,Dwight Sullivan,126,97,22,7
+Galveston,398,County Treasurer,,REP,Kevin C. Walsh,125,96,22,7
+Galveston,398,College of the Mainland Proposition A,,,FOR,133,97,26,10
+Galveston,398,College of the Mainland Proposition A,,,AGAINST,40,30,6,4
+Galveston,399,Ballots Cast,,,,133,91,33,9
+Galveston,399,Straight Party,,REP,Republican,44,35,6,3
+Galveston,399,Straight Party,,DEM,Democrat,48,30,14,4
+Galveston,399,Straight Party,,LIB,Libertarian,0,0,0,0
+Galveston,399,U.S. Senate,,REP,Ted Cruz,54,40,10,4
+Galveston,399,U.S. Senate,,DEM,Beto O'Rourke,76,49,22,5
+Galveston,399,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Galveston,399,U.S. House,14,REP,Randy Weber,57,43,10,4
+Galveston,399,U.S. House,14,DEM,Adrienne Bell,70,46,19,5
+Galveston,399,U.S. House,14,LIB,Don E. Conley III,2,0,2,0
+Galveston,399,Governor,,REP,Greg Abbott,59,42,13,4
+Galveston,399,Governor,,DEM,Lupe Valdez,70,47,18,5
+Galveston,399,Governor,,LIB,Mark Jay Tippetts,1,1,0,0
+Galveston,399,Lieutenant Governor,,REP,Dan Patrick,54,40,10,4
+Galveston,399,Lieutenant Governor,,DEM,Mike Collier,73,49,19,5
+Galveston,399,Lieutenant Governor,,LIB,Kerry Douglas McKennon,3,1,2,0
+Galveston,399,Attorney General,,REP,Ken Paxton,54,39,11,4
+Galveston,399,Attorney General,,DEM,Justin Nelson,70,47,18,5
+Galveston,399,Attorney General,,LIB,Michael Ray Harris,4,3,1,0
+Galveston,399,Comptroller of Public Accounts,,REP,Glenn Hegar,56,41,11,4
+Galveston,399,Comptroller of Public Accounts,,DEM,Joi Chevalier,69,45,19,5
+Galveston,399,Comptroller of Public Accounts,,LIB,Ben Sanders,3,3,0,0
+Galveston,399,Commissioner of General Land Office,,REP,George P. Bush,56,40,12,4
+Galveston,399,Commissioner of General Land Office,,DEM,Miguel Suazo,68,47,16,5
+Galveston,399,Commissioner of General Land Office,,LIB,Matt Pina,5,3,2,0
+Galveston,399,Commissioner of Agriculture,,REP,Sid Miller,54,41,9,4
+Galveston,399,Commissioner of Agriculture,,DEM,Kim Olson,71,47,19,5
+Galveston,399,Commissioner of Agriculture,,LIB,Richard Carpenter,3,2,1,0
+Galveston,399,Railroad Commissioner,,REP,Christi Craddick,54,40,10,4
+Galveston,399,Railroad Commissioner,,DEM,Roman McAllen,65,44,16,5
+Galveston,399,Railroad Commissioner,,LIB,Mike Wright,9,5,4,0
+Galveston,399,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,57,42,11,4
+Galveston,399,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,73,48,20,5
+Galveston,399,"Justice, Supreme Court, Place 4",,REP,John Devine,59,44,11,4
+Galveston,399,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,70,46,19,5
+Galveston,399,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,60,45,11,4
+Galveston,399,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,70,45,20,5
+Galveston,399,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,56,43,9,4
+Galveston,399,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,68,43,20,5
+Galveston,399,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,6,4,2,0
+Galveston,399,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,59,44,11,4
+Galveston,399,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,71,46,20,5
+Galveston,399,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,63,45,14,4
+Galveston,399,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,19,15,4,0
+Galveston,399,"Member, State Board of Education, District 7",,REP,Matt Robinson,54,41,9,4
+Galveston,399,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",74,48,21,5
+Galveston,399,State Representative,24,REP,Greg Bonnen,56,42,10,4
+Galveston,399,State Representative,24,DEM,John Y. Phelps,67,45,17,5
+Galveston,399,State Representative,24,LIB,Dick Illyes,5,3,2,0
+Galveston,399,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,56,42,10,4
+Galveston,399,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,73,48,20,5
+Galveston,399,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,60,44,12,4
+Galveston,399,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,69,46,18,5
+Galveston,399,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,57,43,10,4
+Galveston,399,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,71,47,19,5
+Galveston,399,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,55,41,10,4
+Galveston,399,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,74,49,20,5
+Galveston,399,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,56,42,10,4
+Galveston,399,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,72,47,20,5
+Galveston,399,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,58,44,10,4
+Galveston,399,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,69,46,18,5
+Galveston,399,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,57,44,9,4
+Galveston,399,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,71,46,20,5
+Galveston,399,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,57,43,10,4
+Galveston,399,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,72,47,20,5
+Galveston,399,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,55,42,9,4
+Galveston,399,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,74,47,22,5
+Galveston,399,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,58,44,10,4
+Galveston,399,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",72,46,21,5
+Galveston,399,"District Judge, 122nd Judicial District",,REP,John Ellisor,68,49,15,4
+Galveston,399,"District Judge, 212th Judicial District",,REP,Patricia Grady,65,47,14,4
+Galveston,399,"District Judge, 306th Judicial District",,REP,Anne B. Darring,67,47,16,4
+Galveston,399,Criminal District Attorney,,REP,Jack Roady,65,47,14,4
+Galveston,399,County Judge,,REP,Mark Henry,68,49,15,4
+Galveston,399,"Judge, County Court-at-Law No. 1",,REP,John Grady,67,48,15,4
+Galveston,399,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,56,43,10,3
+Galveston,399,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,73,47,20,6
+Galveston,399,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,65,46,15,4
+Galveston,399,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,66,48,14,4
+Galveston,399,District Clerk,,REP,John D Kinard,66,47,15,4
+Galveston,399,County Clerk,,REP,Dwight Sullivan,67,48,15,4
+Galveston,399,County Treasurer,,REP,Kevin C. Walsh,64,46,14,4
+Galveston,399,College of the Mainland Proposition A,,,FOR,56,39,16,1
+Galveston,399,College of the Mainland Proposition A,,,AGAINST,30,19,5,6
+Galveston,399,Mayor  - League City,,,Sebastian Lofaro,32,21,8,3
+Galveston,399,Mayor  - League City,,,Pat Hallisey,49,35,9,5
+Galveston,399,Council Position 1  - League City,,,Andy Mann,31,22,6,3
+Galveston,399,Council Position 1  - League City,,,Traci Jacobs,39,24,10,5
+Galveston,399,Council Position 2  - League City,,,Hank Dugie,47,27,14,6
+Galveston,399,Council Position 6  - League City,,,Silvio P. Vincenzo,30,21,8,1
+Galveston,399,Council Position 6  - League City,,,Chad Tressler,26,12,8,6
+Galveston,399,Council Position 6  - League City,,,Chris Gross,15,13,2,0
+Galveston,399,Council Position 7  - League City,,,Ange Mertens,28,19,9,0
+Galveston,399,Council Position 7  - League City,,,Nick Long,43,27,9,7
+Galveston,399,League City Proposition A,,,For,63,40,16,7
+Galveston,399,League City Proposition A,,,Against,22,18,3,1
+Galveston,399,League City Proposition B,,,For,75,51,16,8
+Galveston,399,League City Proposition B,,,Against,14,9,5,0
+Galveston,399,League City Proposition C,,,For,76,52,18,6
+Galveston,399,League City Proposition C,,,Against,13,8,3,2
+Galveston,399,League City Proposition D,,,For,76,53,17,6
+Galveston,399,League City Proposition D,,,Against,9,4,3,2
+Galveston,399,League City Proposition E,,,For,74,51,17,6
+Galveston,399,League City Proposition E,,,Against,8,5,1,2
+Galveston,399,League City Proposition F,,,For,69,47,16,6
+Galveston,399,League City Proposition F,,,Against,13,9,2,2
+Galveston,399,League City Proposition G,,,For,72,47,19,6
+Galveston,399,League City Proposition G,,,Against,11,8,1,2
+Galveston,399,League City Proposition H,,,For,47,32,9,6
+Galveston,399,League City Proposition H,,,Against,29,19,8,2
+Galveston,399,League City Proposition I,,,For,67,48,12,7
+Galveston,399,League City Proposition I,,,Against,12,5,6,1
+Galveston,399,League City Proposition J,,,For,64,43,15,6
+Galveston,399,League City Proposition J,,,Against,13,9,2,2
+Galveston,399,League City Proposition K,,,For,71,47,17,7
+Galveston,399,League City Proposition K,,,Against,9,6,2,1
+Galveston,399,League City Proposition L,,,For,56,36,14,6
+Galveston,399,League City Proposition L,,,Against,20,14,4,2
+Galveston,399,League City Proposition M,,,For,69,47,16,6
+Galveston,399,League City Proposition M,,,Against,8,4,2,2
+Galveston,399,League City Proposition N,,,For,58,36,16,6
+Galveston,399,League City Proposition N,,,Against,18,15,1,2
+Galveston,399,League City Proposition O,,,For,64,41,17,6
+Galveston,399,League City Proposition O,,,Against,11,8,1,2
+Galveston,439,Ballots Cast,,,,1935,1482,335,118
+Galveston,439,Straight Party,,REP,Republican,915,702,160,53
+Galveston,439,Straight Party,,DEM,Democrat,344,257,65,22
+Galveston,439,Straight Party,,LIB,Libertarian,8,3,5,0
+Galveston,439,U.S. Senate,,REP,Ted Cruz,1266,990,209,67
+Galveston,439,U.S. Senate,,DEM,Beto O'Rourke,639,476,116,47
+Galveston,439,U.S. Senate,,LIB,Neal M. Dikeman,15,8,7,0
+Galveston,439,U.S. House,14,REP,Randy Weber,1274,997,208,69
+Galveston,439,U.S. House,14,DEM,Adrienne Bell,612,457,109,46
+Galveston,439,U.S. House,14,LIB,Don E. Conley III,35,21,14,0
+Galveston,439,Governor,,REP,Greg Abbott,1335,1039,226,70
+Galveston,439,Governor,,DEM,Lupe Valdez,553,417,93,43
+Galveston,439,Governor,,LIB,Mark Jay Tippetts,32,22,10,0
+Galveston,439,Lieutenant Governor,,REP,Dan Patrick,1263,979,216,68
+Galveston,439,Lieutenant Governor,,DEM,Mike Collier,613,462,106,45
+Galveston,439,Lieutenant Governor,,LIB,Kerry Douglas McKennon,41,31,9,1
+Galveston,439,Attorney General,,REP,Ken Paxton,1233,963,207,63
+Galveston,439,Attorney General,,DEM,Justin Nelson,638,474,113,51
+Galveston,439,Attorney General,,LIB,Michael Ray Harris,46,34,11,1
+Galveston,439,Comptroller of Public Accounts,,REP,Glenn Hegar,1268,993,205,70
+Galveston,439,Comptroller of Public Accounts,,DEM,Joi Chevalier,563,422,99,42
+Galveston,439,Comptroller of Public Accounts,,LIB,Ben Sanders,66,42,22,2
+Galveston,439,Commissioner of General Land Office,,REP,George P. Bush,1280,999,213,68
+Galveston,439,Commissioner of General Land Office,,DEM,Miguel Suazo,570,421,102,47
+Galveston,439,Commissioner of General Land Office,,LIB,Matt Pina,65,47,17,1
+Galveston,439,Commissioner of Agriculture,,REP,Sid Miller,1248,972,209,67
+Galveston,439,Commissioner of Agriculture,,DEM,Kim Olson,628,466,112,50
+Galveston,439,Commissioner of Agriculture,,LIB,Richard Carpenter,39,28,11,0
+Galveston,439,Railroad Commissioner,,REP,Christi Craddick,1284,999,214,71
+Galveston,439,Railroad Commissioner,,DEM,Roman McAllen,566,422,101,43
+Galveston,439,Railroad Commissioner,,LIB,Mike Wright,62,43,18,1
+Galveston,439,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1284,1002,214,68
+Galveston,439,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,620,461,113,46
+Galveston,439,"Justice, Supreme Court, Place 4",,REP,John Devine,1280,997,216,67
+Galveston,439,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,621,463,110,48
+Galveston,439,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1289,1005,213,71
+Galveston,439,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,615,458,113,44
+Galveston,439,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1261,982,211,68
+Galveston,439,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,602,449,108,45
+Galveston,439,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,39,28,10,1
+Galveston,439,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1300,1011,219,70
+Galveston,439,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,597,445,108,44
+Galveston,439,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1363,1064,225,74
+Galveston,439,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,285,224,49,12
+Galveston,439,"Member, State Board of Education, District 7",,REP,Matt Robinson,1271,990,211,70
+Galveston,439,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",637,473,118,46
+Galveston,439,State Representative,24,REP,Greg Bonnen,1280,997,213,70
+Galveston,439,State Representative,24,DEM,John Y. Phelps,590,440,106,44
+Galveston,439,State Representative,24,LIB,Dick Illyes,40,28,11,1
+Galveston,439,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,1291,1003,216,72
+Galveston,439,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,602,450,110,42
+Galveston,439,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,1279,995,214,70
+Galveston,439,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,619,463,112,44
+Galveston,439,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,1279,997,215,67
+Galveston,439,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,616,456,113,47
+Galveston,439,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,1263,981,215,67
+Galveston,439,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,631,474,110,47
+Galveston,439,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,1287,1002,217,68
+Galveston,439,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,605,451,108,46
+Galveston,439,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,1291,1006,215,70
+Galveston,439,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,602,450,108,44
+Galveston,439,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,1292,1005,218,69
+Galveston,439,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,601,450,106,45
+Galveston,439,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,1296,1007,218,71
+Galveston,439,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,594,446,106,42
+Galveston,439,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,1281,996,215,70
+Galveston,439,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,611,458,109,44
+Galveston,439,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,1285,1002,213,70
+Galveston,439,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",606,450,112,44
+Galveston,439,"District Judge, 122nd Judicial District",,REP,John Ellisor,1418,1100,244,74
+Galveston,439,"District Judge, 212th Judicial District",,REP,Patricia Grady,1412,1097,242,73
+Galveston,439,"District Judge, 306th Judicial District",,REP,Anne B. Darring,1415,1100,241,74
+Galveston,439,Criminal District Attorney,,REP,Jack Roady,1416,1101,242,73
+Galveston,439,County Judge,,REP,Mark Henry,1408,1092,243,73
+Galveston,439,"Judge, County Court-at-Law No. 1",,REP,John Grady,1397,1085,238,74
+Galveston,439,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,1293,1006,214,73
+Galveston,439,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,600,447,110,43
+Galveston,439,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,1402,1089,239,74
+Galveston,439,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,1416,1101,240,75
+Galveston,439,District Clerk,,REP,John D Kinard,1412,1101,238,73
+Galveston,439,County Clerk,,REP,Dwight Sullivan,1402,1091,237,74
+Galveston,439,County Treasurer,,REP,Kevin C. Walsh,1406,1094,238,74
+Galveston,439,County Commissioner Pct. 4,,REP,Ken Clark,1401,1090,238,73
+Galveston,439,College of the Mainland Proposition A,,,FOR,1062,821,158,83
+Galveston,439,College of the Mainland Proposition A,,,AGAINST,469,371,79,19
+Galveston,439-1,Ballots Cast,,,,14,11,2,1
+Galveston,439-1,Straight Party,,REP,Republican,9,6,2,1
+Galveston,439-1,Straight Party,,DEM,Democrat,2,2,0,0
+Galveston,439-1,Straight Party,,LIB,Libertarian,0,0,0,0
+Galveston,439-1,U.S. Senate,,REP,Ted Cruz,12,9,2,1
+Galveston,439-1,U.S. Senate,,DEM,Beto O'Rourke,2,2,0,0
+Galveston,439-1,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0,0
+Galveston,439-1,U.S. House,14,REP,Randy Weber,12,9,2,1
+Galveston,439-1,U.S. House,14,DEM,Adrienne Bell,2,2,0,0
+Galveston,439-1,U.S. House,14,LIB,Don E. Conley III,0,0,0,0
+Galveston,439-1,Governor,,REP,Greg Abbott,12,9,2,1
+Galveston,439-1,Governor,,DEM,Lupe Valdez,2,2,0,0
+Galveston,439-1,Governor,,LIB,Mark Jay Tippetts,0,0,0,0
+Galveston,439-1,Lieutenant Governor,,REP,Dan Patrick,12,9,2,1
+Galveston,439-1,Lieutenant Governor,,DEM,Mike Collier,2,2,0,0
+Galveston,439-1,Lieutenant Governor,,LIB,Kerry Douglas McKennon,0,0,0,0
+Galveston,439-1,Attorney General,,REP,Ken Paxton,12,9,2,1
+Galveston,439-1,Attorney General,,DEM,Justin Nelson,2,2,0,0
+Galveston,439-1,Attorney General,,LIB,Michael Ray Harris,0,0,0,0
+Galveston,439-1,Comptroller of Public Accounts,,REP,Glenn Hegar,12,9,2,1
+Galveston,439-1,Comptroller of Public Accounts,,DEM,Joi Chevalier,2,2,0,0
+Galveston,439-1,Comptroller of Public Accounts,,LIB,Ben Sanders,0,0,0,0
+Galveston,439-1,Commissioner of General Land Office,,REP,George P. Bush,12,9,2,1
+Galveston,439-1,Commissioner of General Land Office,,DEM,Miguel Suazo,2,2,0,0
+Galveston,439-1,Commissioner of General Land Office,,LIB,Matt Pina,0,0,0,0
+Galveston,439-1,Commissioner of Agriculture,,REP,Sid Miller,12,9,2,1
+Galveston,439-1,Commissioner of Agriculture,,DEM,Kim Olson,2,2,0,0
+Galveston,439-1,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0,0
+Galveston,439-1,Railroad Commissioner,,REP,Christi Craddick,12,9,2,1
+Galveston,439-1,Railroad Commissioner,,DEM,Roman McAllen,2,2,0,0
+Galveston,439-1,Railroad Commissioner,,LIB,Mike Wright,0,0,0,0
+Galveston,439-1,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,12,9,2,1
+Galveston,439-1,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,2,2,0,0
+Galveston,439-1,"Justice, Supreme Court, Place 4",,REP,John Devine,12,9,2,1
+Galveston,439-1,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,2,2,0,0
+Galveston,439-1,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,12,9,2,1
+Galveston,439-1,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,2,2,0,0
+Galveston,439-1,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,12,9,2,1
+Galveston,439-1,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,2,2,0,0
+Galveston,439-1,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,0,0,0,0
+Galveston,439-1,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,12,9,2,1
+Galveston,439-1,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,2,2,0,0
+Galveston,439-1,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,12,9,2,1
+Galveston,439-1,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,0,0,0,0
+Galveston,439-1,"Member, State Board of Education, District 7",,REP,Matt Robinson,12,9,2,1
+Galveston,439-1,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",2,2,0,0
+Galveston,439-1,State Representative,24,REP,Greg Bonnen,12,9,2,1
+Galveston,439-1,State Representative,24,DEM,John Y. Phelps,2,2,0,0
+Galveston,439-1,State Representative,24,LIB,Dick Illyes,0,0,0,0
+Galveston,439-1,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,12,9,2,1
+Galveston,439-1,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,2,2,0,0
+Galveston,439-1,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,12,9,2,1
+Galveston,439-1,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,2,2,0,0
+Galveston,439-1,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,12,9,2,1
+Galveston,439-1,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,2,2,0,0
+Galveston,439-1,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,12,9,2,1
+Galveston,439-1,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,2,2,0,0
+Galveston,439-1,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,12,9,2,1
+Galveston,439-1,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,2,2,0,0
+Galveston,439-1,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,12,9,2,1
+Galveston,439-1,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,2,2,0,0
+Galveston,439-1,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,12,9,2,1
+Galveston,439-1,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,2,2,0,0
+Galveston,439-1,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,12,9,2,1
+Galveston,439-1,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,2,2,0,0
+Galveston,439-1,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,12,9,2,1
+Galveston,439-1,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,2,2,0,0
+Galveston,439-1,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,12,9,2,1
+Galveston,439-1,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",2,2,0,0
+Galveston,439-1,"District Judge, 122nd Judicial District",,REP,John Ellisor,12,9,2,1
+Galveston,439-1,"District Judge, 212th Judicial District",,REP,Patricia Grady,12,9,2,1
+Galveston,439-1,"District Judge, 306th Judicial District",,REP,Anne B. Darring,12,9,2,1
+Galveston,439-1,Criminal District Attorney,,REP,Jack Roady,12,9,2,1
+Galveston,439-1,County Judge,,REP,Mark Henry,12,9,2,1
+Galveston,439-1,"Judge, County Court-at-Law No. 1",,REP,John Grady,12,9,2,1
+Galveston,439-1,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,12,9,2,1
+Galveston,439-1,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,2,2,0,0
+Galveston,439-1,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,12,9,2,1
+Galveston,439-1,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,12,9,2,1
+Galveston,439-1,District Clerk,,REP,John D Kinard,12,9,2,1
+Galveston,439-1,County Clerk,,REP,Dwight Sullivan,12,9,2,1
+Galveston,439-1,County Treasurer,,REP,Kevin C. Walsh,12,9,2,1
+Galveston,439-1,County Commissioner Pct. 4,,REP,Ken Clark,12,9,2,1
+Galveston,439-1,Justice of the Peace Pct. 2,,REP,Mike Nelson,12,9,2,1
+Galveston,439-1,College of the Mainland Proposition A,,,FOR,5,3,1,1
+Galveston,439-1,College of the Mainland Proposition A,,,AGAINST,6,6,0,0
+Galveston,453,Ballots Cast,,,,2855,1973,600,282
+Galveston,453,Straight Party,,REP,Republican,1216,880,206,130
+Galveston,453,Straight Party,,DEM,Democrat,463,305,99,59
+Galveston,453,Straight Party,,LIB,Libertarian,8,1,6,1
+Galveston,453,U.S. Senate,,REP,Ted Cruz,1791,1281,342,168
+Galveston,453,U.S. Senate,,DEM,Beto O'Rourke,1013,672,232,109
+Galveston,453,U.S. Senate,,LIB,Neal M. Dikeman,30,9,19,2
+Galveston,453,U.S. House,14,REP,Randy Weber,1826,1306,344,176
+Galveston,453,U.S. House,14,DEM,Adrienne Bell,910,603,213,94
+Galveston,453,U.S. House,14,LIB,Don E. Conley III,59,36,22,1
+Galveston,453,Governor,,REP,Greg Abbott,1944,1369,384,191
+Galveston,453,Governor,,DEM,Lupe Valdez,824,554,183,87
+Galveston,453,Governor,,LIB,Mark Jay Tippetts,52,26,24,2
+Galveston,453,Lieutenant Governor,,REP,Dan Patrick,1802,1288,348,166
+Galveston,453,Lieutenant Governor,,DEM,Mike Collier,929,620,200,109
+Galveston,453,Lieutenant Governor,,LIB,Kerry Douglas McKennon,66,32,31,3
+Galveston,453,Attorney General,,REP,Ken Paxton,1740,1243,335,162
+Galveston,453,Attorney General,,DEM,Justin Nelson,971,650,210,111
+Galveston,453,Attorney General,,LIB,Michael Ray Harris,79,45,32,2
+Galveston,453,Comptroller of Public Accounts,,REP,Glenn Hegar,1834,1311,346,177
+Galveston,453,Comptroller of Public Accounts,,DEM,Joi Chevalier,806,540,176,90
+Galveston,453,Comptroller of Public Accounts,,LIB,Ben Sanders,114,65,42,7
+Galveston,453,Commissioner of General Land Office,,REP,George P. Bush,1846,1301,363,182
+Galveston,453,Commissioner of General Land Office,,DEM,Miguel Suazo,844,567,183,94
+Galveston,453,Commissioner of General Land Office,,LIB,Matt Pina,94,64,26,4
+Galveston,453,Commissioner of Agriculture,,REP,Sid Miller,1757,1259,334,164
+Galveston,453,Commissioner of Agriculture,,DEM,Kim Olson,943,628,208,107
+Galveston,453,Commissioner of Agriculture,,LIB,Richard Carpenter,68,38,26,4
+Galveston,453,Railroad Commissioner,,REP,Christi Craddick,1849,1323,351,175
+Galveston,453,Railroad Commissioner,,DEM,Roman McAllen,824,553,177,94
+Galveston,453,Railroad Commissioner,,LIB,Mike Wright,94,53,37,4
+Galveston,453,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1824,1301,359,164
+Galveston,453,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,932,622,204,106
+Galveston,453,"Justice, Supreme Court, Place 4",,REP,John Devine,1829,1305,354,170
+Galveston,453,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,914,609,206,99
+Galveston,453,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1850,1311,361,178
+Galveston,453,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,905,607,202,96
+Galveston,453,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1800,1290,342,168
+Galveston,453,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,899,599,199,101
+Galveston,453,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,57,30,23,4
+Galveston,453,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1862,1324,362,176
+Galveston,453,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,883,588,199,96
+Galveston,453,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1993,1421,384,188
+Galveston,453,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,447,282,134,31
+Galveston,453,"Member, State Board of Education, District 7",,REP,Matt Robinson,1811,1297,349,165
+Galveston,453,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",949,630,212,107
+Galveston,453,State Representative,24,REP,Greg Bonnen,1824,1306,345,173
+Galveston,453,State Representative,24,DEM,John Y. Phelps,891,599,196,96
+Galveston,453,State Representative,24,LIB,Dick Illyes,56,28,25,3
+Galveston,453,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,1864,1333,356,175
+Galveston,453,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,873,581,198,94
+Galveston,453,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,1833,1321,346,166
+Galveston,453,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,908,595,208,105
+Galveston,453,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,1830,1318,344,168
+Galveston,453,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,910,598,212,100
+Galveston,453,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,1816,1300,346,170
+Galveston,453,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,920,611,209,100
+Galveston,453,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,1850,1325,352,173
+Galveston,453,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,885,584,205,96
+Galveston,453,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,1855,1329,352,174
+Galveston,453,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,869,576,199,94
+Galveston,453,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,1846,1319,349,178
+Galveston,453,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,873,581,203,89
+Galveston,453,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,1861,1330,356,175
+Galveston,453,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,857,571,194,92
+Galveston,453,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,1834,1315,351,168
+Galveston,453,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,889,588,202,99
+Galveston,453,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,1834,1316,350,168
+Galveston,453,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",894,590,204,100
+Galveston,453,"District Judge, 122nd Judicial District",,REP,John Ellisor,2058,1454,414,190
+Galveston,453,"District Judge, 212th Judicial District",,REP,Patricia Grady,2065,1455,420,190
+Galveston,453,"District Judge, 306th Judicial District",,REP,Anne B. Darring,2062,1457,416,189
+Galveston,453,Criminal District Attorney,,REP,Jack Roady,2061,1456,412,193
+Galveston,453,County Judge,,REP,Mark Henry,2057,1452,418,187
+Galveston,453,"Judge, County Court-at-Law No. 1",,REP,John Grady,2028,1440,402,186
+Galveston,453,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,1846,1322,357,167
+Galveston,453,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,881,584,197,100
+Galveston,453,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,2043,1447,408,188
+Galveston,453,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,2051,1455,408,188
+Galveston,453,District Clerk,,REP,John D Kinard,2047,1449,412,186
+Galveston,453,County Clerk,,REP,Dwight Sullivan,2043,1445,411,187
+Galveston,453,County Treasurer,,REP,Kevin C. Walsh,2040,1448,405,187
+Galveston,453,County Commissioner Pct. 4,,REP,Ken Clark,2042,1440,411,191
+Galveston,453,College of the Mainland Proposition A,,,FOR,605,427,136,42
+Galveston,453,College of the Mainland Proposition A,,,AGAINST,417,290,81,46
+Galveston,453,Mayor  - League City,,,Sebastian Lofaro,594,409,145,40
+Galveston,453,Mayor  - League City,,,Pat Hallisey,1550,1084,302,164
+Galveston,453,Council Position 1  - League City,,,Andy Mann,1039,751,200,88
+Galveston,453,Council Position 1  - League City,,,Traci Jacobs,792,520,188,84
+Galveston,453,Council Position 2  - League City,,,Hank Dugie,1605,1133,329,143
+Galveston,453,Council Position 6  - League City,,,Silvio P. Vincenzo,467,320,116,31
+Galveston,453,Council Position 6  - League City,,,Chad Tressler,841,596,176,69
+Galveston,453,Council Position 6  - League City,,,Chris Gross,499,347,84,68
+Galveston,453,Council Position 7  - League City,,,Ange Mertens,686,465,160,61
+Galveston,453,Council Position 7  - League City,,,Nick Long,1161,827,217,117
+Galveston,453,League City Proposition A,,,For,1677,1176,307,194
+Galveston,453,League City Proposition A,,,Against,479,323,118,38
+Galveston,453,League City Proposition B,,,For,1929,1335,383,211
+Galveston,453,League City Proposition B,,,Against,350,241,81,28
+Galveston,453,League City Proposition C,,,For,1976,1369,391,216
+Galveston,453,League City Proposition C,,,Against,243,168,56,19
+Galveston,453,League City Proposition D,,,For,1824,1270,351,203
+Galveston,453,League City Proposition D,,,Against,311,217,73,21
+Galveston,453,League City Proposition E,,,For,2046,1415,412,219
+Galveston,453,League City Proposition E,,,Against,146,99,33,14
+Galveston,453,League City Proposition F,,,For,1858,1277,362,219
+Galveston,453,League City Proposition F,,,Against,224,158,55,11
+Galveston,453,League City Proposition G,,,For,1980,1373,388,219
+Galveston,453,League City Proposition G,,,Against,166,107,45,14
+Galveston,453,League City Proposition H,,,For,1244,871,232,141
+Galveston,453,League City Proposition H,,,Against,748,508,163,77
+Galveston,453,League City Proposition I,,,For,1878,1294,361,223
+Galveston,453,League City Proposition I,,,Against,229,158,61,10
+Galveston,453,League City Proposition J,,,For,1824,1247,365,212
+Galveston,453,League City Proposition J,,,Against,274,205,54,15
+Galveston,453,League City Proposition K,,,For,1864,1290,359,215
+Galveston,453,League City Proposition K,,,Against,211,147,51,13
+Galveston,453,League City Proposition L,,,For,1642,1130,319,193
+Galveston,453,League City Proposition L,,,Against,366,261,80,25
+Galveston,453,League City Proposition M,,,For,1790,1242,345,203
+Galveston,453,League City Proposition M,,,Against,250,175,60,15
+Galveston,453,League City Proposition N,,,For,1651,1143,306,202
+Galveston,453,League City Proposition N,,,Against,390,270,100,20
+Galveston,453,League City Proposition O,,,For,1702,1171,331,200
+Galveston,453,League City Proposition O,,,Against,337,229,79,29
+Galveston,454,Ballots Cast,,,,2489,1793,569,127
+Galveston,454,Straight Party,,REP,Republican,908,644,207,57
+Galveston,454,Straight Party,,DEM,Democrat,465,325,115,25
+Galveston,454,Straight Party,,LIB,Libertarian,13,8,2,3
+Galveston,454,U.S. Senate,,REP,Ted Cruz,1478,1056,341,81
+Galveston,454,U.S. Senate,,DEM,Beto O'Rourke,977,714,218,45
+Galveston,454,U.S. Senate,,LIB,Neal M. Dikeman,25,15,9,1
+Galveston,454,U.S. House,14,REP,Randy Weber,1515,1090,344,81
+Galveston,454,U.S. House,14,DEM,Adrienne Bell,893,649,199,45
+Galveston,454,U.S. House,14,LIB,Don E. Conley III,54,36,18,0
+Galveston,454,Governor,,REP,Greg Abbott,1591,1137,371,83
+Galveston,454,Governor,,DEM,Lupe Valdez,824,601,182,41
+Galveston,454,Governor,,LIB,Mark Jay Tippetts,55,38,15,2
+Galveston,454,Lieutenant Governor,,REP,Dan Patrick,1495,1068,345,82
+Galveston,454,Lieutenant Governor,,DEM,Mike Collier,900,665,190,45
+Galveston,454,Lieutenant Governor,,LIB,Kerry Douglas McKennon,72,45,27,0
+Galveston,454,Attorney General,,REP,Ken Paxton,1457,1054,324,79
+Galveston,454,Attorney General,,DEM,Justin Nelson,919,663,208,48
+Galveston,454,Attorney General,,LIB,Michael Ray Harris,77,51,26,0
+Galveston,454,Comptroller of Public Accounts,,REP,Glenn Hegar,1493,1082,330,81
+Galveston,454,Comptroller of Public Accounts,,DEM,Joi Chevalier,835,603,189,43
+Galveston,454,Comptroller of Public Accounts,,LIB,Ben Sanders,99,66,31,2
+Galveston,454,Commissioner of General Land Office,,REP,George P. Bush,1494,1071,339,84
+Galveston,454,Commissioner of General Land Office,,DEM,Miguel Suazo,848,616,190,42
+Galveston,454,Commissioner of General Land Office,,LIB,Matt Pina,102,73,28,1
+Galveston,454,Commissioner of Agriculture,,REP,Sid Miller,1434,1039,318,77
+Galveston,454,Commissioner of Agriculture,,DEM,Kim Olson,932,677,210,45
+Galveston,454,Commissioner of Agriculture,,LIB,Richard Carpenter,64,39,21,4
+Galveston,454,Railroad Commissioner,,REP,Christi Craddick,1501,1079,339,83
+Galveston,454,Railroad Commissioner,,DEM,Roman McAllen,842,614,187,41
+Galveston,454,Railroad Commissioner,,LIB,Mike Wright,88,59,27,2
+Galveston,454,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1517,1090,346,81
+Galveston,454,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,918,670,202,46
+Galveston,454,"Justice, Supreme Court, Place 4",,REP,John Devine,1522,1095,346,81
+Galveston,454,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,916,667,204,45
+Galveston,454,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1531,1106,345,80
+Galveston,454,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,909,656,207,46
+Galveston,454,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1481,1067,332,82
+Galveston,454,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,884,645,196,43
+Galveston,454,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,73,48,23,2
+Galveston,454,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1548,1117,350,81
+Galveston,454,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,883,637,202,44
+Galveston,454,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1669,1213,377,79
+Galveston,454,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,485,357,111,17
+Galveston,454,"Member, State Board of Education, District 7",,REP,Matt Robinson,1491,1079,335,77
+Galveston,454,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",934,675,214,45
+Galveston,454,State Representative,24,REP,Greg Bonnen,1514,1104,334,76
+Galveston,454,State Representative,24,DEM,John Y. Phelps,870,627,198,45
+Galveston,454,State Representative,24,LIB,Dick Illyes,59,34,22,3
+Galveston,454,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,1540,1105,355,80
+Galveston,454,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,878,642,193,43
+Galveston,454,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,1524,1104,344,76
+Galveston,454,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,897,648,203,46
+Galveston,454,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,1525,1104,344,77
+Galveston,454,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,897,647,205,45
+Galveston,454,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,1506,1087,346,73
+Galveston,454,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,913,663,201,49
+Galveston,454,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,1539,1105,356,78
+Galveston,454,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,882,646,192,44
+Galveston,454,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,1539,1112,350,77
+Galveston,454,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,879,638,197,44
+Galveston,454,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,1541,1114,349,78
+Galveston,454,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,877,635,198,44
+Galveston,454,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,1536,1109,350,77
+Galveston,454,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,883,639,199,45
+Galveston,454,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,1505,1080,348,77
+Galveston,454,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,914,668,201,45
+Galveston,454,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,1510,1084,349,77
+Galveston,454,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",909,663,200,46
+Galveston,454,"District Judge, 122nd Judicial District",,REP,John Ellisor,1777,1290,402,85
+Galveston,454,"District Judge, 212th Judicial District",,REP,Patricia Grady,1772,1285,402,85
+Galveston,454,"District Judge, 306th Judicial District",,REP,Anne B. Darring,1772,1285,402,85
+Galveston,454,Criminal District Attorney,,REP,Jack Roady,1763,1273,403,87
+Galveston,454,County Judge,,REP,Mark Henry,1755,1270,400,85
+Galveston,454,"Judge, County Court-at-Law No. 1",,REP,John Grady,1735,1258,392,85
+Galveston,454,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,1557,1129,351,77
+Galveston,454,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,853,618,194,41
+Galveston,454,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,1744,1269,389,86
+Galveston,454,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,1758,1281,391,86
+Galveston,454,District Clerk,,REP,John D Kinard,1747,1270,392,85
+Galveston,454,County Clerk,,REP,Dwight Sullivan,1747,1270,392,85
+Galveston,454,County Treasurer,,REP,Kevin C. Walsh,1739,1263,391,85
+Galveston,454,County Commissioner Pct. 4,,REP,Ken Clark,1726,1250,390,86
+Galveston,454,College of the Mainland Proposition A,,,FOR,10,3,5,2
+Galveston,454,College of the Mainland Proposition A,,,AGAINST,4,3,0,1
+Galveston,454,Mayor  - League City,,,Sebastian Lofaro,629,475,136,18
+Galveston,454,Mayor  - League City,,,Pat Hallisey,1324,948,299,77
+Galveston,454,Council Position 1  - League City,,,Andy Mann,929,653,224,52
+Galveston,454,Council Position 1  - League City,,,Traci Jacobs,819,619,165,35
+Galveston,454,Council Position 2  - League City,,,Hank Dugie,1465,1062,327,76
+Galveston,454,Council Position 6  - League City,,,Silvio P. Vincenzo,434,306,115,13
+Galveston,454,Council Position 6  - League City,,,Chad Tressler,780,591,158,31
+Galveston,454,Council Position 6  - League City,,,Chris Gross,484,339,102,43
+Galveston,454,Council Position 7  - League City,,,Ange Mertens,620,432,151,37
+Galveston,454,Council Position 7  - League City,,,Nick Long,1162,858,249,55
+Galveston,454,League City Proposition A,,,For,1487,1069,332,86
+Galveston,454,League City Proposition A,,,Against,447,328,94,25
+Galveston,454,League City Proposition B,,,For,1723,1255,375,93
+Galveston,454,League City Proposition B,,,Against,332,229,81,22
+Galveston,454,League City Proposition C,,,For,1762,1277,381,104
+Galveston,454,League City Proposition C,,,Against,229,163,57,9
+Galveston,454,League City Proposition D,,,For,1644,1177,370,97
+Galveston,454,League City Proposition D,,,Against,270,202,53,15
+Galveston,454,League City Proposition E,,,For,1848,1335,409,104
+Galveston,454,League City Proposition E,,,Against,144,109,25,10
+Galveston,454,League City Proposition F,,,For,1686,1236,345,105
+Galveston,454,League City Proposition F,,,Against,211,140,64,7
+Galveston,454,League City Proposition G,,,For,1790,1303,387,100
+Galveston,454,League City Proposition G,,,Against,148,105,33,10
+Galveston,454,League City Proposition H,,,For,1142,832,259,51
+Galveston,454,League City Proposition H,,,Against,652,478,122,52
+Galveston,454,League City Proposition I,,,For,1663,1222,341,100
+Galveston,454,League City Proposition I,,,Against,234,162,64,8
+Galveston,454,League City Proposition J,,,For,1621,1186,336,99
+Galveston,454,League City Proposition J,,,Against,263,185,68,10
+Galveston,454,League City Proposition K,,,For,1650,1205,346,99
+Galveston,454,League City Proposition K,,,Against,219,156,53,10
+Galveston,454,League City Proposition L,,,For,1428,1045,300,83
+Galveston,454,League City Proposition L,,,Against,376,272,85,19
+Galveston,454,League City Proposition M,,,For,1594,1164,334,96
+Galveston,454,League City Proposition M,,,Against,252,184,59,9
+Galveston,454,League City Proposition N,,,For,1477,1086,298,93
+Galveston,454,League City Proposition N,,,Against,355,253,90,12
+Galveston,454,League City Proposition O,,,For,1503,1097,322,84
+Galveston,454,League City Proposition O,,,Against,329,235,72,22
+Galveston,455,Ballots Cast,,,,1083,753,204,126
+Galveston,455,Straight Party,,REP,Republican,425,301,74,50
+Galveston,455,Straight Party,,DEM,Democrat,238,146,65,27
+Galveston,455,Straight Party,,LIB,Libertarian,4,2,2,0
+Galveston,455,U.S. Senate,,REP,Ted Cruz,664,484,103,77
+Galveston,455,U.S. Senate,,DEM,Beto O'Rourke,400,262,92,46
+Galveston,455,U.S. Senate,,LIB,Neal M. Dikeman,11,3,7,1
+Galveston,455,U.S. House,14,REP,Randy Weber,676,488,109,79
+Galveston,455,U.S. House,14,DEM,Adrienne Bell,375,245,88,42
+Galveston,455,U.S. House,14,LIB,Don E. Conley III,16,9,5,2
+Galveston,455,Governor,,REP,Greg Abbott,711,510,118,83
+Galveston,455,Governor,,DEM,Lupe Valdez,344,225,79,40
+Galveston,455,Governor,,LIB,Mark Jay Tippetts,16,10,5,1
+Galveston,455,Lieutenant Governor,,REP,Dan Patrick,662,474,109,79
+Galveston,455,Lieutenant Governor,,DEM,Mike Collier,386,254,87,45
+Galveston,455,Lieutenant Governor,,LIB,Kerry Douglas McKennon,18,15,3,0
+Galveston,455,Attorney General,,REP,Ken Paxton,654,474,106,74
+Galveston,455,Attorney General,,DEM,Justin Nelson,391,255,89,47
+Galveston,455,Attorney General,,LIB,Michael Ray Harris,21,15,5,1
+Galveston,455,Comptroller of Public Accounts,,REP,Glenn Hegar,663,486,103,74
+Galveston,455,Comptroller of Public Accounts,,DEM,Joi Chevalier,364,235,83,46
+Galveston,455,Comptroller of Public Accounts,,LIB,Ben Sanders,31,19,9,3
+Galveston,455,Commissioner of General Land Office,,REP,George P. Bush,669,478,112,79
+Galveston,455,Commissioner of General Land Office,,DEM,Miguel Suazo,361,238,81,42
+Galveston,455,Commissioner of General Land Office,,LIB,Matt Pina,32,24,5,3
+Galveston,455,Commissioner of Agriculture,,REP,Sid Miller,649,472,103,74
+Galveston,455,Commissioner of Agriculture,,DEM,Kim Olson,391,257,87,47
+Galveston,455,Commissioner of Agriculture,,LIB,Richard Carpenter,17,10,6,1
+Galveston,455,Railroad Commissioner,,REP,Christi Craddick,669,482,110,77
+Galveston,455,Railroad Commissioner,,DEM,Roman McAllen,365,241,81,43
+Galveston,455,Railroad Commissioner,,LIB,Mike Wright,22,17,3,2
+Galveston,455,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,669,487,107,75
+Galveston,455,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,387,252,89,46
+Galveston,455,"Justice, Supreme Court, Place 4",,REP,John Devine,673,488,112,73
+Galveston,455,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,381,251,83,47
+Galveston,455,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,675,488,110,77
+Galveston,455,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,381,251,86,44
+Galveston,455,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,659,477,107,75
+Galveston,455,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,377,250,82,45
+Galveston,455,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,21,13,7,1
+Galveston,455,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,683,495,111,77
+Galveston,455,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,369,242,83,44
+Galveston,455,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,733,526,121,86
+Galveston,455,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,158,118,30,10
+Galveston,455,"Member, State Board of Education, District 7",,REP,Matt Robinson,660,477,110,73
+Galveston,455,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",392,260,85,47
+Galveston,455,State Representative,24,REP,Greg Bonnen,677,489,112,76
+Galveston,455,State Representative,24,DEM,John Y. Phelps,365,243,79,43
+Galveston,455,State Representative,24,LIB,Dick Illyes,18,9,6,3
+Galveston,455,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,677,488,113,76
+Galveston,455,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,376,252,81,43
+Galveston,455,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,669,491,106,72
+Galveston,455,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,383,248,87,48
+Galveston,455,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,658,480,106,72
+Galveston,455,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,391,257,87,47
+Galveston,455,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,664,485,107,72
+Galveston,455,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,388,253,87,48
+Galveston,455,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,675,488,114,73
+Galveston,455,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,377,251,79,47
+Galveston,455,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,678,491,113,74
+Galveston,455,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,371,246,80,45
+Galveston,455,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,681,494,111,76
+Galveston,455,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,369,244,81,44
+Galveston,455,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,686,496,114,76
+Galveston,455,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,365,242,79,44
+Galveston,455,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,668,485,108,75
+Galveston,455,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,384,254,85,45
+Galveston,455,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,669,487,108,74
+Galveston,455,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",380,250,84,46
+Galveston,455,"District Judge, 122nd Judicial District",,REP,John Ellisor,753,541,128,84
+Galveston,455,"District Judge, 212th Judicial District",,REP,Patricia Grady,750,538,128,84
+Galveston,455,"District Judge, 306th Judicial District",,REP,Anne B. Darring,747,534,129,84
+Galveston,455,Criminal District Attorney,,REP,Jack Roady,753,541,129,83
+Galveston,455,County Judge,,REP,Mark Henry,749,538,127,84
+Galveston,455,"Judge, County Court-at-Law No. 1",,REP,John Grady,744,533,126,85
+Galveston,455,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,672,487,111,74
+Galveston,455,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,383,255,81,47
+Galveston,455,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,744,535,127,82
+Galveston,455,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,745,535,127,83
+Galveston,455,District Clerk,,REP,John D Kinard,746,535,128,83
+Galveston,455,County Clerk,,REP,Dwight Sullivan,748,536,128,84
+Galveston,455,County Treasurer,,REP,Kevin C. Walsh,743,534,127,82
+Galveston,455,County Commissioner Pct. 4,,REP,Ken Clark,735,528,126,81
+Galveston,455,Mayor  - League City,,,Sebastian Lofaro,222,167,39,16
+Galveston,455,Mayor  - League City,,,Pat Hallisey,580,407,93,80
+Galveston,455,Council Position 1  - League City,,,Andy Mann,414,288,62,64
+Galveston,455,Council Position 1  - League City,,,Traci Jacobs,290,207,58,25
+Galveston,455,Council Position 2  - League City,,,Hank Dugie,592,426,95,71
+Galveston,455,Council Position 6  - League City,,,Silvio P. Vincenzo,192,144,31,17
+Galveston,455,Council Position 6  - League City,,,Chad Tressler,316,227,47,42
+Galveston,455,Council Position 6  - League City,,,Chris Gross,189,123,40,26
+Galveston,455,Council Position 7  - League City,,,Ange Mertens,289,205,52,32
+Galveston,455,Council Position 7  - League City,,,Nick Long,437,304,75,58
+Galveston,455,League City Proposition A,,,For,617,414,110,93
+Galveston,455,League City Proposition A,,,Against,192,141,35,16
+Galveston,455,League City Proposition B,,,For,709,488,128,93
+Galveston,455,League City Proposition B,,,Against,147,102,25,20
+Galveston,455,League City Proposition C,,,For,727,495,131,101
+Galveston,455,League City Proposition C,,,Against,93,67,17,9
+Galveston,455,League City Proposition D,,,For,687,472,122,93
+Galveston,455,League City Proposition D,,,Against,118,86,18,14
+Galveston,455,League City Proposition E,,,For,762,532,129,101
+Galveston,455,League City Proposition E,,,Against,68,44,17,7
+Galveston,455,League City Proposition F,,,For,699,477,120,102
+Galveston,455,League City Proposition F,,,Against,101,75,18,8
+Galveston,455,League City Proposition G,,,For,744,514,128,102
+Galveston,455,League City Proposition G,,,Against,65,48,13,4
+Galveston,455,League City Proposition H,,,For,465,318,85,62
+Galveston,455,League City Proposition H,,,Against,302,213,49,40
+Galveston,455,League City Proposition I,,,For,702,480,121,101
+Galveston,455,League City Proposition I,,,Against,100,76,19,5
+Galveston,455,League City Proposition J,,,For,693,475,123,95
+Galveston,455,League City Proposition J,,,Against,110,83,17,10
+Galveston,455,League City Proposition K,,,For,685,466,118,101
+Galveston,455,League City Proposition K,,,Against,97,74,17,6
+Galveston,455,League City Proposition L,,,For,606,415,102,89
+Galveston,455,League City Proposition L,,,Against,162,114,33,15
+Galveston,455,League City Proposition M,,,For,654,439,117,98
+Galveston,455,League City Proposition M,,,Against,124,97,19,8
+Galveston,455,League City Proposition N,,,For,613,423,99,91
+Galveston,455,League City Proposition N,,,Against,156,109,34,13
+Galveston,455,League City Proposition O,,,For,640,438,108,94
+Galveston,455,League City Proposition O,,,Against,138,97,28,13
+Galveston,456,Ballots Cast,,,,2297,1793,311,193
+Galveston,456,Straight Party,,REP,Republican,1157,913,145,99
+Galveston,456,Straight Party,,DEM,Democrat,264,196,35,33
+Galveston,456,Straight Party,,LIB,Libertarian,2,0,2,0
+Galveston,456,U.S. Senate,,REP,Ted Cruz,1704,1336,222,146
+Galveston,456,U.S. Senate,,DEM,Beto O'Rourke,569,440,83,46
+Galveston,456,U.S. Senate,,LIB,Neal M. Dikeman,13,9,4,0
+Galveston,456,U.S. House,14,REP,Randy Weber,1745,1366,233,146
+Galveston,456,U.S. House,14,DEM,Adrienne Bell,486,381,63,42
+Galveston,456,U.S. House,14,LIB,Don E. Conley III,41,28,12,1
+Galveston,456,Governor,,REP,Greg Abbott,1796,1407,240,149
+Galveston,456,Governor,,DEM,Lupe Valdez,445,347,59,39
+Galveston,456,Governor,,LIB,Mark Jay Tippetts,37,25,10,2
+Galveston,456,Lieutenant Governor,,REP,Dan Patrick,1668,1306,227,135
+Galveston,456,Lieutenant Governor,,DEM,Mike Collier,564,446,66,52
+Galveston,456,Lieutenant Governor,,LIB,Kerry Douglas McKennon,45,26,14,5
+Galveston,456,Attorney General,,REP,Ken Paxton,1671,1313,225,133
+Galveston,456,Attorney General,,DEM,Justin Nelson,550,430,66,54
+Galveston,456,Attorney General,,LIB,Michael Ray Harris,42,25,14,3
+Galveston,456,Comptroller of Public Accounts,,REP,Glenn Hegar,1751,1377,229,145
+Galveston,456,Comptroller of Public Accounts,,DEM,Joi Chevalier,436,342,55,39
+Galveston,456,Comptroller of Public Accounts,,LIB,Ben Sanders,63,41,18,4
+Galveston,456,Commissioner of General Land Office,,REP,George P. Bush,1733,1351,235,147
+Galveston,456,Commissioner of General Land Office,,DEM,Miguel Suazo,452,357,55,40
+Galveston,456,Commissioner of General Land Office,,LIB,Matt Pina,71,51,16,4
+Galveston,456,Commissioner of Agriculture,,REP,Sid Miller,1682,1319,226,137
+Galveston,456,Commissioner of Agriculture,,DEM,Kim Olson,533,414,70,49
+Galveston,456,Commissioner of Agriculture,,LIB,Richard Carpenter,42,30,10,2
+Galveston,456,Railroad Commissioner,,REP,Christi Craddick,1766,1387,234,145
+Galveston,456,Railroad Commissioner,,DEM,Roman McAllen,445,348,56,41
+Galveston,456,Railroad Commissioner,,LIB,Mike Wright,48,30,15,3
+Galveston,456,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1740,1367,229,144
+Galveston,456,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,513,396,73,44
+Galveston,456,"Justice, Supreme Court, Place 4",,REP,John Devine,1748,1369,235,144
+Galveston,456,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,507,395,68,44
+Galveston,456,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1766,1389,231,146
+Galveston,456,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,488,375,71,42
+Galveston,456,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1725,1354,228,143
+Galveston,456,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,483,380,59,44
+Galveston,456,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,42,26,14,2
+Galveston,456,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1784,1401,237,146
+Galveston,456,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,459,356,63,40
+Galveston,456,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1830,1434,247,149
+Galveston,456,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,238,199,32,7
+Galveston,456,"Member, State Board of Education, District 7",,REP,Matt Robinson,1742,1367,236,139
+Galveston,456,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",499,387,67,45
+Galveston,456,State Representative,24,REP,Greg Bonnen,1777,1393,237,147
+Galveston,456,State Representative,24,DEM,John Y. Phelps,450,351,58,41
+Galveston,456,State Representative,24,LIB,Dick Illyes,35,22,11,2
+Galveston,456,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,1783,1398,237,148
+Galveston,456,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,459,357,65,37
+Galveston,456,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,1749,1373,233,143
+Galveston,456,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,495,382,69,44
+Galveston,456,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,1745,1369,233,143
+Galveston,456,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,498,386,67,45
+Galveston,456,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,1748,1373,234,141
+Galveston,456,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,494,381,66,47
+Galveston,456,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,1765,1386,234,145
+Galveston,456,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,476,370,66,40
+Galveston,456,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,1758,1382,233,143
+Galveston,456,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,484,373,69,42
+Galveston,456,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,1763,1384,235,144
+Galveston,456,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,470,364,65,41
+Galveston,456,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,1771,1391,236,144
+Galveston,456,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,462,358,64,40
+Galveston,456,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,1751,1380,227,144
+Galveston,456,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,486,372,72,42
+Galveston,456,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,1758,1382,233,143
+Galveston,456,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",476,369,66,41
+Galveston,456,"District Judge, 122nd Judicial District",,REP,John Ellisor,1886,1483,257,146
+Galveston,456,"District Judge, 212th Judicial District",,REP,Patricia Grady,1866,1469,254,143
+Galveston,456,"District Judge, 306th Judicial District",,REP,Anne B. Darring,1870,1472,254,144
+Galveston,456,Criminal District Attorney,,REP,Jack Roady,1866,1468,254,144
+Galveston,456,County Judge,,REP,Mark Henry,1871,1468,258,145
+Galveston,456,"Judge, County Court-at-Law No. 1",,REP,John Grady,1858,1465,249,144
+Galveston,456,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,1752,1379,230,143
+Galveston,456,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,476,369,67,40
+Galveston,456,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,1856,1462,251,143
+Galveston,456,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,1856,1465,249,142
+Galveston,456,District Clerk,,REP,John D Kinard,1853,1459,251,143
+Galveston,456,County Clerk,,REP,Dwight Sullivan,1850,1456,250,144
+Galveston,456,County Treasurer,,REP,Kevin C. Walsh,1853,1458,252,143
+Galveston,456,County Commissioner Pct. 4,,REP,Ken Clark,1858,1463,251,144
+Galveston,456,"Trustee Position 2 (unexpired term, expiring November 2020)  - FISD",,,Dakota Carter,696,543,102,51
+Galveston,456,"Trustee Position 2 (unexpired term, expiring November 2020)  - FISD",,,Denise Ruiz,897,714,121,62
+Galveston,457,Ballots Cast,,,,2787,2131,411,245
+Galveston,457,Straight Party,,REP,Republican,1379,1076,185,118
+Galveston,457,Straight Party,,DEM,Democrat,315,228,49,38
+Galveston,457,Straight Party,,LIB,Libertarian,7,3,3,1
+Galveston,457,U.S. Senate,,REP,Ted Cruz,2031,1592,284,155
+Galveston,457,U.S. Senate,,DEM,Beto O'Rourke,711,512,115,84
+Galveston,457,U.S. Senate,,LIB,Neal M. Dikeman,28,14,10,4
+Galveston,457,U.S. House,14,REP,Randy Weber,2094,1638,294,162
+Galveston,457,U.S. House,14,DEM,Adrienne Bell,611,442,93,76
+Galveston,457,U.S. House,14,LIB,Don E. Conley III,42,25,15,2
+Galveston,457,Governor,,REP,Greg Abbott,2129,1662,306,161
+Galveston,457,Governor,,DEM,Lupe Valdez,585,417,90,78
+Galveston,457,Governor,,LIB,Mark Jay Tippetts,52,35,12,5
+Galveston,457,Lieutenant Governor,,REP,Dan Patrick,2005,1575,277,153
+Galveston,457,Lieutenant Governor,,DEM,Mike Collier,677,489,108,80
+Galveston,457,Lieutenant Governor,,LIB,Kerry Douglas McKennon,75,47,20,8
+Galveston,457,Attorney General,,REP,Ken Paxton,1991,1558,279,154
+Galveston,457,Attorney General,,DEM,Justin Nelson,679,491,107,81
+Galveston,457,Attorney General,,LIB,Michael Ray Harris,82,56,21,5
+Galveston,457,Comptroller of Public Accounts,,REP,Glenn Hegar,2080,1633,283,164
+Galveston,457,Comptroller of Public Accounts,,DEM,Joi Chevalier,561,396,94,71
+Galveston,457,Comptroller of Public Accounts,,LIB,Ben Sanders,100,69,28,3
+Galveston,457,Commissioner of General Land Office,,REP,George P. Bush,2046,1599,289,158
+Galveston,457,Commissioner of General Land Office,,DEM,Miguel Suazo,592,421,94,77
+Galveston,457,Commissioner of General Land Office,,LIB,Matt Pina,112,82,23,7
+Galveston,457,Commissioner of Agriculture,,REP,Sid Miller,2007,1576,275,156
+Galveston,457,Commissioner of Agriculture,,DEM,Kim Olson,672,480,113,79
+Galveston,457,Commissioner of Agriculture,,LIB,Richard Carpenter,69,44,19,6
+Galveston,457,Railroad Commissioner,,REP,Christi Craddick,2084,1628,291,165
+Galveston,457,Railroad Commissioner,,DEM,Roman McAllen,577,412,95,70
+Galveston,457,Railroad Commissioner,,LIB,Mike Wright,83,58,21,4
+Galveston,457,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,2076,1630,288,158
+Galveston,457,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,653,462,113,78
+Galveston,457,"Justice, Supreme Court, Place 4",,REP,John Devine,2079,1626,295,158
+Galveston,457,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,648,464,107,77
+Galveston,457,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,2100,1646,289,165
+Galveston,457,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,631,444,114,73
+Galveston,457,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,2053,1607,290,156
+Galveston,457,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,607,433,93,81
+Galveston,457,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,65,45,18,2
+Galveston,457,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,2113,1649,298,166
+Galveston,457,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,608,432,103,73
+Galveston,457,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,2185,1699,314,172
+Galveston,457,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,341,261,58,22
+Galveston,457,"Member, State Board of Education, District 7",,REP,Matt Robinson,2049,1610,284,155
+Galveston,457,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",677,482,116,79
+Galveston,457,State Representative,24,REP,Greg Bonnen,2102,1645,295,162
+Galveston,457,State Representative,24,DEM,John Y. Phelps,582,417,93,72
+Galveston,457,State Representative,24,LIB,Dick Illyes,61,43,15,3
+Galveston,457,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,2112,1654,294,164
+Galveston,457,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,608,432,105,71
+Galveston,457,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,2081,1627,291,163
+Galveston,457,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,640,457,110,73
+Galveston,457,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,2075,1626,292,157
+Galveston,457,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,643,457,107,79
+Galveston,457,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,2068,1622,289,157
+Galveston,457,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,650,460,111,79
+Galveston,457,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,2102,1642,302,158
+Galveston,457,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,612,437,98,77
+Galveston,457,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,2106,1644,299,163
+Galveston,457,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,612,440,101,71
+Galveston,457,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,2105,1639,301,165
+Galveston,457,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,607,438,99,70
+Galveston,457,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,2110,1648,299,163
+Galveston,457,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,604,432,101,71
+Galveston,457,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,2095,1635,297,163
+Galveston,457,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,623,446,103,74
+Galveston,457,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,2085,1633,293,159
+Galveston,457,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",630,447,106,77
+Galveston,457,"District Judge, 122nd Judicial District",,REP,John Ellisor,2251,1742,333,176
+Galveston,457,"District Judge, 212th Judicial District",,REP,Patricia Grady,2242,1735,332,175
+Galveston,457,"District Judge, 306th Judicial District",,REP,Anne B. Darring,2241,1737,330,174
+Galveston,457,Criminal District Attorney,,REP,Jack Roady,2244,1735,331,178
+Galveston,457,County Judge,,REP,Mark Henry,2241,1742,328,171
+Galveston,457,"Judge, County Court-at-Law No. 1",,REP,John Grady,2224,1727,326,171
+Galveston,457,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,2094,1634,298,162
+Galveston,457,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,608,439,97,72
+Galveston,457,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,2233,1735,326,172
+Galveston,457,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,2236,1736,328,172
+Galveston,457,District Clerk,,REP,John D Kinard,2235,1732,328,175
+Galveston,457,County Clerk,,REP,Dwight Sullivan,2233,1730,328,175
+Galveston,457,County Treasurer,,REP,Kevin C. Walsh,2235,1736,327,172
+Galveston,457,County Commissioner Pct. 4,,REP,Ken Clark,2231,1730,328,173
+Galveston,457,"Trustee Position 2 (unexpired term, expiring November 2020)  - FISD",,,Dakota Carter,847,663,131,53
+Galveston,457,"Trustee Position 2 (unexpired term, expiring November 2020)  - FISD",,,Denise Ruiz,1040,815,139,86
+Galveston,460,Ballots Cast,,,,3339,2685,441,213
+Galveston,460,Straight Party,,REP,Republican,1643,1348,187,108
+Galveston,460,Straight Party,,DEM,Democrat,332,254,43,35
+Galveston,460,Straight Party,,LIB,Libertarian,18,10,4,4
+Galveston,460,U.S. Senate,,REP,Ted Cruz,2503,2042,320,141
+Galveston,460,U.S. Senate,,DEM,Beto O'Rourke,796,615,112,69
+Galveston,460,U.S. Senate,,LIB,Neal M. Dikeman,26,18,7,1
+Galveston,460,U.S. House,14,REP,Randy Weber,2557,2085,332,140
+Galveston,460,U.S. House,14,DEM,Adrienne Bell,682,527,89,66
+Galveston,460,U.S. House,14,LIB,Don E. Conley III,65,46,16,3
+Galveston,460,Governor,,REP,Greg Abbott,2642,2150,346,146
+Galveston,460,Governor,,DEM,Lupe Valdez,625,486,79,60
+Galveston,460,Governor,,LIB,Mark Jay Tippetts,58,38,16,4
+Galveston,460,Lieutenant Governor,,REP,Dan Patrick,2432,1980,318,134
+Galveston,460,Lieutenant Governor,,DEM,Mike Collier,813,635,105,73
+Galveston,460,Lieutenant Governor,,LIB,Kerry Douglas McKennon,70,50,17,3
+Galveston,460,Attorney General,,REP,Ken Paxton,2428,1978,318,132
+Galveston,460,Attorney General,,DEM,Justin Nelson,781,602,105,74
+Galveston,460,Attorney General,,LIB,Michael Ray Harris,93,76,16,1
+Galveston,460,Comptroller of Public Accounts,,REP,Glenn Hegar,2584,2108,335,141
+Galveston,460,Comptroller of Public Accounts,,DEM,Joi Chevalier,598,461,76,61
+Galveston,460,Comptroller of Public Accounts,,LIB,Ben Sanders,98,71,21,6
+Galveston,460,Commissioner of General Land Office,,REP,George P. Bush,2540,2076,328,136
+Galveston,460,Commissioner of General Land Office,,DEM,Miguel Suazo,643,486,88,69
+Galveston,460,Commissioner of General Land Office,,LIB,Matt Pina,114,89,22,3
+Galveston,460,Commissioner of Agriculture,,REP,Sid Miller,2473,2024,319,130
+Galveston,460,Commissioner of Agriculture,,DEM,Kim Olson,739,560,103,76
+Galveston,460,Commissioner of Agriculture,,LIB,Richard Carpenter,76,60,14,2
+Galveston,460,Railroad Commissioner,,REP,Christi Craddick,2560,2090,330,140
+Galveston,460,Railroad Commissioner,,DEM,Roman McAllen,623,475,84,64
+Galveston,460,Railroad Commissioner,,LIB,Mike Wright,97,74,20,3
+Galveston,460,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,2565,2090,337,138
+Galveston,460,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,704,541,95,68
+Galveston,460,"Justice, Supreme Court, Place 4",,REP,John Devine,2570,2093,339,138
+Galveston,460,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,699,538,92,69
+Galveston,460,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,2586,2109,334,143
+Galveston,460,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,686,526,98,62
+Galveston,460,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,2530,2064,330,136
+Galveston,460,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,673,519,87,67
+Galveston,460,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,68,51,14,3
+Galveston,460,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,2604,2122,341,141
+Galveston,460,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,658,503,91,64
+Galveston,460,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,2690,2193,354,143
+Galveston,460,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,341,265,49,27
+Galveston,460,"Member, State Board of Education, District 7",,REP,Matt Robinson,2546,2088,324,134
+Galveston,460,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",722,546,107,69
+Galveston,460,State Representative,24,REP,Greg Bonnen,2598,2118,339,141
+Galveston,460,State Representative,24,DEM,John Y. Phelps,635,495,82,58
+Galveston,460,State Representative,24,LIB,Dick Illyes,60,38,16,6
+Galveston,460,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,2596,2115,342,139
+Galveston,460,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,657,503,90,64
+Galveston,460,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,2578,2107,334,137
+Galveston,460,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,677,516,97,64
+Galveston,460,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,2560,2091,337,132
+Galveston,460,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,691,529,93,69
+Galveston,460,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,2551,2083,333,135
+Galveston,460,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,695,533,96,66
+Galveston,460,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,2590,2103,350,137
+Galveston,460,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,660,516,80,64
+Galveston,460,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,2577,2103,337,137
+Galveston,460,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,672,518,91,63
+Galveston,460,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,2583,2106,339,138
+Galveston,460,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,657,508,87,62
+Galveston,460,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,2596,2113,343,140
+Galveston,460,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,651,505,85,61
+Galveston,460,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,2564,2097,332,135
+Galveston,460,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,682,520,95,67
+Galveston,460,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,2566,2095,334,137
+Galveston,460,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",676,519,93,64
+Galveston,460,"District Judge, 122nd Judicial District",,REP,John Ellisor,2782,2257,378,147
+Galveston,460,"District Judge, 212th Judicial District",,REP,Patricia Grady,2751,2228,378,145
+Galveston,460,"District Judge, 306th Judicial District",,REP,Anne B. Darring,2754,2231,378,145
+Galveston,460,Criminal District Attorney,,REP,Jack Roady,2750,2224,378,148
+Galveston,460,County Judge,,REP,Mark Henry,2749,2225,377,147
+Galveston,460,"Judge, County Court-at-Law No. 1",,REP,John Grady,2746,2226,374,146
+Galveston,460,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,2569,2094,338,137
+Galveston,460,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,667,513,90,64
+Galveston,460,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,2749,2227,375,147
+Galveston,460,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,2747,2228,375,144
+Galveston,460,District Clerk,,REP,John D Kinard,2745,2224,374,147
+Galveston,460,County Clerk,,REP,Dwight Sullivan,2739,2220,373,146
+Galveston,460,County Treasurer,,REP,Kevin C. Walsh,2741,2223,373,145
+Galveston,460,County Commissioner Pct. 4,,REP,Ken Clark,2730,2209,375,146
+Galveston,460,"Trustee Position 2 (unexpired term, expiring November 2020)  - FISD",,,Dakota Carter,969,751,155,63
+Galveston,460,"Trustee Position 2 (unexpired term, expiring November 2020)  - FISD",,,Denise Ruiz,1464,1229,158,77
+Galveston,461,Ballots Cast,,,,2363,1859,384,120
+Galveston,461,Straight Party,,REP,Republican,1178,925,187,66
+Galveston,461,Straight Party,,DEM,Democrat,265,207,42,16
+Galveston,461,Straight Party,,LIB,Libertarian,12,3,3,6
+Galveston,461,U.S. Senate,,REP,Ted Cruz,1750,1398,265,87
+Galveston,461,U.S. Senate,,DEM,Beto O'Rourke,588,444,112,32
+Galveston,461,U.S. Senate,,LIB,Neal M. Dikeman,12,7,4,1
+Galveston,461,U.S. House,14,REP,Randy Weber,1792,1418,283,91
+Galveston,461,U.S. House,14,DEM,Adrienne Bell,507,399,79,29
+Galveston,461,U.S. House,14,LIB,Don E. Conley III,41,27,14,0
+Galveston,461,Governor,,REP,Greg Abbott,1841,1457,293,91
+Galveston,461,Governor,,DEM,Lupe Valdez,467,363,77,27
+Galveston,461,Governor,,LIB,Mark Jay Tippetts,39,26,12,1
+Galveston,461,Lieutenant Governor,,REP,Dan Patrick,1718,1362,270,86
+Galveston,461,Lieutenant Governor,,DEM,Mike Collier,571,445,92,34
+Galveston,461,Lieutenant Governor,,LIB,Kerry Douglas McKennon,52,36,16,0
+Galveston,461,Attorney General,,REP,Ken Paxton,1700,1350,266,84
+Galveston,461,Attorney General,,DEM,Justin Nelson,573,451,89,33
+Galveston,461,Attorney General,,LIB,Michael Ray Harris,60,41,17,2
+Galveston,461,Comptroller of Public Accounts,,REP,Glenn Hegar,1775,1413,269,93
+Galveston,461,Comptroller of Public Accounts,,DEM,Joi Chevalier,465,368,74,23
+Galveston,461,Comptroller of Public Accounts,,LIB,Ben Sanders,72,47,23,2
+Galveston,461,Commissioner of General Land Office,,REP,George P. Bush,1727,1373,267,87
+Galveston,461,Commissioner of General Land Office,,DEM,Miguel Suazo,497,389,75,33
+Galveston,461,Commissioner of General Land Office,,LIB,Matt Pina,96,69,27,0
+Galveston,461,Commissioner of Agriculture,,REP,Sid Miller,1706,1365,258,83
+Galveston,461,Commissioner of Agriculture,,DEM,Kim Olson,564,439,89,36
+Galveston,461,Commissioner of Agriculture,,LIB,Richard Carpenter,51,29,21,1
+Galveston,461,Railroad Commissioner,,REP,Christi Craddick,1784,1418,274,92
+Galveston,461,Railroad Commissioner,,DEM,Roman McAllen,473,371,75,27
+Galveston,461,Railroad Commissioner,,LIB,Mike Wright,63,42,21,0
+Galveston,461,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1783,1417,277,89
+Galveston,461,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,530,407,94,29
+Galveston,461,"Justice, Supreme Court, Place 4",,REP,John Devine,1783,1417,279,87
+Galveston,461,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,525,405,90,30
+Galveston,461,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1793,1423,280,90
+Galveston,461,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,518,401,90,27
+Galveston,461,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1751,1394,269,88
+Galveston,461,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,508,394,84,30
+Galveston,461,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,51,35,16,0
+Galveston,461,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1808,1432,284,92
+Galveston,461,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,501,390,86,25
+Galveston,461,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1849,1475,282,92
+Galveston,461,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,270,197,61,12
+Galveston,461,"Member, State Board of Education, District 7",,REP,Matt Robinson,1774,1415,277,82
+Galveston,461,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",536,411,93,32
+Galveston,461,State Representative,24,REP,Greg Bonnen,1778,1416,277,85
+Galveston,461,State Representative,24,DEM,John Y. Phelps,503,396,80,27
+Galveston,461,State Representative,24,LIB,Dick Illyes,43,24,13,6
+Galveston,461,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,1807,1435,284,88
+Galveston,461,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,501,386,86,29
+Galveston,461,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,1778,1416,277,85
+Galveston,461,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,521,404,90,27
+Galveston,461,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,1780,1417,282,81
+Galveston,461,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,523,406,85,32
+Galveston,461,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,1777,1414,285,78
+Galveston,461,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,526,408,84,34
+Galveston,461,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,1802,1435,282,85
+Galveston,461,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,501,386,85,30
+Galveston,461,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,1790,1425,279,86
+Galveston,461,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,511,399,87,25
+Galveston,461,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,1797,1430,283,84
+Galveston,461,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,501,389,85,27
+Galveston,461,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,1802,1437,282,83
+Galveston,461,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,497,381,86,30
+Galveston,461,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,1778,1417,281,80
+Galveston,461,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,520,401,87,32
+Galveston,461,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,1775,1413,281,81
+Galveston,461,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",522,404,86,32
+Galveston,461,"District Judge, 122nd Judicial District",,REP,John Ellisor,1933,1530,314,89
+Galveston,461,"District Judge, 212th Judicial District",,REP,Patricia Grady,1912,1514,311,87
+Galveston,461,"District Judge, 306th Judicial District",,REP,Anne B. Darring,1911,1512,312,87
+Galveston,461,Criminal District Attorney,,REP,Jack Roady,1919,1518,310,91
+Galveston,461,County Judge,,REP,Mark Henry,1911,1510,312,89
+Galveston,461,"Judge, County Court-at-Law No. 1",,REP,John Grady,1907,1508,310,89
+Galveston,461,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,1795,1428,287,80
+Galveston,461,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,502,387,84,31
+Galveston,461,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,1910,1509,312,89
+Galveston,461,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,1917,1510,315,92
+Galveston,461,District Clerk,,REP,John D Kinard,1908,1505,313,90
+Galveston,461,County Clerk,,REP,Dwight Sullivan,1907,1505,313,89
+Galveston,461,County Treasurer,,REP,Kevin C. Walsh,1908,1507,312,89
+Galveston,461,County Commissioner Pct. 4,,REP,Ken Clark,1902,1498,315,89
+Galveston,461,"Trustee Position 2 (unexpired term, expiring November 2020)  - FISD",,,Dakota Carter,730,570,122,38
+Galveston,461,"Trustee Position 2 (unexpired term, expiring November 2020)  - FISD",,,Denise Ruiz,859,693,130,36
+Galveston,462,Ballots Cast,,,,3063,2428,490,145
+Galveston,462,Straight Party,,REP,Republican,1492,1201,223,68
+Galveston,462,Straight Party,,DEM,Democrat,363,280,59,24
+Galveston,462,Straight Party,,LIB,Libertarian,12,6,3,3
+Galveston,462,U.S. Senate,,REP,Ted Cruz,2237,1796,344,97
+Galveston,462,U.S. Senate,,DEM,Beto O'Rourke,804,620,138,46
+Galveston,462,U.S. Senate,,LIB,Neal M. Dikeman,16,7,8,1
+Galveston,462,U.S. House,14,REP,Randy Weber,2319,1864,355,100
+Galveston,462,U.S. House,14,DEM,Adrienne Bell,678,521,112,45
+Galveston,462,U.S. House,14,LIB,Don E. Conley III,43,25,18,0
+Galveston,462,Governor,,REP,Greg Abbott,2374,1904,366,104
+Galveston,462,Governor,,DEM,Lupe Valdez,621,485,100,36
+Galveston,462,Governor,,LIB,Mark Jay Tippetts,51,27,21,3
+Galveston,462,Lieutenant Governor,,REP,Dan Patrick,2214,1771,344,99
+Galveston,462,Lieutenant Governor,,DEM,Mike Collier,751,594,118,39
+Galveston,462,Lieutenant Governor,,LIB,Kerry Douglas McKennon,69,44,21,4
+Galveston,462,Attorney General,,REP,Ken Paxton,2194,1766,329,99
+Galveston,462,Attorney General,,DEM,Justin Nelson,764,597,127,40
+Galveston,462,Attorney General,,LIB,Michael Ray Harris,68,36,28,4
+Galveston,462,Comptroller of Public Accounts,,REP,Glenn Hegar,2301,1846,354,101
+Galveston,462,Comptroller of Public Accounts,,DEM,Joi Chevalier,626,492,101,33
+Galveston,462,Comptroller of Public Accounts,,LIB,Ben Sanders,80,50,23,7
+Galveston,462,Commissioner of General Land Office,,REP,George P. Bush,2275,1826,352,97
+Galveston,462,Commissioner of General Land Office,,DEM,Miguel Suazo,656,513,106,37
+Galveston,462,Commissioner of General Land Office,,LIB,Matt Pina,87,57,23,7
+Galveston,462,Commissioner of Agriculture,,REP,Sid Miller,2192,1762,332,98
+Galveston,462,Commissioner of Agriculture,,DEM,Kim Olson,754,589,123,42
+Galveston,462,Commissioner of Agriculture,,LIB,Richard Carpenter,62,38,21,3
+Galveston,462,Railroad Commissioner,,REP,Christi Craddick,2297,1858,341,98
+Galveston,462,Railroad Commissioner,,DEM,Roman McAllen,634,489,107,38
+Galveston,462,Railroad Commissioner,,LIB,Mike Wright,75,43,27,5
+Galveston,462,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,2275,1813,362,100
+Galveston,462,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,724,571,112,41
+Galveston,462,"Justice, Supreme Court, Place 4",,REP,John Devine,2282,1822,363,97
+Galveston,462,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,718,565,111,42
+Galveston,462,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,2291,1833,359,99
+Galveston,462,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,706,550,114,42
+Galveston,462,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,2261,1813,348,100
+Galveston,462,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,689,543,109,37
+Galveston,462,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,49,26,18,5
+Galveston,462,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,2324,1855,369,100
+Galveston,462,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,666,520,104,42
+Galveston,462,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,2431,1950,379,102
+Galveston,462,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,316,245,54,17
+Galveston,462,"Member, State Board of Education, District 7",,REP,Matt Robinson,2274,1815,363,96
+Galveston,462,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",718,566,112,40
+Galveston,462,State Representative,24,REP,Greg Bonnen,2300,1847,355,98
+Galveston,462,State Representative,24,DEM,John Y. Phelps,656,519,104,33
+Galveston,462,State Representative,24,LIB,Dick Illyes,61,33,22,6
+Galveston,462,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,2316,1855,362,99
+Galveston,462,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,669,519,109,41
+Galveston,462,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,2279,1825,362,92
+Galveston,462,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,700,549,111,40
+Galveston,462,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,2268,1824,353,91
+Galveston,462,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,713,552,119,42
+Galveston,462,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,2272,1819,359,94
+Galveston,462,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,704,551,112,41
+Galveston,462,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,2307,1847,364,96
+Galveston,462,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,674,527,107,40
+Galveston,462,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,2298,1839,364,95
+Galveston,462,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,675,532,106,37
+Galveston,462,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,2308,1847,367,94
+Galveston,462,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,665,523,102,40
+Galveston,462,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,2311,1853,366,92
+Galveston,462,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,662,517,104,41
+Galveston,462,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,2275,1828,353,94
+Galveston,462,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,704,543,117,44
+Galveston,462,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,2269,1822,355,92
+Galveston,462,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",706,549,115,42
+Galveston,462,"District Judge, 122nd Judicial District",,REP,John Ellisor,2481,1982,397,102
+Galveston,462,"District Judge, 212th Judicial District",,REP,Patricia Grady,2466,1973,398,95
+Galveston,462,"District Judge, 306th Judicial District",,REP,Anne B. Darring,2461,1967,396,98
+Galveston,462,Criminal District Attorney,,REP,Jack Roady,2466,1972,395,99
+Galveston,462,County Judge,,REP,Mark Henry,2461,1965,397,99
+Galveston,462,"Judge, County Court-at-Law No. 1",,REP,John Grady,2452,1962,395,95
+Galveston,462,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,2299,1846,361,92
+Galveston,462,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,681,529,110,42
+Galveston,462,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,2461,1966,397,98
+Galveston,462,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,2472,1974,397,101
+Galveston,462,District Clerk,,REP,John D Kinard,2467,1970,396,101
+Galveston,462,County Clerk,,REP,Dwight Sullivan,2463,1965,398,100
+Galveston,462,County Treasurer,,REP,Kevin C. Walsh,2458,1965,395,98
+Galveston,462,County Commissioner Pct. 4,,REP,Ken Clark,2451,1954,397,100
+Galveston,462,"Trustee Position 2 (unexpired term, expiring November 2020)  - FISD",,,Dakota Carter,933,728,157,48
+Galveston,462,"Trustee Position 2 (unexpired term, expiring November 2020)  - FISD",,,Denise Ruiz,1236,1031,166,39
+Galveston,464,Ballots Cast,,,,1787,1350,297,140
+Galveston,464,Straight Party,,REP,Republican,777,606,112,59
+Galveston,464,Straight Party,,DEM,Democrat,248,181,46,21
+Galveston,464,Straight Party,,LIB,Libertarian,8,5,3,0
+Galveston,464,U.S. Senate,,REP,Ted Cruz,1208,941,182,85
+Galveston,464,U.S. Senate,,DEM,Beto O'Rourke,546,388,105,53
+Galveston,464,U.S. Senate,,LIB,Neal M. Dikeman,21,12,7,2
+Galveston,464,U.S. House,14,REP,Randy Weber,1238,961,186,91
+Galveston,464,U.S. House,14,DEM,Adrienne Bell,493,349,96,48
+Galveston,464,U.S. House,14,LIB,Don E. Conley III,39,28,11,0
+Galveston,464,Governor,,REP,Greg Abbott,1278,991,195,92
+Galveston,464,Governor,,DEM,Lupe Valdez,457,323,89,45
+Galveston,464,Governor,,LIB,Mark Jay Tippetts,40,27,10,3
+Galveston,464,Lieutenant Governor,,REP,Dan Patrick,1172,908,183,81
+Galveston,464,Lieutenant Governor,,DEM,Mike Collier,535,386,93,56
+Galveston,464,Lieutenant Governor,,LIB,Kerry Douglas McKennon,60,41,16,3
+Galveston,464,Attorney General,,REP,Ken Paxton,1165,902,178,85
+Galveston,464,Attorney General,,DEM,Justin Nelson,552,400,98,54
+Galveston,464,Attorney General,,LIB,Michael Ray Harris,47,30,17,0
+Galveston,464,Comptroller of Public Accounts,,REP,Glenn Hegar,1226,950,185,91
+Galveston,464,Comptroller of Public Accounts,,DEM,Joi Chevalier,459,326,89,44
+Galveston,464,Comptroller of Public Accounts,,LIB,Ben Sanders,65,47,18,0
+Galveston,464,Commissioner of General Land Office,,REP,George P. Bush,1208,941,181,86
+Galveston,464,Commissioner of General Land Office,,DEM,Miguel Suazo,484,345,91,48
+Galveston,464,Commissioner of General Land Office,,LIB,Matt Pina,71,47,20,4
+Galveston,464,Commissioner of Agriculture,,REP,Sid Miller,1163,904,173,86
+Galveston,464,Commissioner of Agriculture,,DEM,Kim Olson,541,385,105,51
+Galveston,464,Commissioner of Agriculture,,LIB,Richard Carpenter,46,32,14,0
+Galveston,464,Railroad Commissioner,,REP,Christi Craddick,1220,943,190,87
+Galveston,464,Railroad Commissioner,,DEM,Roman McAllen,466,338,81,47
+Galveston,464,Railroad Commissioner,,LIB,Mike Wright,65,41,21,3
+Galveston,464,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1222,943,193,86
+Galveston,464,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,531,385,99,47
+Galveston,464,"Justice, Supreme Court, Place 4",,REP,John Devine,1231,954,189,88
+Galveston,464,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,521,373,103,45
+Galveston,464,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1233,955,189,89
+Galveston,464,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,517,369,103,45
+Galveston,464,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1201,934,182,85
+Galveston,464,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,498,356,95,47
+Galveston,464,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,53,35,16,2
+Galveston,464,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1249,967,194,88
+Galveston,464,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,496,354,97,45
+Galveston,464,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1316,1011,209,96
+Galveston,464,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,280,204,59,17
+Galveston,464,"Member, State Board of Education, District 7",,REP,Matt Robinson,1211,936,190,85
+Galveston,464,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",530,379,101,50
+Galveston,464,State Representative,24,REP,Greg Bonnen,1230,955,187,88
+Galveston,464,State Representative,24,DEM,John Y. Phelps,488,350,91,47
+Galveston,464,State Representative,24,LIB,Dick Illyes,40,25,15,0
+Galveston,464,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,1248,960,200,88
+Galveston,464,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,492,355,92,45
+Galveston,464,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,1217,939,191,87
+Galveston,464,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,520,373,101,46
+Galveston,464,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,1224,943,193,88
+Galveston,464,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,511,366,99,46
+Galveston,464,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,1225,945,192,88
+Galveston,464,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,516,370,100,46
+Galveston,464,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,1240,955,197,88
+Galveston,464,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,498,358,95,45
+Galveston,464,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,1233,952,194,87
+Galveston,464,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,498,357,96,45
+Galveston,464,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,1225,946,191,88
+Galveston,464,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,504,360,99,45
+Galveston,464,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,1235,952,194,89
+Galveston,464,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,493,354,96,43
+Galveston,464,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,1219,941,195,83
+Galveston,464,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,510,365,95,50
+Galveston,464,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,1209,938,188,83
+Galveston,464,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",522,371,102,49
+Galveston,464,"District Judge, 122nd Judicial District",,REP,John Ellisor,1372,1049,226,97
+Galveston,464,"District Judge, 212th Judicial District",,REP,Patricia Grady,1372,1046,229,97
+Galveston,464,"District Judge, 306th Judicial District",,REP,Anne B. Darring,1367,1042,227,98
+Galveston,464,Criminal District Attorney,,REP,Jack Roady,1369,1045,226,98
+Galveston,464,County Judge,,REP,Mark Henry,1361,1038,225,98
+Galveston,464,"Judge, County Court-at-Law No. 1",,REP,John Grady,1354,1031,226,97
+Galveston,464,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,1230,949,194,87
+Galveston,464,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,500,360,95,45
+Galveston,464,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,1354,1034,222,98
+Galveston,464,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,1359,1035,226,98
+Galveston,464,District Clerk,,REP,John D Kinard,1360,1040,223,97
+Galveston,464,County Clerk,,REP,Dwight Sullivan,1355,1033,223,99
+Galveston,464,County Treasurer,,REP,Kevin C. Walsh,1351,1030,223,98
+Galveston,464,County Commissioner Pct. 4,,REP,Ken Clark,1347,1024,224,99
+Galveston,464,Mayor  - League City,,,Sebastian Lofaro,394,300,73,21
+Galveston,464,Mayor  - League City,,,Pat Hallisey,1054,779,172,103
+Galveston,464,Council Position 1  - League City,,,Andy Mann,607,467,94,46
+Galveston,464,Council Position 1  - League City,,,Traci Jacobs,629,448,122,59
+Galveston,464,Council Position 2  - League City,,,Hank Dugie,1045,780,182,83
+Galveston,464,Council Position 6  - League City,,,Silvio P. Vincenzo,300,230,52,18
+Galveston,464,Council Position 6  - League City,,,Chad Tressler,538,400,92,46
+Galveston,464,Council Position 6  - League City,,,Chris Gross,382,279,68,35
+Galveston,464,Council Position 7  - League City,,,Ange Mertens,474,346,91,37
+Galveston,464,Council Position 7  - League City,,,Nick Long,778,584,128,66
+Galveston,464,League City Proposition A,,,For,1130,846,176,108
+Galveston,464,League City Proposition A,,,Against,286,207,61,18
+Galveston,464,League City Proposition B,,,For,1263,939,207,117
+Galveston,464,League City Proposition B,,,Against,241,182,46,13
+Galveston,464,League City Proposition C,,,For,1318,981,223,114
+Galveston,464,League City Proposition C,,,Against,144,111,20,13
+Galveston,464,League City Proposition D,,,For,1210,900,194,116
+Galveston,464,League City Proposition D,,,Against,187,135,43,9
+Galveston,464,League City Proposition E,,,For,1375,1017,231,127
+Galveston,464,League City Proposition E,,,Against,86,73,11,2
+Galveston,464,League City Proposition F,,,For,1252,933,194,125
+Galveston,464,League City Proposition F,,,Against,138,101,33,4
+Galveston,464,League City Proposition G,,,For,1329,992,215,122
+Galveston,464,League City Proposition G,,,Against,97,76,18,3
+Galveston,464,League City Proposition H,,,For,845,625,144,76
+Galveston,464,League City Proposition H,,,Against,468,351,78,39
+Galveston,464,League City Proposition I,,,For,1269,950,196,123
+Galveston,464,League City Proposition I,,,Against,139,103,33,3
+Galveston,464,League City Proposition J,,,For,1238,927,193,118
+Galveston,464,League City Proposition J,,,Against,175,126,43,6
+Galveston,464,League City Proposition K,,,For,1276,949,206,121
+Galveston,464,League City Proposition K,,,Against,111,85,23,3
+Galveston,464,League City Proposition L,,,For,1089,815,168,106
+Galveston,464,League City Proposition L,,,Against,246,177,54,15
+Galveston,464,League City Proposition M,,,For,1231,914,200,117
+Galveston,464,League City Proposition M,,,Against,153,113,32,8
+Galveston,464,League City Proposition N,,,For,1104,819,174,111
+Galveston,464,League City Proposition N,,,Against,260,192,54,14
+Galveston,464,League City Proposition O,,,For,1153,865,181,107
+Galveston,464,League City Proposition O,,,Against,207,152,43,12
+Galveston,471,Ballots Cast,,,,1393,1016,307,70
+Galveston,471,Straight Party,,REP,Republican,529,401,106,22
+Galveston,471,Straight Party,,DEM,Democrat,300,222,59,19
+Galveston,471,Straight Party,,LIB,Libertarian,6,3,2,1
+Galveston,471,U.S. Senate,,REP,Ted Cruz,780,584,163,33
+Galveston,471,U.S. Senate,,DEM,Beto O'Rourke,589,418,137,34
+Galveston,471,U.S. Senate,,LIB,Neal M. Dikeman,16,9,6,1
+Galveston,471,U.S. House,14,REP,Randy Weber,812,602,176,34
+Galveston,471,U.S. House,14,DEM,Adrienne Bell,538,389,114,35
+Galveston,471,U.S. House,14,LIB,Don E. Conley III,30,19,11,0
+Galveston,471,Governor,,REP,Greg Abbott,851,626,187,38
+Galveston,471,Governor,,DEM,Lupe Valdez,489,360,99,30
+Galveston,471,Governor,,LIB,Mark Jay Tippetts,37,21,16,0
+Galveston,471,Lieutenant Governor,,REP,Dan Patrick,795,588,172,35
+Galveston,471,Lieutenant Governor,,DEM,Mike Collier,548,401,113,34
+Galveston,471,Lieutenant Governor,,LIB,Kerry Douglas McKennon,32,19,13,0
+Galveston,471,Attorney General,,REP,Ken Paxton,770,576,161,33
+Galveston,471,Attorney General,,DEM,Justin Nelson,565,405,126,34
+Galveston,471,Attorney General,,LIB,Michael Ray Harris,38,24,12,2
+Galveston,471,Comptroller of Public Accounts,,REP,Glenn Hegar,809,606,166,37
+Galveston,471,Comptroller of Public Accounts,,DEM,Joi Chevalier,507,368,109,30
+Galveston,471,Comptroller of Public Accounts,,LIB,Ben Sanders,48,25,21,2
+Galveston,471,Commissioner of General Land Office,,REP,George P. Bush,823,607,178,38
+Galveston,471,Commissioner of General Land Office,,DEM,Miguel Suazo,498,365,104,29
+Galveston,471,Commissioner of General Land Office,,LIB,Matt Pina,44,29,13,2
+Galveston,471,Commissioner of Agriculture,,REP,Sid Miller,776,585,157,34
+Galveston,471,Commissioner of Agriculture,,DEM,Kim Olson,556,398,123,35
+Galveston,471,Commissioner of Agriculture,,LIB,Richard Carpenter,32,18,14,0
+Galveston,471,Railroad Commissioner,,REP,Christi Craddick,825,612,174,39
+Galveston,471,Railroad Commissioner,,DEM,Roman McAllen,504,370,104,30
+Galveston,471,Railroad Commissioner,,LIB,Mike Wright,36,19,17,0
+Galveston,471,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,809,604,171,34
+Galveston,471,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,554,396,124,34
+Galveston,471,"Justice, Supreme Court, Place 4",,REP,John Devine,819,609,177,33
+Galveston,471,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,540,390,114,36
+Galveston,471,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,821,611,175,35
+Galveston,471,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,543,389,120,34
+Galveston,471,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,803,599,170,34
+Galveston,471,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,534,381,118,35
+Galveston,471,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,27,19,8,0
+Galveston,471,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,823,611,179,33
+Galveston,471,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,534,384,114,36
+Galveston,471,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,886,651,195,40
+Galveston,471,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,281,204,64,13
+Galveston,471,"Member, State Board of Education, District 7",,REP,Matt Robinson,812,606,172,34
+Galveston,471,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",545,391,123,31
+Galveston,471,State Representative,24,REP,Greg Bonnen,814,608,170,36
+Galveston,471,State Representative,24,DEM,John Y. Phelps,522,379,114,29
+Galveston,471,State Representative,24,LIB,Dick Illyes,30,16,12,2
+Galveston,471,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,838,619,183,36
+Galveston,471,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,517,377,109,31
+Galveston,471,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,813,609,169,35
+Galveston,471,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,539,387,121,31
+Galveston,471,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,812,606,174,32
+Galveston,471,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,541,389,118,34
+Galveston,471,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,812,605,171,36
+Galveston,471,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,540,391,121,28
+Galveston,471,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,825,611,177,37
+Galveston,471,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,524,382,114,28
+Galveston,471,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,828,617,177,34
+Galveston,471,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,518,375,112,31
+Galveston,471,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,830,617,176,37
+Galveston,471,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,518,376,113,29
+Galveston,471,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,830,614,178,38
+Galveston,471,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,517,378,111,28
+Galveston,471,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,813,609,169,35
+Galveston,471,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,535,384,120,31
+Galveston,471,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,816,607,172,37
+Galveston,471,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",532,386,116,30
+Galveston,471,"District Judge, 122nd Judicial District",,REP,John Ellisor,929,684,208,37
+Galveston,471,"District Judge, 212th Judicial District",,REP,Patricia Grady,933,687,209,37
+Galveston,471,"District Judge, 306th Judicial District",,REP,Anne B. Darring,931,682,212,37
+Galveston,471,Criminal District Attorney,,REP,Jack Roady,930,681,211,38
+Galveston,471,County Judge,,REP,Mark Henry,923,670,214,39
+Galveston,471,"Judge, County Court-at-Law No. 1",,REP,John Grady,921,675,208,38
+Galveston,471,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,829,612,181,36
+Galveston,471,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,517,380,108,29
+Galveston,471,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,929,684,208,37
+Galveston,471,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,934,683,211,40
+Galveston,471,District Clerk,,REP,John D Kinard,940,690,212,38
+Galveston,471,County Clerk,,REP,Dwight Sullivan,928,680,211,37
+Galveston,471,County Treasurer,,REP,Kevin C. Walsh,927,680,209,38
+Galveston,471,County Commissioner Pct. 4,,REP,Ken Clark,909,664,207,38
+Galveston,471,College of the Mainland Proposition A,,,FOR,91,63,25,3
+Galveston,471,College of the Mainland Proposition A,,,AGAINST,62,44,16,2
+Galveston,471,Mayor  - League City,,,Sebastian Lofaro,365,274,74,17
+Galveston,471,Mayor  - League City,,,Pat Hallisey,676,500,140,36
+Galveston,471,Council Position 1  - League City,,,Andy Mann,469,359,85,25
+Galveston,471,Council Position 1  - League City,,,Traci Jacobs,429,309,101,19
+Galveston,471,Council Position 2  - League City,,,Hank Dugie,735,539,162,34
+Galveston,471,Council Position 6  - League City,,,Silvio P. Vincenzo,230,172,49,9
+Galveston,471,Council Position 6  - League City,,,Chad Tressler,447,327,88,32
+Galveston,471,Council Position 6  - League City,,,Chris Gross,209,162,42,5
+Galveston,471,Council Position 7  - League City,,,Ange Mertens,385,279,85,21
+Galveston,471,Council Position 7  - League City,,,Nick Long,527,404,95,28
+Galveston,471,League City Proposition A,,,For,782,577,154,51
+Galveston,471,League City Proposition A,,,Against,261,194,59,8
+Galveston,471,League City Proposition B,,,For,949,701,199,49
+Galveston,471,League City Proposition B,,,Against,146,109,28,9
+Galveston,471,League City Proposition C,,,For,953,704,194,55
+Galveston,471,League City Proposition C,,,Against,120,93,23,4
+Galveston,471,League City Proposition D,,,For,862,646,172,44
+Galveston,471,League City Proposition D,,,Against,153,110,31,12
+Galveston,471,League City Proposition E,,,For,993,738,201,54
+Galveston,471,League City Proposition E,,,Against,73,49,18,6
+Galveston,471,League City Proposition F,,,For,906,670,179,57
+Galveston,471,League City Proposition F,,,Against,111,84,26,1
+Galveston,471,League City Proposition G,,,For,974,723,195,56
+Galveston,471,League City Proposition G,,,Against,71,50,16,5
+Galveston,471,League City Proposition H,,,For,608,449,120,39
+Galveston,471,League City Proposition H,,,Against,357,267,70,20
+Galveston,471,League City Proposition I,,,For,904,665,181,58
+Galveston,471,League City Proposition I,,,Against,119,89,27,3
+Galveston,471,League City Proposition J,,,For,891,655,183,53
+Galveston,471,League City Proposition J,,,Against,130,98,26,6
+Galveston,471,League City Proposition K,,,For,891,660,179,52
+Galveston,471,League City Proposition K,,,Against,110,81,22,7
+Galveston,471,League City Proposition L,,,For,785,587,159,39
+Galveston,471,League City Proposition L,,,Against,194,135,41,18
+Galveston,471,League City Proposition M,,,For,879,654,176,49
+Galveston,471,League City Proposition M,,,Against,126,91,27,8
+Galveston,471,League City Proposition N,,,For,800,594,156,50
+Galveston,471,League City Proposition N,,,Against,197,143,46,8
+Galveston,471,League City Proposition O,,,For,810,609,160,41
+Galveston,471,League City Proposition O,,,Against,179,122,42,15
+Galveston,482,Ballots Cast,,,,109,83,17,9
+Galveston,482,Straight Party,,REP,Republican,72,61,10,1
+Galveston,482,Straight Party,,DEM,Democrat,6,1,2,3
+Galveston,482,Straight Party,,LIB,Libertarian,1,0,1,0
+Galveston,482,U.S. Senate,,REP,Ted Cruz,96,80,12,4
+Galveston,482,U.S. Senate,,DEM,Beto O'Rourke,11,3,3,5
+Galveston,482,U.S. Senate,,LIB,Neal M. Dikeman,2,0,2,0
+Galveston,482,U.S. House,14,REP,Randy Weber,98,82,12,4
+Galveston,482,U.S. House,14,DEM,Adrienne Bell,9,1,3,5
+Galveston,482,U.S. House,14,LIB,Don E. Conley III,2,0,2,0
+Galveston,482,Governor,,REP,Greg Abbott,98,81,13,4
+Galveston,482,Governor,,DEM,Lupe Valdez,8,1,3,4
+Galveston,482,Governor,,LIB,Mark Jay Tippetts,2,1,1,0
+Galveston,482,Lieutenant Governor,,REP,Dan Patrick,97,80,13,4
+Galveston,482,Lieutenant Governor,,DEM,Mike Collier,10,2,3,5
+Galveston,482,Lieutenant Governor,,LIB,Kerry Douglas McKennon,2,1,1,0
+Galveston,482,Attorney General,,REP,Ken Paxton,95,79,12,4
+Galveston,482,Attorney General,,DEM,Justin Nelson,12,3,4,5
+Galveston,482,Attorney General,,LIB,Michael Ray Harris,2,1,1,0
+Galveston,482,Comptroller of Public Accounts,,REP,Glenn Hegar,97,81,12,4
+Galveston,482,Comptroller of Public Accounts,,DEM,Joi Chevalier,9,1,3,5
+Galveston,482,Comptroller of Public Accounts,,LIB,Ben Sanders,3,1,2,0
+Galveston,482,Commissioner of General Land Office,,REP,George P. Bush,96,77,13,6
+Galveston,482,Commissioner of General Land Office,,DEM,Miguel Suazo,7,1,3,3
+Galveston,482,Commissioner of General Land Office,,LIB,Matt Pina,6,5,1,0
+Galveston,482,Commissioner of Agriculture,,REP,Sid Miller,95,78,13,4
+Galveston,482,Commissioner of Agriculture,,DEM,Kim Olson,12,4,3,5
+Galveston,482,Commissioner of Agriculture,,LIB,Richard Carpenter,2,1,1,0
+Galveston,482,Railroad Commissioner,,REP,Christi Craddick,98,82,12,4
+Galveston,482,Railroad Commissioner,,DEM,Roman McAllen,10,1,4,5
+Galveston,482,Railroad Commissioner,,LIB,Mike Wright,1,0,1,0
+Galveston,482,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,100,82,14,4
+Galveston,482,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,9,1,3,5
+Galveston,482,"Justice, Supreme Court, Place 4",,REP,John Devine,99,82,13,4
+Galveston,482,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,10,1,4,5
+Galveston,482,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,100,81,14,5
+Galveston,482,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,9,2,3,4
+Galveston,482,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,97,81,12,4
+Galveston,482,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,10,1,4,5
+Galveston,482,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,1,0,1,0
+Galveston,482,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,98,81,13,4
+Galveston,482,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,10,1,4,5
+Galveston,482,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,99,80,14,5
+Galveston,482,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,4,1,2,1
+Galveston,482,"Member, State Board of Education, District 7",,REP,Matt Robinson,98,80,13,5
+Galveston,482,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",10,2,4,4
+Galveston,482,State Representative,24,REP,Greg Bonnen,97,80,12,5
+Galveston,482,State Representative,24,DEM,John Y. Phelps,7,1,2,4
+Galveston,482,State Representative,24,LIB,Dick Illyes,4,1,3,0
+Galveston,482,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,100,81,14,5
+Galveston,482,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,8,1,3,4
+Galveston,482,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,100,81,14,5
+Galveston,482,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,8,1,3,4
+Galveston,482,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,99,81,13,5
+Galveston,482,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,9,1,4,4
+Galveston,482,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,100,81,14,5
+Galveston,482,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,8,1,3,4
+Galveston,482,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,100,81,14,5
+Galveston,482,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,8,1,3,4
+Galveston,482,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,99,81,14,4
+Galveston,482,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,9,1,3,5
+Galveston,482,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,100,81,14,5
+Galveston,482,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,8,1,3,4
+Galveston,482,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,101,81,14,6
+Galveston,482,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,7,1,3,3
+Galveston,482,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,101,81,14,6
+Galveston,482,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,7,1,3,3
+Galveston,482,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,98,80,13,5
+Galveston,482,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",9,1,4,4
+Galveston,482,"District Judge, 122nd Judicial District",,REP,John Ellisor,99,80,14,5
+Galveston,482,"District Judge, 212th Judicial District",,REP,Patricia Grady,100,81,14,5
+Galveston,482,"District Judge, 306th Judicial District",,REP,Anne B. Darring,99,80,14,5
+Galveston,482,Criminal District Attorney,,REP,Jack Roady,98,80,13,5
+Galveston,482,County Judge,,REP,Mark Henry,97,79,13,5
+Galveston,482,"Judge, County Court-at-Law No. 1",,REP,John Grady,99,80,14,5
+Galveston,482,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,98,80,13,5
+Galveston,482,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,8,1,3,4
+Galveston,482,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,98,79,14,5
+Galveston,482,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,98,79,14,5
+Galveston,482,District Clerk,,REP,John D Kinard,98,79,14,5
+Galveston,482,County Clerk,,REP,Dwight Sullivan,99,80,14,5
+Galveston,482,County Treasurer,,REP,Kevin C. Walsh,99,80,14,5
+Galveston,482,County Commissioner Pct. 4,,REP,Ken Clark,98,79,13,6
+Galveston,482,Justice of the Peace Pct. 2,,REP,Mike Nelson,98,79,14,5
+Galveston,482,College of the Mainland Proposition A,,,FOR,40,28,7,5
+Galveston,482,College of the Mainland Proposition A,,,AGAINST,45,40,4,1
+Galveston,482,Mayor  - League City,,,Sebastian Lofaro,8,6,1,1
+Galveston,482,Mayor  - League City,,,Pat Hallisey,22,18,2,2
+Galveston,482,Council Position 1  - League City,,,Andy Mann,12,11,1,0
+Galveston,482,Council Position 1  - League City,,,Traci Jacobs,15,10,2,3
+Galveston,482,Council Position 2  - League City,,,Hank Dugie,21,16,3,2
+Galveston,482,Council Position 6  - League City,,,Silvio P. Vincenzo,8,7,1,0
+Galveston,482,Council Position 6  - League City,,,Chad Tressler,13,11,0,2
+Galveston,482,Council Position 6  - League City,,,Chris Gross,4,1,2,1
+Galveston,482,Council Position 7  - League City,,,Ange Mertens,11,9,2,0
+Galveston,482,Council Position 7  - League City,,,Nick Long,16,12,1,3
+Galveston,482,League City Proposition A,,,For,24,20,1,3
+Galveston,482,League City Proposition A,,,Against,11,9,2,0
+Galveston,482,League City Proposition B,,,For,37,31,3,3
+Galveston,482,League City Proposition B,,,Against,3,3,0,0
+Galveston,482,League City Proposition C,,,For,36,32,2,2
+Galveston,482,League City Proposition C,,,Against,4,2,1,1
+Galveston,482,League City Proposition D,,,For,30,24,3,3
+Galveston,482,League City Proposition D,,,Against,5,5,0,0
+Galveston,482,League City Proposition E,,,For,35,29,3,3
+Galveston,482,League City Proposition E,,,Against,1,1,0,0
+Galveston,482,League City Proposition F,,,For,30,24,3,3
+Galveston,482,League City Proposition F,,,Against,4,4,0,0
+Galveston,482,League City Proposition G,,,For,34,28,3,3
+Galveston,482,League City Proposition G,,,Against,2,2,0,0
+Galveston,482,League City Proposition H,,,For,20,17,2,1
+Galveston,482,League City Proposition H,,,Against,13,10,1,2
+Galveston,482,League City Proposition I,,,For,32,26,3,3
+Galveston,482,League City Proposition I,,,Against,4,4,0,0
+Galveston,482,League City Proposition J,,,For,29,24,2,3
+Galveston,482,League City Proposition J,,,Against,6,5,1,0
+Galveston,482,League City Proposition K,,,For,30,24,3,3
+Galveston,482,League City Proposition K,,,Against,5,5,0,0
+Galveston,482,League City Proposition L,,,For,23,20,2,1
+Galveston,482,League City Proposition L,,,Against,10,7,1,2
+Galveston,482,League City Proposition M,,,For,32,26,3,3
+Galveston,482,League City Proposition M,,,Against,1,1,0,0
+Galveston,482,League City Proposition N,,,For,24,19,2,3
+Galveston,482,League City Proposition N,,,Against,10,9,1,0
+Galveston,482,League City Proposition O,,,For,25,21,2,2
+Galveston,482,League City Proposition O,,,Against,5,3,1,1
+Galveston,482,Trustee Position 4  - SFISD,,,Clay Hertenberger,14,12,2,0
+Galveston,482,Trustee Position 4  - SFISD,,,Donna Hayes,13,9,1,3
+Galveston,482,Trustee Position 4  - SFISD,,,John Rothermel,16,11,3,2
+Galveston,482,Trustee Position 4  - SFISD,,,Jessica Hagewood,10,7,1,2
+Galveston,482,Trustee Position 5  - SFISD,,,James Grassmuck,18,14,2,2
+Galveston,482,Trustee Position 5  - SFISD,,,Sheryl Skufca,19,14,4,1
+Galveston,482,Trustee Position 5  - SFISD,,,Tina Longcoy,7,3,1,3
+Galveston,482,Trustee Position 5  - SFISD,,,Jody Davis,10,8,1,1
+Galveston,482,Trustee Position 6  - SFISD,,,Rusty Norman,55,42,8,5
+Galveston,487,Ballots Cast,,,,3498,2676,696,126
+Galveston,487,Straight Party,,REP,Republican,1507,1162,300,45
+Galveston,487,Straight Party,,DEM,Democrat,562,426,100,36
+Galveston,487,Straight Party,,LIB,Libertarian,14,2,9,3
+Galveston,487,U.S. Senate,,REP,Ted Cruz,2264,1762,444,58
+Galveston,487,U.S. Senate,,DEM,Beto O'Rourke,1183,883,235,65
+Galveston,487,U.S. Senate,,LIB,Neal M. Dikeman,37,19,16,2
+Galveston,487,U.S. House,14,REP,Randy Weber,2314,1796,457,61
+Galveston,487,U.S. House,14,DEM,Adrienne Bell,1095,822,210,63
+Galveston,487,U.S. House,14,LIB,Don E. Conley III,51,35,16,0
+Galveston,487,Governor,,REP,Greg Abbott,2407,1869,477,61
+Galveston,487,Governor,,DEM,Lupe Valdez,1001,756,187,58
+Galveston,487,Governor,,LIB,Mark Jay Tippetts,67,38,24,5
+Galveston,487,Lieutenant Governor,,REP,Dan Patrick,2250,1737,457,56
+Galveston,487,Lieutenant Governor,,DEM,Mike Collier,1125,858,202,65
+Galveston,487,Lieutenant Governor,,LIB,Kerry Douglas McKennon,84,57,26,1
+Galveston,487,Attorney General,,REP,Ken Paxton,2223,1717,451,55
+Galveston,487,Attorney General,,DEM,Justin Nelson,1129,865,201,63
+Galveston,487,Attorney General,,LIB,Michael Ray Harris,99,63,33,3
+Galveston,487,Comptroller of Public Accounts,,REP,Glenn Hegar,2301,1794,453,54
+Galveston,487,Comptroller of Public Accounts,,DEM,Joi Chevalier,1002,757,183,62
+Galveston,487,Comptroller of Public Accounts,,LIB,Ben Sanders,128,83,39,6
+Galveston,487,Commissioner of General Land Office,,REP,George P. Bush,2309,1793,459,57
+Galveston,487,Commissioner of General Land Office,,DEM,Miguel Suazo,1022,769,194,59
+Galveston,487,Commissioner of General Land Office,,LIB,Matt Pina,109,77,25,7
+Galveston,487,Commissioner of Agriculture,,REP,Sid Miller,2215,1727,431,57
+Galveston,487,Commissioner of Agriculture,,DEM,Kim Olson,1129,856,212,61
+Galveston,487,Commissioner of Agriculture,,LIB,Richard Carpenter,91,53,32,6
+Galveston,487,Railroad Commissioner,,REP,Christi Craddick,2328,1812,460,56
+Galveston,487,Railroad Commissioner,,DEM,Roman McAllen,998,748,187,63
+Galveston,487,Railroad Commissioner,,LIB,Mike Wright,111,76,31,4
+Galveston,487,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,2313,1799,455,59
+Galveston,487,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,1115,832,220,63
+Galveston,487,"Justice, Supreme Court, Place 4",,REP,John Devine,2315,1803,454,58
+Galveston,487,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,1112,827,220,65
+Galveston,487,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,2318,1805,454,59
+Galveston,487,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,1106,824,218,64
+Galveston,487,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,2266,1767,441,58
+Galveston,487,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,1069,801,207,61
+Galveston,487,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,93,58,29,6
+Galveston,487,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,2334,1811,464,59
+Galveston,487,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,1085,812,209,64
+Galveston,487,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,2507,1947,501,59
+Galveston,487,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,570,431,114,25
+Galveston,487,"Member, State Board of Education, District 7",,REP,Matt Robinson,2269,1763,450,56
+Galveston,487,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",1151,865,222,64
+Galveston,487,State Representative,24,REP,Greg Bonnen,2308,1808,444,56
+Galveston,487,State Representative,24,DEM,John Y. Phelps,1052,787,203,62
+Galveston,487,State Representative,24,LIB,Dick Illyes,82,48,30,4
+Galveston,487,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,2351,1826,469,56
+Galveston,487,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,1065,797,202,66
+Galveston,487,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,2308,1791,462,55
+Galveston,487,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,1108,832,212,64
+Galveston,487,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,2313,1799,455,59
+Galveston,487,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,1107,829,217,61
+Galveston,487,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,2300,1789,457,54
+Galveston,487,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,1110,831,215,64
+Galveston,487,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,2352,1823,471,58
+Galveston,487,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,1059,795,202,62
+Galveston,487,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,2344,1819,467,58
+Galveston,487,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,1070,805,204,61
+Galveston,487,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,2333,1815,461,57
+Galveston,487,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,1076,805,208,63
+Galveston,487,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,2337,1816,463,58
+Galveston,487,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,1070,803,206,61
+Galveston,487,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,2311,1800,455,56
+Galveston,487,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,1098,820,216,62
+Galveston,487,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,2316,1798,461,57
+Galveston,487,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",1093,824,209,60
+Galveston,487,"District Judge, 122nd Judicial District",,REP,John Ellisor,2631,2019,545,67
+Galveston,487,"District Judge, 212th Judicial District",,REP,Patricia Grady,2628,2020,545,63
+Galveston,487,"District Judge, 306th Judicial District",,REP,Anne B. Darring,2623,2017,543,63
+Galveston,487,Criminal District Attorney,,REP,Jack Roady,2621,2014,542,65
+Galveston,487,County Judge,,REP,Mark Henry,2601,2001,539,61
+Galveston,487,"Judge, County Court-at-Law No. 1",,REP,John Grady,2584,1990,533,61
+Galveston,487,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,2328,1806,465,57
+Galveston,487,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,1073,808,206,59
+Galveston,487,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,2600,2003,537,60
+Galveston,487,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,2610,2007,540,63
+Galveston,487,District Clerk,,REP,John D Kinard,2604,2003,539,62
+Galveston,487,County Clerk,,REP,Dwight Sullivan,2603,1999,539,65
+Galveston,487,County Treasurer,,REP,Kevin C. Walsh,2585,1993,532,60
+Galveston,487,County Commissioner Pct. 4,,REP,Ken Clark,2566,1976,529,61
+Galveston,487,Mayor  - League City,,,Sebastian Lofaro,832,647,149,36
+Galveston,487,Mayor  - League City,,,Pat Hallisey,1891,1456,369,66
+Galveston,487,Council Position 1  - League City,,,Andy Mann,1262,977,251,34
+Galveston,487,Council Position 1  - League City,,,Traci Jacobs,1125,850,225,50
+Galveston,487,Council Position 2  - League City,,,Hank Dugie,1996,1528,409,59
+Galveston,487,Council Position 6  - League City,,,Silvio P. Vincenzo,559,427,111,21
+Galveston,487,Council Position 6  - League City,,,Chad Tressler,1103,851,217,35
+Galveston,487,Council Position 6  - League City,,,Chris Gross,633,487,120,26
+Galveston,487,Council Position 7  - League City,,,Ange Mertens,976,754,191,31
+Galveston,487,Council Position 7  - League City,,,Nick Long,1445,1117,278,50
+Galveston,487,League City Proposition A,,,For,2019,1566,367,86
+Galveston,487,League City Proposition A,,,Against,655,496,140,19
+Galveston,487,League City Proposition B,,,For,2448,1909,442,97
+Galveston,487,League City Proposition B,,,Against,393,277,103,13
+Galveston,487,League City Proposition C,,,For,2447,1887,468,92
+Galveston,487,League City Proposition C,,,Against,321,244,65,12
+Galveston,487,League City Proposition D,,,For,2262,1745,427,90
+Galveston,487,League City Proposition D,,,Against,372,278,79,15
+Galveston,487,League City Proposition E,,,For,2589,1990,493,106
+Galveston,487,League City Proposition E,,,Against,175,139,31,5
+Galveston,487,League City Proposition F,,,For,2336,1811,429,96
+Galveston,487,League City Proposition F,,,Against,289,212,66,11
+Galveston,487,League City Proposition G,,,For,2515,1942,466,107
+Galveston,487,League City Proposition G,,,Against,191,153,34,4
+Galveston,487,League City Proposition H,,,For,1623,1244,315,64
+Galveston,487,League City Proposition H,,,Against,874,679,159,36
+Galveston,487,League City Proposition I,,,For,2363,1834,427,102
+Galveston,487,League City Proposition I,,,Against,284,203,74,7
+Galveston,487,League City Proposition J,,,For,2283,1771,412,100
+Galveston,487,League City Proposition J,,,Against,364,269,84,11
+Galveston,487,League City Proposition K,,,For,2320,1797,424,99
+Galveston,487,League City Proposition K,,,Against,275,207,60,8
+Galveston,487,League City Proposition L,,,For,1974,1521,367,86
+Galveston,487,League City Proposition L,,,Against,522,399,107,16
+Galveston,487,League City Proposition M,,,For,2246,1751,404,91
+Galveston,487,League City Proposition M,,,Against,304,215,78,11
+Galveston,487,League City Proposition N,,,For,2047,1569,389,89
+Galveston,487,League City Proposition N,,,Against,505,392,97,16
+Galveston,487,League City Proposition O,,,For,2128,1652,397,79
+Galveston,487,League City Proposition O,,,Against,412,307,82,23
+Galveston,488,Ballots Cast,,,,2313,1741,449,123
+Galveston,488,Straight Party,,REP,Republican,978,756,163,59
+Galveston,488,Straight Party,,DEM,Democrat,414,305,76,33
+Galveston,488,Straight Party,,LIB,Libertarian,12,9,2,1
+Galveston,488,U.S. Senate,,REP,Ted Cruz,1462,1137,250,75
+Galveston,488,U.S. Senate,,DEM,Beto O'Rourke,820,585,189,46
+Galveston,488,U.S. Senate,,LIB,Neal M. Dikeman,25,15,9,1
+Galveston,488,U.S. House,14,REP,Randy Weber,1494,1155,264,75
+Galveston,488,U.S. House,14,DEM,Adrienne Bell,743,536,162,45
+Galveston,488,U.S. House,14,LIB,Don E. Conley III,50,32,17,1
+Galveston,488,Governor,,REP,Greg Abbott,1569,1205,288,76
+Galveston,488,Governor,,DEM,Lupe Valdez,673,489,138,46
+Galveston,488,Governor,,LIB,Mark Jay Tippetts,56,38,18,0
+Galveston,488,Lieutenant Governor,,REP,Dan Patrick,1479,1136,268,75
+Galveston,488,Lieutenant Governor,,DEM,Mike Collier,754,549,160,45
+Galveston,488,Lieutenant Governor,,LIB,Kerry Douglas McKennon,57,41,15,1
+Galveston,488,Attorney General,,REP,Ken Paxton,1447,1122,251,74
+Galveston,488,Attorney General,,DEM,Justin Nelson,774,562,165,47
+Galveston,488,Attorney General,,LIB,Michael Ray Harris,64,36,27,1
+Galveston,488,Comptroller of Public Accounts,,REP,Glenn Hegar,1487,1148,265,74
+Galveston,488,Comptroller of Public Accounts,,DEM,Joi Chevalier,697,507,145,45
+Galveston,488,Comptroller of Public Accounts,,LIB,Ben Sanders,87,59,27,1
+Galveston,488,Commissioner of General Land Office,,REP,George P. Bush,1484,1144,264,76
+Galveston,488,Commissioner of General Land Office,,DEM,Miguel Suazo,705,506,154,45
+Galveston,488,Commissioner of General Land Office,,LIB,Matt Pina,90,66,24,0
+Galveston,488,Commissioner of Agriculture,,REP,Sid Miller,1441,1121,248,72
+Galveston,488,Commissioner of Agriculture,,DEM,Kim Olson,770,557,166,47
+Galveston,488,Commissioner of Agriculture,,LIB,Richard Carpenter,62,35,26,1
+Galveston,488,Railroad Commissioner,,REP,Christi Craddick,1495,1152,267,76
+Galveston,488,Railroad Commissioner,,DEM,Roman McAllen,696,506,147,43
+Galveston,488,Railroad Commissioner,,LIB,Mike Wright,82,55,26,1
+Galveston,488,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1497,1156,267,74
+Galveston,488,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,764,548,170,46
+Galveston,488,"Justice, Supreme Court, Place 4",,REP,John Devine,1515,1161,279,75
+Galveston,488,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,747,543,159,45
+Galveston,488,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1504,1152,276,76
+Galveston,488,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,757,550,163,44
+Galveston,488,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1464,1134,255,75
+Galveston,488,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,735,533,157,45
+Galveston,488,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,67,42,25,0
+Galveston,488,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1512,1162,274,76
+Galveston,488,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,739,538,157,44
+Galveston,488,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1611,1232,300,79
+Galveston,488,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,395,299,86,10
+Galveston,488,"Member, State Board of Education, District 7",,REP,Matt Robinson,1476,1143,259,74
+Galveston,488,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",785,564,176,45
+Galveston,488,State Representative,24,REP,Greg Bonnen,1506,1167,263,76
+Galveston,488,State Representative,24,DEM,John Y. Phelps,720,521,155,44
+Galveston,488,State Representative,24,LIB,Dick Illyes,51,28,21,2
+Galveston,488,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,1522,1165,281,76
+Galveston,488,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,731,535,153,43
+Galveston,488,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,1494,1152,268,74
+Galveston,488,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,762,548,169,45
+Galveston,488,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,1505,1154,276,75
+Galveston,488,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,748,544,160,44
+Galveston,488,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,1507,1158,275,74
+Galveston,488,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,746,541,159,46
+Galveston,488,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,1532,1175,283,74
+Galveston,488,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,721,524,152,45
+Galveston,488,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,1521,1167,280,74
+Galveston,488,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,729,528,156,45
+Galveston,488,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,1526,1169,283,74
+Galveston,488,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,722,526,151,45
+Galveston,488,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,1520,1166,278,76
+Galveston,488,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,728,529,155,44
+Galveston,488,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,1501,1149,278,74
+Galveston,488,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,745,545,155,45
+Galveston,488,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,1506,1157,274,75
+Galveston,488,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",742,538,160,44
+Galveston,488,"District Judge, 122nd Judicial District",,REP,John Ellisor,1708,1300,329,79
+Galveston,488,"District Judge, 212th Judicial District",,REP,Patricia Grady,1715,1304,331,80
+Galveston,488,"District Judge, 306th Judicial District",,REP,Anne B. Darring,1703,1294,330,79
+Galveston,488,Criminal District Attorney,,REP,Jack Roady,1707,1297,329,81
+Galveston,488,County Judge,,REP,Mark Henry,1694,1286,329,79
+Galveston,488,"Judge, County Court-at-Law No. 1",,REP,John Grady,1686,1280,328,78
+Galveston,488,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,1518,1165,279,74
+Galveston,488,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,724,531,150,43
+Galveston,488,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,1696,1288,328,80
+Galveston,488,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,1695,1288,328,79
+Galveston,488,District Clerk,,REP,John D Kinard,1689,1284,326,79
+Galveston,488,County Clerk,,REP,Dwight Sullivan,1683,1277,326,80
+Galveston,488,County Treasurer,,REP,Kevin C. Walsh,1678,1273,327,78
+Galveston,488,County Commissioner Pct. 4,,REP,Ken Clark,1673,1271,324,78
+Galveston,488,Mayor  - League City,,,Sebastian Lofaro,625,478,132,15
+Galveston,488,Mayor  - League City,,,Pat Hallisey,1135,861,213,61
+Galveston,488,Council Position 1  - League City,,,Andy Mann,845,641,160,44
+Galveston,488,Council Position 1  - League City,,,Traci Jacobs,669,497,145,27
+Galveston,488,Council Position 2  - League City,,,Hank Dugie,1291,978,257,56
+Galveston,488,Council Position 6  - League City,,,Silvio P. Vincenzo,400,304,78,18
+Galveston,488,Council Position 6  - League City,,,Chad Tressler,666,493,143,30
+Galveston,488,Council Position 6  - League City,,,Chris Gross,431,330,81,20
+Galveston,488,Council Position 7  - League City,,,Ange Mertens,566,417,123,26
+Galveston,488,Council Position 7  - League City,,,Nick Long,977,756,173,48
+Galveston,488,League City Proposition A,,,For,1326,974,270,82
+Galveston,488,League City Proposition A,,,Against,405,326,68,11
+Galveston,488,League City Proposition B,,,For,1569,1178,307,84
+Galveston,488,League City Proposition B,,,Against,276,206,56,14
+Galveston,488,League City Proposition C,,,For,1594,1193,313,88
+Galveston,488,League City Proposition C,,,Against,202,154,41,7
+Galveston,488,League City Proposition D,,,For,1464,1091,292,81
+Galveston,488,League City Proposition D,,,Against,252,193,51,8
+Galveston,488,League City Proposition E,,,For,1675,1261,328,86
+Galveston,488,League City Proposition E,,,Against,120,89,23,8
+Galveston,488,League City Proposition F,,,For,1515,1145,283,87
+Galveston,488,League City Proposition F,,,Against,200,144,50,6
+Galveston,488,League City Proposition G,,,For,1631,1228,308,95
+Galveston,488,League City Proposition G,,,Against,129,98,26,5
+Galveston,488,League City Proposition H,,,For,1048,765,220,63
+Galveston,488,League City Proposition H,,,Against,585,455,98,32
+Galveston,488,League City Proposition I,,,For,1508,1127,290,91
+Galveston,488,League City Proposition I,,,Against,211,163,43,5
+Galveston,488,League City Proposition J,,,For,1466,1101,281,84
+Galveston,488,League City Proposition J,,,Against,265,200,54,11
+Galveston,488,League City Proposition K,,,For,1505,1125,290,90
+Galveston,488,League City Proposition K,,,Against,196,148,41,7
+Galveston,488,League City Proposition L,,,For,1315,990,244,81
+Galveston,488,League City Proposition L,,,Against,328,237,78,13
+Galveston,488,League City Proposition M,,,For,1455,1097,273,85
+Galveston,488,League City Proposition M,,,Against,214,154,52,8
+Galveston,488,League City Proposition N,,,For,1332,1001,248,83
+Galveston,488,League City Proposition N,,,Against,338,246,78,14
+Galveston,488,League City Proposition O,,,For,1378,1032,268,78
+Galveston,488,League City Proposition O,,,Against,303,228,62,13
+Galveston,490,Ballots Cast,,,,2812,1996,668,148
+Galveston,490,Straight Party,,REP,Republican,1205,872,259,74
+Galveston,490,Straight Party,,DEM,Democrat,437,317,104,16
+Galveston,490,Straight Party,,LIB,Libertarian,18,3,8,7
+Galveston,490,U.S. Senate,,REP,Ted Cruz,1813,1288,422,103
+Galveston,490,U.S. Senate,,DEM,Beto O'Rourke,959,689,227,43
+Galveston,490,U.S. Senate,,LIB,Neal M. Dikeman,26,11,14,1
+Galveston,490,U.S. House,14,REP,Randy Weber,1846,1309,432,105
+Galveston,490,U.S. House,14,DEM,Adrienne Bell,875,639,196,40
+Galveston,490,U.S. House,14,LIB,Don E. Conley III,59,31,27,1
+Galveston,490,Governor,,REP,Greg Abbott,1938,1367,459,112
+Galveston,490,Governor,,DEM,Lupe Valdez,799,586,178,35
+Galveston,490,Governor,,LIB,Mark Jay Tippetts,60,34,26,0
+Galveston,490,Lieutenant Governor,,REP,Dan Patrick,1812,1276,432,104
+Galveston,490,Lieutenant Governor,,DEM,Mike Collier,896,655,199,42
+Galveston,490,Lieutenant Governor,,LIB,Kerry Douglas McKennon,70,46,24,0
+Galveston,490,Attorney General,,REP,Ken Paxton,1771,1257,411,103
+Galveston,490,Attorney General,,DEM,Justin Nelson,930,671,217,42
+Galveston,490,Attorney General,,LIB,Michael Ray Harris,71,46,24,1
+Galveston,490,Comptroller of Public Accounts,,REP,Glenn Hegar,1833,1305,425,103
+Galveston,490,Comptroller of Public Accounts,,DEM,Joi Chevalier,806,585,181,40
+Galveston,490,Comptroller of Public Accounts,,LIB,Ben Sanders,106,66,38,2
+Galveston,490,Commissioner of General Land Office,,REP,George P. Bush,1849,1299,444,106
+Galveston,490,Commissioner of General Land Office,,DEM,Miguel Suazo,795,579,178,38
+Galveston,490,Commissioner of General Land Office,,LIB,Matt Pina,116,85,29,2
+Galveston,490,Commissioner of Agriculture,,REP,Sid Miller,1784,1265,418,101
+Galveston,490,Commissioner of Agriculture,,DEM,Kim Olson,891,649,200,42
+Galveston,490,Commissioner of Agriculture,,LIB,Richard Carpenter,71,40,28,3
+Galveston,490,Railroad Commissioner,,REP,Christi Craddick,1864,1321,439,104
+Galveston,490,Railroad Commissioner,,DEM,Roman McAllen,793,578,176,39
+Galveston,490,Railroad Commissioner,,LIB,Mike Wright,88,55,31,2
+Galveston,490,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1863,1317,443,103
+Galveston,490,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,891,645,203,43
+Galveston,490,"Justice, Supreme Court, Place 4",,REP,John Devine,1868,1316,446,106
+Galveston,490,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,881,645,198,38
+Galveston,490,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1872,1324,443,105
+Galveston,490,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,880,637,203,40
+Galveston,490,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1817,1278,434,105
+Galveston,490,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,861,635,187,39
+Galveston,490,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,72,45,26,1
+Galveston,490,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1884,1329,449,106
+Galveston,490,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,857,624,196,37
+Galveston,490,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1997,1410,478,109
+Galveston,490,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,478,344,112,22
+Galveston,490,"Member, State Board of Education, District 7",,REP,Matt Robinson,1834,1297,437,100
+Galveston,490,"Member, State Board of Education, District 7",,DEM,"Elizabeth ""Eliz"" Markowitz",905,656,208,41
+Galveston,490,State Representative,24,REP,Greg Bonnen,1853,1316,434,103
+Galveston,490,State Representative,24,DEM,John Y. Phelps,835,611,190,34
+Galveston,490,State Representative,24,LIB,Dick Illyes,60,31,21,8
+Galveston,490,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,1884,1333,446,105
+Galveston,490,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,845,613,194,38
+Galveston,490,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,1852,1306,442,104
+Galveston,490,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,871,638,199,34
+Galveston,490,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,1848,1305,443,100
+Galveston,490,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,876,640,196,40
+Galveston,490,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,1847,1309,438,100
+Galveston,490,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,878,635,202,41
+Galveston,490,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,1873,1325,448,100
+Galveston,490,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,849,618,192,39
+Galveston,490,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,1883,1332,448,103
+Galveston,490,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,838,612,191,35
+Galveston,490,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,1871,1321,449,101
+Galveston,490,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,849,620,189,40
+Galveston,490,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,1871,1326,444,101
+Galveston,490,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,844,615,193,36
+Galveston,490,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,1849,1311,436,102
+Galveston,490,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,870,631,201,38
+Galveston,490,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,1854,1309,444,101
+Galveston,490,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",862,631,192,39
+Galveston,490,"District Judge, 122nd Judicial District",,REP,John Ellisor,2121,1491,526,104
+Galveston,490,"District Judge, 212th Judicial District",,REP,Patricia Grady,2123,1491,529,103
+Galveston,490,"District Judge, 306th Judicial District",,REP,Anne B. Darring,2119,1489,526,104
+Galveston,490,Criminal District Attorney,,REP,Jack Roady,2121,1489,523,109
+Galveston,490,County Judge,,REP,Mark Henry,2114,1482,522,110
+Galveston,490,"Judge, County Court-at-Law No. 1",,REP,John Grady,2103,1478,519,106
+Galveston,490,"Judge, County Court-at-Law No. 2",,REP,Kerri Foley,1861,1316,443,102
+Galveston,490,"Judge, County Court-at-Law No. 2",,DEM,Kerry Pettijohn,847,618,194,35
+Galveston,490,"Judge, County Court-at-Law No. 3",,REP,Jack Ewing,2095,1475,515,105
+Galveston,490,"Judge, County Probate Court-at-Law",,REP,Kim Sullivan,2102,1475,519,108
+Galveston,490,District Clerk,,REP,John D Kinard,2098,1475,517,106
+Galveston,490,County Clerk,,REP,Dwight Sullivan,2095,1474,514,107
+Galveston,490,County Treasurer,,REP,Kevin C. Walsh,2093,1472,516,105
+Galveston,490,County Commissioner Pct. 4,,REP,Ken Clark,2082,1463,513,106
+Galveston,490,Justice of the Peace Pct. 1,,REP,Greg Rikard,2090,1467,513,110
+Galveston,490,Mayor  - League City,,,Sebastian Lofaro,627,462,139,26
+Galveston,490,Mayor  - League City,,,Pat Hallisey,1553,1089,375,89
+Galveston,490,Council Position 1  - League City,,,Andy Mann,1017,731,232,54
+Galveston,490,Council Position 1  - League City,,,Traci Jacobs,933,643,244,46
+Galveston,490,Council Position 2  - League City,,,Hank Dugie,1765,1252,435,78
+Galveston,490,Council Position 6  - League City,,,Silvio P. Vincenzo,512,374,119,19
+Galveston,490,Council Position 6  - League City,,,Chad Tressler,936,657,236,43
+Galveston,490,Council Position 6  - League City,,,Chris Gross,462,314,110,38
+Galveston,490,Council Position 7  - League City,,,Ange Mertens,703,496,170,37
+Galveston,490,Council Position 7  - League City,,,Nick Long,1271,910,290,71
+Galveston,490,League City Proposition A,,,For,1689,1201,379,109
+Galveston,490,League City Proposition A,,,Against,492,338,133,21
+Galveston,490,League City Proposition B,,,For,1953,1399,435,119
+Galveston,490,League City Proposition B,,,Against,343,232,98,13
+Galveston,490,League City Proposition C,,,For,1988,1397,470,121
+Galveston,490,League City Proposition C,,,Against,257,185,60,12
+Galveston,490,League City Proposition D,,,For,1820,1287,423,110
+Galveston,490,League City Proposition D,,,Against,324,234,77,13
+Galveston,490,League City Proposition E,,,For,2079,1473,486,120
+Galveston,490,League City Proposition E,,,Against,146,103,33,10
+Galveston,490,League City Proposition F,,,For,1936,1367,444,125
+Galveston,490,League City Proposition F,,,Against,219,154,56,9
+Galveston,490,League City Proposition G,,,For,2037,1448,468,121
+Galveston,490,League City Proposition G,,,Against,151,106,36,9
+Galveston,490,League City Proposition H,,,For,1320,920,326,74
+Galveston,490,League City Proposition H,,,Against,725,530,154,41
+Galveston,490,League City Proposition I,,,For,1926,1379,427,120
+Galveston,490,League City Proposition I,,,Against,226,153,66,7
+Galveston,490,League City Proposition J,,,For,1874,1324,428,122
+Galveston,490,League City Proposition J,,,Against,295,221,67,7
+Galveston,490,League City Proposition K,,,For,1909,1359,425,125
+Galveston,490,League City Proposition K,,,Against,218,160,56,2
+Galveston,490,League City Proposition L,,,For,1666,1183,370,113
+Galveston,490,League City Proposition L,,,Against,403,292,100,11
+Galveston,490,League City Proposition M,,,For,1872,1343,417,112
+Galveston,490,League City Proposition M,,,Against,229,160,59,10
+Galveston,490,League City Proposition N,,,For,1667,1175,379,113
+Galveston,490,League City Proposition N,,,Against,421,315,93,13
+Galveston,490,League City Proposition O,,,For,1753,1251,395,107
+Galveston,490,League City Proposition O,,,Against,341,241,86,14


### PR DESCRIPTION
These data files, frustratingly, have header fields for fields that aren't actually present (registered voters, over/undervotes).