### PR TITLE
Add precinct-level results for the 2018 general election in Wichita County

### DIFF
--- a/2018/20181106__tx__general__wichita__precinct.csv
+++ b/2018/20181106__tx__general__wichita__precinct.csv
@@ -1,0 +1,8307 @@
+county,precinct,office,district,party,candidate,votes,early_voting,election_day
+Wichita,101,Straight Party,,REP,,71,48,23
+Wichita,101,Straight Party,,DEM,,8,8,0
+Wichita,101,Straight Party,,LIB,,0,0,0
+Wichita,101,Straight Party,,,Over Votes,0,0,0
+Wichita,101,Straight Party,,,Under Votes,118,100,18
+Wichita,101,U.S. Senate,,REP,Ted Cruz,146,109,37
+Wichita,101,U.S. Senate,,DEM,Beto O'Rourke,48,45,3
+Wichita,101,U.S. Senate,,LIB,Neal M. Dikeman,1,1,0
+Wichita,101,U.S. Senate,,,Over Votes,0,0,0
+Wichita,101,U.S. Senate,,,Under Votes,3,2,1
+Wichita,101,U.S. House,13,REP,Mac Thornberry,139,102,37
+Wichita,101,U.S. House,13,DEM,Greg Sagan,32,30,2
+Wichita,101,U.S. House,13,LIB,Calvin DeWeese,4,3,1
+Wichita,101,U.S. House,13,,Over Votes,0,0,0
+Wichita,101,U.S. House,13,,Under Votes,23,22,1
+Wichita,101,Governor,,REP,Greg Abbott,151,114,37
+Wichita,101,Governor,,DEM,Lupe Valdez,42,39,3
+Wichita,101,Governor,,LIB,Mark Jay Tippetts,1,1,0
+Wichita,101,Governor,,,Over Votes,0,0,0
+Wichita,101,Governor,,,Under Votes,4,3,1
+Wichita,101,Lieutenant Governor,,REP,Dan Patrick,145,108,37
+Wichita,101,Lieutenant Governor,,DEM,Mike Collier,48,45,3
+Wichita,101,Lieutenant Governor,,LIB,Kerry Douglas McKennon,1,1,0
+Wichita,101,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,101,Lieutenant Governor,,,Under Votes,4,3,1
+Wichita,101,Attorney General,,REP,Ken Paxton,143,106,37
+Wichita,101,Attorney General,,DEM,Justin Nelson,49,46,3
+Wichita,101,Attorney General,,LIB,Michael Ray Harris,3,3,0
+Wichita,101,Attorney General,,,Over Votes,0,0,0
+Wichita,101,Attorney General,,,Under Votes,3,2,1
+Wichita,101,Comptroller of Public Accounts,,REP,Glenn Hegar,145,108,37
+Wichita,101,Comptroller of Public Accounts,,DEM,Joi Chevalier,40,39,1
+Wichita,101,Comptroller of Public Accounts,,LIB,Ben Sanders,8,6,2
+Wichita,101,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,101,Comptroller of Public Accounts,,,Under Votes,5,4,1
+Wichita,101,Commissioner of the General Land Office,,REP,George P. Bush,141,104,37
+Wichita,101,Commissioner of the General Land Office,,DEM,Miguel Suazo,42,40,2
+Wichita,101,Commissioner of the General Land Office,,LIB,Matt Pina,9,8,1
+Wichita,101,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,101,Commissioner of the General Land Office,,,Under Votes,6,5,1
+Wichita,101,Commissioner of Agriculture,,REP,Sid Miller,143,107,36
+Wichita,101,Commissioner of Agriculture,,DEM,Kim Olson,46,43,3
+Wichita,101,Commissioner of Agriculture,,LIB,Richard Carpenter,5,4,1
+Wichita,101,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,101,Commissioner of Agriculture,,,Under Votes,4,3,1
+Wichita,101,Railroad Commissioner,,REP,Christi Craddick,145,108,37
+Wichita,101,Railroad Commissioner,,DEM,Roman McAllen,40,39,1
+Wichita,101,Railroad Commissioner,,LIB,Mike Wright,8,6,2
+Wichita,101,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,101,Railroad Commissioner,,,Under Votes,5,4,1
+Wichita,101,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,142,106,36
+Wichita,101,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,34,31,3
+Wichita,101,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,101,"Justice, Supreme Court, Place 2",,,Under Votes,22,20,2
+Wichita,101,"Justice, Supreme Court, Place 4",,REP,John Devine,139,101,38
+Wichita,101,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,16,14,2
+Wichita,101,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,101,"Justice, Supreme Court, Place 4",,,Under Votes,42,41,1
+Wichita,101,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,133,96,37
+Wichita,101,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,20,17,3
+Wichita,101,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,101,"Justice, Supreme Court, Place 6",,,Under Votes,44,43,1
+Wichita,101,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,134,97,37
+Wichita,101,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,17,16,1
+Wichita,101,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,2,0,2
+Wichita,101,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,101,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,44,43,1
+Wichita,101,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,137,99,38
+Wichita,101,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,17,15,2
+Wichita,101,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,101,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,43,42,1
+Wichita,101,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,134,97,37
+Wichita,101,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,11,8,3
+Wichita,101,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,101,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,52,51,1
+Wichita,101,State Senator,30,REP,Pat Fallon,134,97,37
+Wichita,101,State Senator,30,DEM,Kevin Lopez,26,23,3
+Wichita,101,State Senator,30,,Over Votes,0,0,0
+Wichita,101,State Senator,30,,Under Votes,37,36,1
+Wichita,101,State Representative,69,REP,James Frank,135,97,38
+Wichita,101,State Representative,69,,Over Votes,0,0,0
+Wichita,101,State Representative,69,,Under Votes,62,59,3
+Wichita,101,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,142,104,38
+Wichita,101,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,101,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,55,52,3
+Wichita,101,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,135,97,38
+Wichita,101,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,101,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,62,59,3
+Wichita,101,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,132,94,38
+Wichita,101,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,19,18,1
+Wichita,101,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,1,1,0
+Wichita,101,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,45,43,2
+Wichita,101,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,137,99,38
+Wichita,101,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,101,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,60,57,3
+Wichita,101,"District Judge, 30th Judicial District",,REP,Jeff McKnight,133,95,38
+Wichita,101,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,101,"District Judge, 30th Judicial District",,,Under Votes,64,61,3
+Wichita,101,Criminal District Attorney,,REP,John Gillespie,132,93,39
+Wichita,101,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,101,Criminal District Attorney,,,Under Votes,65,63,2
+Wichita,101,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",130,93,37
+Wichita,101,County Judge,,,Over Votes,0,0,0
+Wichita,101,County Judge,,,Under Votes,67,63,4
+Wichita,101,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,130,91,39
+Wichita,101,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,101,"Judge, County Court at Law No. 1",,,Under Votes,67,65,2
+Wichita,101,"Judge, County Court at Law No. 2",,REP,Greg King,130,91,39
+Wichita,101,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,101,"Judge, County Court at Law No. 2",,,Under Votes,67,65,2
+Wichita,101,District Clerk,,REP,Patti Flores,133,94,39
+Wichita,101,District Clerk,,,Over Votes,0,0,0
+Wichita,101,District Clerk,,,Under Votes,64,62,2
+Wichita,101,County Clerk,,REP,Lori Bohannon,132,93,39
+Wichita,101,County Clerk,,,Over Votes,0,0,0
+Wichita,101,County Clerk,,,Under Votes,65,63,2
+Wichita,101,County Treasurer,,REP,R. J. Bob Hampton,134,95,39
+Wichita,101,County Treasurer,,,Over Votes,0,0,0
+Wichita,101,County Treasurer,,,Under Votes,63,61,2
+Wichita,101,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,131,92,39
+Wichita,101,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,101,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,66,64,2
+Wichita,101,Wichita Falls ISD Single Member District 3,,,Mark Lukert,70,50,20
+Wichita,101,Wichita Falls ISD Single Member District 3,,,Adam W. Groves,26,20,6
+Wichita,101,Wichita Falls ISD Single Member District 3,,,Over Votes,0,0,0
+Wichita,101,Wichita Falls ISD Single Member District 3,,,Under Votes,101,86,15
+Wichita,101,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,91,65,26
+Wichita,101,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,101,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,106,91,15
+Wichita,101,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,63,44,19
+Wichita,101,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,43,33,10
+Wichita,101,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,101,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,91,79,12
+Wichita,101,Ballots Cast,,,,198,157,41
+Wichita,102,Straight Party,,REP,,220,181,39
+Wichita,102,Straight Party,,DEM,,55,32,23
+Wichita,102,Straight Party,,LIB,,0,0,0
+Wichita,102,Straight Party,,,Over Votes,0,0,0
+Wichita,102,Straight Party,,,Under Votes,293,219,74
+Wichita,102,U.S. Senate,,REP,Ted Cruz,420,335,85
+Wichita,102,U.S. Senate,,DEM,Beto O'Rourke,138,92,46
+Wichita,102,U.S. Senate,,LIB,Neal M. Dikeman,6,3,3
+Wichita,102,U.S. Senate,,,Over Votes,0,0,0
+Wichita,102,U.S. Senate,,,Under Votes,3,1,2
+Wichita,102,U.S. House,13,REP,Mac Thornberry,450,353,97
+Wichita,102,U.S. House,13,DEM,Greg Sagan,108,72,36
+Wichita,102,U.S. House,13,LIB,Calvin DeWeese,7,5,2
+Wichita,102,U.S. House,13,,Over Votes,0,0,0
+Wichita,102,U.S. House,13,,Under Votes,2,1,1
+Wichita,102,Governor,,REP,Greg Abbott,443,349,94
+Wichita,102,Governor,,DEM,Lupe Valdez,104,72,32
+Wichita,102,Governor,,LIB,Mark Jay Tippetts,14,7,7
+Wichita,102,Governor,,,Over Votes,0,0,0
+Wichita,102,Governor,,,Under Votes,6,3,3
+Wichita,102,Lieutenant Governor,,REP,Dan Patrick,403,316,87
+Wichita,102,Lieutenant Governor,,DEM,Mike Collier,142,100,42
+Wichita,102,Lieutenant Governor,,LIB,Kerry Douglas McKennon,17,10,7
+Wichita,102,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,102,Lieutenant Governor,,,Under Votes,5,5,0
+Wichita,102,Attorney General,,REP,Ken Paxton,399,315,84
+Wichita,102,Attorney General,,DEM,Justin Nelson,145,101,44
+Wichita,102,Attorney General,,LIB,Michael Ray Harris,12,8,4
+Wichita,102,Attorney General,,,Over Votes,0,0,0
+Wichita,102,Attorney General,,,Under Votes,11,7,4
+Wichita,102,Comptroller of Public Accounts,,REP,Glenn Hegar,423,333,90
+Wichita,102,Comptroller of Public Accounts,,DEM,Joi Chevalier,116,80,36
+Wichita,102,Comptroller of Public Accounts,,LIB,Ben Sanders,15,8,7
+Wichita,102,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,102,Comptroller of Public Accounts,,,Under Votes,13,10,3
+Wichita,102,Commissioner of the General Land Office,,REP,George P. Bush,435,338,97
+Wichita,102,Commissioner of the General Land Office,,DEM,Miguel Suazo,105,74,31
+Wichita,102,Commissioner of the General Land Office,,LIB,Matt Pina,19,12,7
+Wichita,102,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,102,Commissioner of the General Land Office,,,Under Votes,8,7,1
+Wichita,102,Commissioner of Agriculture,,REP,Sid Miller,407,318,89
+Wichita,102,Commissioner of Agriculture,,DEM,Kim Olson,126,90,36
+Wichita,102,Commissioner of Agriculture,,LIB,Richard Carpenter,16,11,5
+Wichita,102,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,102,Commissioner of Agriculture,,,Under Votes,18,12,6
+Wichita,102,Railroad Commissioner,,REP,Christi Craddick,428,337,91
+Wichita,102,Railroad Commissioner,,DEM,Roman McAllen,112,77,35
+Wichita,102,Railroad Commissioner,,LIB,Mike Wright,11,6,5
+Wichita,102,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,102,Railroad Commissioner,,,Under Votes,16,11,5
+Wichita,102,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,430,335,95
+Wichita,102,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,121,83,38
+Wichita,102,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,102,"Justice, Supreme Court, Place 2",,,Under Votes,16,13,3
+Wichita,102,"Justice, Supreme Court, Place 4",,REP,John Devine,424,332,92
+Wichita,102,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,121,83,38
+Wichita,102,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,102,"Justice, Supreme Court, Place 4",,,Under Votes,22,16,6
+Wichita,102,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,427,334,93
+Wichita,102,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,119,82,37
+Wichita,102,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,102,"Justice, Supreme Court, Place 6",,,Under Votes,21,15,6
+Wichita,102,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,420,330,90
+Wichita,102,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,119,81,38
+Wichita,102,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,11,7,4
+Wichita,102,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,102,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,17,13,4
+Wichita,102,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,427,335,92
+Wichita,102,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,123,82,41
+Wichita,102,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,102,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,17,14,3
+Wichita,102,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,445,347,98
+Wichita,102,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,53,33,20
+Wichita,102,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,102,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,69,51,18
+Wichita,102,State Senator,30,REP,Pat Fallon,428,333,95
+Wichita,102,State Senator,30,DEM,Kevin Lopez,129,89,40
+Wichita,102,State Senator,30,,Over Votes,0,0,0
+Wichita,102,State Senator,30,,Under Votes,10,9,1
+Wichita,102,State Representative,69,REP,James Frank,467,361,106
+Wichita,102,State Representative,69,,Over Votes,0,0,0
+Wichita,102,State Representative,69,,Under Votes,100,70,30
+Wichita,102,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,459,354,105
+Wichita,102,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,102,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,108,77,31
+Wichita,102,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,454,351,103
+Wichita,102,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,102,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,113,80,33
+Wichita,102,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,425,332,93
+Wichita,102,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,121,83,38
+Wichita,102,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,102,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,21,16,5
+Wichita,102,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,453,350,103
+Wichita,102,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,102,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,114,81,33
+Wichita,102,"District Judge, 30th Judicial District",,REP,Jeff McKnight,459,356,103
+Wichita,102,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,102,"District Judge, 30th Judicial District",,,Under Votes,108,75,33
+Wichita,102,Criminal District Attorney,,REP,John Gillespie,455,350,105
+Wichita,102,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,102,Criminal District Attorney,,,Under Votes,112,81,31
+Wichita,102,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",464,355,109
+Wichita,102,County Judge,,,Over Votes,0,0,0
+Wichita,102,County Judge,,,Under Votes,103,76,27
+Wichita,102,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,462,354,108
+Wichita,102,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,102,"Judge, County Court at Law No. 1",,,Under Votes,105,77,28
+Wichita,102,"Judge, County Court at Law No. 2",,REP,Greg King,458,353,105
+Wichita,102,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,102,"Judge, County Court at Law No. 2",,,Under Votes,109,78,31
+Wichita,102,District Clerk,,REP,Patti Flores,458,353,105
+Wichita,102,District Clerk,,,Over Votes,0,0,0
+Wichita,102,District Clerk,,,Under Votes,109,78,31
+Wichita,102,County Clerk,,REP,Lori Bohannon,460,355,105
+Wichita,102,County Clerk,,,Over Votes,0,0,0
+Wichita,102,County Clerk,,,Under Votes,107,76,31
+Wichita,102,County Treasurer,,REP,R. J. Bob Hampton,469,361,108
+Wichita,102,County Treasurer,,,Over Votes,0,0,0
+Wichita,102,County Treasurer,,,Under Votes,98,70,28
+Wichita,102,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,461,358,103
+Wichita,102,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,102,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,106,73,33
+Wichita,102,City of Wichita Falls Mayor,,,Lowry W. Crane,93,68,25
+Wichita,102,City of Wichita Falls Mayor,,,Stephen L. Santellana,390,300,90
+Wichita,102,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,102,City of Wichita Falls Mayor,,,Under Votes,85,64,21
+Wichita,102,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,398,300,98
+Wichita,102,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,102,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,169,131,38
+Wichita,102,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,269,208,61
+Wichita,102,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,218,163,55
+Wichita,102,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,102,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,81,61,20
+Wichita,102,Ballots Cast,,,,568,432,136
+Wichita,103,Straight Party,,REP,,999,746,253
+Wichita,103,Straight Party,,DEM,,298,220,78
+Wichita,103,Straight Party,,LIB,,6,3,3
+Wichita,103,Straight Party,,,Over Votes,0,0,0
+Wichita,103,Straight Party,,,Under Votes,1282,920,362
+Wichita,103,U.S. Senate,,REP,Ted Cruz,1831,1349,482
+Wichita,103,U.S. Senate,,DEM,Beto O'Rourke,719,518,201
+Wichita,103,U.S. Senate,,LIB,Neal M. Dikeman,17,9,8
+Wichita,103,U.S. Senate,,,Over Votes,0,0,0
+Wichita,103,U.S. Senate,,,Under Votes,18,13,5
+Wichita,103,U.S. House,13,REP,Mac Thornberry,1948,1427,521
+Wichita,103,U.S. House,13,DEM,Greg Sagan,571,425,146
+Wichita,103,U.S. House,13,LIB,Calvin DeWeese,39,19,20
+Wichita,103,U.S. House,13,,Over Votes,1,1,0
+Wichita,103,U.S. House,13,,Under Votes,26,17,9
+Wichita,103,Governor,,REP,Greg Abbott,1946,1424,522
+Wichita,103,Governor,,DEM,Lupe Valdez,590,439,151
+Wichita,103,Governor,,LIB,Mark Jay Tippetts,35,19,16
+Wichita,103,Governor,,,Over Votes,0,0,0
+Wichita,103,Governor,,,Under Votes,14,7,7
+Wichita,103,Lieutenant Governor,,REP,Dan Patrick,1798,1330,468
+Wichita,103,Lieutenant Governor,,DEM,Mike Collier,687,503,184
+Wichita,103,Lieutenant Governor,,LIB,Kerry Douglas McKennon,64,34,30
+Wichita,103,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,103,Lieutenant Governor,,,Under Votes,36,22,14
+Wichita,103,Attorney General,,REP,Ken Paxton,1813,1334,479
+Wichita,103,Attorney General,,DEM,Justin Nelson,668,496,172
+Wichita,103,Attorney General,,LIB,Michael Ray Harris,56,28,28
+Wichita,103,Attorney General,,,Over Votes,0,0,0
+Wichita,103,Attorney General,,,Under Votes,48,31,17
+Wichita,103,Comptroller of Public Accounts,,REP,Glenn Hegar,1844,1360,484
+Wichita,103,Comptroller of Public Accounts,,DEM,Joi Chevalier,589,437,152
+Wichita,103,Comptroller of Public Accounts,,LIB,Ben Sanders,79,44,35
+Wichita,103,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,103,Comptroller of Public Accounts,,,Under Votes,73,48,25
+Wichita,103,Commissioner of the General Land Office,,REP,George P. Bush,1835,1352,483
+Wichita,103,Commissioner of the General Land Office,,DEM,Miguel Suazo,601,436,165
+Wichita,103,Commissioner of the General Land Office,,LIB,Matt Pina,96,66,30
+Wichita,103,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,103,Commissioner of the General Land Office,,,Under Votes,53,35,18
+Wichita,103,Commissioner of Agriculture,,REP,Sid Miller,1800,1323,477
+Wichita,103,Commissioner of Agriculture,,DEM,Kim Olson,667,493,174
+Wichita,103,Commissioner of Agriculture,,LIB,Richard Carpenter,49,26,23
+Wichita,103,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,103,Commissioner of Agriculture,,,Under Votes,69,47,22
+Wichita,103,Railroad Commissioner,,REP,Christi Craddick,1863,1366,497
+Wichita,103,Railroad Commissioner,,DEM,Roman McAllen,580,432,148
+Wichita,103,Railroad Commissioner,,LIB,Mike Wright,67,41,26
+Wichita,103,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,103,Railroad Commissioner,,,Under Votes,75,50,25
+Wichita,103,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1851,1353,498
+Wichita,103,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,663,485,178
+Wichita,103,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,103,"Justice, Supreme Court, Place 2",,,Under Votes,71,51,20
+Wichita,103,"Justice, Supreme Court, Place 4",,REP,John Devine,1871,1359,512
+Wichita,103,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,642,481,161
+Wichita,103,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,103,"Justice, Supreme Court, Place 4",,,Under Votes,72,49,23
+Wichita,103,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1866,1363,503
+Wichita,103,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,650,477,173
+Wichita,103,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,103,"Justice, Supreme Court, Place 6",,,Under Votes,69,49,20
+Wichita,103,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1838,1347,491
+Wichita,103,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,624,466,158
+Wichita,103,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,51,27,24
+Wichita,103,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,103,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,72,49,23
+Wichita,103,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1874,1369,505
+Wichita,103,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,634,466,168
+Wichita,103,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,103,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,77,54,23
+Wichita,103,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1963,1434,529
+Wichita,103,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,302,209,93
+Wichita,103,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,103,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,320,246,74
+Wichita,103,State Senator,30,REP,Pat Fallon,1871,1369,502
+Wichita,103,State Senator,30,DEM,Kevin Lopez,670,492,178
+Wichita,103,State Senator,30,,Over Votes,0,0,0
+Wichita,103,State Senator,30,,Under Votes,44,28,16
+Wichita,103,State Representative,69,REP,James Frank,2098,1519,579
+Wichita,103,State Representative,69,,Over Votes,0,0,0
+Wichita,103,State Representative,69,,Under Votes,487,370,117
+Wichita,103,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,2067,1498,569
+Wichita,103,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,103,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,518,391,127
+Wichita,103,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,2050,1484,566
+Wichita,103,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,103,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,535,405,130
+Wichita,103,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,1830,1338,492
+Wichita,103,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,653,480,173
+Wichita,103,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,103,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,102,71,31
+Wichita,103,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,2062,1494,568
+Wichita,103,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,103,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,523,395,128
+Wichita,103,"District Judge, 30th Judicial District",,REP,Jeff McKnight,2082,1513,569
+Wichita,103,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,103,"District Judge, 30th Judicial District",,,Under Votes,503,376,127
+Wichita,103,Criminal District Attorney,,REP,John Gillespie,2090,1514,576
+Wichita,103,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,103,Criminal District Attorney,,,Under Votes,495,375,120
+Wichita,103,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",2075,1499,576
+Wichita,103,County Judge,,,Over Votes,0,0,0
+Wichita,103,County Judge,,,Under Votes,510,390,120
+Wichita,103,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,2084,1506,578
+Wichita,103,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,103,"Judge, County Court at Law No. 1",,,Under Votes,501,383,118
+Wichita,103,"Judge, County Court at Law No. 2",,REP,Greg King,2076,1504,572
+Wichita,103,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,103,"Judge, County Court at Law No. 2",,,Under Votes,509,385,124
+Wichita,103,District Clerk,,REP,Patti Flores,2089,1509,580
+Wichita,103,District Clerk,,,Over Votes,0,0,0
+Wichita,103,District Clerk,,,Under Votes,496,380,116
+Wichita,103,County Clerk,,REP,Lori Bohannon,2101,1522,579
+Wichita,103,County Clerk,,,Over Votes,0,0,0
+Wichita,103,County Clerk,,,Under Votes,484,367,117
+Wichita,103,County Treasurer,,REP,R. J. Bob Hampton,2088,1514,574
+Wichita,103,County Treasurer,,,Over Votes,0,0,0
+Wichita,103,County Treasurer,,,Under Votes,497,375,122
+Wichita,103,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,2043,1476,567
+Wichita,103,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,103,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,542,413,129
+Wichita,103,City of Wichita Falls Mayor,,,Lowry W. Crane,640,464,176
+Wichita,103,City of Wichita Falls Mayor,,,Stephen L. Santellana,1495,1085,410
+Wichita,103,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,103,City of Wichita Falls Mayor,,,Under Votes,450,340,110
+Wichita,103,City of Wichita Falls Councilor District 4,,,Tim Brewer,1132,827,305
+Wichita,103,City of Wichita Falls Councilor District 4,,,Nicholas J. Schreiber,760,540,220
+Wichita,103,City of Wichita Falls Councilor District 4,,,Over Votes,0,0,0
+Wichita,103,City of Wichita Falls Councilor District 4,,,Under Votes,693,522,171
+Wichita,103,Wichita Falls ISD Single Member District 3,,,Mark Lukert,1332,961,371
+Wichita,103,Wichita Falls ISD Single Member District 3,,,Adam W. Groves,561,400,161
+Wichita,103,Wichita Falls ISD Single Member District 3,,,Over Votes,0,0,0
+Wichita,103,Wichita Falls ISD Single Member District 3,,,Under Votes,692,528,164
+Wichita,103,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,1738,1254,484
+Wichita,103,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,103,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,847,635,212
+Wichita,103,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,1169,860,309
+Wichita,103,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,832,588,244
+Wichita,103,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,103,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,584,441,143
+Wichita,103,Ballots Cast,,,,2585,1889,696
+Wichita,104,Straight Party,,REP,,357,313,44
+Wichita,104,Straight Party,,DEM,,98,79,19
+Wichita,104,Straight Party,,LIB,,4,4,0
+Wichita,104,Straight Party,,,Over Votes,0,0,0
+Wichita,104,Straight Party,,,Under Votes,359,289,70
+Wichita,104,U.S. Senate,,REP,Ted Cruz,582,498,84
+Wichita,104,U.S. Senate,,DEM,Beto O'Rourke,221,172,49
+Wichita,104,U.S. Senate,,LIB,Neal M. Dikeman,4,4,0
+Wichita,104,U.S. Senate,,,Over Votes,0,0,0
+Wichita,104,U.S. Senate,,,Under Votes,8,8,0
+Wichita,104,U.S. House,13,REP,Mac Thornberry,617,524,93
+Wichita,104,U.S. House,13,DEM,Greg Sagan,171,135,36
+Wichita,104,U.S. House,13,LIB,Calvin DeWeese,16,14,2
+Wichita,104,U.S. House,13,,Over Votes,0,0,0
+Wichita,104,U.S. House,13,,Under Votes,11,9,2
+Wichita,104,Governor,,REP,Greg Abbott,619,525,94
+Wichita,104,Governor,,DEM,Lupe Valdez,184,146,38
+Wichita,104,Governor,,LIB,Mark Jay Tippetts,6,6,0
+Wichita,104,Governor,,,Over Votes,0,0,0
+Wichita,104,Governor,,,Under Votes,6,5,1
+Wichita,104,Lieutenant Governor,,REP,Dan Patrick,573,487,86
+Wichita,104,Lieutenant Governor,,DEM,Mike Collier,212,170,42
+Wichita,104,Lieutenant Governor,,LIB,Kerry Douglas McKennon,14,11,3
+Wichita,104,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,104,Lieutenant Governor,,,Under Votes,16,14,2
+Wichita,104,Attorney General,,REP,Ken Paxton,566,489,77
+Wichita,104,Attorney General,,DEM,Justin Nelson,213,164,49
+Wichita,104,Attorney General,,LIB,Michael Ray Harris,17,13,4
+Wichita,104,Attorney General,,,Over Votes,0,0,0
+Wichita,104,Attorney General,,,Under Votes,19,16,3
+Wichita,104,Comptroller of Public Accounts,,REP,Glenn Hegar,600,514,86
+Wichita,104,Comptroller of Public Accounts,,DEM,Joi Chevalier,175,137,38
+Wichita,104,Comptroller of Public Accounts,,LIB,Ben Sanders,18,14,4
+Wichita,104,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,104,Comptroller of Public Accounts,,,Under Votes,22,17,5
+Wichita,104,Commissioner of the General Land Office,,REP,George P. Bush,607,519,88
+Wichita,104,Commissioner of the General Land Office,,DEM,Miguel Suazo,170,133,37
+Wichita,104,Commissioner of the General Land Office,,LIB,Matt Pina,18,14,4
+Wichita,104,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,104,Commissioner of the General Land Office,,,Under Votes,20,16,4
+Wichita,104,Commissioner of Agriculture,,REP,Sid Miller,578,495,83
+Wichita,104,Commissioner of Agriculture,,DEM,Kim Olson,200,155,45
+Wichita,104,Commissioner of Agriculture,,LIB,Richard Carpenter,15,13,2
+Wichita,104,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,104,Commissioner of Agriculture,,,Under Votes,22,19,3
+Wichita,104,Railroad Commissioner,,REP,Christi Craddick,599,514,85
+Wichita,104,Railroad Commissioner,,DEM,Roman McAllen,178,135,43
+Wichita,104,Railroad Commissioner,,LIB,Mike Wright,18,15,3
+Wichita,104,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,104,Railroad Commissioner,,,Under Votes,20,18,2
+Wichita,104,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,597,512,85
+Wichita,104,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,194,151,43
+Wichita,104,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,104,"Justice, Supreme Court, Place 2",,,Under Votes,24,19,5
+Wichita,104,"Justice, Supreme Court, Place 4",,REP,John Devine,595,509,86
+Wichita,104,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,191,150,41
+Wichita,104,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,104,"Justice, Supreme Court, Place 4",,,Under Votes,29,23,6
+Wichita,104,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,591,507,84
+Wichita,104,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,198,155,43
+Wichita,104,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,104,"Justice, Supreme Court, Place 6",,,Under Votes,26,20,6
+Wichita,104,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,590,502,88
+Wichita,104,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,192,154,38
+Wichita,104,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,7,6,1
+Wichita,104,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,104,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,26,20,6
+Wichita,104,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,598,512,86
+Wichita,104,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,190,149,41
+Wichita,104,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,104,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,27,21,6
+Wichita,104,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,622,527,95
+Wichita,104,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,78,59,19
+Wichita,104,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,104,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,116,97,19
+Wichita,104,State Senator,30,REP,Pat Fallon,598,511,87
+Wichita,104,State Senator,30,DEM,Kevin Lopez,210,164,46
+Wichita,104,State Senator,30,,Over Votes,0,0,0
+Wichita,104,State Senator,30,,Under Votes,7,7,0
+Wichita,104,State Representative,69,REP,James Frank,659,556,103
+Wichita,104,State Representative,69,,Over Votes,0,0,0
+Wichita,104,State Representative,69,,Under Votes,156,126,30
+Wichita,104,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,650,547,103
+Wichita,104,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,104,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,165,135,30
+Wichita,104,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,642,541,101
+Wichita,104,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,104,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,173,141,32
+Wichita,104,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,582,500,82
+Wichita,104,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,197,156,41
+Wichita,104,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,104,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,36,26,10
+Wichita,104,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,640,539,101
+Wichita,104,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,104,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,175,143,32
+Wichita,104,"District Judge, 30th Judicial District",,REP,Jeff McKnight,650,550,100
+Wichita,104,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,104,"District Judge, 30th Judicial District",,,Under Votes,165,132,33
+Wichita,104,Criminal District Attorney,,REP,John Gillespie,644,547,97
+Wichita,104,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,104,Criminal District Attorney,,,Under Votes,171,135,36
+Wichita,104,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",648,546,102
+Wichita,104,County Judge,,,Over Votes,0,0,0
+Wichita,104,County Judge,,,Under Votes,167,136,31
+Wichita,104,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,646,546,100
+Wichita,104,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,104,"Judge, County Court at Law No. 1",,,Under Votes,169,136,33
+Wichita,104,"Judge, County Court at Law No. 2",,REP,Greg King,642,544,98
+Wichita,104,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,104,"Judge, County Court at Law No. 2",,,Under Votes,173,138,35
+Wichita,104,District Clerk,,REP,Patti Flores,646,545,101
+Wichita,104,District Clerk,,,Over Votes,0,0,0
+Wichita,104,District Clerk,,,Under Votes,169,137,32
+Wichita,104,County Clerk,,REP,Lori Bohannon,659,555,104
+Wichita,104,County Clerk,,,Over Votes,0,0,0
+Wichita,104,County Clerk,,,Under Votes,156,127,29
+Wichita,104,County Treasurer,,REP,R. J. Bob Hampton,656,553,103
+Wichita,104,County Treasurer,,,Over Votes,0,0,0
+Wichita,104,County Treasurer,,,Under Votes,159,129,30
+Wichita,104,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,636,538,98
+Wichita,104,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,104,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,179,144,35
+Wichita,104,City of Wichita Falls Mayor,,,Lowry W. Crane,148,120,28
+Wichita,104,City of Wichita Falls Mayor,,,Stephen L. Santellana,506,425,81
+Wichita,104,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,104,City of Wichita Falls Mayor,,,Under Votes,162,138,24
+Wichita,104,City of Wichita Falls Councilor District 3,,,Jeff L. Browning,509,423,86
+Wichita,104,City of Wichita Falls Councilor District 3,,,Over Votes,0,0,0
+Wichita,104,City of Wichita Falls Councilor District 3,,,Under Votes,306,259,47
+Wichita,104,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,537,451,86
+Wichita,104,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,104,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,278,231,47
+Wichita,104,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,412,355,57
+Wichita,104,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,238,192,46
+Wichita,104,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,104,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,166,136,30
+Wichita,104,Ballots Cast,,,,818,685,133
+Wichita,105,Straight Party,,REP,,633,502,131
+Wichita,105,Straight Party,,DEM,,220,168,52
+Wichita,105,Straight Party,,LIB,,4,1,3
+Wichita,105,Straight Party,,,Over Votes,0,0,0
+Wichita,105,Straight Party,,,Under Votes,850,657,193
+Wichita,105,U.S. Senate,,REP,Ted Cruz,1120,882,238
+Wichita,105,U.S. Senate,,DEM,Beto O'Rourke,551,420,131
+Wichita,105,U.S. Senate,,LIB,Neal M. Dikeman,19,11,8
+Wichita,105,U.S. Senate,,,Over Votes,0,0,0
+Wichita,105,U.S. Senate,,,Under Votes,16,14,2
+Wichita,105,U.S. House,13,REP,Mac Thornberry,1209,952,257
+Wichita,105,U.S. House,13,DEM,Greg Sagan,452,344,108
+Wichita,105,U.S. House,13,LIB,Calvin DeWeese,30,19,11
+Wichita,105,U.S. House,13,,Over Votes,0,0,0
+Wichita,105,U.S. House,13,,Under Votes,15,12,3
+Wichita,105,Governor,,REP,Greg Abbott,1210,948,262
+Wichita,105,Governor,,DEM,Lupe Valdez,454,352,102
+Wichita,105,Governor,,LIB,Mark Jay Tippetts,26,16,10
+Wichita,105,Governor,,,Over Votes,0,0,0
+Wichita,105,Governor,,,Under Votes,16,11,5
+Wichita,105,Lieutenant Governor,,REP,Dan Patrick,1075,845,230
+Wichita,105,Lieutenant Governor,,DEM,Mike Collier,550,424,126
+Wichita,105,Lieutenant Governor,,LIB,Kerry Douglas McKennon,49,32,17
+Wichita,105,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,105,Lieutenant Governor,,,Under Votes,32,26,6
+Wichita,105,Attorney General,,REP,Ken Paxton,1098,858,240
+Wichita,105,Attorney General,,DEM,Justin Nelson,523,412,111
+Wichita,105,Attorney General,,LIB,Michael Ray Harris,44,30,14
+Wichita,105,Attorney General,,,Over Votes,0,0,0
+Wichita,105,Attorney General,,,Under Votes,41,27,14
+Wichita,105,Comptroller of Public Accounts,,REP,Glenn Hegar,1139,898,241
+Wichita,105,Comptroller of Public Accounts,,DEM,Joi Chevalier,460,354,106
+Wichita,105,Comptroller of Public Accounts,,LIB,Ben Sanders,54,37,17
+Wichita,105,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,105,Comptroller of Public Accounts,,,Under Votes,53,38,15
+Wichita,105,Commissioner of the General Land Office,,REP,George P. Bush,1141,896,245
+Wichita,105,Commissioner of the General Land Office,,DEM,Miguel Suazo,446,346,100
+Wichita,105,Commissioner of the General Land Office,,LIB,Matt Pina,69,47,22
+Wichita,105,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,105,Commissioner of the General Land Office,,,Under Votes,50,38,12
+Wichita,105,Commissioner of Agriculture,,REP,Sid Miller,1104,871,233
+Wichita,105,Commissioner of Agriculture,,DEM,Kim Olson,504,389,115
+Wichita,105,Commissioner of Agriculture,,LIB,Richard Carpenter,45,29,16
+Wichita,105,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,105,Commissioner of Agriculture,,,Under Votes,53,38,15
+Wichita,105,Railroad Commissioner,,REP,Christi Craddick,1153,904,249
+Wichita,105,Railroad Commissioner,,DEM,Roman McAllen,448,349,99
+Wichita,105,Railroad Commissioner,,LIB,Mike Wright,50,34,16
+Wichita,105,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,105,Railroad Commissioner,,,Under Votes,55,40,15
+Wichita,105,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1163,912,251
+Wichita,105,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,487,374,113
+Wichita,105,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,105,"Justice, Supreme Court, Place 2",,,Under Votes,56,41,15
+Wichita,105,"Justice, Supreme Court, Place 4",,REP,John Devine,1169,919,250
+Wichita,105,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,481,366,115
+Wichita,105,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,105,"Justice, Supreme Court, Place 4",,,Under Votes,56,42,14
+Wichita,105,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1157,909,248
+Wichita,105,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,491,375,116
+Wichita,105,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,105,"Justice, Supreme Court, Place 6",,,Under Votes,58,43,15
+Wichita,105,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1139,896,243
+Wichita,105,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,459,351,108
+Wichita,105,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,47,32,15
+Wichita,105,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,105,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,61,48,13
+Wichita,105,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1162,907,255
+Wichita,105,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,477,368,109
+Wichita,105,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,1,1,0
+Wichita,105,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,66,51,15
+Wichita,105,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1204,939,265
+Wichita,105,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,240,178,62
+Wichita,105,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,105,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,262,210,52
+Wichita,105,State Senator,30,REP,Pat Fallon,1152,902,250
+Wichita,105,State Senator,30,DEM,Kevin Lopez,517,396,121
+Wichita,105,State Senator,30,,Over Votes,0,0,0
+Wichita,105,State Senator,30,,Under Votes,37,29,8
+Wichita,105,State Representative,69,REP,James Frank,1323,1024,299
+Wichita,105,State Representative,69,,Over Votes,0,0,0
+Wichita,105,State Representative,69,,Under Votes,383,303,80
+Wichita,105,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,1310,1015,295
+Wichita,105,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,105,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,396,312,84
+Wichita,105,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,1284,995,289
+Wichita,105,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,105,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,422,332,90
+Wichita,105,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,1141,897,244
+Wichita,105,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,494,376,118
+Wichita,105,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,105,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,71,54,17
+Wichita,105,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,1295,1006,289
+Wichita,105,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,105,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,411,321,90
+Wichita,105,"District Judge, 30th Judicial District",,REP,Jeff McKnight,1315,1023,292
+Wichita,105,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,105,"District Judge, 30th Judicial District",,,Under Votes,391,304,87
+Wichita,105,Criminal District Attorney,,REP,John Gillespie,1329,1029,300
+Wichita,105,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,105,Criminal District Attorney,,,Under Votes,377,298,79
+Wichita,105,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",1312,1015,297
+Wichita,105,County Judge,,,Over Votes,0,0,0
+Wichita,105,County Judge,,,Under Votes,394,312,82
+Wichita,105,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,1308,1016,292
+Wichita,105,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,105,"Judge, County Court at Law No. 1",,,Under Votes,398,311,87
+Wichita,105,"Judge, County Court at Law No. 2",,REP,Greg King,1313,1021,292
+Wichita,105,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,105,"Judge, County Court at Law No. 2",,,Under Votes,393,306,87
+Wichita,105,District Clerk,,REP,Patti Flores,1306,1013,293
+Wichita,105,District Clerk,,,Over Votes,0,0,0
+Wichita,105,District Clerk,,,Under Votes,400,314,86
+Wichita,105,County Clerk,,REP,Lori Bohannon,1321,1026,295
+Wichita,105,County Clerk,,,Over Votes,0,0,0
+Wichita,105,County Clerk,,,Under Votes,385,301,84
+Wichita,105,County Treasurer,,REP,R. J. Bob Hampton,1317,1023,294
+Wichita,105,County Treasurer,,,Over Votes,0,0,0
+Wichita,105,County Treasurer,,,Under Votes,389,304,85
+Wichita,105,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,1290,998,292
+Wichita,105,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,105,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,416,329,87
+Wichita,105,City of Wichita Falls Mayor,,,Lowry W. Crane,344,270,74
+Wichita,105,City of Wichita Falls Mayor,,,Stephen L. Santellana,1062,815,247
+Wichita,105,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,105,City of Wichita Falls Mayor,,,Under Votes,300,242,58
+Wichita,105,City of Wichita Falls Councilor District 3,,,Jeff L. Browning,1111,839,272
+Wichita,105,City of Wichita Falls Councilor District 3,,,Over Votes,0,0,0
+Wichita,105,City of Wichita Falls Councilor District 3,,,Under Votes,595,488,107
+Wichita,105,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,1176,890,286
+Wichita,105,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,105,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,530,437,93
+Wichita,105,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,748,568,180
+Wichita,105,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,639,496,143
+Wichita,105,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,105,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,319,263,56
+Wichita,105,Ballots Cast,,,,1707,1328,379
+Wichita,106,Straight Party,,REP,,272,162,110
+Wichita,106,Straight Party,,DEM,,35,22,13
+Wichita,106,Straight Party,,LIB,,2,2,0
+Wichita,106,Straight Party,,,Over Votes,0,0,0
+Wichita,106,Straight Party,,,Under Votes,194,118,76
+Wichita,106,U.S. Senate,,REP,Ted Cruz,435,258,177
+Wichita,106,U.S. Senate,,DEM,Beto O'Rourke,60,42,18
+Wichita,106,U.S. Senate,,LIB,Neal M. Dikeman,3,1,2
+Wichita,106,U.S. Senate,,,Over Votes,0,0,0
+Wichita,106,U.S. Senate,,,Under Votes,5,3,2
+Wichita,106,U.S. House,13,REP,Mac Thornberry,436,261,175
+Wichita,106,U.S. House,13,DEM,Greg Sagan,49,32,17
+Wichita,106,U.S. House,13,LIB,Calvin DeWeese,13,7,6
+Wichita,106,U.S. House,13,,Over Votes,0,0,0
+Wichita,106,U.S. House,13,,Under Votes,5,4,1
+Wichita,106,Governor,,REP,Greg Abbott,447,266,181
+Wichita,106,Governor,,DEM,Lupe Valdez,51,35,16
+Wichita,106,Governor,,LIB,Mark Jay Tippetts,4,2,2
+Wichita,106,Governor,,,Over Votes,0,0,0
+Wichita,106,Governor,,,Under Votes,1,1,0
+Wichita,106,Lieutenant Governor,,REP,Dan Patrick,413,249,164
+Wichita,106,Lieutenant Governor,,DEM,Mike Collier,79,50,29
+Wichita,106,Lieutenant Governor,,LIB,Kerry Douglas McKennon,9,4,5
+Wichita,106,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,106,Lieutenant Governor,,,Under Votes,2,1,1
+Wichita,106,Attorney General,,REP,Ken Paxton,413,250,163
+Wichita,106,Attorney General,,DEM,Justin Nelson,68,42,26
+Wichita,106,Attorney General,,LIB,Michael Ray Harris,17,9,8
+Wichita,106,Attorney General,,,Over Votes,0,0,0
+Wichita,106,Attorney General,,,Under Votes,5,3,2
+Wichita,106,Comptroller of Public Accounts,,REP,Glenn Hegar,422,253,169
+Wichita,106,Comptroller of Public Accounts,,DEM,Joi Chevalier,55,35,20
+Wichita,106,Comptroller of Public Accounts,,LIB,Ben Sanders,19,11,8
+Wichita,106,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,106,Comptroller of Public Accounts,,,Under Votes,7,5,2
+Wichita,106,Commissioner of the General Land Office,,REP,George P. Bush,406,244,162
+Wichita,106,Commissioner of the General Land Office,,DEM,Miguel Suazo,56,33,23
+Wichita,106,Commissioner of the General Land Office,,LIB,Matt Pina,31,18,13
+Wichita,106,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,106,Commissioner of the General Land Office,,,Under Votes,10,9,1
+Wichita,106,Commissioner of Agriculture,,REP,Sid Miller,415,246,169
+Wichita,106,Commissioner of Agriculture,,DEM,Kim Olson,66,44,22
+Wichita,106,Commissioner of Agriculture,,LIB,Richard Carpenter,15,8,7
+Wichita,106,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,106,Commissioner of Agriculture,,,Under Votes,7,6,1
+Wichita,106,Railroad Commissioner,,REP,Christi Craddick,422,253,169
+Wichita,106,Railroad Commissioner,,DEM,Roman McAllen,59,38,21
+Wichita,106,Railroad Commissioner,,LIB,Mike Wright,15,8,7
+Wichita,106,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,106,Railroad Commissioner,,,Under Votes,7,5,2
+Wichita,106,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,424,255,169
+Wichita,106,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,73,45,28
+Wichita,106,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,106,"Justice, Supreme Court, Place 2",,,Under Votes,6,4,2
+Wichita,106,"Justice, Supreme Court, Place 4",,REP,John Devine,430,261,169
+Wichita,106,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,64,37,27
+Wichita,106,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,106,"Justice, Supreme Court, Place 4",,,Under Votes,9,6,3
+Wichita,106,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,433,257,176
+Wichita,106,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,60,39,21
+Wichita,106,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,106,"Justice, Supreme Court, Place 6",,,Under Votes,10,8,2
+Wichita,106,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,414,248,166
+Wichita,106,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,66,39,27
+Wichita,106,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,14,10,4
+Wichita,106,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,106,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,9,7,2
+Wichita,106,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,425,255,170
+Wichita,106,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,66,40,26
+Wichita,106,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,106,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,12,9,3
+Wichita,106,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,424,251,173
+Wichita,106,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,43,32,11
+Wichita,106,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,106,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,36,21,15
+Wichita,106,State Senator,30,REP,Pat Fallon,431,259,172
+Wichita,106,State Senator,30,DEM,Kevin Lopez,68,42,26
+Wichita,106,State Senator,30,,Over Votes,0,0,0
+Wichita,106,State Senator,30,,Under Votes,4,3,1
+Wichita,106,State Representative,69,REP,James Frank,454,272,182
+Wichita,106,State Representative,69,,Over Votes,0,0,0
+Wichita,106,State Representative,69,,Under Votes,49,32,17
+Wichita,106,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,445,266,179
+Wichita,106,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,106,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,58,38,20
+Wichita,106,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,442,264,178
+Wichita,106,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,106,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,61,40,21
+Wichita,106,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,422,252,170
+Wichita,106,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,67,43,24
+Wichita,106,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,106,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,14,9,5
+Wichita,106,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,444,266,178
+Wichita,106,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,106,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,59,38,21
+Wichita,106,"District Judge, 30th Judicial District",,REP,Jeff McKnight,445,265,180
+Wichita,106,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,106,"District Judge, 30th Judicial District",,,Under Votes,58,39,19
+Wichita,106,Criminal District Attorney,,REP,John Gillespie,450,270,180
+Wichita,106,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,106,Criminal District Attorney,,,Under Votes,53,34,19
+Wichita,106,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",440,263,177
+Wichita,106,County Judge,,,Over Votes,0,0,0
+Wichita,106,County Judge,,,Under Votes,63,41,22
+Wichita,106,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,446,267,179
+Wichita,106,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,106,"Judge, County Court at Law No. 1",,,Under Votes,57,37,20
+Wichita,106,"Judge, County Court at Law No. 2",,REP,Greg King,447,267,180
+Wichita,106,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,106,"Judge, County Court at Law No. 2",,,Under Votes,56,37,19
+Wichita,106,District Clerk,,REP,Patti Flores,442,265,177
+Wichita,106,District Clerk,,,Over Votes,0,0,0
+Wichita,106,District Clerk,,,Under Votes,61,39,22
+Wichita,106,County Clerk,,REP,Lori Bohannon,446,265,181
+Wichita,106,County Clerk,,,Over Votes,0,0,0
+Wichita,106,County Clerk,,,Under Votes,57,39,18
+Wichita,106,County Treasurer,,REP,R. J. Bob Hampton,448,268,180
+Wichita,106,County Treasurer,,,Over Votes,0,0,0
+Wichita,106,County Treasurer,,,Under Votes,55,36,19
+Wichita,106,"Justice of the Peace, Precinct 4",,REP,Judy Baker,443,265,178
+Wichita,106,"Justice of the Peace, Precinct 4",,,Over Votes,0,0,0
+Wichita,106,"Justice of the Peace, Precinct 4",,,Under Votes,60,39,21
+Wichita,106,City of Wichita Falls Mayor,,,Lowry W. Crane,8,4,4
+Wichita,106,City of Wichita Falls Mayor,,,Stephen L. Santellana,27,14,13
+Wichita,106,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,106,City of Wichita Falls Mayor,,,Under Votes,24,9,15
+Wichita,106,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,30,14,16
+Wichita,106,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,106,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,29,13,16
+Wichita,106,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,21,10,11
+Wichita,106,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,13,6,7
+Wichita,106,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,106,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,25,11,14
+Wichita,106,Ballots Cast,,,,503,304,199
+Wichita,107,Straight Party,,REP,,14,13,1
+Wichita,107,Straight Party,,DEM,,3,0,3
+Wichita,107,Straight Party,,LIB,,0,0,0
+Wichita,107,Straight Party,,,Over Votes,0,0,0
+Wichita,107,Straight Party,,,Under Votes,9,6,3
+Wichita,107,U.S. Senate,,REP,Ted Cruz,21,17,4
+Wichita,107,U.S. Senate,,DEM,Beto O'Rourke,5,2,3
+Wichita,107,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0
+Wichita,107,U.S. Senate,,,Over Votes,0,0,0
+Wichita,107,U.S. Senate,,,Under Votes,0,0,0
+Wichita,107,U.S. House,13,REP,Mac Thornberry,23,19,4
+Wichita,107,U.S. House,13,DEM,Greg Sagan,3,0,3
+Wichita,107,U.S. House,13,LIB,Calvin DeWeese,0,0,0
+Wichita,107,U.S. House,13,,Over Votes,0,0,0
+Wichita,107,U.S. House,13,,Under Votes,0,0,0
+Wichita,107,Governor,,REP,Greg Abbott,22,18,4
+Wichita,107,Governor,,DEM,Lupe Valdez,4,1,3
+Wichita,107,Governor,,LIB,Mark Jay Tippetts,0,0,0
+Wichita,107,Governor,,,Over Votes,0,0,0
+Wichita,107,Governor,,,Under Votes,0,0,0
+Wichita,107,Lieutenant Governor,,REP,Dan Patrick,21,17,4
+Wichita,107,Lieutenant Governor,,DEM,Mike Collier,4,1,3
+Wichita,107,Lieutenant Governor,,LIB,Kerry Douglas McKennon,0,0,0
+Wichita,107,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,107,Lieutenant Governor,,,Under Votes,1,1,0
+Wichita,107,Attorney General,,REP,Ken Paxton,21,17,4
+Wichita,107,Attorney General,,DEM,Justin Nelson,4,1,3
+Wichita,107,Attorney General,,LIB,Michael Ray Harris,0,0,0
+Wichita,107,Attorney General,,,Over Votes,0,0,0
+Wichita,107,Attorney General,,,Under Votes,1,1,0
+Wichita,107,Comptroller of Public Accounts,,REP,Glenn Hegar,21,17,4
+Wichita,107,Comptroller of Public Accounts,,DEM,Joi Chevalier,4,1,3
+Wichita,107,Comptroller of Public Accounts,,LIB,Ben Sanders,0,0,0
+Wichita,107,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,107,Comptroller of Public Accounts,,,Under Votes,1,1,0
+Wichita,107,Commissioner of the General Land Office,,REP,George P. Bush,21,17,4
+Wichita,107,Commissioner of the General Land Office,,DEM,Miguel Suazo,3,0,3
+Wichita,107,Commissioner of the General Land Office,,LIB,Matt Pina,1,1,0
+Wichita,107,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,107,Commissioner of the General Land Office,,,Under Votes,1,1,0
+Wichita,107,Commissioner of Agriculture,,REP,Sid Miller,21,17,4
+Wichita,107,Commissioner of Agriculture,,DEM,Kim Olson,4,1,3
+Wichita,107,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0
+Wichita,107,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,107,Commissioner of Agriculture,,,Under Votes,1,1,0
+Wichita,107,Railroad Commissioner,,REP,Christi Craddick,22,18,4
+Wichita,107,Railroad Commissioner,,DEM,Roman McAllen,3,0,3
+Wichita,107,Railroad Commissioner,,LIB,Mike Wright,0,0,0
+Wichita,107,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,107,Railroad Commissioner,,,Under Votes,1,1,0
+Wichita,107,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,21,17,4
+Wichita,107,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,4,1,3
+Wichita,107,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,107,"Justice, Supreme Court, Place 2",,,Under Votes,1,1,0
+Wichita,107,"Justice, Supreme Court, Place 4",,REP,John Devine,21,17,4
+Wichita,107,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,4,1,3
+Wichita,107,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,107,"Justice, Supreme Court, Place 4",,,Under Votes,1,1,0
+Wichita,107,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,22,18,4
+Wichita,107,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,3,0,3
+Wichita,107,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,107,"Justice, Supreme Court, Place 6",,,Under Votes,1,1,0
+Wichita,107,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,21,17,4
+Wichita,107,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,4,1,3
+Wichita,107,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,0,0,0
+Wichita,107,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,107,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,1,1,0
+Wichita,107,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,22,18,4
+Wichita,107,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,3,0,3
+Wichita,107,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,107,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,1,1,0
+Wichita,107,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,21,17,4
+Wichita,107,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,1,1,0
+Wichita,107,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,107,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,4,1,3
+Wichita,107,State Senator,30,REP,Pat Fallon,20,18,2
+Wichita,107,State Senator,30,DEM,Kevin Lopez,6,1,5
+Wichita,107,State Senator,30,,Over Votes,0,0,0
+Wichita,107,State Senator,30,,Under Votes,0,0,0
+Wichita,107,State Representative,69,REP,James Frank,23,19,4
+Wichita,107,State Representative,69,,Over Votes,0,0,0
+Wichita,107,State Representative,69,,Under Votes,3,0,3
+Wichita,107,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,22,18,4
+Wichita,107,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,107,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,4,1,3
+Wichita,107,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,22,18,4
+Wichita,107,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,107,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,4,1,3
+Wichita,107,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,21,17,4
+Wichita,107,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,4,1,3
+Wichita,107,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,107,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,1,1,0
+Wichita,107,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,22,18,4
+Wichita,107,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,107,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,4,1,3
+Wichita,107,"District Judge, 30th Judicial District",,REP,Jeff McKnight,22,18,4
+Wichita,107,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,107,"District Judge, 30th Judicial District",,,Under Votes,4,1,3
+Wichita,107,Criminal District Attorney,,REP,John Gillespie,22,18,4
+Wichita,107,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,107,Criminal District Attorney,,,Under Votes,4,1,3
+Wichita,107,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",23,19,4
+Wichita,107,County Judge,,,Over Votes,0,0,0
+Wichita,107,County Judge,,,Under Votes,3,0,3
+Wichita,107,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,22,18,4
+Wichita,107,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,107,"Judge, County Court at Law No. 1",,,Under Votes,4,1,3
+Wichita,107,"Judge, County Court at Law No. 2",,REP,Greg King,22,18,4
+Wichita,107,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,107,"Judge, County Court at Law No. 2",,,Under Votes,4,1,3
+Wichita,107,District Clerk,,REP,Patti Flores,22,18,4
+Wichita,107,District Clerk,,,Over Votes,0,0,0
+Wichita,107,District Clerk,,,Under Votes,4,1,3
+Wichita,107,County Clerk,,REP,Lori Bohannon,23,19,4
+Wichita,107,County Clerk,,,Over Votes,0,0,0
+Wichita,107,County Clerk,,,Under Votes,3,0,3
+Wichita,107,County Treasurer,,REP,R. J. Bob Hampton,22,18,4
+Wichita,107,County Treasurer,,,Over Votes,0,0,0
+Wichita,107,County Treasurer,,,Under Votes,4,1,3
+Wichita,107,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,21,17,4
+Wichita,107,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,107,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,5,2,3
+Wichita,107,City of Wichita Falls Mayor,,,Lowry W. Crane,6,4,2
+Wichita,107,City of Wichita Falls Mayor,,,Stephen L. Santellana,16,12,4
+Wichita,107,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,107,City of Wichita Falls Mayor,,,Under Votes,4,3,1
+Wichita,107,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,17,14,3
+Wichita,107,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,107,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,9,5,4
+Wichita,107,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,11,8,3
+Wichita,107,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,10,7,3
+Wichita,107,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,107,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,5,4,1
+Wichita,107,Ballots Cast,,,,26,19,7
+Wichita,108,Straight Party,,REP,,831,675,156
+Wichita,108,Straight Party,,DEM,,217,170,47
+Wichita,108,Straight Party,,LIB,,7,5,2
+Wichita,108,Straight Party,,,Over Votes,0,0,0
+Wichita,108,Straight Party,,,Under Votes,936,721,215
+Wichita,108,U.S. Senate,,REP,Ted Cruz,1479,1184,295
+Wichita,108,U.S. Senate,,DEM,Beto O'Rourke,482,369,113
+Wichita,108,U.S. Senate,,LIB,Neal M. Dikeman,11,6,5
+Wichita,108,U.S. Senate,,,Over Votes,0,0,0
+Wichita,108,U.S. Senate,,,Under Votes,19,12,7
+Wichita,108,U.S. House,13,REP,Mac Thornberry,1563,1237,326
+Wichita,108,U.S. House,13,DEM,Greg Sagan,382,302,80
+Wichita,108,U.S. House,13,LIB,Calvin DeWeese,31,22,9
+Wichita,108,U.S. House,13,,Over Votes,0,0,0
+Wichita,108,U.S. House,13,,Under Votes,15,10,5
+Wichita,108,Governor,,REP,Greg Abbott,1557,1231,326
+Wichita,108,Governor,,DEM,Lupe Valdez,399,315,84
+Wichita,108,Governor,,LIB,Mark Jay Tippetts,22,16,6
+Wichita,108,Governor,,,Over Votes,0,0,0
+Wichita,108,Governor,,,Under Votes,13,9,4
+Wichita,108,Lieutenant Governor,,REP,Dan Patrick,1423,1131,292
+Wichita,108,Lieutenant Governor,,DEM,Mike Collier,485,380,105
+Wichita,108,Lieutenant Governor,,LIB,Kerry Douglas McKennon,51,37,14
+Wichita,108,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,108,Lieutenant Governor,,,Under Votes,32,23,9
+Wichita,108,Attorney General,,REP,Ken Paxton,1466,1166,300
+Wichita,108,Attorney General,,DEM,Justin Nelson,451,348,103
+Wichita,108,Attorney General,,LIB,Michael Ray Harris,39,31,8
+Wichita,108,Attorney General,,,Over Votes,0,0,0
+Wichita,108,Attorney General,,,Under Votes,35,26,9
+Wichita,108,Comptroller of Public Accounts,,REP,Glenn Hegar,1476,1175,301
+Wichita,108,Comptroller of Public Accounts,,DEM,Joi Chevalier,393,307,86
+Wichita,108,Comptroller of Public Accounts,,LIB,Ben Sanders,63,45,18
+Wichita,108,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,108,Comptroller of Public Accounts,,,Under Votes,59,44,15
+Wichita,108,Commissioner of the General Land Office,,REP,George P. Bush,1462,1157,305
+Wichita,108,Commissioner of the General Land Office,,DEM,Miguel Suazo,402,307,95
+Wichita,108,Commissioner of the General Land Office,,LIB,Matt Pina,78,68,10
+Wichita,108,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,108,Commissioner of the General Land Office,,,Under Votes,49,39,10
+Wichita,108,Commissioner of Agriculture,,REP,Sid Miller,1459,1157,302
+Wichita,108,Commissioner of Agriculture,,DEM,Kim Olson,430,334,96
+Wichita,108,Commissioner of Agriculture,,LIB,Richard Carpenter,43,33,10
+Wichita,108,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,108,Commissioner of Agriculture,,,Under Votes,59,47,12
+Wichita,108,Railroad Commissioner,,REP,Christi Craddick,1495,1186,309
+Wichita,108,Railroad Commissioner,,DEM,Roman McAllen,380,296,84
+Wichita,108,Railroad Commissioner,,LIB,Mike Wright,53,41,12
+Wichita,108,Railroad Commissioner,,,Over Votes,1,1,0
+Wichita,108,Railroad Commissioner,,,Under Votes,62,47,15
+Wichita,108,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1498,1188,310
+Wichita,108,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,436,341,95
+Wichita,108,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,108,"Justice, Supreme Court, Place 2",,,Under Votes,57,42,15
+Wichita,108,"Justice, Supreme Court, Place 4",,REP,John Devine,1505,1192,313
+Wichita,108,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,426,332,94
+Wichita,108,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,108,"Justice, Supreme Court, Place 4",,,Under Votes,60,47,13
+Wichita,108,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1505,1195,310
+Wichita,108,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,429,330,99
+Wichita,108,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,108,"Justice, Supreme Court, Place 6",,,Under Votes,57,46,11
+Wichita,108,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1472,1173,299
+Wichita,108,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,415,318,97
+Wichita,108,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,42,31,11
+Wichita,108,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,108,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,62,49,13
+Wichita,108,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1501,1191,310
+Wichita,108,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,423,328,95
+Wichita,108,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,108,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,67,52,15
+Wichita,108,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1555,1233,322
+Wichita,108,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,203,159,44
+Wichita,108,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,108,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,233,179,54
+Wichita,108,State Senator,30,REP,Pat Fallon,1505,1201,304
+Wichita,108,State Senator,30,DEM,Kevin Lopez,449,345,104
+Wichita,108,State Senator,30,,Over Votes,0,0,0
+Wichita,108,State Senator,30,,Under Votes,37,25,12
+Wichita,108,State Representative,69,REP,James Frank,1652,1309,343
+Wichita,108,State Representative,69,,Over Votes,0,0,0
+Wichita,108,State Representative,69,,Under Votes,339,262,77
+Wichita,108,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,1626,1291,335
+Wichita,108,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,108,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,365,280,85
+Wichita,108,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,1610,1278,332
+Wichita,108,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,108,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,381,293,88
+Wichita,108,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,1485,1180,305
+Wichita,108,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,433,337,96
+Wichita,108,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,1,1,0
+Wichita,108,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,72,53,19
+Wichita,108,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,1618,1286,332
+Wichita,108,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,108,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,373,285,88
+Wichita,108,"District Judge, 30th Judicial District",,REP,Jeff McKnight,1629,1294,335
+Wichita,108,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,108,"District Judge, 30th Judicial District",,,Under Votes,362,277,85
+Wichita,108,Criminal District Attorney,,REP,John Gillespie,1645,1303,342
+Wichita,108,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,108,Criminal District Attorney,,,Under Votes,346,268,78
+Wichita,108,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",1639,1298,341
+Wichita,108,County Judge,,,Over Votes,0,0,0
+Wichita,108,County Judge,,,Under Votes,352,273,79
+Wichita,108,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,1635,1298,337
+Wichita,108,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,108,"Judge, County Court at Law No. 1",,,Under Votes,356,273,83
+Wichita,108,"Judge, County Court at Law No. 2",,REP,Greg King,1633,1297,336
+Wichita,108,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,108,"Judge, County Court at Law No. 2",,,Under Votes,358,274,84
+Wichita,108,District Clerk,,REP,Patti Flores,1640,1301,339
+Wichita,108,District Clerk,,,Over Votes,0,0,0
+Wichita,108,District Clerk,,,Under Votes,351,270,81
+Wichita,108,County Clerk,,REP,Lori Bohannon,1643,1307,336
+Wichita,108,County Clerk,,,Over Votes,0,0,0
+Wichita,108,County Clerk,,,Under Votes,348,264,84
+Wichita,108,County Treasurer,,REP,R. J. Bob Hampton,1642,1304,338
+Wichita,108,County Treasurer,,,Over Votes,0,0,0
+Wichita,108,County Treasurer,,,Under Votes,349,267,82
+Wichita,108,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,1627,1293,334
+Wichita,108,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,108,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,364,278,86
+Wichita,108,City of Wichita Falls Mayor,,,Lowry W. Crane,399,306,93
+Wichita,108,City of Wichita Falls Mayor,,,Stephen L. Santellana,1262,998,264
+Wichita,108,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,108,City of Wichita Falls Mayor,,,Under Votes,330,267,63
+Wichita,108,City of Wichita Falls Councilor District 4,,,Tim Brewer,826,659,167
+Wichita,108,City of Wichita Falls Councilor District 4,,,Nicholas J. Schreiber,649,504,145
+Wichita,108,City of Wichita Falls Councilor District 4,,,Over Votes,0,0,0
+Wichita,108,City of Wichita Falls Councilor District 4,,,Under Votes,516,408,108
+Wichita,108,Wichita Falls ISD Single Member District 3,,,Mark Lukert,1100,866,234
+Wichita,108,Wichita Falls ISD Single Member District 3,,,Adam W. Groves,382,301,81
+Wichita,108,Wichita Falls ISD Single Member District 3,,,Over Votes,0,0,0
+Wichita,108,Wichita Falls ISD Single Member District 3,,,Under Votes,509,404,105
+Wichita,108,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,1368,1075,293
+Wichita,108,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,108,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,624,497,127
+Wichita,108,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,933,737,196
+Wichita,108,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,637,493,144
+Wichita,108,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,108,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,421,341,80
+Wichita,108,Ballots Cast,,,,1992,1572,420
+Wichita,109,Straight Party,,REP,,884,686,198
+Wichita,109,Straight Party,,DEM,,229,175,54
+Wichita,109,Straight Party,,LIB,,1,1,0
+Wichita,109,Straight Party,,,Over Votes,0,0,0
+Wichita,109,Straight Party,,,Under Votes,1001,760,241
+Wichita,109,U.S. Senate,,REP,Ted Cruz,1509,1170,339
+Wichita,109,U.S. Senate,,DEM,Beto O'Rourke,570,427,143
+Wichita,109,U.S. Senate,,LIB,Neal M. Dikeman,16,9,7
+Wichita,109,U.S. Senate,,,Over Votes,0,0,0
+Wichita,109,U.S. Senate,,,Under Votes,13,9,4
+Wichita,109,U.S. House,13,REP,Mac Thornberry,1604,1225,379
+Wichita,109,U.S. House,13,DEM,Greg Sagan,456,360,96
+Wichita,109,U.S. House,13,LIB,Calvin DeWeese,22,14,8
+Wichita,109,U.S. House,13,,Over Votes,0,0,0
+Wichita,109,U.S. House,13,,Under Votes,26,16,10
+Wichita,109,Governor,,REP,Greg Abbott,1607,1227,380
+Wichita,109,Governor,,DEM,Lupe Valdez,453,356,97
+Wichita,109,Governor,,LIB,Mark Jay Tippetts,29,17,12
+Wichita,109,Governor,,,Over Votes,0,0,0
+Wichita,109,Governor,,,Under Votes,17,13,4
+Wichita,109,Lieutenant Governor,,REP,Dan Patrick,1482,1146,336
+Wichita,109,Lieutenant Governor,,DEM,Mike Collier,545,418,127
+Wichita,109,Lieutenant Governor,,LIB,Kerry Douglas McKennon,45,28,17
+Wichita,109,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,109,Lieutenant Governor,,,Under Votes,34,21,13
+Wichita,109,Attorney General,,REP,Ken Paxton,1491,1148,343
+Wichita,109,Attorney General,,DEM,Justin Nelson,528,417,111
+Wichita,109,Attorney General,,LIB,Michael Ray Harris,43,23,20
+Wichita,109,Attorney General,,,Over Votes,0,0,0
+Wichita,109,Attorney General,,,Under Votes,44,25,19
+Wichita,109,Comptroller of Public Accounts,,REP,Glenn Hegar,1524,1175,349
+Wichita,109,Comptroller of Public Accounts,,DEM,Joi Chevalier,464,367,97
+Wichita,109,Comptroller of Public Accounts,,LIB,Ben Sanders,61,36,25
+Wichita,109,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,109,Comptroller of Public Accounts,,,Under Votes,57,35,22
+Wichita,109,Commissioner of the General Land Office,,REP,George P. Bush,1518,1157,361
+Wichita,109,Commissioner of the General Land Office,,DEM,Miguel Suazo,447,353,94
+Wichita,109,Commissioner of the General Land Office,,LIB,Matt Pina,90,68,22
+Wichita,109,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,109,Commissioner of the General Land Office,,,Under Votes,51,35,16
+Wichita,109,Commissioner of Agriculture,,REP,Sid Miller,1489,1143,346
+Wichita,109,Commissioner of Agriculture,,DEM,Kim Olson,513,400,113
+Wichita,109,Commissioner of Agriculture,,LIB,Richard Carpenter,39,24,15
+Wichita,109,Commissioner of Agriculture,,,Over Votes,1,1,0
+Wichita,109,Commissioner of Agriculture,,,Under Votes,64,45,19
+Wichita,109,Railroad Commissioner,,REP,Christi Craddick,1532,1178,354
+Wichita,109,Railroad Commissioner,,DEM,Roman McAllen,463,364,99
+Wichita,109,Railroad Commissioner,,LIB,Mike Wright,54,36,18
+Wichita,109,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,109,Railroad Commissioner,,,Under Votes,57,35,22
+Wichita,109,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1539,1174,365
+Wichita,109,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,517,405,112
+Wichita,109,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,109,"Justice, Supreme Court, Place 2",,,Under Votes,50,34,16
+Wichita,109,"Justice, Supreme Court, Place 4",,REP,John Devine,1545,1181,364
+Wichita,109,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,506,397,109
+Wichita,109,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,109,"Justice, Supreme Court, Place 4",,,Under Votes,55,35,20
+Wichita,109,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1548,1184,364
+Wichita,109,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,502,393,109
+Wichita,109,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,109,"Justice, Supreme Court, Place 6",,,Under Votes,56,36,20
+Wichita,109,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1511,1163,348
+Wichita,109,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,489,379,110
+Wichita,109,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,46,32,14
+Wichita,109,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,1,1,0
+Wichita,109,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,59,38,21
+Wichita,109,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1544,1183,361
+Wichita,109,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,501,393,108
+Wichita,109,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,109,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,61,37,24
+Wichita,109,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1610,1233,377
+Wichita,109,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,250,193,57
+Wichita,109,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,109,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,249,190,59
+Wichita,109,State Senator,30,REP,Pat Fallon,1521,1167,354
+Wichita,109,State Senator,30,DEM,Kevin Lopez,543,419,124
+Wichita,109,State Senator,30,,Over Votes,1,1,0
+Wichita,109,State Senator,30,,Under Votes,41,26,15
+Wichita,109,State Representative,69,REP,James Frank,1715,1308,407
+Wichita,109,State Representative,69,,Over Votes,0,0,0
+Wichita,109,State Representative,69,,Under Votes,391,305,86
+Wichita,109,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,1688,1288,400
+Wichita,109,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,109,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,418,325,93
+Wichita,109,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,1673,1277,396
+Wichita,109,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,109,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,433,336,97
+Wichita,109,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,1524,1167,357
+Wichita,109,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,507,397,110
+Wichita,109,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,109,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,75,49,26
+Wichita,109,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,1677,1278,399
+Wichita,109,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,109,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,429,335,94
+Wichita,109,"District Judge, 30th Judicial District",,REP,Jeff McKnight,1697,1296,401
+Wichita,109,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,109,"District Judge, 30th Judicial District",,,Under Votes,409,317,92
+Wichita,109,Criminal District Attorney,,REP,John Gillespie,1695,1292,403
+Wichita,109,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,109,Criminal District Attorney,,,Under Votes,411,321,90
+Wichita,109,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",1711,1301,410
+Wichita,109,County Judge,,,Over Votes,0,0,0
+Wichita,109,County Judge,,,Under Votes,395,312,83
+Wichita,109,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,1693,1289,404
+Wichita,109,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,109,"Judge, County Court at Law No. 1",,,Under Votes,413,324,89
+Wichita,109,"Judge, County Court at Law No. 2",,REP,Greg King,1704,1299,405
+Wichita,109,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,109,"Judge, County Court at Law No. 2",,,Under Votes,402,314,88
+Wichita,109,District Clerk,,REP,Patti Flores,1710,1297,413
+Wichita,109,District Clerk,,,Over Votes,0,0,0
+Wichita,109,District Clerk,,,Under Votes,396,316,80
+Wichita,109,County Clerk,,REP,Lori Bohannon,1719,1306,413
+Wichita,109,County Clerk,,,Over Votes,0,0,0
+Wichita,109,County Clerk,,,Under Votes,387,307,80
+Wichita,109,County Treasurer,,REP,R. J. Bob Hampton,1711,1306,405
+Wichita,109,County Treasurer,,,Over Votes,0,0,0
+Wichita,109,County Treasurer,,,Under Votes,395,307,88
+Wichita,109,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,1676,1274,402
+Wichita,109,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,109,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,430,339,91
+Wichita,109,City of Wichita Falls Mayor,,,Lowry W. Crane,486,391,95
+Wichita,109,City of Wichita Falls Mayor,,,Stephen L. Santellana,1248,922,326
+Wichita,109,City of Wichita Falls Mayor,,,Over Votes,2,2,0
+Wichita,109,City of Wichita Falls Mayor,,,Under Votes,375,303,72
+Wichita,109,City of Wichita Falls Councilor District 4,,,Tim Brewer,867,663,204
+Wichita,109,City of Wichita Falls Councilor District 4,,,Nicholas J. Schreiber,722,540,182
+Wichita,109,City of Wichita Falls Councilor District 4,,,Over Votes,0,0,0
+Wichita,109,City of Wichita Falls Councilor District 4,,,Under Votes,522,415,107
+Wichita,109,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,1460,1102,358
+Wichita,109,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,109,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,649,514,135
+Wichita,109,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,999,745,254
+Wichita,109,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,671,514,157
+Wichita,109,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,109,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,441,359,82
+Wichita,109,Ballots Cast,,,,2115,1622,493
+Wichita,110,Straight Party,,REP,,120,89,31
+Wichita,110,Straight Party,,DEM,,57,44,13
+Wichita,110,Straight Party,,LIB,,3,2,1
+Wichita,110,Straight Party,,,Over Votes,0,0,0
+Wichita,110,Straight Party,,,Under Votes,153,122,31
+Wichita,110,U.S. Senate,,REP,Ted Cruz,188,143,45
+Wichita,110,U.S. Senate,,DEM,Beto O'Rourke,137,108,29
+Wichita,110,U.S. Senate,,LIB,Neal M. Dikeman,6,5,1
+Wichita,110,U.S. Senate,,,Over Votes,0,0,0
+Wichita,110,U.S. Senate,,,Under Votes,2,1,1
+Wichita,110,U.S. House,13,REP,Mac Thornberry,216,165,51
+Wichita,110,U.S. House,13,DEM,Greg Sagan,101,81,20
+Wichita,110,U.S. House,13,LIB,Calvin DeWeese,11,7,4
+Wichita,110,U.S. House,13,,Over Votes,0,0,0
+Wichita,110,U.S. House,13,,Under Votes,5,4,1
+Wichita,110,Governor,,REP,Greg Abbott,211,160,51
+Wichita,110,Governor,,DEM,Lupe Valdez,110,88,22
+Wichita,110,Governor,,LIB,Mark Jay Tippetts,9,7,2
+Wichita,110,Governor,,,Over Votes,0,0,0
+Wichita,110,Governor,,,Under Votes,3,2,1
+Wichita,110,Lieutenant Governor,,REP,Dan Patrick,191,144,47
+Wichita,110,Lieutenant Governor,,DEM,Mike Collier,124,99,25
+Wichita,110,Lieutenant Governor,,LIB,Kerry Douglas McKennon,13,9,4
+Wichita,110,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,110,Lieutenant Governor,,,Under Votes,5,5,0
+Wichita,110,Attorney General,,REP,Ken Paxton,189,144,45
+Wichita,110,Attorney General,,DEM,Justin Nelson,122,98,24
+Wichita,110,Attorney General,,LIB,Michael Ray Harris,16,10,6
+Wichita,110,Attorney General,,,Over Votes,0,0,0
+Wichita,110,Attorney General,,,Under Votes,6,5,1
+Wichita,110,Comptroller of Public Accounts,,REP,Glenn Hegar,194,149,45
+Wichita,110,Comptroller of Public Accounts,,DEM,Joi Chevalier,108,84,24
+Wichita,110,Comptroller of Public Accounts,,LIB,Ben Sanders,21,15,6
+Wichita,110,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,110,Comptroller of Public Accounts,,,Under Votes,10,9,1
+Wichita,110,Commissioner of the General Land Office,,REP,George P. Bush,198,152,46
+Wichita,110,Commissioner of the General Land Office,,DEM,Miguel Suazo,109,86,23
+Wichita,110,Commissioner of the General Land Office,,LIB,Matt Pina,21,14,7
+Wichita,110,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,110,Commissioner of the General Land Office,,,Under Votes,5,5,0
+Wichita,110,Commissioner of Agriculture,,REP,Sid Miller,191,144,47
+Wichita,110,Commissioner of Agriculture,,DEM,Kim Olson,120,96,24
+Wichita,110,Commissioner of Agriculture,,LIB,Richard Carpenter,14,10,4
+Wichita,110,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,110,Commissioner of Agriculture,,,Under Votes,8,7,1
+Wichita,110,Railroad Commissioner,,REP,Christi Craddick,205,159,46
+Wichita,110,Railroad Commissioner,,DEM,Roman McAllen,106,82,24
+Wichita,110,Railroad Commissioner,,LIB,Mike Wright,15,10,5
+Wichita,110,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,110,Railroad Commissioner,,,Under Votes,7,6,1
+Wichita,110,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,199,153,46
+Wichita,110,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,126,97,29
+Wichita,110,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,110,"Justice, Supreme Court, Place 2",,,Under Votes,8,7,1
+Wichita,110,"Justice, Supreme Court, Place 4",,REP,John Devine,200,154,46
+Wichita,110,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,124,96,28
+Wichita,110,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,110,"Justice, Supreme Court, Place 4",,,Under Votes,9,7,2
+Wichita,110,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,197,150,47
+Wichita,110,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,127,99,28
+Wichita,110,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,110,"Justice, Supreme Court, Place 6",,,Under Votes,9,8,1
+Wichita,110,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,192,148,44
+Wichita,110,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,115,91,24
+Wichita,110,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,19,12,7
+Wichita,110,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,110,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,7,6,1
+Wichita,110,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,200,153,47
+Wichita,110,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,124,96,28
+Wichita,110,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,110,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,9,8,1
+Wichita,110,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,218,167,51
+Wichita,110,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,62,45,17
+Wichita,110,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,110,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,53,45,8
+Wichita,110,State Senator,30,REP,Pat Fallon,197,150,47
+Wichita,110,State Senator,30,DEM,Kevin Lopez,129,100,29
+Wichita,110,State Senator,30,,Over Votes,0,0,0
+Wichita,110,State Senator,30,,Under Votes,7,7,0
+Wichita,110,State Representative,69,REP,James Frank,246,185,61
+Wichita,110,State Representative,69,,Over Votes,0,0,0
+Wichita,110,State Representative,69,,Under Votes,87,72,15
+Wichita,110,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,239,181,58
+Wichita,110,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,110,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,94,76,18
+Wichita,110,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,238,179,59
+Wichita,110,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,110,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,95,78,17
+Wichita,110,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,199,151,48
+Wichita,110,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,121,95,26
+Wichita,110,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,110,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,13,11,2
+Wichita,110,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,237,178,59
+Wichita,110,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,110,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,96,79,17
+Wichita,110,"District Judge, 30th Judicial District",,REP,Jeff McKnight,240,179,61
+Wichita,110,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,110,"District Judge, 30th Judicial District",,,Under Votes,93,78,15
+Wichita,110,Criminal District Attorney,,REP,John Gillespie,241,180,61
+Wichita,110,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,110,Criminal District Attorney,,,Under Votes,92,77,15
+Wichita,110,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",242,180,62
+Wichita,110,County Judge,,,Over Votes,0,0,0
+Wichita,110,County Judge,,,Under Votes,91,77,14
+Wichita,110,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,243,182,61
+Wichita,110,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,110,"Judge, County Court at Law No. 1",,,Under Votes,90,75,15
+Wichita,110,"Judge, County Court at Law No. 2",,REP,Greg King,242,181,61
+Wichita,110,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,110,"Judge, County Court at Law No. 2",,,Under Votes,91,76,15
+Wichita,110,District Clerk,,REP,Patti Flores,242,179,63
+Wichita,110,District Clerk,,,Over Votes,0,0,0
+Wichita,110,District Clerk,,,Under Votes,91,78,13
+Wichita,110,County Clerk,,REP,Lori Bohannon,247,184,63
+Wichita,110,County Clerk,,,Over Votes,0,0,0
+Wichita,110,County Clerk,,,Under Votes,86,73,13
+Wichita,110,County Treasurer,,REP,R. J. Bob Hampton,245,182,63
+Wichita,110,County Treasurer,,,Over Votes,0,0,0
+Wichita,110,County Treasurer,,,Under Votes,88,75,13
+Wichita,110,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,242,180,62
+Wichita,110,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,110,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,91,77,14
+Wichita,110,City of Wichita Falls Mayor,,,Lowry W. Crane,72,57,15
+Wichita,110,City of Wichita Falls Mayor,,,Stephen L. Santellana,200,150,50
+Wichita,110,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,110,City of Wichita Falls Mayor,,,Under Votes,61,50,11
+Wichita,110,Wichita Falls ISD Single Member District 1,,,Bob Payton,203,151,52
+Wichita,110,Wichita Falls ISD Single Member District 1,,,Over Votes,0,0,0
+Wichita,110,Wichita Falls ISD Single Member District 1,,,Under Votes,130,106,24
+Wichita,110,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,218,163,55
+Wichita,110,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,110,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,115,94,21
+Wichita,110,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,176,132,44
+Wichita,110,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,79,62,17
+Wichita,110,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,110,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,78,63,15
+Wichita,110,Ballots Cast,,,,333,257,76
+Wichita,111,Straight Party,,REP,,97,62,35
+Wichita,111,Straight Party,,DEM,,126,88,38
+Wichita,111,Straight Party,,LIB,,3,2,1
+Wichita,111,Straight Party,,,Over Votes,0,0,0
+Wichita,111,Straight Party,,,Under Votes,143,104,39
+Wichita,111,U.S. Senate,,REP,Ted Cruz,169,119,50
+Wichita,111,U.S. Senate,,DEM,Beto O'Rourke,195,134,61
+Wichita,111,U.S. Senate,,LIB,Neal M. Dikeman,1,1,0
+Wichita,111,U.S. Senate,,,Over Votes,0,0,0
+Wichita,111,U.S. Senate,,,Under Votes,4,2,2
+Wichita,111,U.S. House,13,REP,Mac Thornberry,182,128,54
+Wichita,111,U.S. House,13,DEM,Greg Sagan,168,118,50
+Wichita,111,U.S. House,13,LIB,Calvin DeWeese,6,2,4
+Wichita,111,U.S. House,13,,Over Votes,0,0,0
+Wichita,111,U.S. House,13,,Under Votes,13,8,5
+Wichita,111,Governor,,REP,Greg Abbott,192,134,58
+Wichita,111,Governor,,DEM,Lupe Valdez,164,115,49
+Wichita,111,Governor,,LIB,Mark Jay Tippetts,8,4,4
+Wichita,111,Governor,,,Over Votes,0,0,0
+Wichita,111,Governor,,,Under Votes,5,3,2
+Wichita,111,Lieutenant Governor,,REP,Dan Patrick,174,118,56
+Wichita,111,Lieutenant Governor,,DEM,Mike Collier,177,125,52
+Wichita,111,Lieutenant Governor,,LIB,Kerry Douglas McKennon,5,4,1
+Wichita,111,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,111,Lieutenant Governor,,,Under Votes,13,9,4
+Wichita,111,Attorney General,,REP,Ken Paxton,170,114,56
+Wichita,111,Attorney General,,DEM,Justin Nelson,179,128,51
+Wichita,111,Attorney General,,LIB,Michael Ray Harris,6,4,2
+Wichita,111,Attorney General,,,Over Votes,0,0,0
+Wichita,111,Attorney General,,,Under Votes,14,10,4
+Wichita,111,Comptroller of Public Accounts,,REP,Glenn Hegar,174,121,53
+Wichita,111,Comptroller of Public Accounts,,DEM,Joi Chevalier,164,116,48
+Wichita,111,Comptroller of Public Accounts,,LIB,Ben Sanders,13,6,7
+Wichita,111,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,111,Comptroller of Public Accounts,,,Under Votes,18,13,5
+Wichita,111,Commissioner of the General Land Office,,REP,George P. Bush,177,120,57
+Wichita,111,Commissioner of the General Land Office,,DEM,Miguel Suazo,165,117,48
+Wichita,111,Commissioner of the General Land Office,,LIB,Matt Pina,10,8,2
+Wichita,111,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,111,Commissioner of the General Land Office,,,Under Votes,17,11,6
+Wichita,111,Commissioner of Agriculture,,REP,Sid Miller,168,114,54
+Wichita,111,Commissioner of Agriculture,,DEM,Kim Olson,176,124,52
+Wichita,111,Commissioner of Agriculture,,LIB,Richard Carpenter,10,7,3
+Wichita,111,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,111,Commissioner of Agriculture,,,Under Votes,15,11,4
+Wichita,111,Railroad Commissioner,,REP,Christi Craddick,178,120,58
+Wichita,111,Railroad Commissioner,,DEM,Roman McAllen,167,119,48
+Wichita,111,Railroad Commissioner,,LIB,Mike Wright,9,6,3
+Wichita,111,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,111,Railroad Commissioner,,,Under Votes,15,11,4
+Wichita,111,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,179,123,56
+Wichita,111,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,172,120,52
+Wichita,111,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,111,"Justice, Supreme Court, Place 2",,,Under Votes,18,13,5
+Wichita,111,"Justice, Supreme Court, Place 4",,REP,John Devine,177,121,56
+Wichita,111,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,172,120,52
+Wichita,111,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,111,"Justice, Supreme Court, Place 4",,,Under Votes,20,15,5
+Wichita,111,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,174,119,55
+Wichita,111,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,174,122,52
+Wichita,111,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,111,"Justice, Supreme Court, Place 6",,,Under Votes,21,15,6
+Wichita,111,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,169,117,52
+Wichita,111,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,173,120,53
+Wichita,111,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,6,4,2
+Wichita,111,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,111,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,21,15,6
+Wichita,111,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,172,120,52
+Wichita,111,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,174,119,55
+Wichita,111,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,111,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,23,17,6
+Wichita,111,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,193,132,61
+Wichita,111,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,73,52,21
+Wichita,111,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,111,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,103,72,31
+Wichita,111,State Senator,30,REP,Pat Fallon,179,122,57
+Wichita,111,State Senator,30,DEM,Kevin Lopez,174,123,51
+Wichita,111,State Senator,30,,Over Votes,0,0,0
+Wichita,111,State Senator,30,,Under Votes,16,11,5
+Wichita,111,State Representative,69,REP,James Frank,220,149,71
+Wichita,111,State Representative,69,,Over Votes,0,0,0
+Wichita,111,State Representative,69,,Under Votes,149,107,42
+Wichita,111,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,220,150,70
+Wichita,111,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,111,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,149,106,43
+Wichita,111,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,216,147,69
+Wichita,111,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,111,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,153,109,44
+Wichita,111,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,166,113,53
+Wichita,111,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,178,126,52
+Wichita,111,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,111,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,25,17,8
+Wichita,111,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,213,146,67
+Wichita,111,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,111,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,156,110,46
+Wichita,111,"District Judge, 30th Judicial District",,REP,Jeff McKnight,213,146,67
+Wichita,111,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,111,"District Judge, 30th Judicial District",,,Under Votes,156,110,46
+Wichita,111,Criminal District Attorney,,REP,John Gillespie,213,146,67
+Wichita,111,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,111,Criminal District Attorney,,,Under Votes,156,110,46
+Wichita,111,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",216,148,68
+Wichita,111,County Judge,,,Over Votes,0,0,0
+Wichita,111,County Judge,,,Under Votes,153,108,45
+Wichita,111,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,212,147,65
+Wichita,111,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,111,"Judge, County Court at Law No. 1",,,Under Votes,157,109,48
+Wichita,111,"Judge, County Court at Law No. 2",,REP,Greg King,214,147,67
+Wichita,111,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,111,"Judge, County Court at Law No. 2",,,Under Votes,155,109,46
+Wichita,111,District Clerk,,REP,Patti Flores,213,146,67
+Wichita,111,District Clerk,,,Over Votes,0,0,0
+Wichita,111,District Clerk,,,Under Votes,156,110,46
+Wichita,111,County Clerk,,REP,Lori Bohannon,216,149,67
+Wichita,111,County Clerk,,,Over Votes,0,0,0
+Wichita,111,County Clerk,,,Under Votes,153,107,46
+Wichita,111,County Treasurer,,REP,R. J. Bob Hampton,216,148,68
+Wichita,111,County Treasurer,,,Over Votes,0,0,0
+Wichita,111,County Treasurer,,,Under Votes,153,108,45
+Wichita,111,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,211,145,66
+Wichita,111,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,111,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,158,111,47
+Wichita,111,City of Wichita Falls Mayor,,,Lowry W. Crane,70,43,27
+Wichita,111,City of Wichita Falls Mayor,,,Stephen L. Santellana,180,128,52
+Wichita,111,City of Wichita Falls Mayor,,,Over Votes,1,1,0
+Wichita,111,City of Wichita Falls Mayor,,,Under Votes,118,84,34
+Wichita,111,City of Wichita Falls Councilor District 3,,,Jeff L. Browning,196,136,60
+Wichita,111,City of Wichita Falls Councilor District 3,,,Over Votes,0,0,0
+Wichita,111,City of Wichita Falls Councilor District 3,,,Under Votes,173,120,53
+Wichita,111,Wichita Falls ISD Single Member District 1,,,Bob Payton,194,134,60
+Wichita,111,Wichita Falls ISD Single Member District 1,,,Over Votes,0,0,0
+Wichita,111,Wichita Falls ISD Single Member District 1,,,Under Votes,175,122,53
+Wichita,111,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,211,145,66
+Wichita,111,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,111,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,158,111,47
+Wichita,111,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,137,89,48
+Wichita,111,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,113,83,30
+Wichita,111,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,111,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,119,84,35
+Wichita,111,Ballots Cast,,,,369,256,113
+Wichita,112,Straight Party,,REP,,3,3,0
+Wichita,112,Straight Party,,DEM,,3,1,2
+Wichita,112,Straight Party,,LIB,,0,0,0
+Wichita,112,Straight Party,,,Over Votes,0,0,0
+Wichita,112,Straight Party,,,Under Votes,4,2,2
+Wichita,112,U.S. Senate,,REP,Ted Cruz,5,4,1
+Wichita,112,U.S. Senate,,DEM,Beto O'Rourke,4,2,2
+Wichita,112,U.S. Senate,,LIB,Neal M. Dikeman,1,0,1
+Wichita,112,U.S. Senate,,,Over Votes,0,0,0
+Wichita,112,U.S. Senate,,,Under Votes,0,0,0
+Wichita,112,U.S. House,13,REP,Mac Thornberry,5,4,1
+Wichita,112,U.S. House,13,DEM,Greg Sagan,5,2,3
+Wichita,112,U.S. House,13,LIB,Calvin DeWeese,0,0,0
+Wichita,112,U.S. House,13,,Over Votes,0,0,0
+Wichita,112,U.S. House,13,,Under Votes,0,0,0
+Wichita,112,Governor,,REP,Greg Abbott,6,4,2
+Wichita,112,Governor,,DEM,Lupe Valdez,4,2,2
+Wichita,112,Governor,,LIB,Mark Jay Tippetts,0,0,0
+Wichita,112,Governor,,,Over Votes,0,0,0
+Wichita,112,Governor,,,Under Votes,0,0,0
+Wichita,112,Lieutenant Governor,,REP,Dan Patrick,5,4,1
+Wichita,112,Lieutenant Governor,,DEM,Mike Collier,5,2,3
+Wichita,112,Lieutenant Governor,,LIB,Kerry Douglas McKennon,0,0,0
+Wichita,112,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,112,Lieutenant Governor,,,Under Votes,0,0,0
+Wichita,112,Attorney General,,REP,Ken Paxton,5,4,1
+Wichita,112,Attorney General,,DEM,Justin Nelson,5,2,3
+Wichita,112,Attorney General,,LIB,Michael Ray Harris,0,0,0
+Wichita,112,Attorney General,,,Over Votes,0,0,0
+Wichita,112,Attorney General,,,Under Votes,0,0,0
+Wichita,112,Comptroller of Public Accounts,,REP,Glenn Hegar,5,4,1
+Wichita,112,Comptroller of Public Accounts,,DEM,Joi Chevalier,5,2,3
+Wichita,112,Comptroller of Public Accounts,,LIB,Ben Sanders,0,0,0
+Wichita,112,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,112,Comptroller of Public Accounts,,,Under Votes,0,0,0
+Wichita,112,Commissioner of the General Land Office,,REP,George P. Bush,4,4,0
+Wichita,112,Commissioner of the General Land Office,,DEM,Miguel Suazo,5,2,3
+Wichita,112,Commissioner of the General Land Office,,LIB,Matt Pina,0,0,0
+Wichita,112,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,112,Commissioner of the General Land Office,,,Under Votes,1,0,1
+Wichita,112,Commissioner of Agriculture,,REP,Sid Miller,5,4,1
+Wichita,112,Commissioner of Agriculture,,DEM,Kim Olson,5,2,3
+Wichita,112,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0
+Wichita,112,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,112,Commissioner of Agriculture,,,Under Votes,0,0,0
+Wichita,112,Railroad Commissioner,,REP,Christi Craddick,5,4,1
+Wichita,112,Railroad Commissioner,,DEM,Roman McAllen,5,2,3
+Wichita,112,Railroad Commissioner,,LIB,Mike Wright,0,0,0
+Wichita,112,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,112,Railroad Commissioner,,,Under Votes,0,0,0
+Wichita,112,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,6,5,1
+Wichita,112,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,4,1,3
+Wichita,112,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,112,"Justice, Supreme Court, Place 2",,,Under Votes,0,0,0
+Wichita,112,"Justice, Supreme Court, Place 4",,REP,John Devine,5,4,1
+Wichita,112,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,5,2,3
+Wichita,112,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,112,"Justice, Supreme Court, Place 4",,,Under Votes,0,0,0
+Wichita,112,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,5,4,1
+Wichita,112,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,5,2,3
+Wichita,112,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,112,"Justice, Supreme Court, Place 6",,,Under Votes,0,0,0
+Wichita,112,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,5,4,1
+Wichita,112,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,5,2,3
+Wichita,112,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,0,0,0
+Wichita,112,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,112,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,0,0,0
+Wichita,112,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,5,4,1
+Wichita,112,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,5,2,3
+Wichita,112,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,112,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,0,0,0
+Wichita,112,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,5,4,1
+Wichita,112,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,2,1,1
+Wichita,112,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,112,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,3,1,2
+Wichita,112,State Senator,30,REP,Pat Fallon,5,4,1
+Wichita,112,State Senator,30,DEM,Kevin Lopez,5,2,3
+Wichita,112,State Senator,30,,Over Votes,0,0,0
+Wichita,112,State Senator,30,,Under Votes,0,0,0
+Wichita,112,State Representative,69,REP,James Frank,7,5,2
+Wichita,112,State Representative,69,,Over Votes,0,0,0
+Wichita,112,State Representative,69,,Under Votes,3,1,2
+Wichita,112,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,6,4,2
+Wichita,112,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,112,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,4,2,2
+Wichita,112,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,6,4,2
+Wichita,112,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,112,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,4,2,2
+Wichita,112,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,5,4,1
+Wichita,112,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,5,2,3
+Wichita,112,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,112,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,0,0,0
+Wichita,112,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,6,4,2
+Wichita,112,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,112,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,4,2,2
+Wichita,112,"District Judge, 30th Judicial District",,REP,Jeff McKnight,7,5,2
+Wichita,112,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,112,"District Judge, 30th Judicial District",,,Under Votes,3,1,2
+Wichita,112,Criminal District Attorney,,REP,John Gillespie,7,5,2
+Wichita,112,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,112,Criminal District Attorney,,,Under Votes,3,1,2
+Wichita,112,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",7,5,2
+Wichita,112,County Judge,,,Over Votes,0,0,0
+Wichita,112,County Judge,,,Under Votes,3,1,2
+Wichita,112,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,7,5,2
+Wichita,112,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,112,"Judge, County Court at Law No. 1",,,Under Votes,3,1,2
+Wichita,112,"Judge, County Court at Law No. 2",,REP,Greg King,7,5,2
+Wichita,112,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,112,"Judge, County Court at Law No. 2",,,Under Votes,3,1,2
+Wichita,112,District Clerk,,REP,Patti Flores,7,5,2
+Wichita,112,District Clerk,,,Over Votes,0,0,0
+Wichita,112,District Clerk,,,Under Votes,3,1,2
+Wichita,112,County Clerk,,REP,Lori Bohannon,7,5,2
+Wichita,112,County Clerk,,,Over Votes,0,0,0
+Wichita,112,County Clerk,,,Under Votes,3,1,2
+Wichita,112,County Treasurer,,REP,R. J. Bob Hampton,7,5,2
+Wichita,112,County Treasurer,,,Over Votes,0,0,0
+Wichita,112,County Treasurer,,,Under Votes,3,1,2
+Wichita,112,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,6,4,2
+Wichita,112,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,112,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,4,2,2
+Wichita,112,City of Wichita Falls Mayor,,,Lowry W. Crane,2,1,1
+Wichita,112,City of Wichita Falls Mayor,,,Stephen L. Santellana,5,3,2
+Wichita,112,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,112,City of Wichita Falls Mayor,,,Under Votes,3,2,1
+Wichita,112,City of Wichita Falls Councilor District 3,,,Jeff L. Browning,5,3,2
+Wichita,112,City of Wichita Falls Councilor District 3,,,Over Votes,0,0,0
+Wichita,112,City of Wichita Falls Councilor District 3,,,Under Votes,5,3,2
+Wichita,112,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,5,3,2
+Wichita,112,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,112,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,5,3,2
+Wichita,112,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,2,2,0
+Wichita,112,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,4,2,2
+Wichita,112,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,112,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,4,2,2
+Wichita,112,Ballots Cast,,,,10,6,4
+Wichita,113,Straight Party,,REP,,139,104,35
+Wichita,113,Straight Party,,DEM,,59,38,21
+Wichita,113,Straight Party,,LIB,,1,1,0
+Wichita,113,Straight Party,,,Over Votes,0,0,0
+Wichita,113,Straight Party,,,Under Votes,101,73,28
+Wichita,113,U.S. Senate,,REP,Ted Cruz,197,144,53
+Wichita,113,U.S. Senate,,DEM,Beto O'Rourke,99,69,30
+Wichita,113,U.S. Senate,,LIB,Neal M. Dikeman,3,2,1
+Wichita,113,U.S. Senate,,,Over Votes,0,0,0
+Wichita,113,U.S. Senate,,,Under Votes,1,1,0
+Wichita,113,U.S. House,13,REP,Mac Thornberry,199,148,51
+Wichita,113,U.S. House,13,DEM,Greg Sagan,88,60,28
+Wichita,113,U.S. House,13,LIB,Calvin DeWeese,6,3,3
+Wichita,113,U.S. House,13,,Over Votes,0,0,0
+Wichita,113,U.S. House,13,,Under Votes,7,5,2
+Wichita,113,Governor,,REP,Greg Abbott,204,151,53
+Wichita,113,Governor,,DEM,Lupe Valdez,86,56,30
+Wichita,113,Governor,,LIB,Mark Jay Tippetts,6,5,1
+Wichita,113,Governor,,,Over Votes,0,0,0
+Wichita,113,Governor,,,Under Votes,4,4,0
+Wichita,113,Lieutenant Governor,,REP,Dan Patrick,191,139,52
+Wichita,113,Lieutenant Governor,,DEM,Mike Collier,97,68,29
+Wichita,113,Lieutenant Governor,,LIB,Kerry Douglas McKennon,8,6,2
+Wichita,113,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,113,Lieutenant Governor,,,Under Votes,4,3,1
+Wichita,113,Attorney General,,REP,Ken Paxton,194,141,53
+Wichita,113,Attorney General,,DEM,Justin Nelson,97,68,29
+Wichita,113,Attorney General,,LIB,Michael Ray Harris,4,3,1
+Wichita,113,Attorney General,,,Over Votes,0,0,0
+Wichita,113,Attorney General,,,Under Votes,5,4,1
+Wichita,113,Comptroller of Public Accounts,,REP,Glenn Hegar,192,143,49
+Wichita,113,Comptroller of Public Accounts,,DEM,Joi Chevalier,89,60,29
+Wichita,113,Comptroller of Public Accounts,,LIB,Ben Sanders,10,7,3
+Wichita,113,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,113,Comptroller of Public Accounts,,,Under Votes,9,6,3
+Wichita,113,Commissioner of the General Land Office,,REP,George P. Bush,198,147,51
+Wichita,113,Commissioner of the General Land Office,,DEM,Miguel Suazo,88,58,30
+Wichita,113,Commissioner of the General Land Office,,LIB,Matt Pina,10,9,1
+Wichita,113,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,113,Commissioner of the General Land Office,,,Under Votes,4,2,2
+Wichita,113,Commissioner of Agriculture,,REP,Sid Miller,197,145,52
+Wichita,113,Commissioner of Agriculture,,DEM,Kim Olson,89,63,26
+Wichita,113,Commissioner of Agriculture,,LIB,Richard Carpenter,9,5,4
+Wichita,113,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,113,Commissioner of Agriculture,,,Under Votes,5,3,2
+Wichita,113,Railroad Commissioner,,REP,Christi Craddick,202,148,54
+Wichita,113,Railroad Commissioner,,DEM,Roman McAllen,84,59,25
+Wichita,113,Railroad Commissioner,,LIB,Mike Wright,9,6,3
+Wichita,113,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,113,Railroad Commissioner,,,Under Votes,5,3,2
+Wichita,113,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,201,146,55
+Wichita,113,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,94,67,27
+Wichita,113,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,113,"Justice, Supreme Court, Place 2",,,Under Votes,5,3,2
+Wichita,113,"Justice, Supreme Court, Place 4",,REP,John Devine,196,145,51
+Wichita,113,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,97,68,29
+Wichita,113,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,113,"Justice, Supreme Court, Place 4",,,Under Votes,7,3,4
+Wichita,113,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,196,146,50
+Wichita,113,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,97,67,30
+Wichita,113,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,113,"Justice, Supreme Court, Place 6",,,Under Votes,7,3,4
+Wichita,113,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,194,145,49
+Wichita,113,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,92,62,30
+Wichita,113,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,7,6,1
+Wichita,113,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,113,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,7,3,4
+Wichita,113,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,200,149,51
+Wichita,113,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,93,64,29
+Wichita,113,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,113,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,7,3,4
+Wichita,113,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,208,154,54
+Wichita,113,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,34,23,11
+Wichita,113,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,113,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,58,39,19
+Wichita,113,State Senator,30,REP,Pat Fallon,198,147,51
+Wichita,113,State Senator,30,DEM,Kevin Lopez,98,67,31
+Wichita,113,State Senator,30,,Over Votes,0,0,0
+Wichita,113,State Senator,30,,Under Votes,4,2,2
+Wichita,113,State Representative,69,REP,James Frank,222,164,58
+Wichita,113,State Representative,69,,Over Votes,0,0,0
+Wichita,113,State Representative,69,,Under Votes,78,52,26
+Wichita,113,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,219,162,57
+Wichita,113,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,113,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,81,54,27
+Wichita,113,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,218,163,55
+Wichita,113,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,113,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,82,53,29
+Wichita,113,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,198,146,52
+Wichita,113,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,96,67,29
+Wichita,113,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,113,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,6,3,3
+Wichita,113,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,220,162,58
+Wichita,113,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,113,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,80,54,26
+Wichita,113,"District Judge, 30th Judicial District",,REP,Jeff McKnight,222,164,58
+Wichita,113,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,113,"District Judge, 30th Judicial District",,,Under Votes,78,52,26
+Wichita,113,Criminal District Attorney,,REP,John Gillespie,225,163,62
+Wichita,113,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,113,Criminal District Attorney,,,Under Votes,75,53,22
+Wichita,113,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",220,163,57
+Wichita,113,County Judge,,,Over Votes,0,0,0
+Wichita,113,County Judge,,,Under Votes,80,53,27
+Wichita,113,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,222,163,59
+Wichita,113,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,113,"Judge, County Court at Law No. 1",,,Under Votes,78,53,25
+Wichita,113,"Judge, County Court at Law No. 2",,REP,Greg King,220,162,58
+Wichita,113,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,113,"Judge, County Court at Law No. 2",,,Under Votes,80,54,26
+Wichita,113,District Clerk,,REP,Patti Flores,218,160,58
+Wichita,113,District Clerk,,,Over Votes,0,0,0
+Wichita,113,District Clerk,,,Under Votes,82,56,26
+Wichita,113,County Clerk,,REP,Lori Bohannon,224,163,61
+Wichita,113,County Clerk,,,Over Votes,0,0,0
+Wichita,113,County Clerk,,,Under Votes,76,53,23
+Wichita,113,County Treasurer,,REP,R. J. Bob Hampton,219,163,56
+Wichita,113,County Treasurer,,,Over Votes,0,0,0
+Wichita,113,County Treasurer,,,Under Votes,81,53,28
+Wichita,113,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,222,162,60
+Wichita,113,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,113,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,78,54,24
+Wichita,113,City of Wichita Falls Mayor,,,Lowry W. Crane,75,54,21
+Wichita,113,City of Wichita Falls Mayor,,,Stephen L. Santellana,152,107,45
+Wichita,113,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,113,City of Wichita Falls Mayor,,,Under Votes,73,55,18
+Wichita,113,City of Wichita Falls Councilor District 4,,,Tim Brewer,115,78,37
+Wichita,113,City of Wichita Falls Councilor District 4,,,Nicholas J. Schreiber,79,57,22
+Wichita,113,City of Wichita Falls Councilor District 4,,,Over Votes,0,0,0
+Wichita,113,City of Wichita Falls Councilor District 4,,,Under Votes,106,81,25
+Wichita,113,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,185,130,55
+Wichita,113,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,113,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,115,86,29
+Wichita,113,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,139,94,45
+Wichita,113,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,71,52,19
+Wichita,113,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,1,1,0
+Wichita,113,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,89,69,20
+Wichita,113,Ballots Cast,,,,300,216,84
+Wichita,114,Straight Party,,REP,,13,10,3
+Wichita,114,Straight Party,,DEM,,1,0,1
+Wichita,114,Straight Party,,LIB,,0,0,0
+Wichita,114,Straight Party,,,Over Votes,0,0,0
+Wichita,114,Straight Party,,,Under Votes,6,4,2
+Wichita,114,U.S. Senate,,REP,Ted Cruz,17,13,4
+Wichita,114,U.S. Senate,,DEM,Beto O'Rourke,4,2,2
+Wichita,114,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0
+Wichita,114,U.S. Senate,,,Over Votes,0,0,0
+Wichita,114,U.S. Senate,,,Under Votes,0,0,0
+Wichita,114,U.S. House,13,REP,Mac Thornberry,17,13,4
+Wichita,114,U.S. House,13,DEM,Greg Sagan,3,1,2
+Wichita,114,U.S. House,13,LIB,Calvin DeWeese,0,0,0
+Wichita,114,U.S. House,13,,Over Votes,0,0,0
+Wichita,114,U.S. House,13,,Under Votes,0,0,0
+Wichita,114,Governor,,REP,Greg Abbott,17,13,4
+Wichita,114,Governor,,DEM,Lupe Valdez,3,1,2
+Wichita,114,Governor,,LIB,Mark Jay Tippetts,0,0,0
+Wichita,114,Governor,,,Over Votes,0,0,0
+Wichita,114,Governor,,,Under Votes,0,0,0
+Wichita,114,Lieutenant Governor,,REP,Dan Patrick,17,13,4
+Wichita,114,Lieutenant Governor,,DEM,Mike Collier,3,1,2
+Wichita,114,Lieutenant Governor,,LIB,Kerry Douglas McKennon,0,0,0
+Wichita,114,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,114,Lieutenant Governor,,,Under Votes,0,0,0
+Wichita,114,Attorney General,,REP,Ken Paxton,18,14,4
+Wichita,114,Attorney General,,DEM,Justin Nelson,3,1,2
+Wichita,114,Attorney General,,LIB,Michael Ray Harris,0,0,0
+Wichita,114,Attorney General,,,Over Votes,0,0,0
+Wichita,114,Attorney General,,,Under Votes,0,0,0
+Wichita,114,Comptroller of Public Accounts,,REP,Glenn Hegar,16,12,4
+Wichita,114,Comptroller of Public Accounts,,DEM,Joi Chevalier,3,1,2
+Wichita,114,Comptroller of Public Accounts,,LIB,Ben Sanders,1,1,0
+Wichita,114,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,114,Comptroller of Public Accounts,,,Under Votes,0,0,0
+Wichita,114,Commissioner of the General Land Office,,REP,George P. Bush,17,13,4
+Wichita,114,Commissioner of the General Land Office,,DEM,Miguel Suazo,3,1,2
+Wichita,114,Commissioner of the General Land Office,,LIB,Matt Pina,0,0,0
+Wichita,114,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,114,Commissioner of the General Land Office,,,Under Votes,0,0,0
+Wichita,114,Commissioner of Agriculture,,REP,Sid Miller,16,12,4
+Wichita,114,Commissioner of Agriculture,,DEM,Kim Olson,4,2,2
+Wichita,114,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0
+Wichita,114,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,114,Commissioner of Agriculture,,,Under Votes,0,0,0
+Wichita,114,Railroad Commissioner,,REP,Christi Craddick,17,13,4
+Wichita,114,Railroad Commissioner,,DEM,Roman McAllen,3,1,2
+Wichita,114,Railroad Commissioner,,LIB,Mike Wright,0,0,0
+Wichita,114,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,114,Railroad Commissioner,,,Under Votes,0,0,0
+Wichita,114,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,17,13,4
+Wichita,114,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,3,1,2
+Wichita,114,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,114,"Justice, Supreme Court, Place 2",,,Under Votes,0,0,0
+Wichita,114,"Justice, Supreme Court, Place 4",,REP,John Devine,16,12,4
+Wichita,114,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,4,2,2
+Wichita,114,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,114,"Justice, Supreme Court, Place 4",,,Under Votes,0,0,0
+Wichita,114,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,17,13,4
+Wichita,114,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,3,1,2
+Wichita,114,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,114,"Justice, Supreme Court, Place 6",,,Under Votes,0,0,0
+Wichita,114,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,16,12,4
+Wichita,114,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,4,2,2
+Wichita,114,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,0,0,0
+Wichita,114,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,114,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,0,0,0
+Wichita,114,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,17,13,4
+Wichita,114,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,3,1,2
+Wichita,114,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,114,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,0,0,0
+Wichita,114,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,17,13,4
+Wichita,114,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,2,1,1
+Wichita,114,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,114,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,1,0,1
+Wichita,114,State Senator,30,REP,Pat Fallon,16,12,4
+Wichita,114,State Senator,30,DEM,Kevin Lopez,4,2,2
+Wichita,114,State Senator,30,,Over Votes,0,0,0
+Wichita,114,State Senator,30,,Under Votes,0,0,0
+Wichita,114,State Representative,69,REP,James Frank,18,13,5
+Wichita,114,State Representative,69,,Over Votes,0,0,0
+Wichita,114,State Representative,69,,Under Votes,2,1,1
+Wichita,114,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,18,13,5
+Wichita,114,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,114,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,2,1,1
+Wichita,114,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,18,13,5
+Wichita,114,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,114,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,2,1,1
+Wichita,114,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,17,13,4
+Wichita,114,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,3,1,2
+Wichita,114,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,114,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,0,0,0
+Wichita,114,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,18,13,5
+Wichita,114,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,114,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,2,1,1
+Wichita,114,"District Judge, 30th Judicial District",,REP,Jeff McKnight,18,13,5
+Wichita,114,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,114,"District Judge, 30th Judicial District",,,Under Votes,2,1,1
+Wichita,114,Criminal District Attorney,,REP,John Gillespie,18,13,5
+Wichita,114,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,114,Criminal District Attorney,,,Under Votes,2,1,1
+Wichita,114,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",18,13,5
+Wichita,114,County Judge,,,Over Votes,0,0,0
+Wichita,114,County Judge,,,Under Votes,2,1,1
+Wichita,114,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,18,13,5
+Wichita,114,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,114,"Judge, County Court at Law No. 1",,,Under Votes,2,1,1
+Wichita,114,"Judge, County Court at Law No. 2",,REP,Greg King,18,13,5
+Wichita,114,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,114,"Judge, County Court at Law No. 2",,,Under Votes,2,1,1
+Wichita,114,District Clerk,,REP,Patti Flores,18,13,5
+Wichita,114,District Clerk,,,Over Votes,0,0,0
+Wichita,114,District Clerk,,,Under Votes,2,1,1
+Wichita,114,County Clerk,,REP,Lori Bohannon,18,13,5
+Wichita,114,County Clerk,,,Over Votes,0,0,0
+Wichita,114,County Clerk,,,Under Votes,2,1,1
+Wichita,114,County Treasurer,,REP,R. J. Bob Hampton,18,13,5
+Wichita,114,County Treasurer,,,Over Votes,0,0,0
+Wichita,114,County Treasurer,,,Under Votes,2,1,1
+Wichita,114,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,18,13,5
+Wichita,114,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,114,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,2,1,1
+Wichita,114,City of Wichita Falls Mayor,,,Lowry W. Crane,7,4,3
+Wichita,114,City of Wichita Falls Mayor,,,Stephen L. Santellana,4,3,1
+Wichita,114,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,114,City of Wichita Falls Mayor,,,Under Votes,2,0,2
+Wichita,114,Wichita Falls ISD Single Member District 3,,,Mark Lukert,7,5,2
+Wichita,114,Wichita Falls ISD Single Member District 3,,,Adam W. Groves,8,6,2
+Wichita,114,Wichita Falls ISD Single Member District 3,,,Over Votes,0,0,0
+Wichita,114,Wichita Falls ISD Single Member District 3,,,Under Votes,5,3,2
+Wichita,114,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,15,11,4
+Wichita,114,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,114,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,5,3,2
+Wichita,114,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,10,7,3
+Wichita,114,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,8,7,1
+Wichita,114,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,114,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,3,1,2
+Wichita,114,Ballots Cast,,,,21,15,6
+Wichita,115,Straight Party,,REP,,1,1,0
+Wichita,115,Straight Party,,DEM,,2,2,0
+Wichita,115,Straight Party,,LIB,,0,0,0
+Wichita,115,Straight Party,,,Over Votes,0,0,0
+Wichita,115,Straight Party,,,Under Votes,0,0,0
+Wichita,115,U.S. Senate,,REP,Ted Cruz,1,1,0
+Wichita,115,U.S. Senate,,DEM,Beto O'Rourke,2,2,0
+Wichita,115,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0
+Wichita,115,U.S. Senate,,,Over Votes,0,0,0
+Wichita,115,U.S. Senate,,,Under Votes,0,0,0
+Wichita,115,U.S. House,13,REP,Mac Thornberry,1,1,0
+Wichita,115,U.S. House,13,DEM,Greg Sagan,2,2,0
+Wichita,115,U.S. House,13,LIB,Calvin DeWeese,0,0,0
+Wichita,115,U.S. House,13,,Over Votes,0,0,0
+Wichita,115,U.S. House,13,,Under Votes,0,0,0
+Wichita,115,Governor,,REP,Greg Abbott,1,1,0
+Wichita,115,Governor,,DEM,Lupe Valdez,2,2,0
+Wichita,115,Governor,,LIB,Mark Jay Tippetts,0,0,0
+Wichita,115,Governor,,,Over Votes,0,0,0
+Wichita,115,Governor,,,Under Votes,0,0,0
+Wichita,115,Lieutenant Governor,,REP,Dan Patrick,1,1,0
+Wichita,115,Lieutenant Governor,,DEM,Mike Collier,2,2,0
+Wichita,115,Lieutenant Governor,,LIB,Kerry Douglas McKennon,0,0,0
+Wichita,115,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,115,Lieutenant Governor,,,Under Votes,0,0,0
+Wichita,115,Attorney General,,REP,Ken Paxton,1,1,0
+Wichita,115,Attorney General,,DEM,Justin Nelson,2,2,0
+Wichita,115,Attorney General,,LIB,Michael Ray Harris,0,0,0
+Wichita,115,Attorney General,,,Over Votes,0,0,0
+Wichita,115,Attorney General,,,Under Votes,0,0,0
+Wichita,115,Comptroller of Public Accounts,,REP,Glenn Hegar,1,1,0
+Wichita,115,Comptroller of Public Accounts,,DEM,Joi Chevalier,2,2,0
+Wichita,115,Comptroller of Public Accounts,,LIB,Ben Sanders,0,0,0
+Wichita,115,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,115,Comptroller of Public Accounts,,,Under Votes,0,0,0
+Wichita,115,Commissioner of the General Land Office,,REP,George P. Bush,1,1,0
+Wichita,115,Commissioner of the General Land Office,,DEM,Miguel Suazo,2,2,0
+Wichita,115,Commissioner of the General Land Office,,LIB,Matt Pina,0,0,0
+Wichita,115,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,115,Commissioner of the General Land Office,,,Under Votes,0,0,0
+Wichita,115,Commissioner of Agriculture,,REP,Sid Miller,1,1,0
+Wichita,115,Commissioner of Agriculture,,DEM,Kim Olson,2,2,0
+Wichita,115,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0
+Wichita,115,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,115,Commissioner of Agriculture,,,Under Votes,0,0,0
+Wichita,115,Railroad Commissioner,,REP,Christi Craddick,1,1,0
+Wichita,115,Railroad Commissioner,,DEM,Roman McAllen,2,2,0
+Wichita,115,Railroad Commissioner,,LIB,Mike Wright,0,0,0
+Wichita,115,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,115,Railroad Commissioner,,,Under Votes,0,0,0
+Wichita,115,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1,1,0
+Wichita,115,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,2,2,0
+Wichita,115,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,115,"Justice, Supreme Court, Place 2",,,Under Votes,0,0,0
+Wichita,115,"Justice, Supreme Court, Place 4",,REP,John Devine,1,1,0
+Wichita,115,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,2,2,0
+Wichita,115,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,115,"Justice, Supreme Court, Place 4",,,Under Votes,0,0,0
+Wichita,115,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1,1,0
+Wichita,115,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,2,2,0
+Wichita,115,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,115,"Justice, Supreme Court, Place 6",,,Under Votes,0,0,0
+Wichita,115,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1,1,0
+Wichita,115,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,2,2,0
+Wichita,115,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,0,0,0
+Wichita,115,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,115,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,0,0,0
+Wichita,115,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1,1,0
+Wichita,115,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,2,2,0
+Wichita,115,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,115,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,0,0,0
+Wichita,115,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1,1,0
+Wichita,115,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,0,0,0
+Wichita,115,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,115,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,2,2,0
+Wichita,115,State Senator,30,REP,Pat Fallon,1,1,0
+Wichita,115,State Senator,30,DEM,Kevin Lopez,2,2,0
+Wichita,115,State Senator,30,,Over Votes,0,0,0
+Wichita,115,State Senator,30,,Under Votes,0,0,0
+Wichita,115,State Representative,69,REP,James Frank,1,1,0
+Wichita,115,State Representative,69,,Over Votes,0,0,0
+Wichita,115,State Representative,69,,Under Votes,2,2,0
+Wichita,115,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,1,1,0
+Wichita,115,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,115,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,2,2,0
+Wichita,115,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,1,1,0
+Wichita,115,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,115,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,2,2,0
+Wichita,115,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,1,1,0
+Wichita,115,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,2,2,0
+Wichita,115,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,115,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,0,0,0
+Wichita,115,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,1,1,0
+Wichita,115,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,115,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,2,2,0
+Wichita,115,"District Judge, 30th Judicial District",,REP,Jeff McKnight,1,1,0
+Wichita,115,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,115,"District Judge, 30th Judicial District",,,Under Votes,2,2,0
+Wichita,115,Criminal District Attorney,,REP,John Gillespie,1,1,0
+Wichita,115,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,115,Criminal District Attorney,,,Under Votes,2,2,0
+Wichita,115,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",1,1,0
+Wichita,115,County Judge,,,Over Votes,0,0,0
+Wichita,115,County Judge,,,Under Votes,2,2,0
+Wichita,115,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,1,1,0
+Wichita,115,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,115,"Judge, County Court at Law No. 1",,,Under Votes,2,2,0
+Wichita,115,"Judge, County Court at Law No. 2",,REP,Greg King,1,1,0
+Wichita,115,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,115,"Judge, County Court at Law No. 2",,,Under Votes,2,2,0
+Wichita,115,District Clerk,,REP,Patti Flores,1,1,0
+Wichita,115,District Clerk,,,Over Votes,0,0,0
+Wichita,115,District Clerk,,,Under Votes,2,2,0
+Wichita,115,County Clerk,,REP,Lori Bohannon,1,1,0
+Wichita,115,County Clerk,,,Over Votes,0,0,0
+Wichita,115,County Clerk,,,Under Votes,2,2,0
+Wichita,115,County Treasurer,,REP,R. J. Bob Hampton,1,1,0
+Wichita,115,County Treasurer,,,Over Votes,0,0,0
+Wichita,115,County Treasurer,,,Under Votes,2,2,0
+Wichita,115,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,1,1,0
+Wichita,115,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,115,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,2,2,0
+Wichita,115,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,0,0,0
+Wichita,115,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,115,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,3,3,0
+Wichita,115,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,0,0,0
+Wichita,115,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,0,0,0
+Wichita,115,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,115,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,3,3,0
+Wichita,115,Ballots Cast,,,,3,3,0
+Wichita,116,Straight Party,,REP,,9,4,5
+Wichita,116,Straight Party,,DEM,,1,1,0
+Wichita,116,Straight Party,,LIB,,0,0,0
+Wichita,116,Straight Party,,,Over Votes,0,0,0
+Wichita,116,Straight Party,,,Under Votes,9,7,2
+Wichita,116,U.S. Senate,,REP,Ted Cruz,17,10,7
+Wichita,116,U.S. Senate,,DEM,Beto O'Rourke,2,2,0
+Wichita,116,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0
+Wichita,116,U.S. Senate,,,Over Votes,0,0,0
+Wichita,116,U.S. Senate,,,Under Votes,0,0,0
+Wichita,116,U.S. House,13,REP,Mac Thornberry,16,9,7
+Wichita,116,U.S. House,13,DEM,Greg Sagan,2,2,0
+Wichita,116,U.S. House,13,LIB,Calvin DeWeese,1,1,0
+Wichita,116,U.S. House,13,,Over Votes,0,0,0
+Wichita,116,U.S. House,13,,Under Votes,0,0,0
+Wichita,116,Governor,,REP,Greg Abbott,17,10,7
+Wichita,116,Governor,,DEM,Lupe Valdez,2,2,0
+Wichita,116,Governor,,LIB,Mark Jay Tippetts,0,0,0
+Wichita,116,Governor,,,Over Votes,0,0,0
+Wichita,116,Governor,,,Under Votes,0,0,0
+Wichita,116,Lieutenant Governor,,REP,Dan Patrick,16,10,6
+Wichita,116,Lieutenant Governor,,DEM,Mike Collier,3,2,1
+Wichita,116,Lieutenant Governor,,LIB,Kerry Douglas McKennon,0,0,0
+Wichita,116,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,116,Lieutenant Governor,,,Under Votes,0,0,0
+Wichita,116,Attorney General,,REP,Ken Paxton,17,10,7
+Wichita,116,Attorney General,,DEM,Justin Nelson,2,2,0
+Wichita,116,Attorney General,,LIB,Michael Ray Harris,0,0,0
+Wichita,116,Attorney General,,,Over Votes,0,0,0
+Wichita,116,Attorney General,,,Under Votes,0,0,0
+Wichita,116,Comptroller of Public Accounts,,REP,Glenn Hegar,17,10,7
+Wichita,116,Comptroller of Public Accounts,,DEM,Joi Chevalier,2,2,0
+Wichita,116,Comptroller of Public Accounts,,LIB,Ben Sanders,0,0,0
+Wichita,116,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,116,Comptroller of Public Accounts,,,Under Votes,0,0,0
+Wichita,116,Commissioner of the General Land Office,,REP,George P. Bush,17,10,7
+Wichita,116,Commissioner of the General Land Office,,DEM,Miguel Suazo,2,2,0
+Wichita,116,Commissioner of the General Land Office,,LIB,Matt Pina,0,0,0
+Wichita,116,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,116,Commissioner of the General Land Office,,,Under Votes,0,0,0
+Wichita,116,Commissioner of Agriculture,,REP,Sid Miller,16,10,6
+Wichita,116,Commissioner of Agriculture,,DEM,Kim Olson,3,2,1
+Wichita,116,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0
+Wichita,116,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,116,Commissioner of Agriculture,,,Under Votes,0,0,0
+Wichita,116,Railroad Commissioner,,REP,Christi Craddick,17,10,7
+Wichita,116,Railroad Commissioner,,DEM,Roman McAllen,2,2,0
+Wichita,116,Railroad Commissioner,,LIB,Mike Wright,0,0,0
+Wichita,116,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,116,Railroad Commissioner,,,Under Votes,0,0,0
+Wichita,116,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,17,10,7
+Wichita,116,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,2,2,0
+Wichita,116,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,116,"Justice, Supreme Court, Place 2",,,Under Votes,0,0,0
+Wichita,116,"Justice, Supreme Court, Place 4",,REP,John Devine,16,10,6
+Wichita,116,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,3,2,1
+Wichita,116,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,116,"Justice, Supreme Court, Place 4",,,Under Votes,0,0,0
+Wichita,116,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,15,9,6
+Wichita,116,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,3,2,1
+Wichita,116,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,116,"Justice, Supreme Court, Place 6",,,Under Votes,1,1,0
+Wichita,116,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,16,10,6
+Wichita,116,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,3,2,1
+Wichita,116,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,0,0,0
+Wichita,116,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,116,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,0,0,0
+Wichita,116,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,16,10,6
+Wichita,116,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,3,2,1
+Wichita,116,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,116,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,0,0,0
+Wichita,116,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,17,10,7
+Wichita,116,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,1,1,0
+Wichita,116,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,116,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,1,1,0
+Wichita,116,State Senator,30,REP,Pat Fallon,17,10,7
+Wichita,116,State Senator,30,DEM,Kevin Lopez,2,2,0
+Wichita,116,State Senator,30,,Over Votes,0,0,0
+Wichita,116,State Senator,30,,Under Votes,0,0,0
+Wichita,116,State Representative,69,REP,James Frank,17,10,7
+Wichita,116,State Representative,69,,Over Votes,0,0,0
+Wichita,116,State Representative,69,,Under Votes,2,2,0
+Wichita,116,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,16,10,6
+Wichita,116,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,116,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,3,2,1
+Wichita,116,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,16,10,6
+Wichita,116,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,116,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,3,2,1
+Wichita,116,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,16,10,6
+Wichita,116,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,3,2,1
+Wichita,116,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,116,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,0,0,0
+Wichita,116,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,16,10,6
+Wichita,116,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,116,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,3,2,1
+Wichita,116,"District Judge, 30th Judicial District",,REP,Jeff McKnight,15,9,6
+Wichita,116,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,116,"District Judge, 30th Judicial District",,,Under Votes,4,3,1
+Wichita,116,Criminal District Attorney,,REP,John Gillespie,16,9,7
+Wichita,116,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,116,Criminal District Attorney,,,Under Votes,3,3,0
+Wichita,116,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",17,10,7
+Wichita,116,County Judge,,,Over Votes,0,0,0
+Wichita,116,County Judge,,,Under Votes,2,2,0
+Wichita,116,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,16,10,6
+Wichita,116,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,116,"Judge, County Court at Law No. 1",,,Under Votes,3,2,1
+Wichita,116,"Judge, County Court at Law No. 2",,REP,Greg King,16,10,6
+Wichita,116,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,116,"Judge, County Court at Law No. 2",,,Under Votes,3,2,1
+Wichita,116,District Clerk,,REP,Patti Flores,17,10,7
+Wichita,116,District Clerk,,,Over Votes,0,0,0
+Wichita,116,District Clerk,,,Under Votes,2,2,0
+Wichita,116,County Clerk,,REP,Lori Bohannon,17,10,7
+Wichita,116,County Clerk,,,Over Votes,0,0,0
+Wichita,116,County Clerk,,,Under Votes,2,2,0
+Wichita,116,County Treasurer,,REP,R. J. Bob Hampton,16,10,6
+Wichita,116,County Treasurer,,,Over Votes,0,0,0
+Wichita,116,County Treasurer,,,Under Votes,3,2,1
+Wichita,116,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,16,10,6
+Wichita,116,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,116,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,3,2,1
+Wichita,116,Wichita Falls ISD Single Member District 5,,,Tom Bursey,9,7,2
+Wichita,116,Wichita Falls ISD Single Member District 5,,,Over Votes,0,0,0
+Wichita,116,Wichita Falls ISD Single Member District 5,,,Under Votes,10,5,5
+Wichita,116,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,11,7,4
+Wichita,116,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,116,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,8,5,3
+Wichita,116,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,7,5,2
+Wichita,116,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,6,3,3
+Wichita,116,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,116,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,6,4,2
+Wichita,116,Ballots Cast,,,,19,12,7
+Wichita,117,Straight Party,,REP,,18,17,1
+Wichita,117,Straight Party,,DEM,,1,1,0
+Wichita,117,Straight Party,,LIB,,0,0,0
+Wichita,117,Straight Party,,,Over Votes,0,0,0
+Wichita,117,Straight Party,,,Under Votes,9,9,0
+Wichita,117,U.S. Senate,,REP,Ted Cruz,26,25,1
+Wichita,117,U.S. Senate,,DEM,Beto O'Rourke,2,2,0
+Wichita,117,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0
+Wichita,117,U.S. Senate,,,Over Votes,0,0,0
+Wichita,117,U.S. Senate,,,Under Votes,0,0,0
+Wichita,117,U.S. House,13,REP,Mac Thornberry,25,24,1
+Wichita,117,U.S. House,13,DEM,Greg Sagan,2,2,0
+Wichita,117,U.S. House,13,LIB,Calvin DeWeese,1,1,0
+Wichita,117,U.S. House,13,,Over Votes,0,0,0
+Wichita,117,U.S. House,13,,Under Votes,0,0,0
+Wichita,117,Governor,,REP,Greg Abbott,26,25,1
+Wichita,117,Governor,,DEM,Lupe Valdez,2,2,0
+Wichita,117,Governor,,LIB,Mark Jay Tippetts,0,0,0
+Wichita,117,Governor,,,Over Votes,0,0,0
+Wichita,117,Governor,,,Under Votes,0,0,0
+Wichita,117,Lieutenant Governor,,REP,Dan Patrick,26,25,1
+Wichita,117,Lieutenant Governor,,DEM,Mike Collier,2,2,0
+Wichita,117,Lieutenant Governor,,LIB,Kerry Douglas McKennon,0,0,0
+Wichita,117,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,117,Lieutenant Governor,,,Under Votes,0,0,0
+Wichita,117,Attorney General,,REP,Ken Paxton,24,23,1
+Wichita,117,Attorney General,,DEM,Justin Nelson,3,3,0
+Wichita,117,Attorney General,,LIB,Michael Ray Harris,0,0,0
+Wichita,117,Attorney General,,,Over Votes,0,0,0
+Wichita,117,Attorney General,,,Under Votes,1,1,0
+Wichita,117,Comptroller of Public Accounts,,REP,Glenn Hegar,25,24,1
+Wichita,117,Comptroller of Public Accounts,,DEM,Joi Chevalier,2,2,0
+Wichita,117,Comptroller of Public Accounts,,LIB,Ben Sanders,0,0,0
+Wichita,117,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,117,Comptroller of Public Accounts,,,Under Votes,1,1,0
+Wichita,117,Commissioner of the General Land Office,,REP,George P. Bush,27,26,1
+Wichita,117,Commissioner of the General Land Office,,DEM,Miguel Suazo,1,1,0
+Wichita,117,Commissioner of the General Land Office,,LIB,Matt Pina,0,0,0
+Wichita,117,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,117,Commissioner of the General Land Office,,,Under Votes,0,0,0
+Wichita,117,Commissioner of Agriculture,,REP,Sid Miller,24,23,1
+Wichita,117,Commissioner of Agriculture,,DEM,Kim Olson,3,3,0
+Wichita,117,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0
+Wichita,117,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,117,Commissioner of Agriculture,,,Under Votes,1,1,0
+Wichita,117,Railroad Commissioner,,REP,Christi Craddick,24,23,1
+Wichita,117,Railroad Commissioner,,DEM,Roman McAllen,3,3,0
+Wichita,117,Railroad Commissioner,,LIB,Mike Wright,0,0,0
+Wichita,117,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,117,Railroad Commissioner,,,Under Votes,1,1,0
+Wichita,117,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,26,25,1
+Wichita,117,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,2,2,0
+Wichita,117,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,117,"Justice, Supreme Court, Place 2",,,Under Votes,0,0,0
+Wichita,117,"Justice, Supreme Court, Place 4",,REP,John Devine,26,25,1
+Wichita,117,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,2,2,0
+Wichita,117,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,117,"Justice, Supreme Court, Place 4",,,Under Votes,0,0,0
+Wichita,117,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,26,25,1
+Wichita,117,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,2,2,0
+Wichita,117,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,117,"Justice, Supreme Court, Place 6",,,Under Votes,0,0,0
+Wichita,117,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,26,25,1
+Wichita,117,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,2,2,0
+Wichita,117,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,0,0,0
+Wichita,117,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,117,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,0,0,0
+Wichita,117,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,25,24,1
+Wichita,117,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,3,3,0
+Wichita,117,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,117,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,0,0,0
+Wichita,117,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,25,24,1
+Wichita,117,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,2,2,0
+Wichita,117,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,117,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,1,1,0
+Wichita,117,State Senator,30,REP,Pat Fallon,26,25,1
+Wichita,117,State Senator,30,DEM,Kevin Lopez,2,2,0
+Wichita,117,State Senator,30,,Over Votes,0,0,0
+Wichita,117,State Senator,30,,Under Votes,0,0,0
+Wichita,117,State Representative,69,REP,James Frank,27,26,1
+Wichita,117,State Representative,69,,Over Votes,0,0,0
+Wichita,117,State Representative,69,,Under Votes,1,1,0
+Wichita,117,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,26,25,1
+Wichita,117,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,117,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,2,2,0
+Wichita,117,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,25,24,1
+Wichita,117,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,117,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,3,3,0
+Wichita,117,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,24,23,1
+Wichita,117,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,4,4,0
+Wichita,117,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,117,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,0,0,0
+Wichita,117,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,26,25,1
+Wichita,117,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,117,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,2,2,0
+Wichita,117,"District Judge, 30th Judicial District",,REP,Jeff McKnight,26,25,1
+Wichita,117,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,117,"District Judge, 30th Judicial District",,,Under Votes,2,2,0
+Wichita,117,Criminal District Attorney,,REP,John Gillespie,26,25,1
+Wichita,117,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,117,Criminal District Attorney,,,Under Votes,2,2,0
+Wichita,117,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",22,21,1
+Wichita,117,County Judge,,,Over Votes,0,0,0
+Wichita,117,County Judge,,,Under Votes,6,6,0
+Wichita,117,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,25,24,1
+Wichita,117,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,117,"Judge, County Court at Law No. 1",,,Under Votes,3,3,0
+Wichita,117,"Judge, County Court at Law No. 2",,REP,Greg King,24,23,1
+Wichita,117,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,117,"Judge, County Court at Law No. 2",,,Under Votes,4,4,0
+Wichita,117,District Clerk,,REP,Patti Flores,24,23,1
+Wichita,117,District Clerk,,,Over Votes,0,0,0
+Wichita,117,District Clerk,,,Under Votes,4,4,0
+Wichita,117,County Clerk,,REP,Lori Bohannon,24,23,1
+Wichita,117,County Clerk,,,Over Votes,0,0,0
+Wichita,117,County Clerk,,,Under Votes,4,4,0
+Wichita,117,County Treasurer,,REP,R. J. Bob Hampton,26,25,1
+Wichita,117,County Treasurer,,,Over Votes,0,0,0
+Wichita,117,County Treasurer,,,Under Votes,2,2,0
+Wichita,117,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,26,25,1
+Wichita,117,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,117,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,2,2,0
+Wichita,117,City of Wichita Falls Mayor,,,Lowry W. Crane,3,3,0
+Wichita,117,City of Wichita Falls Mayor,,,Stephen L. Santellana,1,1,0
+Wichita,117,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,117,City of Wichita Falls Mayor,,,Under Votes,4,4,0
+Wichita,117,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,14,14,0
+Wichita,117,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,117,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,14,13,1
+Wichita,117,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,12,12,0
+Wichita,117,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,5,4,1
+Wichita,117,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,117,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,11,11,0
+Wichita,117,Ballots Cast,,,,28,27,1
+Wichita,201,Straight Party,,REP,,237,163,74
+Wichita,201,Straight Party,,DEM,,77,63,14
+Wichita,201,Straight Party,,LIB,,0,0,0
+Wichita,201,Straight Party,,,Over Votes,0,0,0
+Wichita,201,Straight Party,,,Under Votes,212,154,58
+Wichita,201,U.S. Senate,,REP,Ted Cruz,375,263,112
+Wichita,201,U.S. Senate,,DEM,Beto O'Rourke,136,107,29
+Wichita,201,U.S. Senate,,LIB,Neal M. Dikeman,12,9,3
+Wichita,201,U.S. Senate,,,Over Votes,0,0,0
+Wichita,201,U.S. Senate,,,Under Votes,2,0,2
+Wichita,201,U.S. House,13,REP,Mac Thornberry,391,271,120
+Wichita,201,U.S. House,13,DEM,Greg Sagan,117,94,23
+Wichita,201,U.S. House,13,LIB,Calvin DeWeese,15,13,2
+Wichita,201,U.S. House,13,,Over Votes,0,0,0
+Wichita,201,U.S. House,13,,Under Votes,2,1,1
+Wichita,201,Governor,,REP,Greg Abbott,399,278,121
+Wichita,201,Governor,,DEM,Lupe Valdez,116,93,23
+Wichita,201,Governor,,LIB,Mark Jay Tippetts,8,7,1
+Wichita,201,Governor,,,Over Votes,0,0,0
+Wichita,201,Governor,,,Under Votes,2,1,1
+Wichita,201,Lieutenant Governor,,REP,Dan Patrick,374,263,111
+Wichita,201,Lieutenant Governor,,DEM,Mike Collier,128,99,29
+Wichita,201,Lieutenant Governor,,LIB,Kerry Douglas McKennon,19,14,5
+Wichita,201,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,201,Lieutenant Governor,,,Under Votes,4,3,1
+Wichita,201,Attorney General,,REP,Ken Paxton,374,259,115
+Wichita,201,Attorney General,,DEM,Justin Nelson,127,103,24
+Wichita,201,Attorney General,,LIB,Michael Ray Harris,18,15,3
+Wichita,201,Attorney General,,,Over Votes,1,1,0
+Wichita,201,Attorney General,,,Under Votes,5,1,4
+Wichita,201,Comptroller of Public Accounts,,REP,Glenn Hegar,368,254,114
+Wichita,201,Comptroller of Public Accounts,,DEM,Joi Chevalier,121,98,23
+Wichita,201,Comptroller of Public Accounts,,LIB,Ben Sanders,24,19,5
+Wichita,201,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,201,Comptroller of Public Accounts,,,Under Votes,12,8,4
+Wichita,201,Commissioner of the General Land Office,,REP,George P. Bush,372,260,112
+Wichita,201,Commissioner of the General Land Office,,DEM,Miguel Suazo,119,96,23
+Wichita,201,Commissioner of the General Land Office,,LIB,Matt Pina,21,14,7
+Wichita,201,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,201,Commissioner of the General Land Office,,,Under Votes,13,9,4
+Wichita,201,Commissioner of Agriculture,,REP,Sid Miller,357,246,111
+Wichita,201,Commissioner of Agriculture,,DEM,Kim Olson,132,107,25
+Wichita,201,Commissioner of Agriculture,,LIB,Richard Carpenter,22,16,6
+Wichita,201,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,201,Commissioner of Agriculture,,,Under Votes,14,10,4
+Wichita,201,Railroad Commissioner,,REP,Christi Craddick,373,256,117
+Wichita,201,Railroad Commissioner,,DEM,Roman McAllen,115,92,23
+Wichita,201,Railroad Commissioner,,LIB,Mike Wright,25,22,3
+Wichita,201,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,201,Railroad Commissioner,,,Under Votes,12,9,3
+Wichita,201,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,383,267,116
+Wichita,201,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,130,102,28
+Wichita,201,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,201,"Justice, Supreme Court, Place 2",,,Under Votes,12,10,2
+Wichita,201,"Justice, Supreme Court, Place 4",,REP,John Devine,383,266,117
+Wichita,201,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,122,98,24
+Wichita,201,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,201,"Justice, Supreme Court, Place 4",,,Under Votes,20,15,5
+Wichita,201,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,382,263,119
+Wichita,201,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,125,102,23
+Wichita,201,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,201,"Justice, Supreme Court, Place 6",,,Under Votes,18,14,4
+Wichita,201,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,370,260,110
+Wichita,201,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,122,95,27
+Wichita,201,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,17,12,5
+Wichita,201,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,201,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,16,12,4
+Wichita,201,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,382,265,117
+Wichita,201,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,124,99,25
+Wichita,201,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,201,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,19,15,4
+Wichita,201,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,397,274,123
+Wichita,201,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,55,47,8
+Wichita,201,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,201,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,73,58,15
+Wichita,201,State Senator,30,REP,Pat Fallon,388,271,117
+Wichita,201,State Senator,30,DEM,Kevin Lopez,125,100,25
+Wichita,201,State Senator,30,,Over Votes,0,0,0
+Wichita,201,State Senator,30,,Under Votes,12,8,4
+Wichita,201,State Representative,69,REP,James Frank,419,293,126
+Wichita,201,State Representative,69,,Over Votes,0,0,0
+Wichita,201,State Representative,69,,Under Votes,106,86,20
+Wichita,201,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,415,290,125
+Wichita,201,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,201,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,111,90,21
+Wichita,201,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,410,287,123
+Wichita,201,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,201,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,115,92,23
+Wichita,201,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,375,261,114
+Wichita,201,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,130,104,26
+Wichita,201,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,201,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,20,14,6
+Wichita,201,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,408,284,124
+Wichita,201,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,201,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,117,95,22
+Wichita,201,"District Judge, 30th Judicial District",,REP,Jeff McKnight,410,284,126
+Wichita,201,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,201,"District Judge, 30th Judicial District",,,Under Votes,115,95,20
+Wichita,201,Criminal District Attorney,,REP,John Gillespie,410,283,127
+Wichita,201,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,201,Criminal District Attorney,,,Under Votes,115,96,19
+Wichita,201,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",407,282,125
+Wichita,201,County Judge,,,Over Votes,0,0,0
+Wichita,201,County Judge,,,Under Votes,118,97,21
+Wichita,201,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,411,287,124
+Wichita,201,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,201,"Judge, County Court at Law No. 1",,,Under Votes,114,92,22
+Wichita,201,"Judge, County Court at Law No. 2",,REP,Greg King,412,286,126
+Wichita,201,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,201,"Judge, County Court at Law No. 2",,,Under Votes,113,93,20
+Wichita,201,District Clerk,,REP,Patti Flores,414,286,128
+Wichita,201,District Clerk,,,Over Votes,0,0,0
+Wichita,201,District Clerk,,,Under Votes,111,93,18
+Wichita,201,County Clerk,,REP,Lori Bohannon,414,287,127
+Wichita,201,County Clerk,,,Over Votes,0,0,0
+Wichita,201,County Clerk,,,Under Votes,111,92,19
+Wichita,201,County Treasurer,,REP,R. J. Bob Hampton,410,286,124
+Wichita,201,County Treasurer,,,Over Votes,0,0,0
+Wichita,201,County Treasurer,,,Under Votes,115,93,22
+Wichita,201,"County Commissioner, Precinct 2",,REP,Lee Harvey,406,284,122
+Wichita,201,"County Commissioner, Precinct 2",,,Over Votes,0,0,0
+Wichita,201,"County Commissioner, Precinct 2",,,Under Votes,119,95,24
+Wichita,201,"Justice of the Peace, Precinct 2",,REP,Rodney Burchett,409,283,126
+Wichita,201,"Justice of the Peace, Precinct 2",,,Over Votes,0,0,0
+Wichita,201,"Justice of the Peace, Precinct 2",,,Under Votes,116,96,20
+Wichita,201,City of Wichita Falls Mayor,,,Lowry W. Crane,87,77,10
+Wichita,201,City of Wichita Falls Mayor,,,Stephen L. Santellana,124,97,27
+Wichita,201,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,201,City of Wichita Falls Mayor,,,Under Votes,81,73,8
+Wichita,201,Ballots Cast,,,,526,380,146
+Wichita,202,Straight Party,,REP,,631,382,249
+Wichita,202,Straight Party,,DEM,,315,191,124
+Wichita,202,Straight Party,,LIB,,10,5,5
+Wichita,202,Straight Party,,,Over Votes,0,0,0
+Wichita,202,Straight Party,,,Under Votes,692,436,256
+Wichita,202,U.S. Senate,,REP,Ted Cruz,1022,627,395
+Wichita,202,U.S. Senate,,DEM,Beto O'Rourke,593,367,226
+Wichita,202,U.S. Senate,,LIB,Neal M. Dikeman,18,7,11
+Wichita,202,U.S. Senate,,,Over Votes,0,0,0
+Wichita,202,U.S. Senate,,,Under Votes,11,9,2
+Wichita,202,U.S. House,13,REP,Mac Thornberry,1081,662,419
+Wichita,202,U.S. House,13,DEM,Greg Sagan,511,319,192
+Wichita,202,U.S. House,13,LIB,Calvin DeWeese,41,22,19
+Wichita,202,U.S. House,13,,Over Votes,0,0,0
+Wichita,202,U.S. House,13,,Under Votes,11,7,4
+Wichita,202,Governor,,REP,Greg Abbott,1082,666,416
+Wichita,202,Governor,,DEM,Lupe Valdez,517,325,192
+Wichita,202,Governor,,LIB,Mark Jay Tippetts,34,11,23
+Wichita,202,Governor,,,Over Votes,0,0,0
+Wichita,202,Governor,,,Under Votes,11,8,3
+Wichita,202,Lieutenant Governor,,REP,Dan Patrick,1015,625,390
+Wichita,202,Lieutenant Governor,,DEM,Mike Collier,560,348,212
+Wichita,202,Lieutenant Governor,,LIB,Kerry Douglas McKennon,44,19,25
+Wichita,202,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,202,Lieutenant Governor,,,Under Votes,25,18,7
+Wichita,202,Attorney General,,REP,Ken Paxton,1025,630,395
+Wichita,202,Attorney General,,DEM,Justin Nelson,544,336,208
+Wichita,202,Attorney General,,LIB,Michael Ray Harris,48,23,25
+Wichita,202,Attorney General,,,Over Votes,0,0,0
+Wichita,202,Attorney General,,,Under Votes,26,20,6
+Wichita,202,Comptroller of Public Accounts,,REP,Glenn Hegar,1019,631,388
+Wichita,202,Comptroller of Public Accounts,,DEM,Joi Chevalier,519,318,201
+Wichita,202,Comptroller of Public Accounts,,LIB,Ben Sanders,71,34,37
+Wichita,202,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,202,Comptroller of Public Accounts,,,Under Votes,34,26,8
+Wichita,202,Commissioner of the General Land Office,,REP,George P. Bush,1021,635,386
+Wichita,202,Commissioner of the General Land Office,,DEM,Miguel Suazo,522,316,206
+Wichita,202,Commissioner of the General Land Office,,LIB,Matt Pina,69,37,32
+Wichita,202,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,202,Commissioner of the General Land Office,,,Under Votes,31,21,10
+Wichita,202,Commissioner of Agriculture,,REP,Sid Miller,996,614,382
+Wichita,202,Commissioner of Agriculture,,DEM,Kim Olson,560,343,217
+Wichita,202,Commissioner of Agriculture,,LIB,Richard Carpenter,49,25,24
+Wichita,202,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,202,Commissioner of Agriculture,,,Under Votes,38,27,11
+Wichita,202,Railroad Commissioner,,REP,Christi Craddick,1034,640,394
+Wichita,202,Railroad Commissioner,,DEM,Roman McAllen,520,316,204
+Wichita,202,Railroad Commissioner,,LIB,Mike Wright,55,28,27
+Wichita,202,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,202,Railroad Commissioner,,,Under Votes,34,25,9
+Wichita,202,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1055,647,408
+Wichita,202,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,558,341,217
+Wichita,202,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,202,"Justice, Supreme Court, Place 2",,,Under Votes,30,21,9
+Wichita,202,"Justice, Supreme Court, Place 4",,REP,John Devine,1055,646,409
+Wichita,202,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,549,335,214
+Wichita,202,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,202,"Justice, Supreme Court, Place 4",,,Under Votes,39,28,11
+Wichita,202,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1041,642,399
+Wichita,202,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,569,342,227
+Wichita,202,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,202,"Justice, Supreme Court, Place 6",,,Under Votes,33,25,8
+Wichita,202,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1013,633,380
+Wichita,202,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,544,332,212
+Wichita,202,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,53,20,33
+Wichita,202,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,202,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,33,24,9
+Wichita,202,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1053,648,405
+Wichita,202,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,548,330,218
+Wichita,202,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,202,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,42,31,11
+Wichita,202,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1102,678,424
+Wichita,202,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,245,148,97
+Wichita,202,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,202,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,299,186,113
+Wichita,202,State Senator,30,REP,Pat Fallon,1044,638,406
+Wichita,202,State Senator,30,DEM,Kevin Lopez,570,351,219
+Wichita,202,State Senator,30,,Over Votes,0,0,0
+Wichita,202,State Senator,30,,Under Votes,28,19,9
+Wichita,202,State Representative,69,REP,James Frank,1192,715,477
+Wichita,202,State Representative,69,,Over Votes,0,0,0
+Wichita,202,State Representative,69,,Under Votes,451,294,157
+Wichita,202,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,1183,707,476
+Wichita,202,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,202,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,460,302,158
+Wichita,202,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,1170,701,469
+Wichita,202,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,202,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,473,308,165
+Wichita,202,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,1025,628,397
+Wichita,202,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,567,345,222
+Wichita,202,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,202,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,51,36,15
+Wichita,202,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,1180,705,475
+Wichita,202,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,202,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,464,305,159
+Wichita,202,"District Judge, 30th Judicial District",,REP,Jeff McKnight,1185,712,473
+Wichita,202,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,202,"District Judge, 30th Judicial District",,,Under Votes,459,298,161
+Wichita,202,Criminal District Attorney,,REP,John Gillespie,1206,727,479
+Wichita,202,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,202,Criminal District Attorney,,,Under Votes,438,283,155
+Wichita,202,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",1202,725,477
+Wichita,202,County Judge,,,Over Votes,0,0,0
+Wichita,202,County Judge,,,Under Votes,441,284,157
+Wichita,202,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,1187,713,474
+Wichita,202,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,202,"Judge, County Court at Law No. 1",,,Under Votes,456,296,160
+Wichita,202,"Judge, County Court at Law No. 2",,REP,Greg King,1183,709,474
+Wichita,202,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,202,"Judge, County Court at Law No. 2",,,Under Votes,460,300,160
+Wichita,202,District Clerk,,REP,Patti Flores,1195,718,477
+Wichita,202,District Clerk,,,Over Votes,0,0,0
+Wichita,202,District Clerk,,,Under Votes,448,291,157
+Wichita,202,County Clerk,,REP,Lori Bohannon,1199,720,479
+Wichita,202,County Clerk,,,Over Votes,0,0,0
+Wichita,202,County Clerk,,,Under Votes,444,289,155
+Wichita,202,County Treasurer,,REP,R. J. Bob Hampton,1183,710,473
+Wichita,202,County Treasurer,,,Over Votes,0,0,0
+Wichita,202,County Treasurer,,,Under Votes,460,299,161
+Wichita,202,"County Commissioner, Precinct 2",,REP,Lee Harvey,1171,701,470
+Wichita,202,"County Commissioner, Precinct 2",,,Over Votes,0,0,0
+Wichita,202,"County Commissioner, Precinct 2",,,Under Votes,472,308,164
+Wichita,202,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,1184,713,471
+Wichita,202,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,202,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,459,296,163
+Wichita,202,City of Wichita Falls Mayor,,,Lowry W. Crane,460,297,163
+Wichita,202,City of Wichita Falls Mayor,,,Stephen L. Santellana,852,498,354
+Wichita,202,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,202,City of Wichita Falls Mayor,,,Under Votes,337,220,117
+Wichita,202,City of Wichita Falls Councilor District 5,,,Chris Reitsma,326,184,142
+Wichita,202,City of Wichita Falls Councilor District 5,,,Mitesh Desai,267,175,92
+Wichita,202,City of Wichita Falls Councilor District 5,,,Steve Jackson,590,354,236
+Wichita,202,City of Wichita Falls Councilor District 5,,,Over Votes,0,0,0
+Wichita,202,City of Wichita Falls Councilor District 5,,,Under Votes,464,300,164
+Wichita,202,Ballots Cast,,,,1649,1015,634
+Wichita,203,Straight Party,,REP,,202,122,80
+Wichita,203,Straight Party,,DEM,,155,99,56
+Wichita,203,Straight Party,,LIB,,5,3,2
+Wichita,203,Straight Party,,,Over Votes,0,0,0
+Wichita,203,Straight Party,,,Under Votes,257,171,86
+Wichita,203,U.S. Senate,,REP,Ted Cruz,331,209,122
+Wichita,203,U.S. Senate,,DEM,Beto O'Rourke,273,176,97
+Wichita,203,U.S. Senate,,LIB,Neal M. Dikeman,10,6,4
+Wichita,203,U.S. Senate,,,Over Votes,0,0,0
+Wichita,203,U.S. Senate,,,Under Votes,5,4,1
+Wichita,203,U.S. House,13,REP,Mac Thornberry,352,215,137
+Wichita,203,U.S. House,13,DEM,Greg Sagan,242,163,79
+Wichita,203,U.S. House,13,LIB,Calvin DeWeese,16,9,7
+Wichita,203,U.S. House,13,,Over Votes,0,0,0
+Wichita,203,U.S. House,13,,Under Votes,9,8,1
+Wichita,203,Governor,,REP,Greg Abbott,354,217,137
+Wichita,203,Governor,,DEM,Lupe Valdez,247,164,83
+Wichita,203,Governor,,LIB,Mark Jay Tippetts,11,7,4
+Wichita,203,Governor,,,Over Votes,0,0,0
+Wichita,203,Governor,,,Under Votes,5,5,0
+Wichita,203,Lieutenant Governor,,REP,Dan Patrick,333,208,125
+Wichita,203,Lieutenant Governor,,DEM,Mike Collier,256,163,93
+Wichita,203,Lieutenant Governor,,LIB,Kerry Douglas McKennon,18,13,5
+Wichita,203,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,203,Lieutenant Governor,,,Under Votes,10,9,1
+Wichita,203,Attorney General,,REP,Ken Paxton,325,203,122
+Wichita,203,Attorney General,,DEM,Justin Nelson,261,168,93
+Wichita,203,Attorney General,,LIB,Michael Ray Harris,23,14,9
+Wichita,203,Attorney General,,,Over Votes,1,1,0
+Wichita,203,Attorney General,,,Under Votes,7,7,0
+Wichita,203,Comptroller of Public Accounts,,REP,Glenn Hegar,328,203,125
+Wichita,203,Comptroller of Public Accounts,,DEM,Joi Chevalier,242,158,84
+Wichita,203,Comptroller of Public Accounts,,LIB,Ben Sanders,30,19,11
+Wichita,203,Comptroller of Public Accounts,,,Over Votes,1,1,0
+Wichita,203,Comptroller of Public Accounts,,,Under Votes,16,12,4
+Wichita,203,Commissioner of the General Land Office,,REP,George P. Bush,325,205,120
+Wichita,203,Commissioner of the General Land Office,,DEM,Miguel Suazo,246,158,88
+Wichita,203,Commissioner of the General Land Office,,LIB,Matt Pina,31,19,12
+Wichita,203,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,203,Commissioner of the General Land Office,,,Under Votes,15,11,4
+Wichita,203,Commissioner of Agriculture,,REP,Sid Miller,318,194,124
+Wichita,203,Commissioner of Agriculture,,DEM,Kim Olson,262,173,89
+Wichita,203,Commissioner of Agriculture,,LIB,Richard Carpenter,22,14,8
+Wichita,203,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,203,Commissioner of Agriculture,,,Under Votes,15,12,3
+Wichita,203,Railroad Commissioner,,REP,Christi Craddick,328,203,125
+Wichita,203,Railroad Commissioner,,DEM,Roman McAllen,245,160,85
+Wichita,203,Railroad Commissioner,,LIB,Mike Wright,27,18,9
+Wichita,203,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,203,Railroad Commissioner,,,Under Votes,17,12,5
+Wichita,203,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,335,207,128
+Wichita,203,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,268,174,94
+Wichita,203,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,203,"Justice, Supreme Court, Place 2",,,Under Votes,14,12,2
+Wichita,203,"Justice, Supreme Court, Place 4",,REP,John Devine,340,209,131
+Wichita,203,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,262,171,91
+Wichita,203,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,203,"Justice, Supreme Court, Place 4",,,Under Votes,15,13,2
+Wichita,203,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,340,211,129
+Wichita,203,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,262,169,93
+Wichita,203,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,203,"Justice, Supreme Court, Place 6",,,Under Votes,15,13,2
+Wichita,203,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,326,199,127
+Wichita,203,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,254,167,87
+Wichita,203,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,21,13,8
+Wichita,203,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,203,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,16,14,2
+Wichita,203,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,338,207,131
+Wichita,203,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,260,169,91
+Wichita,203,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,203,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,19,17,2
+Wichita,203,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,360,223,137
+Wichita,203,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,112,71,41
+Wichita,203,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,203,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,145,99,46
+Wichita,203,State Senator,30,REP,Pat Fallon,341,209,132
+Wichita,203,State Senator,30,DEM,Kevin Lopez,259,170,89
+Wichita,203,State Senator,30,,Over Votes,0,0,0
+Wichita,203,State Senator,30,,Under Votes,17,14,3
+Wichita,203,State Representative,69,REP,James Frank,393,245,148
+Wichita,203,State Representative,69,,Over Votes,0,0,0
+Wichita,203,State Representative,69,,Under Votes,223,147,76
+Wichita,203,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,397,246,151
+Wichita,203,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,203,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,219,146,73
+Wichita,203,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,389,240,149
+Wichita,203,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,203,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,227,152,75
+Wichita,203,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,336,206,130
+Wichita,203,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,264,173,91
+Wichita,203,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,203,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,18,15,3
+Wichita,203,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,391,241,150
+Wichita,203,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,203,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,225,151,74
+Wichita,203,"District Judge, 30th Judicial District",,REP,Jeff McKnight,395,243,152
+Wichita,203,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,203,"District Judge, 30th Judicial District",,,Under Votes,221,149,72
+Wichita,203,Criminal District Attorney,,REP,John Gillespie,394,243,151
+Wichita,203,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,203,Criminal District Attorney,,,Under Votes,221,148,73
+Wichita,203,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",404,246,158
+Wichita,203,County Judge,,,Over Votes,0,0,0
+Wichita,203,County Judge,,,Under Votes,211,145,66
+Wichita,203,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,387,237,150
+Wichita,203,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,203,"Judge, County Court at Law No. 1",,,Under Votes,228,154,74
+Wichita,203,"Judge, County Court at Law No. 2",,REP,Greg King,384,237,147
+Wichita,203,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,203,"Judge, County Court at Law No. 2",,,Under Votes,231,154,77
+Wichita,203,District Clerk,,REP,Patti Flores,395,242,153
+Wichita,203,District Clerk,,,Over Votes,0,0,0
+Wichita,203,District Clerk,,,Under Votes,220,149,71
+Wichita,203,County Clerk,,REP,Lori Bohannon,406,251,155
+Wichita,203,County Clerk,,,Over Votes,0,0,0
+Wichita,203,County Clerk,,,Under Votes,210,141,69
+Wichita,203,County Treasurer,,REP,R. J. Bob Hampton,389,237,152
+Wichita,203,County Treasurer,,,Over Votes,0,0,0
+Wichita,203,County Treasurer,,,Under Votes,226,154,72
+Wichita,203,"County Commissioner, Precinct 2",,REP,Lee Harvey,395,243,152
+Wichita,203,"County Commissioner, Precinct 2",,,Over Votes,0,0,0
+Wichita,203,"County Commissioner, Precinct 2",,,Under Votes,220,148,72
+Wichita,203,"Justice of the Peace, Precinct 2",,REP,Rodney Burchett,391,242,149
+Wichita,203,"Justice of the Peace, Precinct 2",,,Over Votes,0,0,0
+Wichita,203,"Justice of the Peace, Precinct 2",,,Under Votes,224,149,75
+Wichita,203,City of Wichita Falls Mayor,,,Lowry W. Crane,144,100,44
+Wichita,203,City of Wichita Falls Mayor,,,Stephen L. Santellana,292,179,113
+Wichita,203,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,203,City of Wichita Falls Mayor,,,Under Votes,164,102,62
+Wichita,203,City of Wichita Falls Councilor District 5,,,Chris Reitsma,104,62,42
+Wichita,203,City of Wichita Falls Councilor District 5,,,Mitesh Desai,106,64,42
+Wichita,203,City of Wichita Falls Councilor District 5,,,Steve Jackson,156,108,48
+Wichita,203,City of Wichita Falls Councilor District 5,,,Over Votes,1,1,0
+Wichita,203,City of Wichita Falls Councilor District 5,,,Under Votes,233,146,87
+Wichita,203,Wichita Falls ISD Single Member District 5,,,Tom Bursey,358,224,134
+Wichita,203,Wichita Falls ISD Single Member District 5,,,Over Votes,0,0,0
+Wichita,203,Wichita Falls ISD Single Member District 5,,,Under Votes,251,163,88
+Wichita,203,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,337,213,124
+Wichita,203,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,203,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,272,174,98
+Wichita,203,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,266,172,94
+Wichita,203,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,140,89,51
+Wichita,203,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,203,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,203,126,77
+Wichita,203,Ballots Cast,,,,619,395,224
+Wichita,204,Straight Party,,REP,,71,51,20
+Wichita,204,Straight Party,,DEM,,6,5,1
+Wichita,204,Straight Party,,LIB,,0,0,0
+Wichita,204,Straight Party,,,Over Votes,0,0,0
+Wichita,204,Straight Party,,,Under Votes,38,27,11
+Wichita,204,U.S. Senate,,REP,Ted Cruz,103,75,28
+Wichita,204,U.S. Senate,,DEM,Beto O'Rourke,12,8,4
+Wichita,204,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0
+Wichita,204,U.S. Senate,,,Over Votes,0,0,0
+Wichita,204,U.S. Senate,,,Under Votes,0,0,0
+Wichita,204,U.S. House,13,REP,Mac Thornberry,100,73,27
+Wichita,204,U.S. House,13,DEM,Greg Sagan,11,7,4
+Wichita,204,U.S. House,13,LIB,Calvin DeWeese,3,2,1
+Wichita,204,U.S. House,13,,Over Votes,0,0,0
+Wichita,204,U.S. House,13,,Under Votes,1,1,0
+Wichita,204,Governor,,REP,Greg Abbott,102,74,28
+Wichita,204,Governor,,DEM,Lupe Valdez,9,6,3
+Wichita,204,Governor,,LIB,Mark Jay Tippetts,4,3,1
+Wichita,204,Governor,,,Over Votes,0,0,0
+Wichita,204,Governor,,,Under Votes,0,0,0
+Wichita,204,Lieutenant Governor,,REP,Dan Patrick,97,70,27
+Wichita,204,Lieutenant Governor,,DEM,Mike Collier,12,8,4
+Wichita,204,Lieutenant Governor,,LIB,Kerry Douglas McKennon,6,5,1
+Wichita,204,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,204,Lieutenant Governor,,,Under Votes,0,0,0
+Wichita,204,Attorney General,,REP,Ken Paxton,96,70,26
+Wichita,204,Attorney General,,DEM,Justin Nelson,14,9,5
+Wichita,204,Attorney General,,LIB,Michael Ray Harris,5,4,1
+Wichita,204,Attorney General,,,Over Votes,0,0,0
+Wichita,204,Attorney General,,,Under Votes,0,0,0
+Wichita,204,Comptroller of Public Accounts,,REP,Glenn Hegar,99,72,27
+Wichita,204,Comptroller of Public Accounts,,DEM,Joi Chevalier,10,7,3
+Wichita,204,Comptroller of Public Accounts,,LIB,Ben Sanders,5,4,1
+Wichita,204,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,204,Comptroller of Public Accounts,,,Under Votes,1,0,1
+Wichita,204,Commissioner of the General Land Office,,REP,George P. Bush,91,69,22
+Wichita,204,Commissioner of the General Land Office,,DEM,Miguel Suazo,10,7,3
+Wichita,204,Commissioner of the General Land Office,,LIB,Matt Pina,13,7,6
+Wichita,204,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,204,Commissioner of the General Land Office,,,Under Votes,1,0,1
+Wichita,204,Commissioner of Agriculture,,REP,Sid Miller,97,72,25
+Wichita,204,Commissioner of Agriculture,,DEM,Kim Olson,11,7,4
+Wichita,204,Commissioner of Agriculture,,LIB,Richard Carpenter,6,4,2
+Wichita,204,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,204,Commissioner of Agriculture,,,Under Votes,1,0,1
+Wichita,204,Railroad Commissioner,,REP,Christi Craddick,97,71,26
+Wichita,204,Railroad Commissioner,,DEM,Roman McAllen,10,7,3
+Wichita,204,Railroad Commissioner,,LIB,Mike Wright,7,5,2
+Wichita,204,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,204,Railroad Commissioner,,,Under Votes,1,0,1
+Wichita,204,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,97,71,26
+Wichita,204,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,16,11,5
+Wichita,204,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,204,"Justice, Supreme Court, Place 2",,,Under Votes,2,1,1
+Wichita,204,"Justice, Supreme Court, Place 4",,REP,John Devine,99,73,26
+Wichita,204,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,14,9,5
+Wichita,204,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,204,"Justice, Supreme Court, Place 4",,,Under Votes,2,1,1
+Wichita,204,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,101,74,27
+Wichita,204,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,12,8,4
+Wichita,204,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,204,"Justice, Supreme Court, Place 6",,,Under Votes,2,1,1
+Wichita,204,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,99,73,26
+Wichita,204,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,10,7,3
+Wichita,204,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,4,2,2
+Wichita,204,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,204,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,2,1,1
+Wichita,204,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,102,75,27
+Wichita,204,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,11,7,4
+Wichita,204,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,204,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,2,1,1
+Wichita,204,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,101,74,27
+Wichita,204,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,8,6,2
+Wichita,204,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,204,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,6,3,3
+Wichita,204,State Senator,30,REP,Pat Fallon,100,73,27
+Wichita,204,State Senator,30,DEM,Kevin Lopez,14,9,5
+Wichita,204,State Senator,30,,Over Votes,0,0,0
+Wichita,204,State Senator,30,,Under Votes,1,1,0
+Wichita,204,State Representative,69,REP,James Frank,104,74,30
+Wichita,204,State Representative,69,,Over Votes,0,0,0
+Wichita,204,State Representative,69,,Under Votes,11,9,2
+Wichita,204,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,101,72,29
+Wichita,204,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,204,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,14,11,3
+Wichita,204,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,102,73,29
+Wichita,204,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,204,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,13,10,3
+Wichita,204,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,100,73,27
+Wichita,204,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,13,9,4
+Wichita,204,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,204,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,2,1,1
+Wichita,204,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,102,73,29
+Wichita,204,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,204,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,13,10,3
+Wichita,204,"District Judge, 30th Judicial District",,REP,Jeff McKnight,102,73,29
+Wichita,204,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,204,"District Judge, 30th Judicial District",,,Under Votes,13,10,3
+Wichita,204,Criminal District Attorney,,REP,John Gillespie,103,73,30
+Wichita,204,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,204,Criminal District Attorney,,,Under Votes,12,10,2
+Wichita,204,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",102,74,28
+Wichita,204,County Judge,,,Over Votes,0,0,0
+Wichita,204,County Judge,,,Under Votes,13,9,4
+Wichita,204,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,101,72,29
+Wichita,204,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,204,"Judge, County Court at Law No. 1",,,Under Votes,14,11,3
+Wichita,204,"Judge, County Court at Law No. 2",,REP,Greg King,102,73,29
+Wichita,204,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,204,"Judge, County Court at Law No. 2",,,Under Votes,13,10,3
+Wichita,204,District Clerk,,REP,Patti Flores,101,72,29
+Wichita,204,District Clerk,,,Over Votes,0,0,0
+Wichita,204,District Clerk,,,Under Votes,14,11,3
+Wichita,204,County Clerk,,REP,Lori Bohannon,101,72,29
+Wichita,204,County Clerk,,,Over Votes,0,0,0
+Wichita,204,County Clerk,,,Under Votes,14,11,3
+Wichita,204,County Treasurer,,REP,R. J. Bob Hampton,102,73,29
+Wichita,204,County Treasurer,,,Over Votes,0,0,0
+Wichita,204,County Treasurer,,,Under Votes,13,10,3
+Wichita,204,"County Commissioner, Precinct 2",,REP,Lee Harvey,101,72,29
+Wichita,204,"County Commissioner, Precinct 2",,,Over Votes,0,0,0
+Wichita,204,"County Commissioner, Precinct 2",,,Under Votes,14,11,3
+Wichita,204,"Justice of the Peace, Precinct 2",,REP,Rodney Burchett,103,73,30
+Wichita,204,"Justice of the Peace, Precinct 2",,,Over Votes,0,0,0
+Wichita,204,"Justice of the Peace, Precinct 2",,,Under Votes,12,10,2
+Wichita,204,Wichita Falls ISD Single Member District 5,,,Tom Bursey,48,28,20
+Wichita,204,Wichita Falls ISD Single Member District 5,,,Over Votes,0,0,0
+Wichita,204,Wichita Falls ISD Single Member District 5,,,Under Votes,67,55,12
+Wichita,204,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,52,30,22
+Wichita,204,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,204,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,63,53,10
+Wichita,204,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,25,13,12
+Wichita,204,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,28,19,9
+Wichita,204,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,204,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,62,51,11
+Wichita,204,Ballots Cast,,,,115,83,32
+Wichita,205,Straight Party,,REP,,1114,820,294
+Wichita,205,Straight Party,,DEM,,166,121,45
+Wichita,205,Straight Party,,LIB,,4,3,1
+Wichita,205,Straight Party,,,Over Votes,0,0,0
+Wichita,205,Straight Party,,,Under Votes,766,571,195
+Wichita,205,U.S. Senate,,REP,Ted Cruz,1659,1235,424
+Wichita,205,U.S. Senate,,DEM,Beto O'Rourke,353,250,103
+Wichita,205,U.S. Senate,,LIB,Neal M. Dikeman,16,11,5
+Wichita,205,U.S. Senate,,,Over Votes,0,0,0
+Wichita,205,U.S. Senate,,,Under Votes,22,19,3
+Wichita,205,U.S. House,13,REP,Mac Thornberry,1695,1261,434
+Wichita,205,U.S. House,13,DEM,Greg Sagan,300,216,84
+Wichita,205,U.S. House,13,LIB,Calvin DeWeese,29,18,11
+Wichita,205,U.S. House,13,,Over Votes,0,0,0
+Wichita,205,U.S. House,13,,Under Votes,25,19,6
+Wichita,205,Governor,,REP,Greg Abbott,1706,1269,437
+Wichita,205,Governor,,DEM,Lupe Valdez,302,218,84
+Wichita,205,Governor,,LIB,Mark Jay Tippetts,18,12,6
+Wichita,205,Governor,,,Over Votes,0,0,0
+Wichita,205,Governor,,,Under Votes,24,16,8
+Wichita,205,Lieutenant Governor,,REP,Dan Patrick,1615,1203,412
+Wichita,205,Lieutenant Governor,,DEM,Mike Collier,373,274,99
+Wichita,205,Lieutenant Governor,,LIB,Kerry Douglas McKennon,34,17,17
+Wichita,205,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,205,Lieutenant Governor,,,Under Votes,28,21,7
+Wichita,205,Attorney General,,REP,Ken Paxton,1621,1203,418
+Wichita,205,Attorney General,,DEM,Justin Nelson,358,262,96
+Wichita,205,Attorney General,,LIB,Michael Ray Harris,37,25,12
+Wichita,205,Attorney General,,,Over Votes,0,0,0
+Wichita,205,Attorney General,,,Under Votes,34,25,9
+Wichita,205,Comptroller of Public Accounts,,REP,Glenn Hegar,1633,1212,421
+Wichita,205,Comptroller of Public Accounts,,DEM,Joi Chevalier,318,237,81
+Wichita,205,Comptroller of Public Accounts,,LIB,Ben Sanders,56,35,21
+Wichita,205,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,205,Comptroller of Public Accounts,,,Under Votes,43,31,12
+Wichita,205,Commissioner of the General Land Office,,REP,George P. Bush,1622,1207,415
+Wichita,205,Commissioner of the General Land Office,,DEM,Miguel Suazo,325,239,86
+Wichita,205,Commissioner of the General Land Office,,LIB,Matt Pina,62,43,19
+Wichita,205,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,205,Commissioner of the General Land Office,,,Under Votes,41,26,15
+Wichita,205,Commissioner of Agriculture,,REP,Sid Miller,1629,1215,414
+Wichita,205,Commissioner of Agriculture,,DEM,Kim Olson,340,250,90
+Wichita,205,Commissioner of Agriculture,,LIB,Richard Carpenter,37,21,16
+Wichita,205,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,205,Commissioner of Agriculture,,,Under Votes,44,29,15
+Wichita,205,Railroad Commissioner,,REP,Christi Craddick,1631,1220,411
+Wichita,205,Railroad Commissioner,,DEM,Roman McAllen,312,227,85
+Wichita,205,Railroad Commissioner,,LIB,Mike Wright,59,34,25
+Wichita,205,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,205,Railroad Commissioner,,,Under Votes,48,34,14
+Wichita,205,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1657,1231,426
+Wichita,205,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,350,255,95
+Wichita,205,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,205,"Justice, Supreme Court, Place 2",,,Under Votes,42,28,14
+Wichita,205,"Justice, Supreme Court, Place 4",,REP,John Devine,1666,1238,428
+Wichita,205,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,335,241,94
+Wichita,205,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,205,"Justice, Supreme Court, Place 4",,,Under Votes,48,35,13
+Wichita,205,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1657,1232,425
+Wichita,205,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,342,247,95
+Wichita,205,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,205,"Justice, Supreme Court, Place 6",,,Under Votes,50,35,15
+Wichita,205,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1639,1217,422
+Wichita,205,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,325,238,87
+Wichita,205,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,36,22,14
+Wichita,205,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,205,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,49,37,12
+Wichita,205,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1667,1239,428
+Wichita,205,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,334,242,92
+Wichita,205,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,205,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,48,33,15
+Wichita,205,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1701,1269,432
+Wichita,205,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,157,108,49
+Wichita,205,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,205,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,191,137,54
+Wichita,205,State Senator,30,REP,Pat Fallon,1669,1238,431
+Wichita,205,State Senator,30,DEM,Kevin Lopez,353,261,92
+Wichita,205,State Senator,30,,Over Votes,0,0,0
+Wichita,205,State Senator,30,,Under Votes,27,15,12
+Wichita,205,State Representative,69,REP,James Frank,1770,1308,462
+Wichita,205,State Representative,69,,Over Votes,0,0,0
+Wichita,205,State Representative,69,,Under Votes,279,206,73
+Wichita,205,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,1758,1300,458
+Wichita,205,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,205,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,291,214,77
+Wichita,205,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,1745,1290,455
+Wichita,205,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,205,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,304,224,80
+Wichita,205,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,1646,1225,421
+Wichita,205,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,335,241,94
+Wichita,205,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,205,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,68,48,20
+Wichita,205,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,1748,1293,455
+Wichita,205,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,205,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,301,221,80
+Wichita,205,"District Judge, 30th Judicial District",,REP,Jeff McKnight,1760,1299,461
+Wichita,205,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,205,"District Judge, 30th Judicial District",,,Under Votes,289,215,74
+Wichita,205,Criminal District Attorney,,REP,John Gillespie,1789,1324,465
+Wichita,205,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,205,Criminal District Attorney,,,Under Votes,260,190,70
+Wichita,205,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",1780,1318,462
+Wichita,205,County Judge,,,Over Votes,0,0,0
+Wichita,205,County Judge,,,Under Votes,269,196,73
+Wichita,205,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,1758,1297,461
+Wichita,205,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,205,"Judge, County Court at Law No. 1",,,Under Votes,291,217,74
+Wichita,205,"Judge, County Court at Law No. 2",,REP,Greg King,1763,1301,462
+Wichita,205,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,205,"Judge, County Court at Law No. 2",,,Under Votes,286,213,73
+Wichita,205,District Clerk,,REP,Patti Flores,1768,1305,463
+Wichita,205,District Clerk,,,Over Votes,0,0,0
+Wichita,205,District Clerk,,,Under Votes,281,209,72
+Wichita,205,County Clerk,,REP,Lori Bohannon,1779,1312,467
+Wichita,205,County Clerk,,,Over Votes,0,0,0
+Wichita,205,County Clerk,,,Under Votes,270,202,68
+Wichita,205,County Treasurer,,REP,R. J. Bob Hampton,1766,1311,455
+Wichita,205,County Treasurer,,,Over Votes,0,0,0
+Wichita,205,County Treasurer,,,Under Votes,283,203,80
+Wichita,205,"County Commissioner, Precinct 2",,REP,Lee Harvey,1762,1301,461
+Wichita,205,"County Commissioner, Precinct 2",,,Over Votes,0,0,0
+Wichita,205,"County Commissioner, Precinct 2",,,Under Votes,287,213,74
+Wichita,205,"Justice of the Peace, Precinct 2",,REP,Rodney Burchett,1782,1321,461
+Wichita,205,"Justice of the Peace, Precinct 2",,,Over Votes,0,0,0
+Wichita,205,"Justice of the Peace, Precinct 2",,,Under Votes,267,193,74
+Wichita,205,Ballots Cast,,,,2050,1515,535
+Wichita,206,Straight Party,,REP,,726,533,193
+Wichita,206,Straight Party,,DEM,,140,101,39
+Wichita,206,Straight Party,,LIB,,4,4,0
+Wichita,206,Straight Party,,,Over Votes,0,0,0
+Wichita,206,Straight Party,,,Under Votes,510,366,144
+Wichita,206,U.S. Senate,,REP,Ted Cruz,1077,786,291
+Wichita,206,U.S. Senate,,DEM,Beto O'Rourke,275,199,76
+Wichita,206,U.S. Senate,,LIB,Neal M. Dikeman,14,9,5
+Wichita,206,U.S. Senate,,,Over Votes,0,0,0
+Wichita,206,U.S. Senate,,,Under Votes,14,10,4
+Wichita,206,U.S. House,13,REP,Mac Thornberry,1110,804,306
+Wichita,206,U.S. House,13,DEM,Greg Sagan,235,171,64
+Wichita,206,U.S. House,13,LIB,Calvin DeWeese,19,15,4
+Wichita,206,U.S. House,13,,Over Votes,0,0,0
+Wichita,206,U.S. House,13,,Under Votes,16,14,2
+Wichita,206,Governor,,REP,Greg Abbott,1104,804,300
+Wichita,206,Governor,,DEM,Lupe Valdez,246,179,67
+Wichita,206,Governor,,LIB,Mark Jay Tippetts,19,11,8
+Wichita,206,Governor,,,Over Votes,0,0,0
+Wichita,206,Governor,,,Under Votes,11,10,1
+Wichita,206,Lieutenant Governor,,REP,Dan Patrick,1052,768,284
+Wichita,206,Lieutenant Governor,,DEM,Mike Collier,279,203,76
+Wichita,206,Lieutenant Governor,,LIB,Kerry Douglas McKennon,32,21,11
+Wichita,206,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,206,Lieutenant Governor,,,Under Votes,17,12,5
+Wichita,206,Attorney General,,REP,Ken Paxton,1048,766,282
+Wichita,206,Attorney General,,DEM,Justin Nelson,281,202,79
+Wichita,206,Attorney General,,LIB,Michael Ray Harris,30,20,10
+Wichita,206,Attorney General,,,Over Votes,0,0,0
+Wichita,206,Attorney General,,,Under Votes,21,16,5
+Wichita,206,Comptroller of Public Accounts,,REP,Glenn Hegar,1070,781,289
+Wichita,206,Comptroller of Public Accounts,,DEM,Joi Chevalier,242,177,65
+Wichita,206,Comptroller of Public Accounts,,LIB,Ben Sanders,38,24,14
+Wichita,206,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,206,Comptroller of Public Accounts,,,Under Votes,30,22,8
+Wichita,206,Commissioner of the General Land Office,,REP,George P. Bush,1042,752,290
+Wichita,206,Commissioner of the General Land Office,,DEM,Miguel Suazo,248,181,67
+Wichita,206,Commissioner of the General Land Office,,LIB,Matt Pina,60,47,13
+Wichita,206,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,206,Commissioner of the General Land Office,,,Under Votes,30,24,6
+Wichita,206,Commissioner of Agriculture,,REP,Sid Miller,1063,777,286
+Wichita,206,Commissioner of Agriculture,,DEM,Kim Olson,265,192,73
+Wichita,206,Commissioner of Agriculture,,LIB,Richard Carpenter,28,19,9
+Wichita,206,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,206,Commissioner of Agriculture,,,Under Votes,24,16,8
+Wichita,206,Railroad Commissioner,,REP,Christi Craddick,1069,782,287
+Wichita,206,Railroad Commissioner,,DEM,Roman McAllen,247,177,70
+Wichita,206,Railroad Commissioner,,LIB,Mike Wright,37,26,11
+Wichita,206,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,206,Railroad Commissioner,,,Under Votes,27,19,8
+Wichita,206,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1086,791,295
+Wichita,206,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,267,193,74
+Wichita,206,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,206,"Justice, Supreme Court, Place 2",,,Under Votes,27,20,7
+Wichita,206,"Justice, Supreme Court, Place 4",,REP,John Devine,1086,792,294
+Wichita,206,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,263,191,72
+Wichita,206,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,206,"Justice, Supreme Court, Place 4",,,Under Votes,31,21,10
+Wichita,206,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1084,790,294
+Wichita,206,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,265,192,73
+Wichita,206,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,206,"Justice, Supreme Court, Place 6",,,Under Votes,31,22,9
+Wichita,206,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1062,776,286
+Wichita,206,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,254,186,68
+Wichita,206,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,34,20,14
+Wichita,206,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,206,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,30,22,8
+Wichita,206,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1087,793,294
+Wichita,206,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,258,187,71
+Wichita,206,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,206,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,35,24,11
+Wichita,206,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1109,805,304
+Wichita,206,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,116,80,36
+Wichita,206,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,206,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,155,119,36
+Wichita,206,State Senator,30,REP,Pat Fallon,1093,797,296
+Wichita,206,State Senator,30,DEM,Kevin Lopez,267,192,75
+Wichita,206,State Senator,30,,Over Votes,0,0,0
+Wichita,206,State Senator,30,,Under Votes,20,15,5
+Wichita,206,State Representative,69,REP,James Frank,1165,841,324
+Wichita,206,State Representative,69,,Over Votes,0,0,0
+Wichita,206,State Representative,69,,Under Votes,215,163,52
+Wichita,206,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,1153,833,320
+Wichita,206,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,206,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,227,171,56
+Wichita,206,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,1149,830,319
+Wichita,206,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,206,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,230,173,57
+Wichita,206,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,1069,784,285
+Wichita,206,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,264,189,75
+Wichita,206,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,206,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,47,31,16
+Wichita,206,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,1153,833,320
+Wichita,206,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,206,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,227,171,56
+Wichita,206,"District Judge, 30th Judicial District",,REP,Jeff McKnight,1152,833,319
+Wichita,206,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,206,"District Judge, 30th Judicial District",,,Under Votes,228,171,57
+Wichita,206,Criminal District Attorney,,REP,John Gillespie,1177,850,327
+Wichita,206,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,206,Criminal District Attorney,,,Under Votes,203,154,49
+Wichita,206,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",1167,839,328
+Wichita,206,County Judge,,,Over Votes,0,0,0
+Wichita,206,County Judge,,,Under Votes,213,165,48
+Wichita,206,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,1155,836,319
+Wichita,206,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,206,"Judge, County Court at Law No. 1",,,Under Votes,225,168,57
+Wichita,206,"Judge, County Court at Law No. 2",,REP,Greg King,1153,831,322
+Wichita,206,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,206,"Judge, County Court at Law No. 2",,,Under Votes,227,173,54
+Wichita,206,District Clerk,,REP,Patti Flores,1157,835,322
+Wichita,206,District Clerk,,,Over Votes,0,0,0
+Wichita,206,District Clerk,,,Under Votes,223,169,54
+Wichita,206,County Clerk,,REP,Lori Bohannon,1169,847,322
+Wichita,206,County Clerk,,,Over Votes,0,0,0
+Wichita,206,County Clerk,,,Under Votes,211,157,54
+Wichita,206,County Treasurer,,REP,R. J. Bob Hampton,1166,849,317
+Wichita,206,County Treasurer,,,Over Votes,0,0,0
+Wichita,206,County Treasurer,,,Under Votes,214,155,59
+Wichita,206,"County Commissioner, Precinct 2",,REP,Lee Harvey,1157,836,321
+Wichita,206,"County Commissioner, Precinct 2",,,Over Votes,0,0,0
+Wichita,206,"County Commissioner, Precinct 2",,,Under Votes,222,167,55
+Wichita,206,"Justice of the Peace, Precinct 2",,REP,Rodney Burchett,1179,855,324
+Wichita,206,"Justice of the Peace, Precinct 2",,,Over Votes,0,0,0
+Wichita,206,"Justice of the Peace, Precinct 2",,,Under Votes,201,149,52
+Wichita,206,Ballots Cast,,,,1380,1004,376
+Wichita,207,Straight Party,,REP,,114,65,49
+Wichita,207,Straight Party,,DEM,,82,55,27
+Wichita,207,Straight Party,,LIB,,2,1,1
+Wichita,207,Straight Party,,,Over Votes,0,0,0
+Wichita,207,Straight Party,,,Under Votes,115,82,33
+Wichita,207,U.S. Senate,,REP,Ted Cruz,173,112,61
+Wichita,207,U.S. Senate,,DEM,Beto O'Rourke,129,84,45
+Wichita,207,U.S. Senate,,LIB,Neal M. Dikeman,4,2,2
+Wichita,207,U.S. Senate,,,Over Votes,0,0,0
+Wichita,207,U.S. Senate,,,Under Votes,7,5,2
+Wichita,207,U.S. House,13,REP,Mac Thornberry,180,113,67
+Wichita,207,U.S. House,13,DEM,Greg Sagan,112,75,37
+Wichita,207,U.S. House,13,LIB,Calvin DeWeese,9,5,4
+Wichita,207,U.S. House,13,,Over Votes,0,0,0
+Wichita,207,U.S. House,13,,Under Votes,12,10,2
+Wichita,207,Governor,,REP,Greg Abbott,178,113,65
+Wichita,207,Governor,,DEM,Lupe Valdez,120,80,40
+Wichita,207,Governor,,LIB,Mark Jay Tippetts,6,3,3
+Wichita,207,Governor,,,Over Votes,0,0,0
+Wichita,207,Governor,,,Under Votes,9,7,2
+Wichita,207,Lieutenant Governor,,REP,Dan Patrick,172,107,65
+Wichita,207,Lieutenant Governor,,DEM,Mike Collier,122,82,40
+Wichita,207,Lieutenant Governor,,LIB,Kerry Douglas McKennon,8,4,4
+Wichita,207,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,207,Lieutenant Governor,,,Under Votes,11,10,1
+Wichita,207,Attorney General,,REP,Ken Paxton,167,105,62
+Wichita,207,Attorney General,,DEM,Justin Nelson,129,86,43
+Wichita,207,Attorney General,,LIB,Michael Ray Harris,5,3,2
+Wichita,207,Attorney General,,,Over Votes,0,0,0
+Wichita,207,Attorney General,,,Under Votes,12,9,3
+Wichita,207,Comptroller of Public Accounts,,REP,Glenn Hegar,168,104,64
+Wichita,207,Comptroller of Public Accounts,,DEM,Joi Chevalier,116,77,39
+Wichita,207,Comptroller of Public Accounts,,LIB,Ben Sanders,16,12,4
+Wichita,207,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,207,Comptroller of Public Accounts,,,Under Votes,13,10,3
+Wichita,207,Commissioner of the General Land Office,,REP,George P. Bush,166,103,63
+Wichita,207,Commissioner of the General Land Office,,DEM,Miguel Suazo,118,79,39
+Wichita,207,Commissioner of the General Land Office,,LIB,Matt Pina,13,9,4
+Wichita,207,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,207,Commissioner of the General Land Office,,,Under Votes,16,12,4
+Wichita,207,Commissioner of Agriculture,,REP,Sid Miller,167,102,65
+Wichita,207,Commissioner of Agriculture,,DEM,Kim Olson,125,85,40
+Wichita,207,Commissioner of Agriculture,,LIB,Richard Carpenter,8,6,2
+Wichita,207,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,207,Commissioner of Agriculture,,,Under Votes,13,10,3
+Wichita,207,Railroad Commissioner,,REP,Christi Craddick,170,106,64
+Wichita,207,Railroad Commissioner,,DEM,Roman McAllen,118,80,38
+Wichita,207,Railroad Commissioner,,LIB,Mike Wright,11,7,4
+Wichita,207,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,207,Railroad Commissioner,,,Under Votes,14,10,4
+Wichita,207,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,167,107,60
+Wichita,207,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,130,86,44
+Wichita,207,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,207,"Justice, Supreme Court, Place 2",,,Under Votes,16,10,6
+Wichita,207,"Justice, Supreme Court, Place 4",,REP,John Devine,172,107,65
+Wichita,207,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,125,85,40
+Wichita,207,"Justice, Supreme Court, Place 4",,,Over Votes,1,1,0
+Wichita,207,"Justice, Supreme Court, Place 4",,,Under Votes,15,10,5
+Wichita,207,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,172,108,64
+Wichita,207,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,130,86,44
+Wichita,207,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,207,"Justice, Supreme Court, Place 6",,,Under Votes,11,9,2
+Wichita,207,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,169,107,62
+Wichita,207,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,119,79,40
+Wichita,207,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,10,7,3
+Wichita,207,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,207,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,15,10,5
+Wichita,207,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,177,113,64
+Wichita,207,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,121,79,42
+Wichita,207,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,207,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,15,11,4
+Wichita,207,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,173,110,63
+Wichita,207,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,50,35,15
+Wichita,207,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,207,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,90,58,32
+Wichita,207,State Senator,30,REP,Pat Fallon,174,110,64
+Wichita,207,State Senator,30,DEM,Kevin Lopez,127,83,44
+Wichita,207,State Senator,30,,Over Votes,0,0,0
+Wichita,207,State Senator,30,,Under Votes,12,10,2
+Wichita,207,State Representative,69,REP,James Frank,197,125,72
+Wichita,207,State Representative,69,,Over Votes,0,0,0
+Wichita,207,State Representative,69,,Under Votes,115,77,38
+Wichita,207,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,197,125,72
+Wichita,207,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,207,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,115,77,38
+Wichita,207,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,196,126,70
+Wichita,207,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,207,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,117,77,40
+Wichita,207,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,171,109,62
+Wichita,207,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,128,83,45
+Wichita,207,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,207,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,14,11,3
+Wichita,207,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,194,124,70
+Wichita,207,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,207,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,118,78,40
+Wichita,207,"District Judge, 30th Judicial District",,REP,Jeff McKnight,200,129,71
+Wichita,207,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,207,"District Judge, 30th Judicial District",,,Under Votes,112,73,39
+Wichita,207,Criminal District Attorney,,REP,John Gillespie,197,127,70
+Wichita,207,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,207,Criminal District Attorney,,,Under Votes,116,76,40
+Wichita,207,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",203,130,73
+Wichita,207,County Judge,,,Over Votes,0,0,0
+Wichita,207,County Judge,,,Under Votes,110,73,37
+Wichita,207,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,194,124,70
+Wichita,207,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,207,"Judge, County Court at Law No. 1",,,Under Votes,119,79,40
+Wichita,207,"Judge, County Court at Law No. 2",,REP,Greg King,196,126,70
+Wichita,207,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,207,"Judge, County Court at Law No. 2",,,Under Votes,116,76,40
+Wichita,207,District Clerk,,REP,Patti Flores,197,125,72
+Wichita,207,District Clerk,,,Over Votes,0,0,0
+Wichita,207,District Clerk,,,Under Votes,115,77,38
+Wichita,207,County Clerk,,REP,Lori Bohannon,203,132,71
+Wichita,207,County Clerk,,,Over Votes,0,0,0
+Wichita,207,County Clerk,,,Under Votes,110,71,39
+Wichita,207,County Treasurer,,REP,R. J. Bob Hampton,196,124,72
+Wichita,207,County Treasurer,,,Over Votes,0,0,0
+Wichita,207,County Treasurer,,,Under Votes,116,78,38
+Wichita,207,"County Commissioner, Precinct 2",,REP,Lee Harvey,194,123,71
+Wichita,207,"County Commissioner, Precinct 2",,,Over Votes,0,0,0
+Wichita,207,"County Commissioner, Precinct 2",,,Under Votes,118,79,39
+Wichita,207,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,198,127,71
+Wichita,207,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,207,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,115,76,39
+Wichita,207,City of Wichita Falls Mayor,,,Lowry W. Crane,85,62,23
+Wichita,207,City of Wichita Falls Mayor,,,Stephen L. Santellana,165,104,61
+Wichita,207,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,207,City of Wichita Falls Mayor,,,Under Votes,65,39,26
+Wichita,207,City of Wichita Falls Councilor District 5,,,Chris Reitsma,55,34,21
+Wichita,207,City of Wichita Falls Councilor District 5,,,Mitesh Desai,53,36,17
+Wichita,207,City of Wichita Falls Councilor District 5,,,Steve Jackson,108,76,32
+Wichita,207,City of Wichita Falls Councilor District 5,,,Over Votes,0,0,0
+Wichita,207,City of Wichita Falls Councilor District 5,,,Under Votes,99,59,40
+Wichita,207,Wichita Falls ISD Single Member District 5,,,Tom Bursey,169,117,52
+Wichita,207,Wichita Falls ISD Single Member District 5,,,Over Votes,0,0,0
+Wichita,207,Wichita Falls ISD Single Member District 5,,,Under Votes,134,80,54
+Wichita,207,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,164,114,50
+Wichita,207,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,207,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,139,83,56
+Wichita,207,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,135,90,45
+Wichita,207,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,83,53,30
+Wichita,207,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,207,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,85,54,31
+Wichita,207,Ballots Cast,,,,315,205,110
+Wichita,208,Straight Party,,REP,,34,23,11
+Wichita,208,Straight Party,,DEM,,9,5,4
+Wichita,208,Straight Party,,LIB,,0,0,0
+Wichita,208,Straight Party,,,Over Votes,0,0,0
+Wichita,208,Straight Party,,,Under Votes,35,23,12
+Wichita,208,U.S. Senate,,REP,Ted Cruz,59,37,22
+Wichita,208,U.S. Senate,,DEM,Beto O'Rourke,18,14,4
+Wichita,208,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0
+Wichita,208,U.S. Senate,,,Over Votes,0,0,0
+Wichita,208,U.S. Senate,,,Under Votes,1,0,1
+Wichita,208,U.S. House,13,REP,Mac Thornberry,58,37,21
+Wichita,208,U.S. House,13,DEM,Greg Sagan,15,11,4
+Wichita,208,U.S. House,13,LIB,Calvin DeWeese,4,2,2
+Wichita,208,U.S. House,13,,Over Votes,0,0,0
+Wichita,208,U.S. House,13,,Under Votes,1,1,0
+Wichita,208,Governor,,REP,Greg Abbott,60,38,22
+Wichita,208,Governor,,DEM,Lupe Valdez,15,10,5
+Wichita,208,Governor,,LIB,Mark Jay Tippetts,2,2,0
+Wichita,208,Governor,,,Over Votes,0,0,0
+Wichita,208,Governor,,,Under Votes,1,1,0
+Wichita,208,Lieutenant Governor,,REP,Dan Patrick,57,35,22
+Wichita,208,Lieutenant Governor,,DEM,Mike Collier,17,13,4
+Wichita,208,Lieutenant Governor,,LIB,Kerry Douglas McKennon,3,2,1
+Wichita,208,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,208,Lieutenant Governor,,,Under Votes,1,1,0
+Wichita,208,Attorney General,,REP,Ken Paxton,57,36,21
+Wichita,208,Attorney General,,DEM,Justin Nelson,19,13,6
+Wichita,208,Attorney General,,LIB,Michael Ray Harris,1,1,0
+Wichita,208,Attorney General,,,Over Votes,0,0,0
+Wichita,208,Attorney General,,,Under Votes,1,1,0
+Wichita,208,Comptroller of Public Accounts,,REP,Glenn Hegar,55,36,19
+Wichita,208,Comptroller of Public Accounts,,DEM,Joi Chevalier,17,12,5
+Wichita,208,Comptroller of Public Accounts,,LIB,Ben Sanders,5,2,3
+Wichita,208,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,208,Comptroller of Public Accounts,,,Under Votes,1,1,0
+Wichita,208,Commissioner of the General Land Office,,REP,George P. Bush,55,35,20
+Wichita,208,Commissioner of the General Land Office,,DEM,Miguel Suazo,20,13,7
+Wichita,208,Commissioner of the General Land Office,,LIB,Matt Pina,1,1,0
+Wichita,208,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,208,Commissioner of the General Land Office,,,Under Votes,2,2,0
+Wichita,208,Commissioner of Agriculture,,REP,Sid Miller,59,37,22
+Wichita,208,Commissioner of Agriculture,,DEM,Kim Olson,17,12,5
+Wichita,208,Commissioner of Agriculture,,LIB,Richard Carpenter,1,1,0
+Wichita,208,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,208,Commissioner of Agriculture,,,Under Votes,1,1,0
+Wichita,208,Railroad Commissioner,,REP,Christi Craddick,56,35,21
+Wichita,208,Railroad Commissioner,,DEM,Roman McAllen,17,12,5
+Wichita,208,Railroad Commissioner,,LIB,Mike Wright,4,3,1
+Wichita,208,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,208,Railroad Commissioner,,,Under Votes,1,1,0
+Wichita,208,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,59,37,22
+Wichita,208,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,18,13,5
+Wichita,208,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,208,"Justice, Supreme Court, Place 2",,,Under Votes,1,1,0
+Wichita,208,"Justice, Supreme Court, Place 4",,REP,John Devine,60,38,22
+Wichita,208,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,17,12,5
+Wichita,208,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,208,"Justice, Supreme Court, Place 4",,,Under Votes,1,1,0
+Wichita,208,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,58,37,21
+Wichita,208,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,19,13,6
+Wichita,208,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,208,"Justice, Supreme Court, Place 6",,,Under Votes,1,1,0
+Wichita,208,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,56,36,20
+Wichita,208,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,18,11,7
+Wichita,208,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,3,3,0
+Wichita,208,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,208,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,1,1,0
+Wichita,208,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,59,37,22
+Wichita,208,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,18,13,5
+Wichita,208,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,208,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,1,1,0
+Wichita,208,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,60,38,22
+Wichita,208,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,9,7,2
+Wichita,208,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,208,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,9,6,3
+Wichita,208,State Senator,30,REP,Pat Fallon,58,38,20
+Wichita,208,State Senator,30,DEM,Kevin Lopez,19,12,7
+Wichita,208,State Senator,30,,Over Votes,0,0,0
+Wichita,208,State Senator,30,,Under Votes,1,1,0
+Wichita,208,State Representative,69,REP,James Frank,65,42,23
+Wichita,208,State Representative,69,,Over Votes,0,0,0
+Wichita,208,State Representative,69,,Under Votes,13,9,4
+Wichita,208,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,64,41,23
+Wichita,208,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,208,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,14,10,4
+Wichita,208,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,64,41,23
+Wichita,208,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,208,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,14,10,4
+Wichita,208,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,60,38,22
+Wichita,208,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,17,12,5
+Wichita,208,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,208,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,1,1,0
+Wichita,208,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,64,41,23
+Wichita,208,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,208,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,14,10,4
+Wichita,208,"District Judge, 30th Judicial District",,REP,Jeff McKnight,65,42,23
+Wichita,208,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,208,"District Judge, 30th Judicial District",,,Under Votes,13,9,4
+Wichita,208,Criminal District Attorney,,REP,John Gillespie,64,42,22
+Wichita,208,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,208,Criminal District Attorney,,,Under Votes,14,9,5
+Wichita,208,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",63,41,22
+Wichita,208,County Judge,,,Over Votes,0,0,0
+Wichita,208,County Judge,,,Under Votes,15,10,5
+Wichita,208,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,66,43,23
+Wichita,208,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,208,"Judge, County Court at Law No. 1",,,Under Votes,12,8,4
+Wichita,208,"Judge, County Court at Law No. 2",,REP,Greg King,65,42,23
+Wichita,208,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,208,"Judge, County Court at Law No. 2",,,Under Votes,13,9,4
+Wichita,208,District Clerk,,REP,Patti Flores,65,43,22
+Wichita,208,District Clerk,,,Over Votes,0,0,0
+Wichita,208,District Clerk,,,Under Votes,13,8,5
+Wichita,208,County Clerk,,REP,Lori Bohannon,65,42,23
+Wichita,208,County Clerk,,,Over Votes,0,0,0
+Wichita,208,County Clerk,,,Under Votes,13,9,4
+Wichita,208,County Treasurer,,REP,R. J. Bob Hampton,64,42,22
+Wichita,208,County Treasurer,,,Over Votes,0,0,0
+Wichita,208,County Treasurer,,,Under Votes,14,9,5
+Wichita,208,"County Commissioner, Precinct 2",,REP,Lee Harvey,65,42,23
+Wichita,208,"County Commissioner, Precinct 2",,,Over Votes,0,0,0
+Wichita,208,"County Commissioner, Precinct 2",,,Under Votes,13,9,4
+Wichita,208,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,67,44,23
+Wichita,208,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,208,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,11,7,4
+Wichita,208,City of Wichita Falls Mayor,,,Lowry W. Crane,25,16,9
+Wichita,208,City of Wichita Falls Mayor,,,Stephen L. Santellana,35,24,11
+Wichita,208,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,208,City of Wichita Falls Mayor,,,Under Votes,18,11,7
+Wichita,208,City of Wichita Falls Councilor District 5,,,Chris Reitsma,17,12,5
+Wichita,208,City of Wichita Falls Councilor District 5,,,Mitesh Desai,8,4,4
+Wichita,208,City of Wichita Falls Councilor District 5,,,Steve Jackson,31,21,10
+Wichita,208,City of Wichita Falls Councilor District 5,,,Over Votes,0,0,0
+Wichita,208,City of Wichita Falls Councilor District 5,,,Under Votes,22,14,8
+Wichita,208,Ballots Cast,,,,78,51,27
+Wichita,209,Straight Party,,REP,,0,0,0
+Wichita,209,Straight Party,,DEM,,0,0,0
+Wichita,209,Straight Party,,LIB,,0,0,0
+Wichita,209,Straight Party,,,Over Votes,0,0,0
+Wichita,209,Straight Party,,,Under Votes,0,0,0
+Wichita,209,U.S. Senate,,REP,Ted Cruz,0,0,0
+Wichita,209,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
+Wichita,209,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0
+Wichita,209,U.S. Senate,,,Over Votes,0,0,0
+Wichita,209,U.S. Senate,,,Under Votes,0,0,0
+Wichita,209,U.S. House,13,REP,Mac Thornberry,0,0,0
+Wichita,209,U.S. House,13,DEM,Greg Sagan,0,0,0
+Wichita,209,U.S. House,13,LIB,Calvin DeWeese,0,0,0
+Wichita,209,U.S. House,13,,Over Votes,0,0,0
+Wichita,209,U.S. House,13,,Under Votes,0,0,0
+Wichita,209,Governor,,REP,Greg Abbott,0,0,0
+Wichita,209,Governor,,DEM,Lupe Valdez,0,0,0
+Wichita,209,Governor,,LIB,Mark Jay Tippetts,0,0,0
+Wichita,209,Governor,,,Over Votes,0,0,0
+Wichita,209,Governor,,,Under Votes,0,0,0
+Wichita,209,Lieutenant Governor,,REP,Dan Patrick,0,0,0
+Wichita,209,Lieutenant Governor,,DEM,Mike Collier,0,0,0
+Wichita,209,Lieutenant Governor,,LIB,Kerry Douglas McKennon,0,0,0
+Wichita,209,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,209,Lieutenant Governor,,,Under Votes,0,0,0
+Wichita,209,Attorney General,,REP,Ken Paxton,0,0,0
+Wichita,209,Attorney General,,DEM,Justin Nelson,0,0,0
+Wichita,209,Attorney General,,LIB,Michael Ray Harris,0,0,0
+Wichita,209,Attorney General,,,Over Votes,0,0,0
+Wichita,209,Attorney General,,,Under Votes,0,0,0
+Wichita,209,Comptroller of Public Accounts,,REP,Glenn Hegar,0,0,0
+Wichita,209,Comptroller of Public Accounts,,DEM,Joi Chevalier,0,0,0
+Wichita,209,Comptroller of Public Accounts,,LIB,Ben Sanders,0,0,0
+Wichita,209,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,209,Comptroller of Public Accounts,,,Under Votes,0,0,0
+Wichita,209,Commissioner of the General Land Office,,REP,George P. Bush,0,0,0
+Wichita,209,Commissioner of the General Land Office,,DEM,Miguel Suazo,0,0,0
+Wichita,209,Commissioner of the General Land Office,,LIB,Matt Pina,0,0,0
+Wichita,209,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,209,Commissioner of the General Land Office,,,Under Votes,0,0,0
+Wichita,209,Commissioner of Agriculture,,REP,Sid Miller,0,0,0
+Wichita,209,Commissioner of Agriculture,,DEM,Kim Olson,0,0,0
+Wichita,209,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0
+Wichita,209,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,209,Commissioner of Agriculture,,,Under Votes,0,0,0
+Wichita,209,Railroad Commissioner,,REP,Christi Craddick,0,0,0
+Wichita,209,Railroad Commissioner,,DEM,Roman McAllen,0,0,0
+Wichita,209,Railroad Commissioner,,LIB,Mike Wright,0,0,0
+Wichita,209,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,209,Railroad Commissioner,,,Under Votes,0,0,0
+Wichita,209,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,0,0,0
+Wichita,209,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,0,0,0
+Wichita,209,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,209,"Justice, Supreme Court, Place 2",,,Under Votes,0,0,0
+Wichita,209,"Justice, Supreme Court, Place 4",,REP,John Devine,0,0,0
+Wichita,209,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,0,0,0
+Wichita,209,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,209,"Justice, Supreme Court, Place 4",,,Under Votes,0,0,0
+Wichita,209,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,0,0,0
+Wichita,209,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,0,0,0
+Wichita,209,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,209,"Justice, Supreme Court, Place 6",,,Under Votes,0,0,0
+Wichita,209,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,0,0,0
+Wichita,209,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,0,0,0
+Wichita,209,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,0,0,0
+Wichita,209,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,209,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,0,0,0
+Wichita,209,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,0,0,0
+Wichita,209,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0,0
+Wichita,209,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,209,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,0,0,0
+Wichita,209,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,0,0,0
+Wichita,209,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,0,0,0
+Wichita,209,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,209,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,0,0,0
+Wichita,209,State Senator,30,REP,Pat Fallon,0,0,0
+Wichita,209,State Senator,30,DEM,Kevin Lopez,0,0,0
+Wichita,209,State Senator,30,,Over Votes,0,0,0
+Wichita,209,State Senator,30,,Under Votes,0,0,0
+Wichita,209,State Representative,69,REP,James Frank,0,0,0
+Wichita,209,State Representative,69,,Over Votes,0,0,0
+Wichita,209,State Representative,69,,Under Votes,0,0,0
+Wichita,209,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,0,0,0
+Wichita,209,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,209,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,0,0,0
+Wichita,209,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,0,0,0
+Wichita,209,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,209,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,0,0,0
+Wichita,209,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,0,0,0
+Wichita,209,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,0,0,0
+Wichita,209,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,209,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,0,0,0
+Wichita,209,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,0,0,0
+Wichita,209,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,209,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,0,0,0
+Wichita,209,"District Judge, 30th Judicial District",,REP,Jeff McKnight,0,0,0
+Wichita,209,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,209,"District Judge, 30th Judicial District",,,Under Votes,0,0,0
+Wichita,209,Criminal District Attorney,,REP,John Gillespie,0,0,0
+Wichita,209,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,209,Criminal District Attorney,,,Under Votes,0,0,0
+Wichita,209,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",0,0,0
+Wichita,209,County Judge,,,Over Votes,0,0,0
+Wichita,209,County Judge,,,Under Votes,0,0,0
+Wichita,209,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,0,0,0
+Wichita,209,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,209,"Judge, County Court at Law No. 1",,,Under Votes,0,0,0
+Wichita,209,"Judge, County Court at Law No. 2",,REP,Greg King,0,0,0
+Wichita,209,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,209,"Judge, County Court at Law No. 2",,,Under Votes,0,0,0
+Wichita,209,District Clerk,,REP,Patti Flores,0,0,0
+Wichita,209,District Clerk,,,Over Votes,0,0,0
+Wichita,209,District Clerk,,,Under Votes,0,0,0
+Wichita,209,County Clerk,,REP,Lori Bohannon,0,0,0
+Wichita,209,County Clerk,,,Over Votes,0,0,0
+Wichita,209,County Clerk,,,Under Votes,0,0,0
+Wichita,209,County Treasurer,,REP,R. J. Bob Hampton,0,0,0
+Wichita,209,County Treasurer,,,Over Votes,0,0,0
+Wichita,209,County Treasurer,,,Under Votes,0,0,0
+Wichita,209,"County Commissioner, Precinct 2",,REP,Lee Harvey,0,0,0
+Wichita,209,"County Commissioner, Precinct 2",,,Over Votes,0,0,0
+Wichita,209,"County Commissioner, Precinct 2",,,Under Votes,0,0,0
+Wichita,209,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,0,0,0
+Wichita,209,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,209,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,0,0,0
+Wichita,209,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,0,0,0
+Wichita,209,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,209,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,0,0,0
+Wichita,209,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,0,0,0
+Wichita,209,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,0,0,0
+Wichita,209,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,209,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,0,0,0
+Wichita,209,Ballots Cast,,,,0,0,0
+Wichita,210,Straight Party,,REP,,0,0,0
+Wichita,210,Straight Party,,DEM,,0,0,0
+Wichita,210,Straight Party,,LIB,,0,0,0
+Wichita,210,Straight Party,,,Over Votes,0,0,0
+Wichita,210,Straight Party,,,Under Votes,0,0,0
+Wichita,210,U.S. Senate,,REP,Ted Cruz,0,0,0
+Wichita,210,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
+Wichita,210,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0
+Wichita,210,U.S. Senate,,,Over Votes,0,0,0
+Wichita,210,U.S. Senate,,,Under Votes,0,0,0
+Wichita,210,U.S. House,13,REP,Mac Thornberry,0,0,0
+Wichita,210,U.S. House,13,DEM,Greg Sagan,0,0,0
+Wichita,210,U.S. House,13,LIB,Calvin DeWeese,0,0,0
+Wichita,210,U.S. House,13,,Over Votes,0,0,0
+Wichita,210,U.S. House,13,,Under Votes,0,0,0
+Wichita,210,Governor,,REP,Greg Abbott,0,0,0
+Wichita,210,Governor,,DEM,Lupe Valdez,0,0,0
+Wichita,210,Governor,,LIB,Mark Jay Tippetts,0,0,0
+Wichita,210,Governor,,,Over Votes,0,0,0
+Wichita,210,Governor,,,Under Votes,0,0,0
+Wichita,210,Lieutenant Governor,,REP,Dan Patrick,0,0,0
+Wichita,210,Lieutenant Governor,,DEM,Mike Collier,0,0,0
+Wichita,210,Lieutenant Governor,,LIB,Kerry Douglas McKennon,0,0,0
+Wichita,210,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,210,Lieutenant Governor,,,Under Votes,0,0,0
+Wichita,210,Attorney General,,REP,Ken Paxton,0,0,0
+Wichita,210,Attorney General,,DEM,Justin Nelson,0,0,0
+Wichita,210,Attorney General,,LIB,Michael Ray Harris,0,0,0
+Wichita,210,Attorney General,,,Over Votes,0,0,0
+Wichita,210,Attorney General,,,Under Votes,0,0,0
+Wichita,210,Comptroller of Public Accounts,,REP,Glenn Hegar,0,0,0
+Wichita,210,Comptroller of Public Accounts,,DEM,Joi Chevalier,0,0,0
+Wichita,210,Comptroller of Public Accounts,,LIB,Ben Sanders,0,0,0
+Wichita,210,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,210,Comptroller of Public Accounts,,,Under Votes,0,0,0
+Wichita,210,Commissioner of the General Land Office,,REP,George P. Bush,0,0,0
+Wichita,210,Commissioner of the General Land Office,,DEM,Miguel Suazo,0,0,0
+Wichita,210,Commissioner of the General Land Office,,LIB,Matt Pina,0,0,0
+Wichita,210,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,210,Commissioner of the General Land Office,,,Under Votes,0,0,0
+Wichita,210,Commissioner of Agriculture,,REP,Sid Miller,0,0,0
+Wichita,210,Commissioner of Agriculture,,DEM,Kim Olson,0,0,0
+Wichita,210,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0
+Wichita,210,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,210,Commissioner of Agriculture,,,Under Votes,0,0,0
+Wichita,210,Railroad Commissioner,,REP,Christi Craddick,0,0,0
+Wichita,210,Railroad Commissioner,,DEM,Roman McAllen,0,0,0
+Wichita,210,Railroad Commissioner,,LIB,Mike Wright,0,0,0
+Wichita,210,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,210,Railroad Commissioner,,,Under Votes,0,0,0
+Wichita,210,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,0,0,0
+Wichita,210,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,0,0,0
+Wichita,210,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,210,"Justice, Supreme Court, Place 2",,,Under Votes,0,0,0
+Wichita,210,"Justice, Supreme Court, Place 4",,REP,John Devine,0,0,0
+Wichita,210,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,0,0,0
+Wichita,210,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,210,"Justice, Supreme Court, Place 4",,,Under Votes,0,0,0
+Wichita,210,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,0,0,0
+Wichita,210,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,0,0,0
+Wichita,210,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,210,"Justice, Supreme Court, Place 6",,,Under Votes,0,0,0
+Wichita,210,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,0,0,0
+Wichita,210,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,0,0,0
+Wichita,210,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,0,0,0
+Wichita,210,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,210,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,0,0,0
+Wichita,210,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,0,0,0
+Wichita,210,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0,0
+Wichita,210,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,210,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,0,0,0
+Wichita,210,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,0,0,0
+Wichita,210,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,0,0,0
+Wichita,210,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,210,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,0,0,0
+Wichita,210,State Senator,30,REP,Pat Fallon,0,0,0
+Wichita,210,State Senator,30,DEM,Kevin Lopez,0,0,0
+Wichita,210,State Senator,30,,Over Votes,0,0,0
+Wichita,210,State Senator,30,,Under Votes,0,0,0
+Wichita,210,State Representative,69,REP,James Frank,0,0,0
+Wichita,210,State Representative,69,,Over Votes,0,0,0
+Wichita,210,State Representative,69,,Under Votes,0,0,0
+Wichita,210,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,0,0,0
+Wichita,210,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,210,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,0,0,0
+Wichita,210,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,0,0,0
+Wichita,210,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,210,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,0,0,0
+Wichita,210,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,0,0,0
+Wichita,210,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,0,0,0
+Wichita,210,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,210,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,0,0,0
+Wichita,210,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,0,0,0
+Wichita,210,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,210,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,0,0,0
+Wichita,210,"District Judge, 30th Judicial District",,REP,Jeff McKnight,0,0,0
+Wichita,210,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,210,"District Judge, 30th Judicial District",,,Under Votes,0,0,0
+Wichita,210,Criminal District Attorney,,REP,John Gillespie,0,0,0
+Wichita,210,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,210,Criminal District Attorney,,,Under Votes,0,0,0
+Wichita,210,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",0,0,0
+Wichita,210,County Judge,,,Over Votes,0,0,0
+Wichita,210,County Judge,,,Under Votes,0,0,0
+Wichita,210,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,0,0,0
+Wichita,210,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,210,"Judge, County Court at Law No. 1",,,Under Votes,0,0,0
+Wichita,210,"Judge, County Court at Law No. 2",,REP,Greg King,0,0,0
+Wichita,210,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,210,"Judge, County Court at Law No. 2",,,Under Votes,0,0,0
+Wichita,210,District Clerk,,REP,Patti Flores,0,0,0
+Wichita,210,District Clerk,,,Over Votes,0,0,0
+Wichita,210,District Clerk,,,Under Votes,0,0,0
+Wichita,210,County Clerk,,REP,Lori Bohannon,0,0,0
+Wichita,210,County Clerk,,,Over Votes,0,0,0
+Wichita,210,County Clerk,,,Under Votes,0,0,0
+Wichita,210,County Treasurer,,REP,R. J. Bob Hampton,0,0,0
+Wichita,210,County Treasurer,,,Over Votes,0,0,0
+Wichita,210,County Treasurer,,,Under Votes,0,0,0
+Wichita,210,"County Commissioner, Precinct 2",,REP,Lee Harvey,0,0,0
+Wichita,210,"County Commissioner, Precinct 2",,,Over Votes,0,0,0
+Wichita,210,"County Commissioner, Precinct 2",,,Under Votes,0,0,0
+Wichita,210,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,0,0,0
+Wichita,210,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,210,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,0,0,0
+Wichita,210,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,0,0,0
+Wichita,210,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,210,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,0,0,0
+Wichita,210,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,0,0,0
+Wichita,210,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,0,0,0
+Wichita,210,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,210,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,0,0,0
+Wichita,210,Ballots Cast,,,,0,0,0
+Wichita,211,Straight Party,,REP,,37,15,22
+Wichita,211,Straight Party,,DEM,,26,15,11
+Wichita,211,Straight Party,,LIB,,0,0,0
+Wichita,211,Straight Party,,,Over Votes,0,0,0
+Wichita,211,Straight Party,,,Under Votes,26,14,12
+Wichita,211,U.S. Senate,,REP,Ted Cruz,50,22,28
+Wichita,211,U.S. Senate,,DEM,Beto O'Rourke,37,21,16
+Wichita,211,U.S. Senate,,LIB,Neal M. Dikeman,1,0,1
+Wichita,211,U.S. Senate,,,Over Votes,0,0,0
+Wichita,211,U.S. Senate,,,Under Votes,1,1,0
+Wichita,211,U.S. House,13,REP,Mac Thornberry,51,21,30
+Wichita,211,U.S. House,13,DEM,Greg Sagan,36,22,14
+Wichita,211,U.S. House,13,LIB,Calvin DeWeese,2,1,1
+Wichita,211,U.S. House,13,,Over Votes,0,0,0
+Wichita,211,U.S. House,13,,Under Votes,0,0,0
+Wichita,211,Governor,,REP,Greg Abbott,52,22,30
+Wichita,211,Governor,,DEM,Lupe Valdez,37,22,15
+Wichita,211,Governor,,LIB,Mark Jay Tippetts,0,0,0
+Wichita,211,Governor,,,Over Votes,0,0,0
+Wichita,211,Governor,,,Under Votes,0,0,0
+Wichita,211,Lieutenant Governor,,REP,Dan Patrick,48,21,27
+Wichita,211,Lieutenant Governor,,DEM,Mike Collier,38,21,17
+Wichita,211,Lieutenant Governor,,LIB,Kerry Douglas McKennon,3,2,1
+Wichita,211,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,211,Lieutenant Governor,,,Under Votes,0,0,0
+Wichita,211,Attorney General,,REP,Ken Paxton,46,21,25
+Wichita,211,Attorney General,,DEM,Justin Nelson,39,22,17
+Wichita,211,Attorney General,,LIB,Michael Ray Harris,3,1,2
+Wichita,211,Attorney General,,,Over Votes,0,0,0
+Wichita,211,Attorney General,,,Under Votes,1,0,1
+Wichita,211,Comptroller of Public Accounts,,REP,Glenn Hegar,47,22,25
+Wichita,211,Comptroller of Public Accounts,,DEM,Joi Chevalier,39,22,17
+Wichita,211,Comptroller of Public Accounts,,LIB,Ben Sanders,3,0,3
+Wichita,211,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,211,Comptroller of Public Accounts,,,Under Votes,0,0,0
+Wichita,211,Commissioner of the General Land Office,,REP,George P. Bush,49,22,27
+Wichita,211,Commissioner of the General Land Office,,DEM,Miguel Suazo,40,22,18
+Wichita,211,Commissioner of the General Land Office,,LIB,Matt Pina,0,0,0
+Wichita,211,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,211,Commissioner of the General Land Office,,,Under Votes,0,0,0
+Wichita,211,Commissioner of Agriculture,,REP,Sid Miller,48,22,26
+Wichita,211,Commissioner of Agriculture,,DEM,Kim Olson,40,22,18
+Wichita,211,Commissioner of Agriculture,,LIB,Richard Carpenter,1,0,1
+Wichita,211,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,211,Commissioner of Agriculture,,,Under Votes,0,0,0
+Wichita,211,Railroad Commissioner,,REP,Christi Craddick,46,22,24
+Wichita,211,Railroad Commissioner,,DEM,Roman McAllen,40,22,18
+Wichita,211,Railroad Commissioner,,LIB,Mike Wright,3,0,3
+Wichita,211,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,211,Railroad Commissioner,,,Under Votes,0,0,0
+Wichita,211,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,49,22,27
+Wichita,211,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,40,22,18
+Wichita,211,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,211,"Justice, Supreme Court, Place 2",,,Under Votes,0,0,0
+Wichita,211,"Justice, Supreme Court, Place 4",,REP,John Devine,49,22,27
+Wichita,211,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,40,22,18
+Wichita,211,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,211,"Justice, Supreme Court, Place 4",,,Under Votes,0,0,0
+Wichita,211,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,49,22,27
+Wichita,211,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,40,22,18
+Wichita,211,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,211,"Justice, Supreme Court, Place 6",,,Under Votes,0,0,0
+Wichita,211,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,48,22,26
+Wichita,211,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,40,22,18
+Wichita,211,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,1,0,1
+Wichita,211,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,211,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,0,0,0
+Wichita,211,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,48,22,26
+Wichita,211,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,41,22,19
+Wichita,211,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,211,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,0,0,0
+Wichita,211,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,50,23,27
+Wichita,211,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,15,8,7
+Wichita,211,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,211,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,24,13,11
+Wichita,211,State Senator,30,REP,Pat Fallon,49,22,27
+Wichita,211,State Senator,30,DEM,Kevin Lopez,40,22,18
+Wichita,211,State Senator,30,,Over Votes,0,0,0
+Wichita,211,State Senator,30,,Under Votes,0,0,0
+Wichita,211,State Representative,69,REP,James Frank,58,26,32
+Wichita,211,State Representative,69,,Over Votes,0,0,0
+Wichita,211,State Representative,69,,Under Votes,31,18,13
+Wichita,211,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,56,26,30
+Wichita,211,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,211,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,33,18,15
+Wichita,211,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,54,25,29
+Wichita,211,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,211,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,35,19,16
+Wichita,211,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,49,22,27
+Wichita,211,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,40,22,18
+Wichita,211,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,211,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,0,0,0
+Wichita,211,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,54,25,29
+Wichita,211,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,211,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,35,19,16
+Wichita,211,"District Judge, 30th Judicial District",,REP,Jeff McKnight,55,26,29
+Wichita,211,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,211,"District Judge, 30th Judicial District",,,Under Votes,34,18,16
+Wichita,211,Criminal District Attorney,,REP,John Gillespie,55,26,29
+Wichita,211,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,211,Criminal District Attorney,,,Under Votes,34,18,16
+Wichita,211,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",57,27,30
+Wichita,211,County Judge,,,Over Votes,0,0,0
+Wichita,211,County Judge,,,Under Votes,32,17,15
+Wichita,211,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,55,26,29
+Wichita,211,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,211,"Judge, County Court at Law No. 1",,,Under Votes,34,18,16
+Wichita,211,"Judge, County Court at Law No. 2",,REP,Greg King,53,25,28
+Wichita,211,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,211,"Judge, County Court at Law No. 2",,,Under Votes,36,19,17
+Wichita,211,District Clerk,,REP,Patti Flores,56,27,29
+Wichita,211,District Clerk,,,Over Votes,0,0,0
+Wichita,211,District Clerk,,,Under Votes,33,17,16
+Wichita,211,County Clerk,,REP,Lori Bohannon,56,26,30
+Wichita,211,County Clerk,,,Over Votes,0,0,0
+Wichita,211,County Clerk,,,Under Votes,33,18,15
+Wichita,211,County Treasurer,,REP,R. J. Bob Hampton,55,25,30
+Wichita,211,County Treasurer,,,Over Votes,0,0,0
+Wichita,211,County Treasurer,,,Under Votes,34,19,15
+Wichita,211,"County Commissioner, Precinct 2",,REP,Lee Harvey,54,24,30
+Wichita,211,"County Commissioner, Precinct 2",,,Over Votes,0,0,0
+Wichita,211,"County Commissioner, Precinct 2",,,Under Votes,35,20,15
+Wichita,211,"Justice of the Peace, Precinct 2",,REP,Rodney Burchett,53,25,28
+Wichita,211,"Justice of the Peace, Precinct 2",,,Over Votes,0,0,0
+Wichita,211,"Justice of the Peace, Precinct 2",,,Under Votes,36,19,17
+Wichita,211,City of Wichita Falls Mayor,,,Lowry W. Crane,3,2,1
+Wichita,211,City of Wichita Falls Mayor,,,Stephen L. Santellana,14,9,5
+Wichita,211,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,211,City of Wichita Falls Mayor,,,Under Votes,12,7,5
+Wichita,211,Wichita Falls ISD Single Member District 5,,,Tom Bursey,22,13,9
+Wichita,211,Wichita Falls ISD Single Member District 5,,,Over Votes,0,0,0
+Wichita,211,Wichita Falls ISD Single Member District 5,,,Under Votes,54,28,26
+Wichita,211,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,23,15,8
+Wichita,211,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,211,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,53,26,27
+Wichita,211,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,21,12,9
+Wichita,211,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,14,9,5
+Wichita,211,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,211,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,41,20,21
+Wichita,211,Ballots Cast,,,,89,44,45
+Wichita,301,Straight Party,,REP,,2,2,0
+Wichita,301,Straight Party,,DEM,,1,0,1
+Wichita,301,Straight Party,,LIB,,0,0,0
+Wichita,301,Straight Party,,,Over Votes,0,0,0
+Wichita,301,Straight Party,,,Under Votes,1,0,1
+Wichita,301,U.S. Senate,,REP,Ted Cruz,2,2,0
+Wichita,301,U.S. Senate,,DEM,Beto O'Rourke,2,0,2
+Wichita,301,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0
+Wichita,301,U.S. Senate,,,Over Votes,0,0,0
+Wichita,301,U.S. Senate,,,Under Votes,0,0,0
+Wichita,301,U.S. House,13,REP,Mac Thornberry,3,2,1
+Wichita,301,U.S. House,13,DEM,Greg Sagan,1,0,1
+Wichita,301,U.S. House,13,LIB,Calvin DeWeese,0,0,0
+Wichita,301,U.S. House,13,,Over Votes,0,0,0
+Wichita,301,U.S. House,13,,Under Votes,0,0,0
+Wichita,301,Governor,,REP,Greg Abbott,3,2,1
+Wichita,301,Governor,,DEM,Lupe Valdez,1,0,1
+Wichita,301,Governor,,LIB,Mark Jay Tippetts,0,0,0
+Wichita,301,Governor,,,Over Votes,0,0,0
+Wichita,301,Governor,,,Under Votes,0,0,0
+Wichita,301,Lieutenant Governor,,REP,Dan Patrick,2,2,0
+Wichita,301,Lieutenant Governor,,DEM,Mike Collier,2,0,2
+Wichita,301,Lieutenant Governor,,LIB,Kerry Douglas McKennon,0,0,0
+Wichita,301,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,301,Lieutenant Governor,,,Under Votes,0,0,0
+Wichita,301,Attorney General,,REP,Ken Paxton,2,2,0
+Wichita,301,Attorney General,,DEM,Justin Nelson,2,0,2
+Wichita,301,Attorney General,,LIB,Michael Ray Harris,0,0,0
+Wichita,301,Attorney General,,,Over Votes,0,0,0
+Wichita,301,Attorney General,,,Under Votes,0,0,0
+Wichita,301,Comptroller of Public Accounts,,REP,Glenn Hegar,2,2,0
+Wichita,301,Comptroller of Public Accounts,,DEM,Joi Chevalier,1,0,1
+Wichita,301,Comptroller of Public Accounts,,LIB,Ben Sanders,1,0,1
+Wichita,301,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,301,Comptroller of Public Accounts,,,Under Votes,0,0,0
+Wichita,301,Commissioner of the General Land Office,,REP,George P. Bush,3,2,1
+Wichita,301,Commissioner of the General Land Office,,DEM,Miguel Suazo,1,0,1
+Wichita,301,Commissioner of the General Land Office,,LIB,Matt Pina,0,0,0
+Wichita,301,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,301,Commissioner of the General Land Office,,,Under Votes,0,0,0
+Wichita,301,Commissioner of Agriculture,,REP,Sid Miller,2,2,0
+Wichita,301,Commissioner of Agriculture,,DEM,Kim Olson,2,0,2
+Wichita,301,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0
+Wichita,301,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,301,Commissioner of Agriculture,,,Under Votes,0,0,0
+Wichita,301,Railroad Commissioner,,REP,Christi Craddick,2,2,0
+Wichita,301,Railroad Commissioner,,DEM,Roman McAllen,2,0,2
+Wichita,301,Railroad Commissioner,,LIB,Mike Wright,0,0,0
+Wichita,301,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,301,Railroad Commissioner,,,Under Votes,0,0,0
+Wichita,301,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,2,2,0
+Wichita,301,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,2,0,2
+Wichita,301,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,301,"Justice, Supreme Court, Place 2",,,Under Votes,0,0,0
+Wichita,301,"Justice, Supreme Court, Place 4",,REP,John Devine,2,2,0
+Wichita,301,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,2,0,2
+Wichita,301,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,301,"Justice, Supreme Court, Place 4",,,Under Votes,0,0,0
+Wichita,301,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,2,2,0
+Wichita,301,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,2,0,2
+Wichita,301,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,301,"Justice, Supreme Court, Place 6",,,Under Votes,0,0,0
+Wichita,301,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,2,2,0
+Wichita,301,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,2,0,2
+Wichita,301,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,0,0,0
+Wichita,301,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,301,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,0,0,0
+Wichita,301,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,2,2,0
+Wichita,301,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,2,0,2
+Wichita,301,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,301,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,0,0,0
+Wichita,301,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,2,2,0
+Wichita,301,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,2,0,2
+Wichita,301,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,301,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,0,0,0
+Wichita,301,State Senator,30,REP,Pat Fallon,2,2,0
+Wichita,301,State Senator,30,DEM,Kevin Lopez,2,0,2
+Wichita,301,State Senator,30,,Over Votes,0,0,0
+Wichita,301,State Senator,30,,Under Votes,0,0,0
+Wichita,301,State Representative,69,REP,James Frank,4,2,2
+Wichita,301,State Representative,69,,Over Votes,0,0,0
+Wichita,301,State Representative,69,,Under Votes,0,0,0
+Wichita,301,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,4,2,2
+Wichita,301,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,301,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,0,0,0
+Wichita,301,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,4,2,2
+Wichita,301,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,301,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,0,0,0
+Wichita,301,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,2,2,0
+Wichita,301,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,2,0,2
+Wichita,301,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,301,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,0,0,0
+Wichita,301,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,4,2,2
+Wichita,301,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,301,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,0,0,0
+Wichita,301,"District Judge, 30th Judicial District",,REP,Jeff McKnight,4,2,2
+Wichita,301,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,301,"District Judge, 30th Judicial District",,,Under Votes,0,0,0
+Wichita,301,Criminal District Attorney,,REP,John Gillespie,4,2,2
+Wichita,301,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,301,Criminal District Attorney,,,Under Votes,0,0,0
+Wichita,301,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",4,2,2
+Wichita,301,County Judge,,,Over Votes,0,0,0
+Wichita,301,County Judge,,,Under Votes,0,0,0
+Wichita,301,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,4,2,2
+Wichita,301,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,301,"Judge, County Court at Law No. 1",,,Under Votes,0,0,0
+Wichita,301,"Judge, County Court at Law No. 2",,REP,Greg King,4,2,2
+Wichita,301,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,301,"Judge, County Court at Law No. 2",,,Under Votes,0,0,0
+Wichita,301,District Clerk,,REP,Patti Flores,4,2,2
+Wichita,301,District Clerk,,,Over Votes,0,0,0
+Wichita,301,District Clerk,,,Under Votes,0,0,0
+Wichita,301,County Clerk,,REP,Lori Bohannon,4,2,2
+Wichita,301,County Clerk,,,Over Votes,0,0,0
+Wichita,301,County Clerk,,,Under Votes,0,0,0
+Wichita,301,County Treasurer,,REP,R. J. Bob Hampton,4,2,2
+Wichita,301,County Treasurer,,,Over Votes,0,0,0
+Wichita,301,County Treasurer,,,Under Votes,0,0,0
+Wichita,301,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,4,2,2
+Wichita,301,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,301,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,0,0,0
+Wichita,301,City of Wichita Falls Mayor,,,Lowry W. Crane,0,0,0
+Wichita,301,City of Wichita Falls Mayor,,,Stephen L. Santellana,3,1,2
+Wichita,301,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,301,City of Wichita Falls Mayor,,,Under Votes,1,1,0
+Wichita,301,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,3,1,2
+Wichita,301,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,301,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,1,1,0
+Wichita,301,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,2,1,1
+Wichita,301,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,1,0,1
+Wichita,301,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,301,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,1,1,0
+Wichita,301,Ballots Cast,,,,4,2,2
+Wichita,302,Straight Party,,REP,,210,138,72
+Wichita,302,Straight Party,,DEM,,208,129,79
+Wichita,302,Straight Party,,LIB,,5,3,2
+Wichita,302,Straight Party,,,Over Votes,0,0,0
+Wichita,302,Straight Party,,,Under Votes,234,151,83
+Wichita,302,U.S. Senate,,REP,Ted Cruz,328,214,114
+Wichita,302,U.S. Senate,,DEM,Beto O'Rourke,311,193,118
+Wichita,302,U.S. Senate,,LIB,Neal M. Dikeman,7,6,1
+Wichita,302,U.S. Senate,,,Over Votes,0,0,0
+Wichita,302,U.S. Senate,,,Under Votes,10,7,3
+Wichita,302,U.S. House,13,REP,Mac Thornberry,349,228,121
+Wichita,302,U.S. House,13,DEM,Greg Sagan,272,169,103
+Wichita,302,U.S. House,13,LIB,Calvin DeWeese,20,14,6
+Wichita,302,U.S. House,13,,Over Votes,0,0,0
+Wichita,302,U.S. House,13,,Under Votes,14,8,6
+Wichita,302,Governor,,REP,Greg Abbott,349,230,119
+Wichita,302,Governor,,DEM,Lupe Valdez,280,174,106
+Wichita,302,Governor,,LIB,Mark Jay Tippetts,16,9,7
+Wichita,302,Governor,,,Over Votes,0,0,0
+Wichita,302,Governor,,,Under Votes,11,7,4
+Wichita,302,Lieutenant Governor,,REP,Dan Patrick,323,213,110
+Wichita,302,Lieutenant Governor,,DEM,Mike Collier,300,187,113
+Wichita,302,Lieutenant Governor,,LIB,Kerry Douglas McKennon,20,12,8
+Wichita,302,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,302,Lieutenant Governor,,,Under Votes,13,8,5
+Wichita,302,Attorney General,,REP,Ken Paxton,316,210,106
+Wichita,302,Attorney General,,DEM,Justin Nelson,301,185,116
+Wichita,302,Attorney General,,LIB,Michael Ray Harris,18,12,6
+Wichita,302,Attorney General,,,Over Votes,0,0,0
+Wichita,302,Attorney General,,,Under Votes,21,13,8
+Wichita,302,Comptroller of Public Accounts,,REP,Glenn Hegar,323,216,107
+Wichita,302,Comptroller of Public Accounts,,DEM,Joi Chevalier,284,174,110
+Wichita,302,Comptroller of Public Accounts,,LIB,Ben Sanders,30,17,13
+Wichita,302,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,302,Comptroller of Public Accounts,,,Under Votes,19,13,6
+Wichita,302,Commissioner of the General Land Office,,REP,George P. Bush,313,209,104
+Wichita,302,Commissioner of the General Land Office,,DEM,Miguel Suazo,290,178,112
+Wichita,302,Commissioner of the General Land Office,,LIB,Matt Pina,32,20,12
+Wichita,302,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,302,Commissioner of the General Land Office,,,Under Votes,21,13,8
+Wichita,302,Commissioner of Agriculture,,REP,Sid Miller,314,208,106
+Wichita,302,Commissioner of Agriculture,,DEM,Kim Olson,306,189,117
+Wichita,302,Commissioner of Agriculture,,LIB,Richard Carpenter,17,10,7
+Wichita,302,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,302,Commissioner of Agriculture,,,Under Votes,19,13,6
+Wichita,302,Railroad Commissioner,,REP,Christi Craddick,321,212,109
+Wichita,302,Railroad Commissioner,,DEM,Roman McAllen,283,171,112
+Wichita,302,Railroad Commissioner,,LIB,Mike Wright,31,21,10
+Wichita,302,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,302,Railroad Commissioner,,,Under Votes,21,16,5
+Wichita,302,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,326,214,112
+Wichita,302,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,305,188,117
+Wichita,302,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,302,"Justice, Supreme Court, Place 2",,,Under Votes,23,16,7
+Wichita,302,"Justice, Supreme Court, Place 4",,REP,John Devine,333,218,115
+Wichita,302,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,298,185,113
+Wichita,302,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,302,"Justice, Supreme Court, Place 4",,,Under Votes,23,15,8
+Wichita,302,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,327,216,111
+Wichita,302,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,303,186,117
+Wichita,302,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,302,"Justice, Supreme Court, Place 6",,,Under Votes,24,16,8
+Wichita,302,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,320,212,108
+Wichita,302,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,297,184,113
+Wichita,302,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,18,10,8
+Wichita,302,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,302,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,20,13,7
+Wichita,302,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,330,215,115
+Wichita,302,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,302,187,115
+Wichita,302,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,302,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,22,16,6
+Wichita,302,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,354,231,123
+Wichita,302,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,115,77,38
+Wichita,302,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,302,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,187,112,75
+Wichita,302,State Senator,30,REP,Pat Fallon,329,215,114
+Wichita,302,State Senator,30,DEM,Kevin Lopez,308,192,116
+Wichita,302,State Senator,30,,Over Votes,0,0,0
+Wichita,302,State Senator,30,,Under Votes,17,11,6
+Wichita,302,State Representative,69,REP,James Frank,399,254,145
+Wichita,302,State Representative,69,,Over Votes,0,0,0
+Wichita,302,State Representative,69,,Under Votes,254,163,91
+Wichita,302,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,398,251,147
+Wichita,302,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,302,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,256,167,89
+Wichita,302,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,394,253,141
+Wichita,302,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,302,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,260,165,95
+Wichita,302,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,324,213,111
+Wichita,302,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,305,190,115
+Wichita,302,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,302,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,26,16,10
+Wichita,302,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,395,253,142
+Wichita,302,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,302,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,259,165,94
+Wichita,302,"District Judge, 30th Judicial District",,REP,Jeff McKnight,404,254,150
+Wichita,302,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,302,"District Judge, 30th Judicial District",,,Under Votes,249,163,86
+Wichita,302,Criminal District Attorney,,REP,John Gillespie,402,256,146
+Wichita,302,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,302,Criminal District Attorney,,,Under Votes,251,161,90
+Wichita,302,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",414,257,157
+Wichita,302,County Judge,,,Over Votes,0,0,0
+Wichita,302,County Judge,,,Under Votes,239,160,79
+Wichita,302,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,397,252,145
+Wichita,302,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,302,"Judge, County Court at Law No. 1",,,Under Votes,256,165,91
+Wichita,302,"Judge, County Court at Law No. 2",,REP,Greg King,404,256,148
+Wichita,302,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,302,"Judge, County Court at Law No. 2",,,Under Votes,249,161,88
+Wichita,302,District Clerk,,REP,Patti Flores,408,257,151
+Wichita,302,District Clerk,,,Over Votes,0,0,0
+Wichita,302,District Clerk,,,Under Votes,245,160,85
+Wichita,302,County Clerk,,REP,Lori Bohannon,411,256,155
+Wichita,302,County Clerk,,,Over Votes,0,0,0
+Wichita,302,County Clerk,,,Under Votes,242,161,81
+Wichita,302,County Treasurer,,REP,R. J. Bob Hampton,405,258,147
+Wichita,302,County Treasurer,,,Over Votes,0,0,0
+Wichita,302,County Treasurer,,,Under Votes,248,159,89
+Wichita,302,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,401,255,146
+Wichita,302,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,302,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,253,163,90
+Wichita,302,City of Wichita Falls Mayor,,,Lowry W. Crane,155,104,51
+Wichita,302,City of Wichita Falls Mayor,,,Stephen L. Santellana,343,215,128
+Wichita,302,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,302,City of Wichita Falls Mayor,,,Under Votes,155,99,56
+Wichita,302,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,363,230,133
+Wichita,302,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,302,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,292,189,103
+Wichita,302,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,309,194,115
+Wichita,302,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,153,106,47
+Wichita,302,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,302,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,196,122,74
+Wichita,302,Ballots Cast,,,,659,420,236
+Wichita,303,Straight Party,,REP,,122,72,50
+Wichita,303,Straight Party,,DEM,,332,184,148
+Wichita,303,Straight Party,,LIB,,4,3,1
+Wichita,303,Straight Party,,,Over Votes,0,0,0
+Wichita,303,Straight Party,,,Under Votes,208,142,66
+Wichita,303,U.S. Senate,,REP,Ted Cruz,194,123,71
+Wichita,303,U.S. Senate,,DEM,Beto O'Rourke,452,267,185
+Wichita,303,U.S. Senate,,LIB,Neal M. Dikeman,6,2,4
+Wichita,303,U.S. Senate,,,Over Votes,0,0,0
+Wichita,303,U.S. Senate,,,Under Votes,10,5,5
+Wichita,303,U.S. House,13,REP,Mac Thornberry,217,135,82
+Wichita,303,U.S. House,13,DEM,Greg Sagan,422,246,176
+Wichita,303,U.S. House,13,LIB,Calvin DeWeese,13,8,5
+Wichita,303,U.S. House,13,,Over Votes,1,1,0
+Wichita,303,U.S. House,13,,Under Votes,9,7,2
+Wichita,303,Governor,,REP,Greg Abbott,221,137,84
+Wichita,303,Governor,,DEM,Lupe Valdez,424,248,176
+Wichita,303,Governor,,LIB,Mark Jay Tippetts,9,7,2
+Wichita,303,Governor,,,Over Votes,0,0,0
+Wichita,303,Governor,,,Under Votes,8,5,3
+Wichita,303,Lieutenant Governor,,REP,Dan Patrick,200,128,72
+Wichita,303,Lieutenant Governor,,DEM,Mike Collier,434,254,180
+Wichita,303,Lieutenant Governor,,LIB,Kerry Douglas McKennon,18,8,10
+Wichita,303,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,303,Lieutenant Governor,,,Under Votes,10,7,3
+Wichita,303,Attorney General,,REP,Ken Paxton,191,121,70
+Wichita,303,Attorney General,,DEM,Justin Nelson,434,254,180
+Wichita,303,Attorney General,,LIB,Michael Ray Harris,27,16,11
+Wichita,303,Attorney General,,,Over Votes,0,0,0
+Wichita,303,Attorney General,,,Under Votes,10,6,4
+Wichita,303,Comptroller of Public Accounts,,REP,Glenn Hegar,199,132,67
+Wichita,303,Comptroller of Public Accounts,,DEM,Joi Chevalier,424,244,180
+Wichita,303,Comptroller of Public Accounts,,LIB,Ben Sanders,26,12,14
+Wichita,303,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,303,Comptroller of Public Accounts,,,Under Votes,13,9,4
+Wichita,303,Commissioner of the General Land Office,,REP,George P. Bush,193,120,73
+Wichita,303,Commissioner of the General Land Office,,DEM,Miguel Suazo,435,254,181
+Wichita,303,Commissioner of the General Land Office,,LIB,Matt Pina,19,11,8
+Wichita,303,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,303,Commissioner of the General Land Office,,,Under Votes,15,12,3
+Wichita,303,Commissioner of Agriculture,,REP,Sid Miller,193,122,71
+Wichita,303,Commissioner of Agriculture,,DEM,Kim Olson,435,254,181
+Wichita,303,Commissioner of Agriculture,,LIB,Richard Carpenter,21,11,10
+Wichita,303,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,303,Commissioner of Agriculture,,,Under Votes,13,10,3
+Wichita,303,Railroad Commissioner,,REP,Christi Craddick,203,131,72
+Wichita,303,Railroad Commissioner,,DEM,Roman McAllen,420,243,177
+Wichita,303,Railroad Commissioner,,LIB,Mike Wright,24,11,13
+Wichita,303,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,303,Railroad Commissioner,,,Under Votes,15,12,3
+Wichita,303,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,202,131,71
+Wichita,303,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,445,255,190
+Wichita,303,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,303,"Justice, Supreme Court, Place 2",,,Under Votes,15,11,4
+Wichita,303,"Justice, Supreme Court, Place 4",,REP,John Devine,204,131,73
+Wichita,303,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,442,255,187
+Wichita,303,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,303,"Justice, Supreme Court, Place 4",,,Under Votes,16,11,5
+Wichita,303,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,192,125,67
+Wichita,303,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,455,261,194
+Wichita,303,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,303,"Justice, Supreme Court, Place 6",,,Under Votes,15,11,4
+Wichita,303,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,194,124,70
+Wichita,303,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,437,253,184
+Wichita,303,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,17,9,8
+Wichita,303,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,303,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,14,11,3
+Wichita,303,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,202,128,74
+Wichita,303,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,446,259,187
+Wichita,303,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,303,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,14,10,4
+Wichita,303,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,233,144,89
+Wichita,303,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,125,81,44
+Wichita,303,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,303,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,304,172,132
+Wichita,303,State Senator,30,REP,Pat Fallon,194,122,72
+Wichita,303,State Senator,30,DEM,Kevin Lopez,455,267,188
+Wichita,303,State Senator,30,,Over Votes,0,0,0
+Wichita,303,State Senator,30,,Under Votes,13,8,5
+Wichita,303,State Representative,69,REP,James Frank,283,177,106
+Wichita,303,State Representative,69,,Over Votes,0,0,0
+Wichita,303,State Representative,69,,Under Votes,379,220,159
+Wichita,303,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,277,178,99
+Wichita,303,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,303,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,385,219,166
+Wichita,303,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,268,172,96
+Wichita,303,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,303,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,395,226,169
+Wichita,303,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,194,125,69
+Wichita,303,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,444,255,189
+Wichita,303,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,303,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,24,17,7
+Wichita,303,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,269,170,99
+Wichita,303,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,303,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,394,228,166
+Wichita,303,"District Judge, 30th Judicial District",,REP,Jeff McKnight,272,171,101
+Wichita,303,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,303,"District Judge, 30th Judicial District",,,Under Votes,391,227,164
+Wichita,303,Criminal District Attorney,,REP,John Gillespie,277,177,100
+Wichita,303,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,303,Criminal District Attorney,,,Under Votes,386,221,165
+Wichita,303,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",303,193,110
+Wichita,303,County Judge,,,Over Votes,0,0,0
+Wichita,303,County Judge,,,Under Votes,360,205,155
+Wichita,303,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,271,173,98
+Wichita,303,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,303,"Judge, County Court at Law No. 1",,,Under Votes,392,225,167
+Wichita,303,"Judge, County Court at Law No. 2",,REP,Greg King,277,174,103
+Wichita,303,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,303,"Judge, County Court at Law No. 2",,,Under Votes,386,224,162
+Wichita,303,District Clerk,,REP,Patti Flores,288,182,106
+Wichita,303,District Clerk,,,Over Votes,0,0,0
+Wichita,303,District Clerk,,,Under Votes,374,215,159
+Wichita,303,County Clerk,,REP,Lori Bohannon,290,185,105
+Wichita,303,County Clerk,,,Over Votes,0,0,0
+Wichita,303,County Clerk,,,Under Votes,373,213,160
+Wichita,303,County Treasurer,,REP,R. J. Bob Hampton,284,180,104
+Wichita,303,County Treasurer,,,Over Votes,0,0,0
+Wichita,303,County Treasurer,,,Under Votes,379,218,161
+Wichita,303,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,284,179,105
+Wichita,303,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,303,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,380,220,160
+Wichita,303,City of Wichita Falls Mayor,,,Lowry W. Crane,133,89,44
+Wichita,303,City of Wichita Falls Mayor,,,Stephen L. Santellana,334,211,123
+Wichita,303,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,303,City of Wichita Falls Mayor,,,Under Votes,198,100,98
+Wichita,303,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,323,206,117
+Wichita,303,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,303,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,342,194,148
+Wichita,303,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,307,202,105
+Wichita,303,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,128,74,54
+Wichita,303,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,303,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,230,124,106
+Wichita,303,Ballots Cast,,,,666,401,265
+Wichita,304,Straight Party,,REP,,21,13,8
+Wichita,304,Straight Party,,DEM,,26,16,10
+Wichita,304,Straight Party,,LIB,,1,0,1
+Wichita,304,Straight Party,,,Over Votes,0,0,0
+Wichita,304,Straight Party,,,Under Votes,43,30,13
+Wichita,304,U.S. Senate,,REP,Ted Cruz,44,30,14
+Wichita,304,U.S. Senate,,DEM,Beto O'Rourke,46,29,17
+Wichita,304,U.S. Senate,,LIB,Neal M. Dikeman,1,0,1
+Wichita,304,U.S. Senate,,,Over Votes,0,0,0
+Wichita,304,U.S. Senate,,,Under Votes,0,0,0
+Wichita,304,U.S. House,13,REP,Mac Thornberry,50,33,17
+Wichita,304,U.S. House,13,DEM,Greg Sagan,36,23,13
+Wichita,304,U.S. House,13,LIB,Calvin DeWeese,5,3,2
+Wichita,304,U.S. House,13,,Over Votes,0,0,0
+Wichita,304,U.S. House,13,,Under Votes,0,0,0
+Wichita,304,Governor,,REP,Greg Abbott,48,33,15
+Wichita,304,Governor,,DEM,Lupe Valdez,42,26,16
+Wichita,304,Governor,,LIB,Mark Jay Tippetts,1,0,1
+Wichita,304,Governor,,,Over Votes,0,0,0
+Wichita,304,Governor,,,Under Votes,0,0,0
+Wichita,304,Lieutenant Governor,,REP,Dan Patrick,37,26,11
+Wichita,304,Lieutenant Governor,,DEM,Mike Collier,46,29,17
+Wichita,304,Lieutenant Governor,,LIB,Kerry Douglas McKennon,7,4,3
+Wichita,304,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,304,Lieutenant Governor,,,Under Votes,1,0,1
+Wichita,304,Attorney General,,REP,Ken Paxton,39,26,13
+Wichita,304,Attorney General,,DEM,Justin Nelson,49,31,18
+Wichita,304,Attorney General,,LIB,Michael Ray Harris,3,2,1
+Wichita,304,Attorney General,,,Over Votes,0,0,0
+Wichita,304,Attorney General,,,Under Votes,0,0,0
+Wichita,304,Comptroller of Public Accounts,,REP,Glenn Hegar,39,26,13
+Wichita,304,Comptroller of Public Accounts,,DEM,Joi Chevalier,45,29,16
+Wichita,304,Comptroller of Public Accounts,,LIB,Ben Sanders,7,4,3
+Wichita,304,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,304,Comptroller of Public Accounts,,,Under Votes,0,0,0
+Wichita,304,Commissioner of the General Land Office,,REP,George P. Bush,42,27,15
+Wichita,304,Commissioner of the General Land Office,,DEM,Miguel Suazo,40,26,14
+Wichita,304,Commissioner of the General Land Office,,LIB,Matt Pina,8,6,2
+Wichita,304,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,304,Commissioner of the General Land Office,,,Under Votes,1,0,1
+Wichita,304,Commissioner of Agriculture,,REP,Sid Miller,39,26,13
+Wichita,304,Commissioner of Agriculture,,DEM,Kim Olson,48,31,17
+Wichita,304,Commissioner of Agriculture,,LIB,Richard Carpenter,4,2,2
+Wichita,304,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,304,Commissioner of Agriculture,,,Under Votes,0,0,0
+Wichita,304,Railroad Commissioner,,REP,Christi Craddick,44,29,15
+Wichita,304,Railroad Commissioner,,DEM,Roman McAllen,41,27,14
+Wichita,304,Railroad Commissioner,,LIB,Mike Wright,5,3,2
+Wichita,304,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,304,Railroad Commissioner,,,Under Votes,1,0,1
+Wichita,304,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,40,26,14
+Wichita,304,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,50,33,17
+Wichita,304,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,304,"Justice, Supreme Court, Place 2",,,Under Votes,1,0,1
+Wichita,304,"Justice, Supreme Court, Place 4",,REP,John Devine,44,30,14
+Wichita,304,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,46,28,18
+Wichita,304,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,304,"Justice, Supreme Court, Place 4",,,Under Votes,1,1,0
+Wichita,304,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,43,28,15
+Wichita,304,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,47,30,17
+Wichita,304,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,304,"Justice, Supreme Court, Place 6",,,Under Votes,1,1,0
+Wichita,304,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,40,26,14
+Wichita,304,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,45,29,16
+Wichita,304,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,5,3,2
+Wichita,304,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,304,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,1,1,0
+Wichita,304,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,42,28,14
+Wichita,304,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,46,30,16
+Wichita,304,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,304,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,3,1,2
+Wichita,304,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,48,31,17
+Wichita,304,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,20,12,8
+Wichita,304,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,304,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,23,16,7
+Wichita,304,State Senator,30,REP,Pat Fallon,44,30,14
+Wichita,304,State Senator,30,DEM,Kevin Lopez,46,28,18
+Wichita,304,State Senator,30,,Over Votes,0,0,0
+Wichita,304,State Senator,30,,Under Votes,1,1,0
+Wichita,304,State Representative,69,REP,James Frank,58,35,23
+Wichita,304,State Representative,69,,Over Votes,0,0,0
+Wichita,304,State Representative,69,,Under Votes,33,24,9
+Wichita,304,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,57,36,21
+Wichita,304,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,304,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,34,23,11
+Wichita,304,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,55,34,21
+Wichita,304,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,304,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,36,25,11
+Wichita,304,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,39,26,13
+Wichita,304,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,49,32,17
+Wichita,304,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,304,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,3,1,2
+Wichita,304,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,55,34,21
+Wichita,304,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,304,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,36,25,11
+Wichita,304,"District Judge, 30th Judicial District",,REP,Jeff McKnight,54,33,21
+Wichita,304,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,304,"District Judge, 30th Judicial District",,,Under Votes,37,26,11
+Wichita,304,Criminal District Attorney,,REP,John Gillespie,54,34,20
+Wichita,304,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,304,Criminal District Attorney,,,Under Votes,37,25,12
+Wichita,304,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",58,35,23
+Wichita,304,County Judge,,,Over Votes,0,0,0
+Wichita,304,County Judge,,,Under Votes,33,24,9
+Wichita,304,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,53,34,19
+Wichita,304,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,304,"Judge, County Court at Law No. 1",,,Under Votes,38,25,13
+Wichita,304,"Judge, County Court at Law No. 2",,REP,Greg King,56,35,21
+Wichita,304,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,304,"Judge, County Court at Law No. 2",,,Under Votes,35,24,11
+Wichita,304,District Clerk,,REP,Patti Flores,54,34,20
+Wichita,304,District Clerk,,,Over Votes,0,0,0
+Wichita,304,District Clerk,,,Under Votes,37,25,12
+Wichita,304,County Clerk,,REP,Lori Bohannon,56,34,22
+Wichita,304,County Clerk,,,Over Votes,0,0,0
+Wichita,304,County Clerk,,,Under Votes,35,25,10
+Wichita,304,County Treasurer,,REP,R. J. Bob Hampton,56,36,20
+Wichita,304,County Treasurer,,,Over Votes,0,0,0
+Wichita,304,County Treasurer,,,Under Votes,35,23,12
+Wichita,304,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,57,36,21
+Wichita,304,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,304,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,34,23,11
+Wichita,304,City of Wichita Falls Mayor,,,Lowry W. Crane,21,11,10
+Wichita,304,City of Wichita Falls Mayor,,,Stephen L. Santellana,47,32,15
+Wichita,304,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,304,City of Wichita Falls Mayor,,,Under Votes,21,14,7
+Wichita,304,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,58,36,22
+Wichita,304,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,304,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,33,23,10
+Wichita,304,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,42,25,17
+Wichita,304,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,25,16,9
+Wichita,304,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,304,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,24,18,6
+Wichita,304,Ballots Cast,,,,91,59,32
+Wichita,305,Straight Party,,REP,,58,40,18
+Wichita,305,Straight Party,,DEM,,39,31,8
+Wichita,305,Straight Party,,LIB,,0,0,0
+Wichita,305,Straight Party,,,Over Votes,0,0,0
+Wichita,305,Straight Party,,,Under Votes,80,53,27
+Wichita,305,U.S. Senate,,REP,Ted Cruz,101,70,31
+Wichita,305,U.S. Senate,,DEM,Beto O'Rourke,70,50,20
+Wichita,305,U.S. Senate,,LIB,Neal M. Dikeman,2,0,2
+Wichita,305,U.S. Senate,,,Over Votes,0,0,0
+Wichita,305,U.S. Senate,,,Under Votes,3,3,0
+Wichita,305,U.S. House,13,REP,Mac Thornberry,108,76,32
+Wichita,305,U.S. House,13,DEM,Greg Sagan,60,44,16
+Wichita,305,U.S. House,13,LIB,Calvin DeWeese,6,1,5
+Wichita,305,U.S. House,13,,Over Votes,0,0,0
+Wichita,305,U.S. House,13,,Under Votes,2,2,0
+Wichita,305,Governor,,REP,Greg Abbott,103,72,31
+Wichita,305,Governor,,DEM,Lupe Valdez,69,50,19
+Wichita,305,Governor,,LIB,Mark Jay Tippetts,2,0,2
+Wichita,305,Governor,,,Over Votes,0,0,0
+Wichita,305,Governor,,,Under Votes,2,1,1
+Wichita,305,Lieutenant Governor,,REP,Dan Patrick,97,69,28
+Wichita,305,Lieutenant Governor,,DEM,Mike Collier,65,48,17
+Wichita,305,Lieutenant Governor,,LIB,Kerry Douglas McKennon,12,5,7
+Wichita,305,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,305,Lieutenant Governor,,,Under Votes,2,1,1
+Wichita,305,Attorney General,,REP,Ken Paxton,97,67,30
+Wichita,305,Attorney General,,DEM,Justin Nelson,70,53,17
+Wichita,305,Attorney General,,LIB,Michael Ray Harris,5,0,5
+Wichita,305,Attorney General,,,Over Votes,0,0,0
+Wichita,305,Attorney General,,,Under Votes,4,3,1
+Wichita,305,Comptroller of Public Accounts,,REP,Glenn Hegar,97,68,29
+Wichita,305,Comptroller of Public Accounts,,DEM,Joi Chevalier,67,50,17
+Wichita,305,Comptroller of Public Accounts,,LIB,Ben Sanders,8,2,6
+Wichita,305,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,305,Comptroller of Public Accounts,,,Under Votes,4,3,1
+Wichita,305,Commissioner of the General Land Office,,REP,George P. Bush,95,69,26
+Wichita,305,Commissioner of the General Land Office,,DEM,Miguel Suazo,66,48,18
+Wichita,305,Commissioner of the General Land Office,,LIB,Matt Pina,10,2,8
+Wichita,305,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,305,Commissioner of the General Land Office,,,Under Votes,5,4,1
+Wichita,305,Commissioner of Agriculture,,REP,Sid Miller,96,66,30
+Wichita,305,Commissioner of Agriculture,,DEM,Kim Olson,71,52,19
+Wichita,305,Commissioner of Agriculture,,LIB,Richard Carpenter,5,2,3
+Wichita,305,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,305,Commissioner of Agriculture,,,Under Votes,4,3,1
+Wichita,305,Railroad Commissioner,,REP,Christi Craddick,100,71,29
+Wichita,305,Railroad Commissioner,,DEM,Roman McAllen,67,49,18
+Wichita,305,Railroad Commissioner,,LIB,Mike Wright,4,0,4
+Wichita,305,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,305,Railroad Commissioner,,,Under Votes,5,3,2
+Wichita,305,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,101,69,32
+Wichita,305,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,73,53,20
+Wichita,305,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,305,"Justice, Supreme Court, Place 2",,,Under Votes,2,1,1
+Wichita,305,"Justice, Supreme Court, Place 4",,REP,John Devine,99,68,31
+Wichita,305,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,70,51,19
+Wichita,305,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,305,"Justice, Supreme Court, Place 4",,,Under Votes,7,4,3
+Wichita,305,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,99,66,33
+Wichita,305,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,72,54,18
+Wichita,305,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,305,"Justice, Supreme Court, Place 6",,,Under Votes,5,3,2
+Wichita,305,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,91,64,27
+Wichita,305,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,73,55,18
+Wichita,305,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,5,0,5
+Wichita,305,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,305,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,7,4,3
+Wichita,305,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,97,66,31
+Wichita,305,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,73,53,20
+Wichita,305,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,305,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,6,4,2
+Wichita,305,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,107,75,32
+Wichita,305,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,28,17,11
+Wichita,305,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,305,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,41,31,10
+Wichita,305,State Senator,30,REP,Pat Fallon,98,66,32
+Wichita,305,State Senator,30,DEM,Kevin Lopez,71,53,18
+Wichita,305,State Senator,30,,Over Votes,0,0,0
+Wichita,305,State Senator,30,,Under Votes,7,4,3
+Wichita,305,State Representative,69,REP,James Frank,121,82,39
+Wichita,305,State Representative,69,,Over Votes,0,0,0
+Wichita,305,State Representative,69,,Under Votes,55,41,14
+Wichita,305,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,120,81,39
+Wichita,305,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,305,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,56,42,14
+Wichita,305,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,117,79,38
+Wichita,305,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,305,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,59,44,15
+Wichita,305,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,94,63,31
+Wichita,305,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,75,56,19
+Wichita,305,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,305,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,7,4,3
+Wichita,305,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,119,80,39
+Wichita,305,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,305,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,57,43,14
+Wichita,305,"District Judge, 30th Judicial District",,REP,Jeff McKnight,119,81,38
+Wichita,305,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,305,"District Judge, 30th Judicial District",,,Under Votes,57,42,15
+Wichita,305,Criminal District Attorney,,REP,John Gillespie,123,84,39
+Wichita,305,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,305,Criminal District Attorney,,,Under Votes,53,39,14
+Wichita,305,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",124,86,38
+Wichita,305,County Judge,,,Over Votes,0,0,0
+Wichita,305,County Judge,,,Under Votes,52,37,15
+Wichita,305,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,119,81,38
+Wichita,305,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,305,"Judge, County Court at Law No. 1",,,Under Votes,57,42,15
+Wichita,305,"Judge, County Court at Law No. 2",,REP,Greg King,122,82,40
+Wichita,305,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,305,"Judge, County Court at Law No. 2",,,Under Votes,54,41,13
+Wichita,305,District Clerk,,REP,Patti Flores,121,82,39
+Wichita,305,District Clerk,,,Over Votes,0,0,0
+Wichita,305,District Clerk,,,Under Votes,55,41,14
+Wichita,305,County Clerk,,REP,Lori Bohannon,124,85,39
+Wichita,305,County Clerk,,,Over Votes,0,0,0
+Wichita,305,County Clerk,,,Under Votes,52,38,14
+Wichita,305,County Treasurer,,REP,R. J. Bob Hampton,124,85,39
+Wichita,305,County Treasurer,,,Over Votes,0,0,0
+Wichita,305,County Treasurer,,,Under Votes,52,38,14
+Wichita,305,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,121,83,38
+Wichita,305,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,305,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,55,40,15
+Wichita,305,City of Wichita Falls Mayor,,,Lowry W. Crane,45,24,21
+Wichita,305,City of Wichita Falls Mayor,,,Stephen L. Santellana,92,66,26
+Wichita,305,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,305,City of Wichita Falls Mayor,,,Under Votes,40,34,6
+Wichita,305,Wichita Falls ISD Single Member District 5,,,Tom Bursey,104,72,32
+Wichita,305,Wichita Falls ISD Single Member District 5,,,Over Votes,0,0,0
+Wichita,305,Wichita Falls ISD Single Member District 5,,,Under Votes,73,52,21
+Wichita,305,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,111,76,35
+Wichita,305,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,305,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,66,48,18
+Wichita,305,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,80,54,26
+Wichita,305,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,50,30,20
+Wichita,305,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,305,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,47,40,7
+Wichita,305,Ballots Cast,,,,177,124,53
+Wichita,306,Straight Party,,REP,,60,38,22
+Wichita,306,Straight Party,,DEM,,227,143,84
+Wichita,306,Straight Party,,LIB,,2,0,2
+Wichita,306,Straight Party,,,Over Votes,1,1,0
+Wichita,306,Straight Party,,,Under Votes,126,70,56
+Wichita,306,U.S. Senate,,REP,Ted Cruz,99,60,39
+Wichita,306,U.S. Senate,,DEM,Beto O'Rourke,304,187,117
+Wichita,306,U.S. Senate,,LIB,Neal M. Dikeman,5,1,4
+Wichita,306,U.S. Senate,,,Over Votes,0,0,0
+Wichita,306,U.S. Senate,,,Under Votes,8,4,4
+Wichita,306,U.S. House,13,REP,Mac Thornberry,110,66,44
+Wichita,306,U.S. House,13,DEM,Greg Sagan,282,176,106
+Wichita,306,U.S. House,13,LIB,Calvin DeWeese,10,3,7
+Wichita,306,U.S. House,13,,Over Votes,0,0,0
+Wichita,306,U.S. House,13,,Under Votes,14,7,7
+Wichita,306,Governor,,REP,Greg Abbott,107,65,42
+Wichita,306,Governor,,DEM,Lupe Valdez,292,178,114
+Wichita,306,Governor,,LIB,Mark Jay Tippetts,8,3,5
+Wichita,306,Governor,,,Over Votes,0,0,0
+Wichita,306,Governor,,,Under Votes,9,6,3
+Wichita,306,Lieutenant Governor,,REP,Dan Patrick,93,58,35
+Wichita,306,Lieutenant Governor,,DEM,Mike Collier,301,184,117
+Wichita,306,Lieutenant Governor,,LIB,Kerry Douglas McKennon,12,3,9
+Wichita,306,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,306,Lieutenant Governor,,,Under Votes,10,7,3
+Wichita,306,Attorney General,,REP,Ken Paxton,91,57,34
+Wichita,306,Attorney General,,DEM,Justin Nelson,300,184,116
+Wichita,306,Attorney General,,LIB,Michael Ray Harris,14,6,8
+Wichita,306,Attorney General,,,Over Votes,0,0,0
+Wichita,306,Attorney General,,,Under Votes,11,5,6
+Wichita,306,Comptroller of Public Accounts,,REP,Glenn Hegar,89,55,34
+Wichita,306,Comptroller of Public Accounts,,DEM,Joi Chevalier,298,187,111
+Wichita,306,Comptroller of Public Accounts,,LIB,Ben Sanders,17,4,13
+Wichita,306,Comptroller of Public Accounts,,,Over Votes,1,1,0
+Wichita,306,Comptroller of Public Accounts,,,Under Votes,11,5,6
+Wichita,306,Commissioner of the General Land Office,,REP,George P. Bush,84,52,32
+Wichita,306,Commissioner of the General Land Office,,DEM,Miguel Suazo,301,187,114
+Wichita,306,Commissioner of the General Land Office,,LIB,Matt Pina,20,8,12
+Wichita,306,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,306,Commissioner of the General Land Office,,,Under Votes,11,5,6
+Wichita,306,Commissioner of Agriculture,,REP,Sid Miller,91,57,34
+Wichita,306,Commissioner of Agriculture,,DEM,Kim Olson,303,186,117
+Wichita,306,Commissioner of Agriculture,,LIB,Richard Carpenter,11,4,7
+Wichita,306,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,306,Commissioner of Agriculture,,,Under Votes,11,5,6
+Wichita,306,Railroad Commissioner,,REP,Christi Craddick,94,58,36
+Wichita,306,Railroad Commissioner,,DEM,Roman McAllen,299,185,114
+Wichita,306,Railroad Commissioner,,LIB,Mike Wright,11,4,7
+Wichita,306,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,306,Railroad Commissioner,,,Under Votes,12,5,7
+Wichita,306,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,92,56,36
+Wichita,306,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,312,190,122
+Wichita,306,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,306,"Justice, Supreme Court, Place 2",,,Under Votes,12,6,6
+Wichita,306,"Justice, Supreme Court, Place 4",,REP,John Devine,95,56,39
+Wichita,306,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,307,190,117
+Wichita,306,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,306,"Justice, Supreme Court, Place 4",,,Under Votes,14,6,8
+Wichita,306,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,94,58,36
+Wichita,306,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,310,188,122
+Wichita,306,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,306,"Justice, Supreme Court, Place 6",,,Under Votes,12,6,6
+Wichita,306,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,91,55,36
+Wichita,306,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,303,187,116
+Wichita,306,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,12,5,7
+Wichita,306,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,306,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,10,5,5
+Wichita,306,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,94,56,38
+Wichita,306,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,309,190,119
+Wichita,306,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,306,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,13,6,7
+Wichita,306,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,113,66,47
+Wichita,306,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,90,47,43
+Wichita,306,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,306,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,213,139,74
+Wichita,306,State Senator,30,REP,Pat Fallon,95,55,40
+Wichita,306,State Senator,30,DEM,Kevin Lopez,310,191,119
+Wichita,306,State Senator,30,,Over Votes,0,0,0
+Wichita,306,State Senator,30,,Under Votes,11,6,5
+Wichita,306,State Representative,69,REP,James Frank,145,82,63
+Wichita,306,State Representative,69,,Over Votes,0,0,0
+Wichita,306,State Representative,69,,Under Votes,271,170,101
+Wichita,306,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,146,81,65
+Wichita,306,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,306,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,270,171,99
+Wichita,306,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,136,83,53
+Wichita,306,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,306,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,280,169,111
+Wichita,306,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,93,58,35
+Wichita,306,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,311,188,123
+Wichita,306,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,306,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,12,6,6
+Wichita,306,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,142,84,58
+Wichita,306,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,306,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,274,168,106
+Wichita,306,"District Judge, 30th Judicial District",,REP,Jeff McKnight,144,86,58
+Wichita,306,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,306,"District Judge, 30th Judicial District",,,Under Votes,272,166,106
+Wichita,306,Criminal District Attorney,,REP,John Gillespie,145,88,57
+Wichita,306,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,306,Criminal District Attorney,,,Under Votes,271,164,107
+Wichita,306,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",159,96,63
+Wichita,306,County Judge,,,Over Votes,0,0,0
+Wichita,306,County Judge,,,Under Votes,257,156,101
+Wichita,306,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,140,84,56
+Wichita,306,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,306,"Judge, County Court at Law No. 1",,,Under Votes,276,168,108
+Wichita,306,"Judge, County Court at Law No. 2",,REP,Greg King,149,86,63
+Wichita,306,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,306,"Judge, County Court at Law No. 2",,,Under Votes,267,166,101
+Wichita,306,District Clerk,,REP,Patti Flores,151,87,64
+Wichita,306,District Clerk,,,Over Votes,0,0,0
+Wichita,306,District Clerk,,,Under Votes,265,165,100
+Wichita,306,County Clerk,,REP,Lori Bohannon,156,91,65
+Wichita,306,County Clerk,,,Over Votes,0,0,0
+Wichita,306,County Clerk,,,Under Votes,260,161,99
+Wichita,306,County Treasurer,,REP,R. J. Bob Hampton,147,87,60
+Wichita,306,County Treasurer,,,Over Votes,0,0,0
+Wichita,306,County Treasurer,,,Under Votes,269,165,104
+Wichita,306,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,147,88,59
+Wichita,306,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,306,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,269,164,105
+Wichita,306,City of Wichita Falls Mayor,,,Lowry W. Crane,84,54,30
+Wichita,306,City of Wichita Falls Mayor,,,Stephen L. Santellana,199,117,82
+Wichita,306,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,306,City of Wichita Falls Mayor,,,Under Votes,128,78,50
+Wichita,306,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,197,111,86
+Wichita,306,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,306,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,216,140,76
+Wichita,306,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,176,108,68
+Wichita,306,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,92,56,36
+Wichita,306,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,1,1,0
+Wichita,306,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,144,86,58
+Wichita,306,Ballots Cast,,,,416,252,164
+Wichita,307,Straight Party,,REP,,59,38,21
+Wichita,307,Straight Party,,DEM,,25,16,9
+Wichita,307,Straight Party,,LIB,,0,0,0
+Wichita,307,Straight Party,,,Over Votes,0,0,0
+Wichita,307,Straight Party,,,Under Votes,48,26,22
+Wichita,307,U.S. Senate,,REP,Ted Cruz,94,58,36
+Wichita,307,U.S. Senate,,DEM,Beto O'Rourke,37,23,14
+Wichita,307,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0
+Wichita,307,U.S. Senate,,,Over Votes,0,0,0
+Wichita,307,U.S. Senate,,,Under Votes,2,0,2
+Wichita,307,U.S. House,13,REP,Mac Thornberry,95,59,36
+Wichita,307,U.S. House,13,DEM,Greg Sagan,34,20,14
+Wichita,307,U.S. House,13,LIB,Calvin DeWeese,2,1,1
+Wichita,307,U.S. House,13,,Over Votes,0,0,0
+Wichita,307,U.S. House,13,,Under Votes,2,1,1
+Wichita,307,Governor,,REP,Greg Abbott,95,58,37
+Wichita,307,Governor,,DEM,Lupe Valdez,37,22,15
+Wichita,307,Governor,,LIB,Mark Jay Tippetts,0,0,0
+Wichita,307,Governor,,,Over Votes,0,0,0
+Wichita,307,Governor,,,Under Votes,1,1,0
+Wichita,307,Lieutenant Governor,,REP,Dan Patrick,91,55,36
+Wichita,307,Lieutenant Governor,,DEM,Mike Collier,39,25,14
+Wichita,307,Lieutenant Governor,,LIB,Kerry Douglas McKennon,1,0,1
+Wichita,307,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,307,Lieutenant Governor,,,Under Votes,2,1,1
+Wichita,307,Attorney General,,REP,Ken Paxton,90,55,35
+Wichita,307,Attorney General,,DEM,Justin Nelson,38,23,15
+Wichita,307,Attorney General,,LIB,Michael Ray Harris,3,1,2
+Wichita,307,Attorney General,,,Over Votes,0,0,0
+Wichita,307,Attorney General,,,Under Votes,2,2,0
+Wichita,307,Comptroller of Public Accounts,,REP,Glenn Hegar,89,54,35
+Wichita,307,Comptroller of Public Accounts,,DEM,Joi Chevalier,37,22,15
+Wichita,307,Comptroller of Public Accounts,,LIB,Ben Sanders,3,2,1
+Wichita,307,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,307,Comptroller of Public Accounts,,,Under Votes,4,3,1
+Wichita,307,Commissioner of the General Land Office,,REP,George P. Bush,91,55,36
+Wichita,307,Commissioner of the General Land Office,,DEM,Miguel Suazo,35,20,15
+Wichita,307,Commissioner of the General Land Office,,LIB,Matt Pina,5,4,1
+Wichita,307,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,307,Commissioner of the General Land Office,,,Under Votes,2,2,0
+Wichita,307,Commissioner of Agriculture,,REP,Sid Miller,89,54,35
+Wichita,307,Commissioner of Agriculture,,DEM,Kim Olson,37,22,15
+Wichita,307,Commissioner of Agriculture,,LIB,Richard Carpenter,3,2,1
+Wichita,307,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,307,Commissioner of Agriculture,,,Under Votes,4,3,1
+Wichita,307,Railroad Commissioner,,REP,Christi Craddick,94,58,36
+Wichita,307,Railroad Commissioner,,DEM,Roman McAllen,32,20,12
+Wichita,307,Railroad Commissioner,,LIB,Mike Wright,4,1,3
+Wichita,307,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,307,Railroad Commissioner,,,Under Votes,3,2,1
+Wichita,307,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,93,57,36
+Wichita,307,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,37,21,16
+Wichita,307,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,307,"Justice, Supreme Court, Place 2",,,Under Votes,3,3,0
+Wichita,307,"Justice, Supreme Court, Place 4",,REP,John Devine,90,55,35
+Wichita,307,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,38,22,16
+Wichita,307,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,307,"Justice, Supreme Court, Place 4",,,Under Votes,5,4,1
+Wichita,307,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,90,55,35
+Wichita,307,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,37,21,16
+Wichita,307,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,307,"Justice, Supreme Court, Place 6",,,Under Votes,6,5,1
+Wichita,307,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,89,55,34
+Wichita,307,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,38,23,15
+Wichita,307,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,2,0,2
+Wichita,307,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,307,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,4,3,1
+Wichita,307,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,90,55,35
+Wichita,307,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,38,22,16
+Wichita,307,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,307,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,5,4,1
+Wichita,307,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,93,56,37
+Wichita,307,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,12,6,6
+Wichita,307,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,307,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,28,19,9
+Wichita,307,State Senator,30,REP,Pat Fallon,91,54,37
+Wichita,307,State Senator,30,DEM,Kevin Lopez,39,24,15
+Wichita,307,State Senator,30,,Over Votes,0,0,0
+Wichita,307,State Senator,30,,Under Votes,3,3,0
+Wichita,307,State Representative,69,REP,James Frank,98,60,38
+Wichita,307,State Representative,69,,Over Votes,0,0,0
+Wichita,307,State Representative,69,,Under Votes,35,21,14
+Wichita,307,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,98,60,38
+Wichita,307,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,307,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,35,21,14
+Wichita,307,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,98,60,38
+Wichita,307,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,307,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,35,21,14
+Wichita,307,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,90,55,35
+Wichita,307,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,39,23,16
+Wichita,307,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,307,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,4,3,1
+Wichita,307,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,97,59,38
+Wichita,307,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,307,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,36,22,14
+Wichita,307,"District Judge, 30th Judicial District",,REP,Jeff McKnight,95,57,38
+Wichita,307,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,307,"District Judge, 30th Judicial District",,,Under Votes,37,23,14
+Wichita,307,Criminal District Attorney,,REP,John Gillespie,97,58,39
+Wichita,307,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,307,Criminal District Attorney,,,Under Votes,36,23,13
+Wichita,307,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",97,57,40
+Wichita,307,County Judge,,,Over Votes,0,0,0
+Wichita,307,County Judge,,,Under Votes,36,24,12
+Wichita,307,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,96,58,38
+Wichita,307,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,307,"Judge, County Court at Law No. 1",,,Under Votes,37,23,14
+Wichita,307,"Judge, County Court at Law No. 2",,REP,Greg King,96,58,38
+Wichita,307,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,307,"Judge, County Court at Law No. 2",,,Under Votes,37,23,14
+Wichita,307,District Clerk,,REP,Patti Flores,96,58,38
+Wichita,307,District Clerk,,,Over Votes,0,0,0
+Wichita,307,District Clerk,,,Under Votes,37,23,14
+Wichita,307,County Clerk,,REP,Lori Bohannon,96,58,38
+Wichita,307,County Clerk,,,Over Votes,0,0,0
+Wichita,307,County Clerk,,,Under Votes,37,23,14
+Wichita,307,County Treasurer,,REP,R. J. Bob Hampton,98,58,40
+Wichita,307,County Treasurer,,,Over Votes,0,0,0
+Wichita,307,County Treasurer,,,Under Votes,35,23,12
+Wichita,307,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,95,57,38
+Wichita,307,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,307,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,38,24,14
+Wichita,307,City of Wichita Falls Mayor,,,Lowry W. Crane,38,19,19
+Wichita,307,City of Wichita Falls Mayor,,,Stephen L. Santellana,50,29,21
+Wichita,307,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,307,City of Wichita Falls Mayor,,,Under Votes,34,26,8
+Wichita,307,City of Wichita Falls Councilor District 5,,,Chris Reitsma,22,10,12
+Wichita,307,City of Wichita Falls Councilor District 5,,,Mitesh Desai,12,7,5
+Wichita,307,City of Wichita Falls Councilor District 5,,,Steve Jackson,52,28,24
+Wichita,307,City of Wichita Falls Councilor District 5,,,Over Votes,0,0,0
+Wichita,307,City of Wichita Falls Councilor District 5,,,Under Votes,36,29,7
+Wichita,307,Ballots Cast,,,,133,81,52
+Wichita,308,Straight Party,,REP,,61,45,16
+Wichita,308,Straight Party,,DEM,,91,53,38
+Wichita,308,Straight Party,,LIB,,2,1,1
+Wichita,308,Straight Party,,,Over Votes,0,0,0
+Wichita,308,Straight Party,,,Under Votes,102,69,33
+Wichita,308,U.S. Senate,,REP,Ted Cruz,109,77,32
+Wichita,308,U.S. Senate,,DEM,Beto O'Rourke,141,86,55
+Wichita,308,U.S. Senate,,LIB,Neal M. Dikeman,1,0,1
+Wichita,308,U.S. Senate,,,Over Votes,0,0,0
+Wichita,308,U.S. Senate,,,Under Votes,3,3,0
+Wichita,308,U.S. House,13,REP,Mac Thornberry,119,82,37
+Wichita,308,U.S. House,13,DEM,Greg Sagan,124,79,45
+Wichita,308,U.S. House,13,LIB,Calvin DeWeese,3,0,3
+Wichita,308,U.S. House,13,,Over Votes,0,0,0
+Wichita,308,U.S. House,13,,Under Votes,8,5,3
+Wichita,308,Governor,,REP,Greg Abbott,114,79,35
+Wichita,308,Governor,,DEM,Lupe Valdez,128,80,48
+Wichita,308,Governor,,LIB,Mark Jay Tippetts,7,5,2
+Wichita,308,Governor,,,Over Votes,0,0,0
+Wichita,308,Governor,,,Under Votes,5,2,3
+Wichita,308,Lieutenant Governor,,REP,Dan Patrick,108,75,33
+Wichita,308,Lieutenant Governor,,DEM,Mike Collier,135,86,49
+Wichita,308,Lieutenant Governor,,LIB,Kerry Douglas McKennon,4,1,3
+Wichita,308,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,308,Lieutenant Governor,,,Under Votes,7,4,3
+Wichita,308,Attorney General,,REP,Ken Paxton,104,73,31
+Wichita,308,Attorney General,,DEM,Justin Nelson,139,88,51
+Wichita,308,Attorney General,,LIB,Michael Ray Harris,3,1,2
+Wichita,308,Attorney General,,,Over Votes,0,0,0
+Wichita,308,Attorney General,,,Under Votes,8,4,4
+Wichita,308,Comptroller of Public Accounts,,REP,Glenn Hegar,103,71,32
+Wichita,308,Comptroller of Public Accounts,,DEM,Joi Chevalier,130,83,47
+Wichita,308,Comptroller of Public Accounts,,LIB,Ben Sanders,9,4,5
+Wichita,308,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,308,Comptroller of Public Accounts,,,Under Votes,12,8,4
+Wichita,308,Commissioner of the General Land Office,,REP,George P. Bush,104,75,29
+Wichita,308,Commissioner of the General Land Office,,DEM,Miguel Suazo,126,81,45
+Wichita,308,Commissioner of the General Land Office,,LIB,Matt Pina,14,4,10
+Wichita,308,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,308,Commissioner of the General Land Office,,,Under Votes,10,6,4
+Wichita,308,Commissioner of Agriculture,,REP,Sid Miller,100,70,30
+Wichita,308,Commissioner of Agriculture,,DEM,Kim Olson,135,87,48
+Wichita,308,Commissioner of Agriculture,,LIB,Richard Carpenter,6,1,5
+Wichita,308,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,308,Commissioner of Agriculture,,,Under Votes,13,8,5
+Wichita,308,Railroad Commissioner,,REP,Christi Craddick,102,71,31
+Wichita,308,Railroad Commissioner,,DEM,Roman McAllen,129,81,48
+Wichita,308,Railroad Commissioner,,LIB,Mike Wright,11,6,5
+Wichita,308,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,308,Railroad Commissioner,,,Under Votes,12,8,4
+Wichita,308,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,105,73,32
+Wichita,308,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,136,86,50
+Wichita,308,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,308,"Justice, Supreme Court, Place 2",,,Under Votes,13,7,6
+Wichita,308,"Justice, Supreme Court, Place 4",,REP,John Devine,106,74,32
+Wichita,308,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,133,84,49
+Wichita,308,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,308,"Justice, Supreme Court, Place 4",,,Under Votes,15,8,7
+Wichita,308,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,104,72,32
+Wichita,308,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,136,86,50
+Wichita,308,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,308,"Justice, Supreme Court, Place 6",,,Under Votes,14,8,6
+Wichita,308,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,102,71,31
+Wichita,308,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,134,86,48
+Wichita,308,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,6,3,3
+Wichita,308,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,308,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,12,6,6
+Wichita,308,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,107,74,33
+Wichita,308,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,132,83,49
+Wichita,308,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,308,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,15,9,6
+Wichita,308,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,121,83,38
+Wichita,308,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,54,38,16
+Wichita,308,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,308,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,79,45,34
+Wichita,308,State Senator,30,REP,Pat Fallon,109,74,35
+Wichita,308,State Senator,30,DEM,Kevin Lopez,135,87,48
+Wichita,308,State Senator,30,,Over Votes,0,0,0
+Wichita,308,State Senator,30,,Under Votes,10,5,5
+Wichita,308,State Representative,69,REP,James Frank,148,100,48
+Wichita,308,State Representative,69,,Over Votes,0,0,0
+Wichita,308,State Representative,69,,Under Votes,106,66,40
+Wichita,308,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,142,95,47
+Wichita,308,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,308,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,112,71,41
+Wichita,308,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,141,95,46
+Wichita,308,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,308,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,113,71,42
+Wichita,308,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,108,76,32
+Wichita,308,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,132,82,50
+Wichita,308,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,308,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,14,8,6
+Wichita,308,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,138,93,45
+Wichita,308,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,308,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,116,73,43
+Wichita,308,"District Judge, 30th Judicial District",,REP,Jeff McKnight,141,95,46
+Wichita,308,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,308,"District Judge, 30th Judicial District",,,Under Votes,113,71,42
+Wichita,308,Criminal District Attorney,,REP,John Gillespie,145,97,48
+Wichita,308,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,308,Criminal District Attorney,,,Under Votes,109,69,40
+Wichita,308,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",145,98,47
+Wichita,308,County Judge,,,Over Votes,0,0,0
+Wichita,308,County Judge,,,Under Votes,109,68,41
+Wichita,308,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,141,94,47
+Wichita,308,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,308,"Judge, County Court at Law No. 1",,,Under Votes,113,72,41
+Wichita,308,"Judge, County Court at Law No. 2",,REP,Greg King,139,94,45
+Wichita,308,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,308,"Judge, County Court at Law No. 2",,,Under Votes,115,72,43
+Wichita,308,District Clerk,,REP,Patti Flores,145,98,47
+Wichita,308,District Clerk,,,Over Votes,0,0,0
+Wichita,308,District Clerk,,,Under Votes,109,68,41
+Wichita,308,County Clerk,,REP,Lori Bohannon,150,102,48
+Wichita,308,County Clerk,,,Over Votes,0,0,0
+Wichita,308,County Clerk,,,Under Votes,104,64,40
+Wichita,308,County Treasurer,,REP,R. J. Bob Hampton,146,97,49
+Wichita,308,County Treasurer,,,Over Votes,0,0,0
+Wichita,308,County Treasurer,,,Under Votes,108,69,39
+Wichita,308,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,140,95,45
+Wichita,308,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,308,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,114,71,43
+Wichita,308,City of Wichita Falls Mayor,,,Lowry W. Crane,63,46,17
+Wichita,308,City of Wichita Falls Mayor,,,Stephen L. Santellana,128,83,45
+Wichita,308,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,308,City of Wichita Falls Mayor,,,Under Votes,63,37,26
+Wichita,308,Wichita Falls ISD Single Member District 5,,,Tom Bursey,122,80,42
+Wichita,308,Wichita Falls ISD Single Member District 5,,,Over Votes,0,0,0
+Wichita,308,Wichita Falls ISD Single Member District 5,,,Under Votes,132,86,46
+Wichita,308,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,134,90,44
+Wichita,308,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,308,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,120,76,44
+Wichita,308,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,123,82,41
+Wichita,308,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,58,42,16
+Wichita,308,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,308,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,73,42,31
+Wichita,308,Ballots Cast,,,,256,168,88
+Wichita,309,Straight Party,,REP,,1139,819,320
+Wichita,309,Straight Party,,DEM,,121,94,27
+Wichita,309,Straight Party,,LIB,,2,0,2
+Wichita,309,Straight Party,,,Over Votes,0,0,0
+Wichita,309,Straight Party,,,Under Votes,800,552,248
+Wichita,309,U.S. Senate,,REP,Ted Cruz,1770,1257,513
+Wichita,309,U.S. Senate,,DEM,Beto O'Rourke,257,185,72
+Wichita,309,U.S. Senate,,LIB,Neal M. Dikeman,14,7,7
+Wichita,309,U.S. Senate,,,Over Votes,0,0,0
+Wichita,309,U.S. Senate,,,Under Votes,21,16,5
+Wichita,309,U.S. House,13,REP,Mac Thornberry,1784,1266,518
+Wichita,309,U.S. House,13,DEM,Greg Sagan,213,160,53
+Wichita,309,U.S. House,13,LIB,Calvin DeWeese,46,25,21
+Wichita,309,U.S. House,13,,Over Votes,0,0,0
+Wichita,309,U.S. House,13,,Under Votes,19,14,5
+Wichita,309,Governor,,REP,Greg Abbott,1796,1274,522
+Wichita,309,Governor,,DEM,Lupe Valdez,229,168,61
+Wichita,309,Governor,,LIB,Mark Jay Tippetts,21,9,12
+Wichita,309,Governor,,,Over Votes,0,0,0
+Wichita,309,Governor,,,Under Votes,16,14,2
+Wichita,309,Lieutenant Governor,,REP,Dan Patrick,1691,1213,478
+Wichita,309,Lieutenant Governor,,DEM,Mike Collier,305,214,91
+Wichita,309,Lieutenant Governor,,LIB,Kerry Douglas McKennon,39,18,21
+Wichita,309,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,309,Lieutenant Governor,,,Under Votes,27,20,7
+Wichita,309,Attorney General,,REP,Ken Paxton,1731,1236,495
+Wichita,309,Attorney General,,DEM,Justin Nelson,272,194,78
+Wichita,309,Attorney General,,LIB,Michael Ray Harris,32,17,15
+Wichita,309,Attorney General,,,Over Votes,0,0,0
+Wichita,309,Attorney General,,,Under Votes,27,18,9
+Wichita,309,Comptroller of Public Accounts,,REP,Glenn Hegar,1747,1245,502
+Wichita,309,Comptroller of Public Accounts,,DEM,Joi Chevalier,214,161,53
+Wichita,309,Comptroller of Public Accounts,,LIB,Ben Sanders,61,34,27
+Wichita,309,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,309,Comptroller of Public Accounts,,,Under Votes,40,25,15
+Wichita,309,Commissioner of the General Land Office,,REP,George P. Bush,1699,1195,504
+Wichita,309,Commissioner of the General Land Office,,DEM,Miguel Suazo,229,170,59
+Wichita,309,Commissioner of the General Land Office,,LIB,Matt Pina,89,64,25
+Wichita,309,Commissioner of the General Land Office,,,Over Votes,1,1,0
+Wichita,309,Commissioner of the General Land Office,,,Under Votes,44,35,9
+Wichita,309,Commissioner of Agriculture,,REP,Sid Miller,1735,1236,499
+Wichita,309,Commissioner of Agriculture,,DEM,Kim Olson,247,179,68
+Wichita,309,Commissioner of Agriculture,,LIB,Richard Carpenter,43,26,17
+Wichita,309,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,309,Commissioner of Agriculture,,,Under Votes,37,24,13
+Wichita,309,Railroad Commissioner,,REP,Christi Craddick,1745,1242,503
+Wichita,309,Railroad Commissioner,,DEM,Roman McAllen,224,165,59
+Wichita,309,Railroad Commissioner,,LIB,Mike Wright,48,29,19
+Wichita,309,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,309,Railroad Commissioner,,,Under Votes,45,29,16
+Wichita,309,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1772,1257,515
+Wichita,309,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,249,181,68
+Wichita,309,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,309,"Justice, Supreme Court, Place 2",,,Under Votes,41,27,14
+Wichita,309,"Justice, Supreme Court, Place 4",,REP,John Devine,1780,1257,523
+Wichita,309,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,238,178,60
+Wichita,309,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,309,"Justice, Supreme Court, Place 4",,,Under Votes,44,30,14
+Wichita,309,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1770,1250,520
+Wichita,309,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,253,188,65
+Wichita,309,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,309,"Justice, Supreme Court, Place 6",,,Under Votes,39,27,12
+Wichita,309,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1748,1248,500
+Wichita,309,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,232,175,57
+Wichita,309,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,38,14,24
+Wichita,309,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,309,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,44,28,16
+Wichita,309,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1787,1266,521
+Wichita,309,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,228,169,59
+Wichita,309,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,309,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,47,30,17
+Wichita,309,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1794,1277,517
+Wichita,309,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,117,76,41
+Wichita,309,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,309,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,151,112,39
+Wichita,309,State Senator,30,REP,Pat Fallon,1764,1250,514
+Wichita,309,State Senator,30,DEM,Kevin Lopez,273,196,77
+Wichita,309,State Senator,30,,Over Votes,0,0,0
+Wichita,309,State Senator,30,,Under Votes,25,19,6
+Wichita,309,State Representative,69,REP,James Frank,1837,1289,548
+Wichita,309,State Representative,69,,Over Votes,0,0,0
+Wichita,309,State Representative,69,,Under Votes,225,176,49
+Wichita,309,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,1845,1300,545
+Wichita,309,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,309,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,217,165,52
+Wichita,309,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,1836,1293,543
+Wichita,309,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,309,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,226,172,54
+Wichita,309,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,1760,1252,508
+Wichita,309,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,246,177,69
+Wichita,309,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,309,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,56,36,20
+Wichita,309,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,1837,1294,543
+Wichita,309,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,309,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,225,171,54
+Wichita,309,"District Judge, 30th Judicial District",,REP,Jeff McKnight,1860,1309,551
+Wichita,309,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,309,"District Judge, 30th Judicial District",,,Under Votes,202,156,46
+Wichita,309,Criminal District Attorney,,REP,John Gillespie,1860,1308,552
+Wichita,309,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,309,Criminal District Attorney,,,Under Votes,202,157,45
+Wichita,309,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",1821,1282,539
+Wichita,309,County Judge,,,Over Votes,0,0,0
+Wichita,309,County Judge,,,Under Votes,241,183,58
+Wichita,309,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,1850,1303,547
+Wichita,309,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,309,"Judge, County Court at Law No. 1",,,Under Votes,212,162,50
+Wichita,309,"Judge, County Court at Law No. 2",,REP,Greg King,1848,1300,548
+Wichita,309,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,309,"Judge, County Court at Law No. 2",,,Under Votes,214,165,49
+Wichita,309,District Clerk,,REP,Patti Flores,1848,1299,549
+Wichita,309,District Clerk,,,Over Votes,0,0,0
+Wichita,309,District Clerk,,,Under Votes,214,166,48
+Wichita,309,County Clerk,,REP,Lori Bohannon,1864,1314,550
+Wichita,309,County Clerk,,,Over Votes,0,0,0
+Wichita,309,County Clerk,,,Under Votes,198,151,47
+Wichita,309,County Treasurer,,REP,R. J. Bob Hampton,1848,1303,545
+Wichita,309,County Treasurer,,,Over Votes,0,0,0
+Wichita,309,County Treasurer,,,Under Votes,214,162,52
+Wichita,309,"Justice of the Peace, Precinct 3",,REP,Robert Johnson,1872,1318,554
+Wichita,309,"Justice of the Peace, Precinct 3",,,Over Votes,0,0,0
+Wichita,309,"Justice of the Peace, Precinct 3",,,Under Votes,190,147,43
+Wichita,309,City of Wichita Falls Mayor,,,Lowry W. Crane,8,1,7
+Wichita,309,City of Wichita Falls Mayor,,,Stephen L. Santellana,26,9,17
+Wichita,309,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,309,City of Wichita Falls Mayor,,,Under Votes,21,8,13
+Wichita,309,Ballots Cast,,,,2062,1465,597
+Wichita,310,Straight Party,,REP,,439,338,101
+Wichita,310,Straight Party,,DEM,,49,37,12
+Wichita,310,Straight Party,,LIB,,4,1,3
+Wichita,310,Straight Party,,,Over Votes,0,0,0
+Wichita,310,Straight Party,,,Under Votes,310,213,97
+Wichita,310,U.S. Senate,,REP,Ted Cruz,693,511,182
+Wichita,310,U.S. Senate,,DEM,Beto O'Rourke,89,66,23
+Wichita,310,U.S. Senate,,LIB,Neal M. Dikeman,9,2,7
+Wichita,310,U.S. Senate,,,Over Votes,0,0,0
+Wichita,310,U.S. Senate,,,Under Votes,11,10,1
+Wichita,310,U.S. House,13,REP,Mac Thornberry,695,512,183
+Wichita,310,U.S. House,13,DEM,Greg Sagan,79,60,19
+Wichita,310,U.S. House,13,LIB,Calvin DeWeese,21,12,9
+Wichita,310,U.S. House,13,,Over Votes,0,0,0
+Wichita,310,U.S. House,13,,Under Votes,7,5,2
+Wichita,310,Governor,,REP,Greg Abbott,706,520,186
+Wichita,310,Governor,,DEM,Lupe Valdez,81,62,19
+Wichita,310,Governor,,LIB,Mark Jay Tippetts,10,3,7
+Wichita,310,Governor,,,Over Votes,0,0,0
+Wichita,310,Governor,,,Under Votes,5,4,1
+Wichita,310,Lieutenant Governor,,REP,Dan Patrick,672,500,172
+Wichita,310,Lieutenant Governor,,DEM,Mike Collier,101,73,28
+Wichita,310,Lieutenant Governor,,LIB,Kerry Douglas McKennon,20,11,9
+Wichita,310,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,310,Lieutenant Governor,,,Under Votes,9,5,4
+Wichita,310,Attorney General,,REP,Ken Paxton,684,506,178
+Wichita,310,Attorney General,,DEM,Justin Nelson,92,67,25
+Wichita,310,Attorney General,,LIB,Michael Ray Harris,17,10,7
+Wichita,310,Attorney General,,,Over Votes,0,0,0
+Wichita,310,Attorney General,,,Under Votes,9,6,3
+Wichita,310,Comptroller of Public Accounts,,REP,Glenn Hegar,686,509,177
+Wichita,310,Comptroller of Public Accounts,,DEM,Joi Chevalier,81,62,19
+Wichita,310,Comptroller of Public Accounts,,LIB,Ben Sanders,19,7,12
+Wichita,310,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,310,Comptroller of Public Accounts,,,Under Votes,16,11,5
+Wichita,310,Commissioner of the General Land Office,,REP,George P. Bush,664,489,175
+Wichita,310,Commissioner of the General Land Office,,DEM,Miguel Suazo,90,67,23
+Wichita,310,Commissioner of the General Land Office,,LIB,Matt Pina,30,20,10
+Wichita,310,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,310,Commissioner of the General Land Office,,,Under Votes,18,13,5
+Wichita,310,Commissioner of Agriculture,,REP,Sid Miller,679,506,173
+Wichita,310,Commissioner of Agriculture,,DEM,Kim Olson,94,66,28
+Wichita,310,Commissioner of Agriculture,,LIB,Richard Carpenter,16,8,8
+Wichita,310,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,310,Commissioner of Agriculture,,,Under Votes,13,9,4
+Wichita,310,Railroad Commissioner,,REP,Christi Craddick,678,504,174
+Wichita,310,Railroad Commissioner,,DEM,Roman McAllen,81,61,20
+Wichita,310,Railroad Commissioner,,LIB,Mike Wright,27,13,14
+Wichita,310,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,310,Railroad Commissioner,,,Under Votes,16,11,5
+Wichita,310,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,694,511,183
+Wichita,310,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,94,69,25
+Wichita,310,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,310,"Justice, Supreme Court, Place 2",,,Under Votes,14,9,5
+Wichita,310,"Justice, Supreme Court, Place 4",,REP,John Devine,689,507,182
+Wichita,310,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,94,68,26
+Wichita,310,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,310,"Justice, Supreme Court, Place 4",,,Under Votes,19,14,5
+Wichita,310,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,689,502,187
+Wichita,310,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,93,73,20
+Wichita,310,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,310,"Justice, Supreme Court, Place 6",,,Under Votes,20,14,6
+Wichita,310,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,679,503,176
+Wichita,310,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,84,64,20
+Wichita,310,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,21,9,12
+Wichita,310,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,310,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,18,13,5
+Wichita,310,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,692,508,184
+Wichita,310,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,90,67,23
+Wichita,310,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,310,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,20,14,6
+Wichita,310,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,695,512,183
+Wichita,310,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,51,33,18
+Wichita,310,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,310,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,56,44,12
+Wichita,310,State Senator,30,REP,Pat Fallon,701,515,186
+Wichita,310,State Senator,30,DEM,Kevin Lopez,93,68,25
+Wichita,310,State Senator,30,,Over Votes,0,0,0
+Wichita,310,State Senator,30,,Under Votes,8,6,2
+Wichita,310,State Representative,69,REP,James Frank,727,529,198
+Wichita,310,State Representative,69,,Over Votes,0,0,0
+Wichita,310,State Representative,69,,Under Votes,75,60,15
+Wichita,310,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,721,523,198
+Wichita,310,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,310,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,81,66,15
+Wichita,310,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,707,512,195
+Wichita,310,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,310,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,95,77,18
+Wichita,310,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,680,500,180
+Wichita,310,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,94,68,26
+Wichita,310,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,310,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,28,21,7
+Wichita,310,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,711,516,195
+Wichita,310,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,310,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,91,73,18
+Wichita,310,"District Judge, 30th Judicial District",,REP,Jeff McKnight,719,522,197
+Wichita,310,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,310,"District Judge, 30th Judicial District",,,Under Votes,83,67,16
+Wichita,310,Criminal District Attorney,,REP,John Gillespie,722,525,197
+Wichita,310,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,310,Criminal District Attorney,,,Under Votes,80,64,16
+Wichita,310,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",704,515,189
+Wichita,310,County Judge,,,Over Votes,0,0,0
+Wichita,310,County Judge,,,Under Votes,98,74,24
+Wichita,310,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,713,516,197
+Wichita,310,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,310,"Judge, County Court at Law No. 1",,,Under Votes,89,73,16
+Wichita,310,"Judge, County Court at Law No. 2",,REP,Greg King,715,518,197
+Wichita,310,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,310,"Judge, County Court at Law No. 2",,,Under Votes,87,71,16
+Wichita,310,District Clerk,,REP,Patti Flores,717,521,196
+Wichita,310,District Clerk,,,Over Votes,0,0,0
+Wichita,310,District Clerk,,,Under Votes,85,68,17
+Wichita,310,County Clerk,,REP,Lori Bohannon,723,526,197
+Wichita,310,County Clerk,,,Over Votes,0,0,0
+Wichita,310,County Clerk,,,Under Votes,79,63,16
+Wichita,310,County Treasurer,,REP,R. J. Bob Hampton,720,522,198
+Wichita,310,County Treasurer,,,Over Votes,0,0,0
+Wichita,310,County Treasurer,,,Under Votes,82,67,15
+Wichita,310,"Justice of the Peace, Precinct 3",,REP,Robert Johnson,728,529,199
+Wichita,310,"Justice of the Peace, Precinct 3",,,Over Votes,0,0,0
+Wichita,310,"Justice of the Peace, Precinct 3",,,Under Votes,74,60,14
+Wichita,310,City of Wichita Falls Mayor,,,Lowry W. Crane,10,2,8
+Wichita,310,City of Wichita Falls Mayor,,,Stephen L. Santellana,25,4,21
+Wichita,310,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,310,City of Wichita Falls Mayor,,,Under Votes,14,5,9
+Wichita,310,Ballots Cast,,,,802,589,213
+Wichita,311,Straight Party,,REP,,91,56,35
+Wichita,311,Straight Party,,DEM,,319,177,142
+Wichita,311,Straight Party,,LIB,,1,0,1
+Wichita,311,Straight Party,,,Over Votes,0,0,0
+Wichita,311,Straight Party,,,Under Votes,161,93,68
+Wichita,311,U.S. Senate,,REP,Ted Cruz,140,86,54
+Wichita,311,U.S. Senate,,DEM,Beto O'Rourke,416,229,187
+Wichita,311,U.S. Senate,,LIB,Neal M. Dikeman,2,1,1
+Wichita,311,U.S. Senate,,,Over Votes,0,0,0
+Wichita,311,U.S. Senate,,,Under Votes,13,9,4
+Wichita,311,U.S. House,13,REP,Mac Thornberry,160,95,65
+Wichita,311,U.S. House,13,DEM,Greg Sagan,392,217,175
+Wichita,311,U.S. House,13,LIB,Calvin DeWeese,5,4,1
+Wichita,311,U.S. House,13,,Over Votes,0,0,0
+Wichita,311,U.S. House,13,,Under Votes,14,9,5
+Wichita,311,Governor,,REP,Greg Abbott,158,99,59
+Wichita,311,Governor,,DEM,Lupe Valdez,396,216,180
+Wichita,311,Governor,,LIB,Mark Jay Tippetts,3,2,1
+Wichita,311,Governor,,,Over Votes,0,0,0
+Wichita,311,Governor,,,Under Votes,14,8,6
+Wichita,311,Lieutenant Governor,,REP,Dan Patrick,139,87,52
+Wichita,311,Lieutenant Governor,,DEM,Mike Collier,404,222,182
+Wichita,311,Lieutenant Governor,,LIB,Kerry Douglas McKennon,15,9,6
+Wichita,311,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,311,Lieutenant Governor,,,Under Votes,13,7,6
+Wichita,311,Attorney General,,REP,Ken Paxton,142,87,55
+Wichita,311,Attorney General,,DEM,Justin Nelson,414,230,184
+Wichita,311,Attorney General,,LIB,Michael Ray Harris,5,2,3
+Wichita,311,Attorney General,,,Over Votes,0,0,0
+Wichita,311,Attorney General,,,Under Votes,10,6,4
+Wichita,311,Comptroller of Public Accounts,,REP,Glenn Hegar,139,86,53
+Wichita,311,Comptroller of Public Accounts,,DEM,Joi Chevalier,397,216,181
+Wichita,311,Comptroller of Public Accounts,,LIB,Ben Sanders,18,13,5
+Wichita,311,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,311,Comptroller of Public Accounts,,,Under Votes,17,10,7
+Wichita,311,Commissioner of the General Land Office,,REP,George P. Bush,144,88,56
+Wichita,311,Commissioner of the General Land Office,,DEM,Miguel Suazo,397,219,178
+Wichita,311,Commissioner of the General Land Office,,LIB,Matt Pina,13,7,6
+Wichita,311,Commissioner of the General Land Office,,,Over Votes,1,1,0
+Wichita,311,Commissioner of the General Land Office,,,Under Votes,16,10,6
+Wichita,311,Commissioner of Agriculture,,REP,Sid Miller,131,81,50
+Wichita,311,Commissioner of Agriculture,,DEM,Kim Olson,412,226,186
+Wichita,311,Commissioner of Agriculture,,LIB,Richard Carpenter,13,9,4
+Wichita,311,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,311,Commissioner of Agriculture,,,Under Votes,15,9,6
+Wichita,311,Railroad Commissioner,,REP,Christi Craddick,151,91,60
+Wichita,311,Railroad Commissioner,,DEM,Roman McAllen,393,215,178
+Wichita,311,Railroad Commissioner,,LIB,Mike Wright,12,9,3
+Wichita,311,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,311,Railroad Commissioner,,,Under Votes,15,10,5
+Wichita,311,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,140,88,52
+Wichita,311,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,416,227,189
+Wichita,311,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,311,"Justice, Supreme Court, Place 2",,,Under Votes,14,9,5
+Wichita,311,"Justice, Supreme Court, Place 4",,REP,John Devine,144,87,57
+Wichita,311,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,413,229,184
+Wichita,311,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,311,"Justice, Supreme Court, Place 4",,,Under Votes,14,9,5
+Wichita,311,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,144,89,55
+Wichita,311,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,413,228,185
+Wichita,311,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,311,"Justice, Supreme Court, Place 6",,,Under Votes,14,8,6
+Wichita,311,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,136,85,51
+Wichita,311,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,408,224,184
+Wichita,311,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,11,7,4
+Wichita,311,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,1,1,0
+Wichita,311,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,15,8,7
+Wichita,311,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,140,86,54
+Wichita,311,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,415,230,185
+Wichita,311,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,311,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,16,9,7
+Wichita,311,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,173,103,70
+Wichita,311,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,89,50,39
+Wichita,311,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,311,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,311,174,137
+Wichita,311,State Senator,30,REP,Pat Fallon,140,86,54
+Wichita,311,State Senator,30,DEM,Kevin Lopez,420,232,188
+Wichita,311,State Senator,30,,Over Votes,0,0,0
+Wichita,311,State Senator,30,,Under Votes,11,7,4
+Wichita,311,State Representative,69,REP,James Frank,215,129,86
+Wichita,311,State Representative,69,,Over Votes,0,0,0
+Wichita,311,State Representative,69,,Under Votes,356,196,160
+Wichita,311,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,212,125,87
+Wichita,311,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,311,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,359,200,159
+Wichita,311,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,202,122,80
+Wichita,311,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,311,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,369,203,166
+Wichita,311,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,137,84,53
+Wichita,311,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,416,230,186
+Wichita,311,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,311,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,18,11,7
+Wichita,311,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,205,125,80
+Wichita,311,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,311,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,365,199,166
+Wichita,311,"District Judge, 30th Judicial District",,REP,Jeff McKnight,210,124,86
+Wichita,311,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,311,"District Judge, 30th Judicial District",,,Under Votes,361,201,160
+Wichita,311,Criminal District Attorney,,REP,John Gillespie,211,127,84
+Wichita,311,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,311,Criminal District Attorney,,,Under Votes,360,198,162
+Wichita,311,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",225,134,91
+Wichita,311,County Judge,,,Over Votes,0,0,0
+Wichita,311,County Judge,,,Under Votes,346,191,155
+Wichita,311,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,209,128,81
+Wichita,311,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,311,"Judge, County Court at Law No. 1",,,Under Votes,362,197,165
+Wichita,311,"Judge, County Court at Law No. 2",,REP,Greg King,210,128,82
+Wichita,311,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,311,"Judge, County Court at Law No. 2",,,Under Votes,361,197,164
+Wichita,311,District Clerk,,REP,Patti Flores,221,132,89
+Wichita,311,District Clerk,,,Over Votes,0,0,0
+Wichita,311,District Clerk,,,Under Votes,350,193,157
+Wichita,311,County Clerk,,REP,Lori Bohannon,220,131,89
+Wichita,311,County Clerk,,,Over Votes,0,0,0
+Wichita,311,County Clerk,,,Under Votes,351,194,157
+Wichita,311,County Treasurer,,REP,R. J. Bob Hampton,210,125,85
+Wichita,311,County Treasurer,,,Over Votes,0,0,0
+Wichita,311,County Treasurer,,,Under Votes,361,200,161
+Wichita,311,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,211,129,82
+Wichita,311,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,311,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,359,195,164
+Wichita,311,City of Wichita Falls Mayor,,,Lowry W. Crane,93,56,37
+Wichita,311,City of Wichita Falls Mayor,,,Stephen L. Santellana,314,184,130
+Wichita,311,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,311,City of Wichita Falls Mayor,,,Under Votes,166,87,79
+Wichita,311,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,265,154,111
+Wichita,311,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,311,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,307,172,135
+Wichita,311,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,255,150,105
+Wichita,311,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,121,67,54
+Wichita,311,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,311,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,197,110,87
+Wichita,311,Ballots Cast,,,,573,327,246
+Wichita,312,Straight Party,,REP,,0,0,0
+Wichita,312,Straight Party,,DEM,,1,1,0
+Wichita,312,Straight Party,,LIB,,0,0,0
+Wichita,312,Straight Party,,,Over Votes,0,0,0
+Wichita,312,Straight Party,,,Under Votes,1,0,1
+Wichita,312,U.S. Senate,,REP,Ted Cruz,1,0,1
+Wichita,312,U.S. Senate,,DEM,Beto O'Rourke,1,1,0
+Wichita,312,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0
+Wichita,312,U.S. Senate,,,Over Votes,0,0,0
+Wichita,312,U.S. Senate,,,Under Votes,0,0,0
+Wichita,312,U.S. House,13,REP,Mac Thornberry,1,0,1
+Wichita,312,U.S. House,13,DEM,Greg Sagan,1,1,0
+Wichita,312,U.S. House,13,LIB,Calvin DeWeese,0,0,0
+Wichita,312,U.S. House,13,,Over Votes,0,0,0
+Wichita,312,U.S. House,13,,Under Votes,0,0,0
+Wichita,312,Governor,,REP,Greg Abbott,1,0,1
+Wichita,312,Governor,,DEM,Lupe Valdez,1,1,0
+Wichita,312,Governor,,LIB,Mark Jay Tippetts,0,0,0
+Wichita,312,Governor,,,Over Votes,0,0,0
+Wichita,312,Governor,,,Under Votes,0,0,0
+Wichita,312,Lieutenant Governor,,REP,Dan Patrick,1,0,1
+Wichita,312,Lieutenant Governor,,DEM,Mike Collier,1,1,0
+Wichita,312,Lieutenant Governor,,LIB,Kerry Douglas McKennon,0,0,0
+Wichita,312,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,312,Lieutenant Governor,,,Under Votes,0,0,0
+Wichita,312,Attorney General,,REP,Ken Paxton,1,0,1
+Wichita,312,Attorney General,,DEM,Justin Nelson,1,1,0
+Wichita,312,Attorney General,,LIB,Michael Ray Harris,0,0,0
+Wichita,312,Attorney General,,,Over Votes,0,0,0
+Wichita,312,Attorney General,,,Under Votes,0,0,0
+Wichita,312,Comptroller of Public Accounts,,REP,Glenn Hegar,1,0,1
+Wichita,312,Comptroller of Public Accounts,,DEM,Joi Chevalier,1,1,0
+Wichita,312,Comptroller of Public Accounts,,LIB,Ben Sanders,0,0,0
+Wichita,312,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,312,Comptroller of Public Accounts,,,Under Votes,0,0,0
+Wichita,312,Commissioner of the General Land Office,,REP,George P. Bush,1,0,1
+Wichita,312,Commissioner of the General Land Office,,DEM,Miguel Suazo,1,1,0
+Wichita,312,Commissioner of the General Land Office,,LIB,Matt Pina,0,0,0
+Wichita,312,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,312,Commissioner of the General Land Office,,,Under Votes,0,0,0
+Wichita,312,Commissioner of Agriculture,,REP,Sid Miller,1,0,1
+Wichita,312,Commissioner of Agriculture,,DEM,Kim Olson,1,1,0
+Wichita,312,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0
+Wichita,312,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,312,Commissioner of Agriculture,,,Under Votes,0,0,0
+Wichita,312,Railroad Commissioner,,REP,Christi Craddick,1,0,1
+Wichita,312,Railroad Commissioner,,DEM,Roman McAllen,1,1,0
+Wichita,312,Railroad Commissioner,,LIB,Mike Wright,0,0,0
+Wichita,312,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,312,Railroad Commissioner,,,Under Votes,0,0,0
+Wichita,312,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1,0,1
+Wichita,312,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,1,1,0
+Wichita,312,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,312,"Justice, Supreme Court, Place 2",,,Under Votes,0,0,0
+Wichita,312,"Justice, Supreme Court, Place 4",,REP,John Devine,1,0,1
+Wichita,312,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,1,1,0
+Wichita,312,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,312,"Justice, Supreme Court, Place 4",,,Under Votes,0,0,0
+Wichita,312,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1,0,1
+Wichita,312,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,1,1,0
+Wichita,312,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,312,"Justice, Supreme Court, Place 6",,,Under Votes,0,0,0
+Wichita,312,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1,0,1
+Wichita,312,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,1,1,0
+Wichita,312,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,0,0,0
+Wichita,312,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,312,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,0,0,0
+Wichita,312,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1,0,1
+Wichita,312,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,1,1,0
+Wichita,312,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,312,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,0,0,0
+Wichita,312,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1,0,1
+Wichita,312,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,0,0,0
+Wichita,312,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,312,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,1,1,0
+Wichita,312,State Senator,30,REP,Pat Fallon,1,0,1
+Wichita,312,State Senator,30,DEM,Kevin Lopez,1,1,0
+Wichita,312,State Senator,30,,Over Votes,0,0,0
+Wichita,312,State Senator,30,,Under Votes,0,0,0
+Wichita,312,State Representative,69,REP,James Frank,0,0,0
+Wichita,312,State Representative,69,,Over Votes,0,0,0
+Wichita,312,State Representative,69,,Under Votes,2,1,1
+Wichita,312,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,0,0,0
+Wichita,312,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,312,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,2,1,1
+Wichita,312,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,0,0,0
+Wichita,312,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,312,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,2,1,1
+Wichita,312,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,0,0,0
+Wichita,312,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,1,1,0
+Wichita,312,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,312,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,1,0,1
+Wichita,312,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,0,0,0
+Wichita,312,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,312,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,2,1,1
+Wichita,312,"District Judge, 30th Judicial District",,REP,Jeff McKnight,0,0,0
+Wichita,312,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,312,"District Judge, 30th Judicial District",,,Under Votes,2,1,1
+Wichita,312,Criminal District Attorney,,REP,John Gillespie,0,0,0
+Wichita,312,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,312,Criminal District Attorney,,,Under Votes,2,1,1
+Wichita,312,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",0,0,0
+Wichita,312,County Judge,,,Over Votes,0,0,0
+Wichita,312,County Judge,,,Under Votes,2,1,1
+Wichita,312,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,0,0,0
+Wichita,312,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,312,"Judge, County Court at Law No. 1",,,Under Votes,2,1,1
+Wichita,312,"Judge, County Court at Law No. 2",,REP,Greg King,0,0,0
+Wichita,312,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,312,"Judge, County Court at Law No. 2",,,Under Votes,2,1,1
+Wichita,312,District Clerk,,REP,Patti Flores,0,0,0
+Wichita,312,District Clerk,,,Over Votes,0,0,0
+Wichita,312,District Clerk,,,Under Votes,2,1,1
+Wichita,312,County Clerk,,REP,Lori Bohannon,0,0,0
+Wichita,312,County Clerk,,,Over Votes,0,0,0
+Wichita,312,County Clerk,,,Under Votes,2,1,1
+Wichita,312,County Treasurer,,REP,R. J. Bob Hampton,0,0,0
+Wichita,312,County Treasurer,,,Over Votes,0,0,0
+Wichita,312,County Treasurer,,,Under Votes,2,1,1
+Wichita,312,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,0,0,0
+Wichita,312,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,312,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,2,1,1
+Wichita,312,City of Wichita Falls Mayor,,,Lowry W. Crane,1,0,1
+Wichita,312,City of Wichita Falls Mayor,,,Stephen L. Santellana,0,0,0
+Wichita,312,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,312,City of Wichita Falls Mayor,,,Under Votes,1,1,0
+Wichita,312,Wichita Falls ISD Single Member District 5,,,Tom Bursey,0,0,0
+Wichita,312,Wichita Falls ISD Single Member District 5,,,Over Votes,0,0,0
+Wichita,312,Wichita Falls ISD Single Member District 5,,,Under Votes,2,1,1
+Wichita,312,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,0,0,0
+Wichita,312,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,312,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,2,1,1
+Wichita,312,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,1,0,1
+Wichita,312,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,0,0,0
+Wichita,312,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,312,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,1,1,0
+Wichita,312,Ballots Cast,,,,2,1,1
+Wichita,313,Straight Party,,REP,,0,0,0
+Wichita,313,Straight Party,,DEM,,4,2,2
+Wichita,313,Straight Party,,LIB,,0,0,0
+Wichita,313,Straight Party,,,Over Votes,0,0,0
+Wichita,313,Straight Party,,,Under Votes,1,0,1
+Wichita,313,U.S. Senate,,REP,Ted Cruz,0,0,0
+Wichita,313,U.S. Senate,,DEM,Beto O'Rourke,5,2,3
+Wichita,313,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0
+Wichita,313,U.S. Senate,,,Over Votes,0,0,0
+Wichita,313,U.S. Senate,,,Under Votes,0,0,0
+Wichita,313,U.S. House,13,REP,Mac Thornberry,0,0,0
+Wichita,313,U.S. House,13,DEM,Greg Sagan,5,2,3
+Wichita,313,U.S. House,13,LIB,Calvin DeWeese,0,0,0
+Wichita,313,U.S. House,13,,Over Votes,0,0,0
+Wichita,313,U.S. House,13,,Under Votes,0,0,0
+Wichita,313,Governor,,REP,Greg Abbott,0,0,0
+Wichita,313,Governor,,DEM,Lupe Valdez,5,2,3
+Wichita,313,Governor,,LIB,Mark Jay Tippetts,0,0,0
+Wichita,313,Governor,,,Over Votes,0,0,0
+Wichita,313,Governor,,,Under Votes,0,0,0
+Wichita,313,Lieutenant Governor,,REP,Dan Patrick,0,0,0
+Wichita,313,Lieutenant Governor,,DEM,Mike Collier,5,2,3
+Wichita,313,Lieutenant Governor,,LIB,Kerry Douglas McKennon,0,0,0
+Wichita,313,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,313,Lieutenant Governor,,,Under Votes,0,0,0
+Wichita,313,Attorney General,,REP,Ken Paxton,0,0,0
+Wichita,313,Attorney General,,DEM,Justin Nelson,5,2,3
+Wichita,313,Attorney General,,LIB,Michael Ray Harris,0,0,0
+Wichita,313,Attorney General,,,Over Votes,0,0,0
+Wichita,313,Attorney General,,,Under Votes,0,0,0
+Wichita,313,Comptroller of Public Accounts,,REP,Glenn Hegar,0,0,0
+Wichita,313,Comptroller of Public Accounts,,DEM,Joi Chevalier,5,2,3
+Wichita,313,Comptroller of Public Accounts,,LIB,Ben Sanders,0,0,0
+Wichita,313,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,313,Comptroller of Public Accounts,,,Under Votes,0,0,0
+Wichita,313,Commissioner of the General Land Office,,REP,George P. Bush,0,0,0
+Wichita,313,Commissioner of the General Land Office,,DEM,Miguel Suazo,5,2,3
+Wichita,313,Commissioner of the General Land Office,,LIB,Matt Pina,0,0,0
+Wichita,313,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,313,Commissioner of the General Land Office,,,Under Votes,0,0,0
+Wichita,313,Commissioner of Agriculture,,REP,Sid Miller,0,0,0
+Wichita,313,Commissioner of Agriculture,,DEM,Kim Olson,5,2,3
+Wichita,313,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0
+Wichita,313,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,313,Commissioner of Agriculture,,,Under Votes,0,0,0
+Wichita,313,Railroad Commissioner,,REP,Christi Craddick,0,0,0
+Wichita,313,Railroad Commissioner,,DEM,Roman McAllen,5,2,3
+Wichita,313,Railroad Commissioner,,LIB,Mike Wright,0,0,0
+Wichita,313,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,313,Railroad Commissioner,,,Under Votes,0,0,0
+Wichita,313,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,0,0,0
+Wichita,313,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,5,2,3
+Wichita,313,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,313,"Justice, Supreme Court, Place 2",,,Under Votes,0,0,0
+Wichita,313,"Justice, Supreme Court, Place 4",,REP,John Devine,0,0,0
+Wichita,313,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,5,2,3
+Wichita,313,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,313,"Justice, Supreme Court, Place 4",,,Under Votes,0,0,0
+Wichita,313,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,0,0,0
+Wichita,313,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,5,2,3
+Wichita,313,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,313,"Justice, Supreme Court, Place 6",,,Under Votes,0,0,0
+Wichita,313,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,0,0,0
+Wichita,313,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,5,2,3
+Wichita,313,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,0,0,0
+Wichita,313,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,313,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,0,0,0
+Wichita,313,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,0,0,0
+Wichita,313,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,5,2,3
+Wichita,313,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,313,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,0,0,0
+Wichita,313,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,0,0,0
+Wichita,313,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,1,0,1
+Wichita,313,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,313,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,4,2,2
+Wichita,313,State Senator,30,REP,Pat Fallon,0,0,0
+Wichita,313,State Senator,30,DEM,Kevin Lopez,5,2,3
+Wichita,313,State Senator,30,,Over Votes,0,0,0
+Wichita,313,State Senator,30,,Under Votes,0,0,0
+Wichita,313,State Representative,69,REP,James Frank,0,0,0
+Wichita,313,State Representative,69,,Over Votes,0,0,0
+Wichita,313,State Representative,69,,Under Votes,5,2,3
+Wichita,313,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,0,0,0
+Wichita,313,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,313,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,5,2,3
+Wichita,313,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,0,0,0
+Wichita,313,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,313,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,5,2,3
+Wichita,313,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,0,0,0
+Wichita,313,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,5,2,3
+Wichita,313,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,313,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,0,0,0
+Wichita,313,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,0,0,0
+Wichita,313,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,313,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,5,2,3
+Wichita,313,"District Judge, 30th Judicial District",,REP,Jeff McKnight,1,0,1
+Wichita,313,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,313,"District Judge, 30th Judicial District",,,Under Votes,4,2,2
+Wichita,313,Criminal District Attorney,,REP,John Gillespie,1,0,1
+Wichita,313,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,313,Criminal District Attorney,,,Under Votes,4,2,2
+Wichita,313,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",1,0,1
+Wichita,313,County Judge,,,Over Votes,0,0,0
+Wichita,313,County Judge,,,Under Votes,4,2,2
+Wichita,313,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,1,0,1
+Wichita,313,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,313,"Judge, County Court at Law No. 1",,,Under Votes,4,2,2
+Wichita,313,"Judge, County Court at Law No. 2",,REP,Greg King,1,0,1
+Wichita,313,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,313,"Judge, County Court at Law No. 2",,,Under Votes,4,2,2
+Wichita,313,District Clerk,,REP,Patti Flores,1,0,1
+Wichita,313,District Clerk,,,Over Votes,0,0,0
+Wichita,313,District Clerk,,,Under Votes,4,2,2
+Wichita,313,County Clerk,,REP,Lori Bohannon,1,0,1
+Wichita,313,County Clerk,,,Over Votes,0,0,0
+Wichita,313,County Clerk,,,Under Votes,4,2,2
+Wichita,313,County Treasurer,,REP,R. J. Bob Hampton,1,0,1
+Wichita,313,County Treasurer,,,Over Votes,0,0,0
+Wichita,313,County Treasurer,,,Under Votes,4,2,2
+Wichita,313,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,2,0,2
+Wichita,313,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,313,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,3,2,1
+Wichita,313,City of Wichita Falls Mayor,,,Lowry W. Crane,2,1,1
+Wichita,313,City of Wichita Falls Mayor,,,Stephen L. Santellana,3,1,2
+Wichita,313,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,313,City of Wichita Falls Mayor,,,Under Votes,0,0,0
+Wichita,313,Wichita Falls ISD Single Member District 5,,,Tom Bursey,4,2,2
+Wichita,313,Wichita Falls ISD Single Member District 5,,,Over Votes,0,0,0
+Wichita,313,Wichita Falls ISD Single Member District 5,,,Under Votes,1,0,1
+Wichita,313,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,3,1,2
+Wichita,313,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,313,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,2,1,1
+Wichita,313,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,2,1,1
+Wichita,313,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,2,1,1
+Wichita,313,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,313,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,1,0,1
+Wichita,313,Ballots Cast,,,,5,2,3
+Wichita,314,Straight Party,,REP,,5,5,0
+Wichita,314,Straight Party,,DEM,,0,0,0
+Wichita,314,Straight Party,,LIB,,0,0,0
+Wichita,314,Straight Party,,,Over Votes,0,0,0
+Wichita,314,Straight Party,,,Under Votes,1,1,0
+Wichita,314,U.S. Senate,,REP,Ted Cruz,5,5,0
+Wichita,314,U.S. Senate,,DEM,Beto O'Rourke,1,1,0
+Wichita,314,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0
+Wichita,314,U.S. Senate,,,Over Votes,0,0,0
+Wichita,314,U.S. Senate,,,Under Votes,0,0,0
+Wichita,314,U.S. House,13,REP,Mac Thornberry,5,5,0
+Wichita,314,U.S. House,13,DEM,Greg Sagan,1,1,0
+Wichita,314,U.S. House,13,LIB,Calvin DeWeese,0,0,0
+Wichita,314,U.S. House,13,,Over Votes,0,0,0
+Wichita,314,U.S. House,13,,Under Votes,0,0,0
+Wichita,314,Governor,,REP,Greg Abbott,5,5,0
+Wichita,314,Governor,,DEM,Lupe Valdez,1,1,0
+Wichita,314,Governor,,LIB,Mark Jay Tippetts,0,0,0
+Wichita,314,Governor,,,Over Votes,0,0,0
+Wichita,314,Governor,,,Under Votes,0,0,0
+Wichita,314,Lieutenant Governor,,REP,Dan Patrick,5,5,0
+Wichita,314,Lieutenant Governor,,DEM,Mike Collier,1,1,0
+Wichita,314,Lieutenant Governor,,LIB,Kerry Douglas McKennon,0,0,0
+Wichita,314,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,314,Lieutenant Governor,,,Under Votes,0,0,0
+Wichita,314,Attorney General,,REP,Ken Paxton,5,5,0
+Wichita,314,Attorney General,,DEM,Justin Nelson,1,1,0
+Wichita,314,Attorney General,,LIB,Michael Ray Harris,0,0,0
+Wichita,314,Attorney General,,,Over Votes,0,0,0
+Wichita,314,Attorney General,,,Under Votes,0,0,0
+Wichita,314,Comptroller of Public Accounts,,REP,Glenn Hegar,5,5,0
+Wichita,314,Comptroller of Public Accounts,,DEM,Joi Chevalier,1,1,0
+Wichita,314,Comptroller of Public Accounts,,LIB,Ben Sanders,0,0,0
+Wichita,314,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,314,Comptroller of Public Accounts,,,Under Votes,0,0,0
+Wichita,314,Commissioner of the General Land Office,,REP,George P. Bush,5,5,0
+Wichita,314,Commissioner of the General Land Office,,DEM,Miguel Suazo,1,1,0
+Wichita,314,Commissioner of the General Land Office,,LIB,Matt Pina,0,0,0
+Wichita,314,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,314,Commissioner of the General Land Office,,,Under Votes,0,0,0
+Wichita,314,Commissioner of Agriculture,,REP,Sid Miller,5,5,0
+Wichita,314,Commissioner of Agriculture,,DEM,Kim Olson,1,1,0
+Wichita,314,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0
+Wichita,314,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,314,Commissioner of Agriculture,,,Under Votes,0,0,0
+Wichita,314,Railroad Commissioner,,REP,Christi Craddick,5,5,0
+Wichita,314,Railroad Commissioner,,DEM,Roman McAllen,1,1,0
+Wichita,314,Railroad Commissioner,,LIB,Mike Wright,0,0,0
+Wichita,314,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,314,Railroad Commissioner,,,Under Votes,0,0,0
+Wichita,314,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,5,5,0
+Wichita,314,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,1,1,0
+Wichita,314,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,314,"Justice, Supreme Court, Place 2",,,Under Votes,0,0,0
+Wichita,314,"Justice, Supreme Court, Place 4",,REP,John Devine,5,5,0
+Wichita,314,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,1,1,0
+Wichita,314,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,314,"Justice, Supreme Court, Place 4",,,Under Votes,0,0,0
+Wichita,314,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,5,5,0
+Wichita,314,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,1,1,0
+Wichita,314,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,314,"Justice, Supreme Court, Place 6",,,Under Votes,0,0,0
+Wichita,314,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,5,5,0
+Wichita,314,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,1,1,0
+Wichita,314,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,0,0,0
+Wichita,314,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,314,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,0,0,0
+Wichita,314,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,5,5,0
+Wichita,314,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,1,1,0
+Wichita,314,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,314,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,0,0,0
+Wichita,314,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,6,6,0
+Wichita,314,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,0,0,0
+Wichita,314,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,314,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,0,0,0
+Wichita,314,State Senator,30,REP,Pat Fallon,5,5,0
+Wichita,314,State Senator,30,DEM,Kevin Lopez,1,1,0
+Wichita,314,State Senator,30,,Over Votes,0,0,0
+Wichita,314,State Senator,30,,Under Votes,0,0,0
+Wichita,314,State Representative,69,REP,James Frank,6,6,0
+Wichita,314,State Representative,69,,Over Votes,0,0,0
+Wichita,314,State Representative,69,,Under Votes,0,0,0
+Wichita,314,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,6,6,0
+Wichita,314,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,314,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,0,0,0
+Wichita,314,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,6,6,0
+Wichita,314,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,314,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,0,0,0
+Wichita,314,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,5,5,0
+Wichita,314,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,1,1,0
+Wichita,314,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,314,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,0,0,0
+Wichita,314,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,6,6,0
+Wichita,314,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,314,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,0,0,0
+Wichita,314,"District Judge, 30th Judicial District",,REP,Jeff McKnight,6,6,0
+Wichita,314,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,314,"District Judge, 30th Judicial District",,,Under Votes,0,0,0
+Wichita,314,Criminal District Attorney,,REP,John Gillespie,6,6,0
+Wichita,314,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,314,Criminal District Attorney,,,Under Votes,0,0,0
+Wichita,314,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",6,6,0
+Wichita,314,County Judge,,,Over Votes,0,0,0
+Wichita,314,County Judge,,,Under Votes,0,0,0
+Wichita,314,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,6,6,0
+Wichita,314,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,314,"Judge, County Court at Law No. 1",,,Under Votes,0,0,0
+Wichita,314,"Judge, County Court at Law No. 2",,REP,Greg King,5,5,0
+Wichita,314,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,314,"Judge, County Court at Law No. 2",,,Under Votes,1,1,0
+Wichita,314,District Clerk,,REP,Patti Flores,5,5,0
+Wichita,314,District Clerk,,,Over Votes,0,0,0
+Wichita,314,District Clerk,,,Under Votes,1,1,0
+Wichita,314,County Clerk,,REP,Lori Bohannon,5,5,0
+Wichita,314,County Clerk,,,Over Votes,0,0,0
+Wichita,314,County Clerk,,,Under Votes,1,1,0
+Wichita,314,County Treasurer,,REP,R. J. Bob Hampton,5,5,0
+Wichita,314,County Treasurer,,,Over Votes,0,0,0
+Wichita,314,County Treasurer,,,Under Votes,1,1,0
+Wichita,314,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,5,5,0
+Wichita,314,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,314,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,1,1,0
+Wichita,314,City of Wichita Falls Mayor,,,Lowry W. Crane,0,0,0
+Wichita,314,City of Wichita Falls Mayor,,,Stephen L. Santellana,4,4,0
+Wichita,314,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,314,City of Wichita Falls Mayor,,,Under Votes,2,2,0
+Wichita,314,City of Wichita Falls Councilor District 5,,,Chris Reitsma,0,0,0
+Wichita,314,City of Wichita Falls Councilor District 5,,,Mitesh Desai,0,0,0
+Wichita,314,City of Wichita Falls Councilor District 5,,,Steve Jackson,3,3,0
+Wichita,314,City of Wichita Falls Councilor District 5,,,Over Votes,0,0,0
+Wichita,314,City of Wichita Falls Councilor District 5,,,Under Votes,3,3,0
+Wichita,314,Wichita Falls ISD Single Member District 1,,,Bob Payton,2,2,0
+Wichita,314,Wichita Falls ISD Single Member District 1,,,Over Votes,0,0,0
+Wichita,314,Wichita Falls ISD Single Member District 1,,,Under Votes,4,4,0
+Wichita,314,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,3,3,0
+Wichita,314,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,314,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,3,3,0
+Wichita,314,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,2,2,0
+Wichita,314,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,1,1,0
+Wichita,314,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,314,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,3,3,0
+Wichita,314,Ballots Cast,,,,6,6,0
+Wichita,315,Straight Party,,REP,,34,19,15
+Wichita,315,Straight Party,,DEM,,12,10,2
+Wichita,315,Straight Party,,LIB,,0,0,0
+Wichita,315,Straight Party,,,Over Votes,0,0,0
+Wichita,315,Straight Party,,,Under Votes,30,21,9
+Wichita,315,U.S. Senate,,REP,Ted Cruz,55,32,23
+Wichita,315,U.S. Senate,,DEM,Beto O'Rourke,20,17,3
+Wichita,315,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0
+Wichita,315,U.S. Senate,,,Over Votes,0,0,0
+Wichita,315,U.S. Senate,,,Under Votes,1,1,0
+Wichita,315,U.S. House,13,REP,Mac Thornberry,56,34,22
+Wichita,315,U.S. House,13,DEM,Greg Sagan,18,15,3
+Wichita,315,U.S. House,13,LIB,Calvin DeWeese,1,0,1
+Wichita,315,U.S. House,13,,Over Votes,0,0,0
+Wichita,315,U.S. House,13,,Under Votes,1,1,0
+Wichita,315,Governor,,REP,Greg Abbott,55,34,21
+Wichita,315,Governor,,DEM,Lupe Valdez,19,16,3
+Wichita,315,Governor,,LIB,Mark Jay Tippetts,2,0,2
+Wichita,315,Governor,,,Over Votes,0,0,0
+Wichita,315,Governor,,,Under Votes,0,0,0
+Wichita,315,Lieutenant Governor,,REP,Dan Patrick,54,32,22
+Wichita,315,Lieutenant Governor,,DEM,Mike Collier,19,16,3
+Wichita,315,Lieutenant Governor,,LIB,Kerry Douglas McKennon,2,1,1
+Wichita,315,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,315,Lieutenant Governor,,,Under Votes,1,1,0
+Wichita,315,Attorney General,,REP,Ken Paxton,53,32,21
+Wichita,315,Attorney General,,DEM,Justin Nelson,21,18,3
+Wichita,315,Attorney General,,LIB,Michael Ray Harris,2,0,2
+Wichita,315,Attorney General,,,Over Votes,0,0,0
+Wichita,315,Attorney General,,,Under Votes,0,0,0
+Wichita,315,Comptroller of Public Accounts,,REP,Glenn Hegar,56,33,23
+Wichita,315,Comptroller of Public Accounts,,DEM,Joi Chevalier,18,16,2
+Wichita,315,Comptroller of Public Accounts,,LIB,Ben Sanders,2,1,1
+Wichita,315,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,315,Comptroller of Public Accounts,,,Under Votes,0,0,0
+Wichita,315,Commissioner of the General Land Office,,REP,George P. Bush,52,31,21
+Wichita,315,Commissioner of the General Land Office,,DEM,Miguel Suazo,20,17,3
+Wichita,315,Commissioner of the General Land Office,,LIB,Matt Pina,4,2,2
+Wichita,315,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,315,Commissioner of the General Land Office,,,Under Votes,0,0,0
+Wichita,315,Commissioner of Agriculture,,REP,Sid Miller,52,30,22
+Wichita,315,Commissioner of Agriculture,,DEM,Kim Olson,22,19,3
+Wichita,315,Commissioner of Agriculture,,LIB,Richard Carpenter,2,1,1
+Wichita,315,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,315,Commissioner of Agriculture,,,Under Votes,0,0,0
+Wichita,315,Railroad Commissioner,,REP,Christi Craddick,56,33,23
+Wichita,315,Railroad Commissioner,,DEM,Roman McAllen,18,16,2
+Wichita,315,Railroad Commissioner,,LIB,Mike Wright,2,1,1
+Wichita,315,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,315,Railroad Commissioner,,,Under Votes,0,0,0
+Wichita,315,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,56,33,23
+Wichita,315,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,20,17,3
+Wichita,315,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,315,"Justice, Supreme Court, Place 2",,,Under Votes,0,0,0
+Wichita,315,"Justice, Supreme Court, Place 4",,REP,John Devine,56,33,23
+Wichita,315,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,20,17,3
+Wichita,315,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,315,"Justice, Supreme Court, Place 4",,,Under Votes,0,0,0
+Wichita,315,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,55,32,23
+Wichita,315,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,21,18,3
+Wichita,315,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,315,"Justice, Supreme Court, Place 6",,,Under Votes,0,0,0
+Wichita,315,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,53,32,21
+Wichita,315,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,20,17,3
+Wichita,315,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,3,1,2
+Wichita,315,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,315,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,0,0,0
+Wichita,315,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,54,31,23
+Wichita,315,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,20,17,3
+Wichita,315,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,315,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,2,2,0
+Wichita,315,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,55,31,24
+Wichita,315,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,5,4,1
+Wichita,315,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,1,1,0
+Wichita,315,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,15,14,1
+Wichita,315,State Senator,30,REP,Pat Fallon,55,32,23
+Wichita,315,State Senator,30,DEM,Kevin Lopez,21,18,3
+Wichita,315,State Senator,30,,Over Votes,0,0,0
+Wichita,315,State Senator,30,,Under Votes,0,0,0
+Wichita,315,State Representative,69,REP,James Frank,58,34,24
+Wichita,315,State Representative,69,,Over Votes,0,0,0
+Wichita,315,State Representative,69,,Under Votes,18,16,2
+Wichita,315,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,58,34,24
+Wichita,315,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,315,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,18,16,2
+Wichita,315,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,58,34,24
+Wichita,315,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,315,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,18,16,2
+Wichita,315,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,54,32,22
+Wichita,315,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,22,18,4
+Wichita,315,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,315,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,0,0,0
+Wichita,315,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,58,34,24
+Wichita,315,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,315,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,18,16,2
+Wichita,315,"District Judge, 30th Judicial District",,REP,Jeff McKnight,58,34,24
+Wichita,315,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,315,"District Judge, 30th Judicial District",,,Under Votes,18,16,2
+Wichita,315,Criminal District Attorney,,REP,John Gillespie,60,35,25
+Wichita,315,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,315,Criminal District Attorney,,,Under Votes,16,15,1
+Wichita,315,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",59,34,25
+Wichita,315,County Judge,,,Over Votes,0,0,0
+Wichita,315,County Judge,,,Under Votes,17,16,1
+Wichita,315,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,58,34,24
+Wichita,315,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,315,"Judge, County Court at Law No. 1",,,Under Votes,18,16,2
+Wichita,315,"Judge, County Court at Law No. 2",,REP,Greg King,56,33,23
+Wichita,315,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,315,"Judge, County Court at Law No. 2",,,Under Votes,20,17,3
+Wichita,315,District Clerk,,REP,Patti Flores,59,35,24
+Wichita,315,District Clerk,,,Over Votes,0,0,0
+Wichita,315,District Clerk,,,Under Votes,17,15,2
+Wichita,315,County Clerk,,REP,Lori Bohannon,60,36,24
+Wichita,315,County Clerk,,,Over Votes,0,0,0
+Wichita,315,County Clerk,,,Under Votes,16,14,2
+Wichita,315,County Treasurer,,REP,R. J. Bob Hampton,56,32,24
+Wichita,315,County Treasurer,,,Over Votes,0,0,0
+Wichita,315,County Treasurer,,,Under Votes,20,18,2
+Wichita,315,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,56,33,23
+Wichita,315,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,315,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,20,17,3
+Wichita,315,City of Wichita Falls Mayor,,,Lowry W. Crane,20,14,6
+Wichita,315,City of Wichita Falls Mayor,,,Stephen L. Santellana,33,20,13
+Wichita,315,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,315,City of Wichita Falls Mayor,,,Under Votes,23,16,7
+Wichita,315,City of Wichita Falls Councilor District 5,,,Chris Reitsma,15,11,4
+Wichita,315,City of Wichita Falls Councilor District 5,,,Mitesh Desai,11,9,2
+Wichita,315,City of Wichita Falls Councilor District 5,,,Steve Jackson,23,14,9
+Wichita,315,City of Wichita Falls Councilor District 5,,,Over Votes,0,0,0
+Wichita,315,City of Wichita Falls Councilor District 5,,,Under Votes,27,16,11
+Wichita,315,Wichita Falls ISD Single Member District 5,,,Tom Bursey,43,30,13
+Wichita,315,Wichita Falls ISD Single Member District 5,,,Over Votes,0,0,0
+Wichita,315,Wichita Falls ISD Single Member District 5,,,Under Votes,33,20,13
+Wichita,315,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,43,30,13
+Wichita,315,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,315,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,33,20,13
+Wichita,315,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,31,23,8
+Wichita,315,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,21,11,10
+Wichita,315,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,315,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,24,16,8
+Wichita,315,Ballots Cast,,,,76,50,26
+Wichita,316,Straight Party,,REP,,9,6,3
+Wichita,316,Straight Party,,DEM,,4,2,2
+Wichita,316,Straight Party,,LIB,,0,0,0
+Wichita,316,Straight Party,,,Over Votes,0,0,0
+Wichita,316,Straight Party,,,Under Votes,6,3,3
+Wichita,316,U.S. Senate,,REP,Ted Cruz,11,7,4
+Wichita,316,U.S. Senate,,DEM,Beto O'Rourke,7,4,3
+Wichita,316,U.S. Senate,,LIB,Neal M. Dikeman,1,0,1
+Wichita,316,U.S. Senate,,,Over Votes,0,0,0
+Wichita,316,U.S. Senate,,,Under Votes,0,0,0
+Wichita,316,U.S. House,13,REP,Mac Thornberry,11,7,4
+Wichita,316,U.S. House,13,DEM,Greg Sagan,7,4,3
+Wichita,316,U.S. House,13,LIB,Calvin DeWeese,1,0,1
+Wichita,316,U.S. House,13,,Over Votes,0,0,0
+Wichita,316,U.S. House,13,,Under Votes,0,0,0
+Wichita,316,Governor,,REP,Greg Abbott,11,7,4
+Wichita,316,Governor,,DEM,Lupe Valdez,7,4,3
+Wichita,316,Governor,,LIB,Mark Jay Tippetts,1,0,1
+Wichita,316,Governor,,,Over Votes,0,0,0
+Wichita,316,Governor,,,Under Votes,0,0,0
+Wichita,316,Lieutenant Governor,,REP,Dan Patrick,11,7,4
+Wichita,316,Lieutenant Governor,,DEM,Mike Collier,7,4,3
+Wichita,316,Lieutenant Governor,,LIB,Kerry Douglas McKennon,1,0,1
+Wichita,316,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,316,Lieutenant Governor,,,Under Votes,0,0,0
+Wichita,316,Attorney General,,REP,Ken Paxton,11,7,4
+Wichita,316,Attorney General,,DEM,Justin Nelson,7,4,3
+Wichita,316,Attorney General,,LIB,Michael Ray Harris,1,0,1
+Wichita,316,Attorney General,,,Over Votes,0,0,0
+Wichita,316,Attorney General,,,Under Votes,0,0,0
+Wichita,316,Comptroller of Public Accounts,,REP,Glenn Hegar,11,7,4
+Wichita,316,Comptroller of Public Accounts,,DEM,Joi Chevalier,7,4,3
+Wichita,316,Comptroller of Public Accounts,,LIB,Ben Sanders,1,0,1
+Wichita,316,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,316,Comptroller of Public Accounts,,,Under Votes,0,0,0
+Wichita,316,Commissioner of the General Land Office,,REP,George P. Bush,11,7,4
+Wichita,316,Commissioner of the General Land Office,,DEM,Miguel Suazo,7,4,3
+Wichita,316,Commissioner of the General Land Office,,LIB,Matt Pina,1,0,1
+Wichita,316,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,316,Commissioner of the General Land Office,,,Under Votes,0,0,0
+Wichita,316,Commissioner of Agriculture,,REP,Sid Miller,11,7,4
+Wichita,316,Commissioner of Agriculture,,DEM,Kim Olson,7,4,3
+Wichita,316,Commissioner of Agriculture,,LIB,Richard Carpenter,1,0,1
+Wichita,316,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,316,Commissioner of Agriculture,,,Under Votes,0,0,0
+Wichita,316,Railroad Commissioner,,REP,Christi Craddick,11,7,4
+Wichita,316,Railroad Commissioner,,DEM,Roman McAllen,7,4,3
+Wichita,316,Railroad Commissioner,,LIB,Mike Wright,1,0,1
+Wichita,316,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,316,Railroad Commissioner,,,Under Votes,0,0,0
+Wichita,316,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,12,7,5
+Wichita,316,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,7,4,3
+Wichita,316,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,316,"Justice, Supreme Court, Place 2",,,Under Votes,0,0,0
+Wichita,316,"Justice, Supreme Court, Place 4",,REP,John Devine,12,7,5
+Wichita,316,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,7,4,3
+Wichita,316,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,316,"Justice, Supreme Court, Place 4",,,Under Votes,0,0,0
+Wichita,316,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,12,7,5
+Wichita,316,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,7,4,3
+Wichita,316,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,316,"Justice, Supreme Court, Place 6",,,Under Votes,0,0,0
+Wichita,316,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,11,7,4
+Wichita,316,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,7,4,3
+Wichita,316,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,1,0,1
+Wichita,316,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,316,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,0,0,0
+Wichita,316,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,12,7,5
+Wichita,316,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,7,4,3
+Wichita,316,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,316,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,0,0,0
+Wichita,316,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,12,8,4
+Wichita,316,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,4,2,2
+Wichita,316,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,316,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,3,1,2
+Wichita,316,State Senator,30,REP,Pat Fallon,12,7,5
+Wichita,316,State Senator,30,DEM,Kevin Lopez,7,4,3
+Wichita,316,State Senator,30,,Over Votes,0,0,0
+Wichita,316,State Senator,30,,Under Votes,0,0,0
+Wichita,316,State Representative,69,REP,James Frank,16,10,6
+Wichita,316,State Representative,69,,Over Votes,0,0,0
+Wichita,316,State Representative,69,,Under Votes,3,1,2
+Wichita,316,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,16,10,6
+Wichita,316,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,316,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,3,1,2
+Wichita,316,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,15,10,5
+Wichita,316,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,316,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,4,1,3
+Wichita,316,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,12,7,5
+Wichita,316,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,7,4,3
+Wichita,316,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,316,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,0,0,0
+Wichita,316,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,15,10,5
+Wichita,316,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,316,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,4,1,3
+Wichita,316,"District Judge, 30th Judicial District",,REP,Jeff McKnight,16,10,6
+Wichita,316,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,316,"District Judge, 30th Judicial District",,,Under Votes,3,1,2
+Wichita,316,Criminal District Attorney,,REP,John Gillespie,16,10,6
+Wichita,316,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,316,Criminal District Attorney,,,Under Votes,3,1,2
+Wichita,316,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",15,10,5
+Wichita,316,County Judge,,,Over Votes,0,0,0
+Wichita,316,County Judge,,,Under Votes,4,1,3
+Wichita,316,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,15,10,5
+Wichita,316,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,316,"Judge, County Court at Law No. 1",,,Under Votes,4,1,3
+Wichita,316,"Judge, County Court at Law No. 2",,REP,Greg King,15,10,5
+Wichita,316,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,316,"Judge, County Court at Law No. 2",,,Under Votes,4,1,3
+Wichita,316,District Clerk,,REP,Patti Flores,16,10,6
+Wichita,316,District Clerk,,,Over Votes,0,0,0
+Wichita,316,District Clerk,,,Under Votes,3,1,2
+Wichita,316,County Clerk,,REP,Lori Bohannon,16,10,6
+Wichita,316,County Clerk,,,Over Votes,0,0,0
+Wichita,316,County Clerk,,,Under Votes,3,1,2
+Wichita,316,County Treasurer,,REP,R. J. Bob Hampton,16,10,6
+Wichita,316,County Treasurer,,,Over Votes,0,0,0
+Wichita,316,County Treasurer,,,Under Votes,3,1,2
+Wichita,316,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,16,10,6
+Wichita,316,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,316,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,3,1,2
+Wichita,316,City of Wichita Falls Mayor,,,Lowry W. Crane,5,2,3
+Wichita,316,City of Wichita Falls Mayor,,,Stephen L. Santellana,10,7,3
+Wichita,316,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,316,City of Wichita Falls Mayor,,,Under Votes,4,2,2
+Wichita,316,Wichita Falls ISD Single Member District 5,,,Tom Bursey,14,8,6
+Wichita,316,Wichita Falls ISD Single Member District 5,,,Over Votes,0,0,0
+Wichita,316,Wichita Falls ISD Single Member District 5,,,Under Votes,5,3,2
+Wichita,316,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,13,7,6
+Wichita,316,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,316,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,6,4,2
+Wichita,316,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,8,5,3
+Wichita,316,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,7,4,3
+Wichita,316,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,316,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,4,2,2
+Wichita,316,Ballots Cast,,,,19,11,8
+Wichita,317,Straight Party,,REP,,30,14,16
+Wichita,317,Straight Party,,DEM,,5,3,2
+Wichita,317,Straight Party,,LIB,,0,0,0
+Wichita,317,Straight Party,,,Over Votes,0,0,0
+Wichita,317,Straight Party,,,Under Votes,16,12,4
+Wichita,317,U.S. Senate,,REP,Ted Cruz,41,22,19
+Wichita,317,U.S. Senate,,DEM,Beto O'Rourke,10,7,3
+Wichita,317,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0
+Wichita,317,U.S. Senate,,,Over Votes,0,0,0
+Wichita,317,U.S. Senate,,,Under Votes,0,0,0
+Wichita,317,U.S. House,13,REP,Mac Thornberry,42,23,19
+Wichita,317,U.S. House,13,DEM,Greg Sagan,9,6,3
+Wichita,317,U.S. House,13,LIB,Calvin DeWeese,0,0,0
+Wichita,317,U.S. House,13,,Over Votes,0,0,0
+Wichita,317,U.S. House,13,,Under Votes,0,0,0
+Wichita,317,Governor,,REP,Greg Abbott,41,22,19
+Wichita,317,Governor,,DEM,Lupe Valdez,9,7,2
+Wichita,317,Governor,,LIB,Mark Jay Tippetts,1,0,1
+Wichita,317,Governor,,,Over Votes,0,0,0
+Wichita,317,Governor,,,Under Votes,0,0,0
+Wichita,317,Lieutenant Governor,,REP,Dan Patrick,38,20,18
+Wichita,317,Lieutenant Governor,,DEM,Mike Collier,11,8,3
+Wichita,317,Lieutenant Governor,,LIB,Kerry Douglas McKennon,2,1,1
+Wichita,317,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,317,Lieutenant Governor,,,Under Votes,0,0,0
+Wichita,317,Attorney General,,REP,Ken Paxton,40,22,18
+Wichita,317,Attorney General,,DEM,Justin Nelson,11,7,4
+Wichita,317,Attorney General,,LIB,Michael Ray Harris,0,0,0
+Wichita,317,Attorney General,,,Over Votes,0,0,0
+Wichita,317,Attorney General,,,Under Votes,0,0,0
+Wichita,317,Comptroller of Public Accounts,,REP,Glenn Hegar,40,22,18
+Wichita,317,Comptroller of Public Accounts,,DEM,Joi Chevalier,10,7,3
+Wichita,317,Comptroller of Public Accounts,,LIB,Ben Sanders,1,0,1
+Wichita,317,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,317,Comptroller of Public Accounts,,,Under Votes,0,0,0
+Wichita,317,Commissioner of the General Land Office,,REP,George P. Bush,38,20,18
+Wichita,317,Commissioner of the General Land Office,,DEM,Miguel Suazo,11,7,4
+Wichita,317,Commissioner of the General Land Office,,LIB,Matt Pina,2,2,0
+Wichita,317,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,317,Commissioner of the General Land Office,,,Under Votes,0,0,0
+Wichita,317,Commissioner of Agriculture,,REP,Sid Miller,39,21,18
+Wichita,317,Commissioner of Agriculture,,DEM,Kim Olson,12,8,4
+Wichita,317,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0
+Wichita,317,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,317,Commissioner of Agriculture,,,Under Votes,0,0,0
+Wichita,317,Railroad Commissioner,,REP,Christi Craddick,39,22,17
+Wichita,317,Railroad Commissioner,,DEM,Roman McAllen,9,7,2
+Wichita,317,Railroad Commissioner,,LIB,Mike Wright,3,0,3
+Wichita,317,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,317,Railroad Commissioner,,,Under Votes,0,0,0
+Wichita,317,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,41,22,19
+Wichita,317,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,10,7,3
+Wichita,317,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,317,"Justice, Supreme Court, Place 2",,,Under Votes,0,0,0
+Wichita,317,"Justice, Supreme Court, Place 4",,REP,John Devine,40,21,19
+Wichita,317,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,11,8,3
+Wichita,317,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,317,"Justice, Supreme Court, Place 4",,,Under Votes,0,0,0
+Wichita,317,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,38,21,17
+Wichita,317,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,13,8,5
+Wichita,317,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,317,"Justice, Supreme Court, Place 6",,,Under Votes,0,0,0
+Wichita,317,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,40,21,19
+Wichita,317,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,10,8,2
+Wichita,317,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,1,0,1
+Wichita,317,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,317,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,0,0,0
+Wichita,317,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,40,21,19
+Wichita,317,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,11,8,3
+Wichita,317,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,317,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,0,0,0
+Wichita,317,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,42,23,19
+Wichita,317,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,4,3,1
+Wichita,317,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,317,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,5,3,2
+Wichita,317,State Senator,30,REP,Pat Fallon,42,23,19
+Wichita,317,State Senator,30,DEM,Kevin Lopez,9,6,3
+Wichita,317,State Senator,30,,Over Votes,0,0,0
+Wichita,317,State Senator,30,,Under Votes,0,0,0
+Wichita,317,State Representative,69,REP,James Frank,44,25,19
+Wichita,317,State Representative,69,,Over Votes,0,0,0
+Wichita,317,State Representative,69,,Under Votes,7,4,3
+Wichita,317,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,43,24,19
+Wichita,317,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,317,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,8,5,3
+Wichita,317,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,42,23,19
+Wichita,317,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,317,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,9,6,3
+Wichita,317,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,40,21,19
+Wichita,317,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,11,8,3
+Wichita,317,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,317,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,0,0,0
+Wichita,317,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,43,24,19
+Wichita,317,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,317,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,8,5,3
+Wichita,317,"District Judge, 30th Judicial District",,REP,Jeff McKnight,43,24,19
+Wichita,317,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,317,"District Judge, 30th Judicial District",,,Under Votes,8,5,3
+Wichita,317,Criminal District Attorney,,REP,John Gillespie,44,25,19
+Wichita,317,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,317,Criminal District Attorney,,,Under Votes,7,4,3
+Wichita,317,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",45,26,19
+Wichita,317,County Judge,,,Over Votes,0,0,0
+Wichita,317,County Judge,,,Under Votes,6,3,3
+Wichita,317,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,43,24,19
+Wichita,317,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,317,"Judge, County Court at Law No. 1",,,Under Votes,8,5,3
+Wichita,317,"Judge, County Court at Law No. 2",,REP,Greg King,43,24,19
+Wichita,317,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,317,"Judge, County Court at Law No. 2",,,Under Votes,8,5,3
+Wichita,317,District Clerk,,REP,Patti Flores,44,25,19
+Wichita,317,District Clerk,,,Over Votes,0,0,0
+Wichita,317,District Clerk,,,Under Votes,7,4,3
+Wichita,317,County Clerk,,REP,Lori Bohannon,43,24,19
+Wichita,317,County Clerk,,,Over Votes,0,0,0
+Wichita,317,County Clerk,,,Under Votes,8,5,3
+Wichita,317,County Treasurer,,REP,R. J. Bob Hampton,43,24,19
+Wichita,317,County Treasurer,,,Over Votes,0,0,0
+Wichita,317,County Treasurer,,,Under Votes,8,5,3
+Wichita,317,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,45,25,20
+Wichita,317,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,317,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,6,4,2
+Wichita,317,City of Wichita Falls Mayor,,,Lowry W. Crane,1,1,0
+Wichita,317,City of Wichita Falls Mayor,,,Stephen L. Santellana,0,0,0
+Wichita,317,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,317,City of Wichita Falls Mayor,,,Under Votes,0,0,0
+Wichita,317,Ballots Cast,,,,51,29,22
+Wichita,318,Straight Party,,REP,,95,76,19
+Wichita,318,Straight Party,,DEM,,31,18,13
+Wichita,318,Straight Party,,LIB,,1,0,1
+Wichita,318,Straight Party,,,Over Votes,0,0,0
+Wichita,318,Straight Party,,,Under Votes,101,75,26
+Wichita,318,U.S. Senate,,REP,Ted Cruz,166,132,34
+Wichita,318,U.S. Senate,,DEM,Beto O'Rourke,55,35,20
+Wichita,318,U.S. Senate,,LIB,Neal M. Dikeman,3,0,3
+Wichita,318,U.S. Senate,,,Over Votes,0,0,0
+Wichita,318,U.S. Senate,,,Under Votes,4,2,2
+Wichita,318,U.S. House,13,REP,Mac Thornberry,165,130,35
+Wichita,318,U.S. House,13,DEM,Greg Sagan,47,30,17
+Wichita,318,U.S. House,13,LIB,Calvin DeWeese,8,3,5
+Wichita,318,U.S. House,13,,Over Votes,0,0,0
+Wichita,318,U.S. House,13,,Under Votes,8,6,2
+Wichita,318,Governor,,REP,Greg Abbott,170,129,41
+Wichita,318,Governor,,DEM,Lupe Valdez,46,33,13
+Wichita,318,Governor,,LIB,Mark Jay Tippetts,8,3,5
+Wichita,318,Governor,,,Over Votes,0,0,0
+Wichita,318,Governor,,,Under Votes,4,4,0
+Wichita,318,Lieutenant Governor,,REP,Dan Patrick,164,130,34
+Wichita,318,Lieutenant Governor,,DEM,Mike Collier,48,31,17
+Wichita,318,Lieutenant Governor,,LIB,Kerry Douglas McKennon,9,3,6
+Wichita,318,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,318,Lieutenant Governor,,,Under Votes,7,5,2
+Wichita,318,Attorney General,,REP,Ken Paxton,162,129,33
+Wichita,318,Attorney General,,DEM,Justin Nelson,50,33,17
+Wichita,318,Attorney General,,LIB,Michael Ray Harris,10,2,8
+Wichita,318,Attorney General,,,Over Votes,0,0,0
+Wichita,318,Attorney General,,,Under Votes,6,5,1
+Wichita,318,Comptroller of Public Accounts,,REP,Glenn Hegar,159,128,31
+Wichita,318,Comptroller of Public Accounts,,DEM,Joi Chevalier,49,31,18
+Wichita,318,Comptroller of Public Accounts,,LIB,Ben Sanders,12,4,8
+Wichita,318,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,318,Comptroller of Public Accounts,,,Under Votes,8,6,2
+Wichita,318,Commissioner of the General Land Office,,REP,George P. Bush,166,128,38
+Wichita,318,Commissioner of the General Land Office,,DEM,Miguel Suazo,40,27,13
+Wichita,318,Commissioner of the General Land Office,,LIB,Matt Pina,14,8,6
+Wichita,318,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,318,Commissioner of the General Land Office,,,Under Votes,8,6,2
+Wichita,318,Commissioner of Agriculture,,REP,Sid Miller,162,129,33
+Wichita,318,Commissioner of Agriculture,,DEM,Kim Olson,49,31,18
+Wichita,318,Commissioner of Agriculture,,LIB,Richard Carpenter,9,3,6
+Wichita,318,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,318,Commissioner of Agriculture,,,Under Votes,8,6,2
+Wichita,318,Railroad Commissioner,,REP,Christi Craddick,162,131,31
+Wichita,318,Railroad Commissioner,,DEM,Roman McAllen,46,28,18
+Wichita,318,Railroad Commissioner,,LIB,Mike Wright,12,4,8
+Wichita,318,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,318,Railroad Commissioner,,,Under Votes,8,6,2
+Wichita,318,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,172,133,39
+Wichita,318,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,48,30,18
+Wichita,318,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,318,"Justice, Supreme Court, Place 2",,,Under Votes,8,6,2
+Wichita,318,"Justice, Supreme Court, Place 4",,REP,John Devine,171,132,39
+Wichita,318,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,48,30,18
+Wichita,318,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,318,"Justice, Supreme Court, Place 4",,,Under Votes,9,7,2
+Wichita,318,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,173,133,40
+Wichita,318,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,47,30,17
+Wichita,318,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,318,"Justice, Supreme Court, Place 6",,,Under Votes,8,6,2
+Wichita,318,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,160,128,32
+Wichita,318,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,50,31,19
+Wichita,318,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,10,4,6
+Wichita,318,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,318,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,8,6,2
+Wichita,318,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,168,133,35
+Wichita,318,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,50,29,21
+Wichita,318,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,318,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,10,7,3
+Wichita,318,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,174,136,38
+Wichita,318,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,24,12,12
+Wichita,318,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,318,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,30,21,9
+Wichita,318,State Senator,30,REP,Pat Fallon,167,131,36
+Wichita,318,State Senator,30,DEM,Kevin Lopez,55,34,21
+Wichita,318,State Senator,30,,Over Votes,0,0,0
+Wichita,318,State Senator,30,,Under Votes,6,4,2
+Wichita,318,State Representative,69,REP,James Frank,183,138,45
+Wichita,318,State Representative,69,,Over Votes,0,0,0
+Wichita,318,State Representative,69,,Under Votes,45,31,14
+Wichita,318,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,181,135,46
+Wichita,318,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,318,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,47,34,13
+Wichita,318,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,182,138,44
+Wichita,318,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,318,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,46,31,15
+Wichita,318,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,169,131,38
+Wichita,318,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,48,29,19
+Wichita,318,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,318,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,11,9,2
+Wichita,318,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,186,140,46
+Wichita,318,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,318,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,42,29,13
+Wichita,318,"District Judge, 30th Judicial District",,REP,Jeff McKnight,190,144,46
+Wichita,318,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,318,"District Judge, 30th Judicial District",,,Under Votes,38,25,13
+Wichita,318,Criminal District Attorney,,REP,John Gillespie,185,140,45
+Wichita,318,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,318,Criminal District Attorney,,,Under Votes,43,29,14
+Wichita,318,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",189,143,46
+Wichita,318,County Judge,,,Over Votes,0,0,0
+Wichita,318,County Judge,,,Under Votes,39,26,13
+Wichita,318,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,188,140,48
+Wichita,318,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,318,"Judge, County Court at Law No. 1",,,Under Votes,40,29,11
+Wichita,318,"Judge, County Court at Law No. 2",,REP,Greg King,189,144,45
+Wichita,318,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,318,"Judge, County Court at Law No. 2",,,Under Votes,39,25,14
+Wichita,318,District Clerk,,REP,Patti Flores,188,142,46
+Wichita,318,District Clerk,,,Over Votes,0,0,0
+Wichita,318,District Clerk,,,Under Votes,40,27,13
+Wichita,318,County Clerk,,REP,Lori Bohannon,186,140,46
+Wichita,318,County Clerk,,,Over Votes,0,0,0
+Wichita,318,County Clerk,,,Under Votes,42,29,13
+Wichita,318,County Treasurer,,REP,R. J. Bob Hampton,185,140,45
+Wichita,318,County Treasurer,,,Over Votes,0,0,0
+Wichita,318,County Treasurer,,,Under Votes,43,29,14
+Wichita,318,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,182,140,42
+Wichita,318,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,318,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,46,29,17
+Wichita,318,City of Wichita Falls Mayor,,,Lowry W. Crane,59,41,18
+Wichita,318,City of Wichita Falls Mayor,,,Stephen L. Santellana,114,84,30
+Wichita,318,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,318,City of Wichita Falls Mayor,,,Under Votes,55,44,11
+Wichita,318,City of Wichita Falls Councilor District 4,,,Tim Brewer,117,88,29
+Wichita,318,City of Wichita Falls Councilor District 4,,,Nicholas J. Schreiber,51,34,17
+Wichita,318,City of Wichita Falls Councilor District 4,,,Over Votes,0,0,0
+Wichita,318,City of Wichita Falls Councilor District 4,,,Under Votes,60,47,13
+Wichita,318,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,149,109,40
+Wichita,318,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,318,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,79,60,19
+Wichita,318,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,115,83,32
+Wichita,318,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,55,40,15
+Wichita,318,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,318,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,58,46,12
+Wichita,318,Ballots Cast,,,,228,169,59
+Wichita,319,Straight Party,,REP,,9,4,5
+Wichita,319,Straight Party,,DEM,,3,3,0
+Wichita,319,Straight Party,,LIB,,1,1,0
+Wichita,319,Straight Party,,,Over Votes,0,0,0
+Wichita,319,Straight Party,,,Under Votes,16,13,3
+Wichita,319,U.S. Senate,,REP,Ted Cruz,22,17,5
+Wichita,319,U.S. Senate,,DEM,Beto O'Rourke,7,4,3
+Wichita,319,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0
+Wichita,319,U.S. Senate,,,Over Votes,0,0,0
+Wichita,319,U.S. Senate,,,Under Votes,0,0,0
+Wichita,319,U.S. House,13,REP,Mac Thornberry,24,17,7
+Wichita,319,U.S. House,13,DEM,Greg Sagan,5,4,1
+Wichita,319,U.S. House,13,LIB,Calvin DeWeese,0,0,0
+Wichita,319,U.S. House,13,,Over Votes,0,0,0
+Wichita,319,U.S. House,13,,Under Votes,0,0,0
+Wichita,319,Governor,,REP,Greg Abbott,25,18,7
+Wichita,319,Governor,,DEM,Lupe Valdez,4,3,1
+Wichita,319,Governor,,LIB,Mark Jay Tippetts,0,0,0
+Wichita,319,Governor,,,Over Votes,0,0,0
+Wichita,319,Governor,,,Under Votes,0,0,0
+Wichita,319,Lieutenant Governor,,REP,Dan Patrick,22,16,6
+Wichita,319,Lieutenant Governor,,DEM,Mike Collier,7,5,2
+Wichita,319,Lieutenant Governor,,LIB,Kerry Douglas McKennon,0,0,0
+Wichita,319,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,319,Lieutenant Governor,,,Under Votes,0,0,0
+Wichita,319,Attorney General,,REP,Ken Paxton,21,16,5
+Wichita,319,Attorney General,,DEM,Justin Nelson,7,4,3
+Wichita,319,Attorney General,,LIB,Michael Ray Harris,1,1,0
+Wichita,319,Attorney General,,,Over Votes,0,0,0
+Wichita,319,Attorney General,,,Under Votes,0,0,0
+Wichita,319,Comptroller of Public Accounts,,REP,Glenn Hegar,22,17,5
+Wichita,319,Comptroller of Public Accounts,,DEM,Joi Chevalier,7,4,3
+Wichita,319,Comptroller of Public Accounts,,LIB,Ben Sanders,0,0,0
+Wichita,319,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,319,Comptroller of Public Accounts,,,Under Votes,0,0,0
+Wichita,319,Commissioner of the General Land Office,,REP,George P. Bush,22,16,6
+Wichita,319,Commissioner of the General Land Office,,DEM,Miguel Suazo,6,4,2
+Wichita,319,Commissioner of the General Land Office,,LIB,Matt Pina,1,1,0
+Wichita,319,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,319,Commissioner of the General Land Office,,,Under Votes,0,0,0
+Wichita,319,Commissioner of Agriculture,,REP,Sid Miller,20,15,5
+Wichita,319,Commissioner of Agriculture,,DEM,Kim Olson,7,4,3
+Wichita,319,Commissioner of Agriculture,,LIB,Richard Carpenter,2,2,0
+Wichita,319,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,319,Commissioner of Agriculture,,,Under Votes,0,0,0
+Wichita,319,Railroad Commissioner,,REP,Christi Craddick,22,16,6
+Wichita,319,Railroad Commissioner,,DEM,Roman McAllen,6,4,2
+Wichita,319,Railroad Commissioner,,LIB,Mike Wright,1,1,0
+Wichita,319,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,319,Railroad Commissioner,,,Under Votes,0,0,0
+Wichita,319,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,22,16,6
+Wichita,319,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,6,4,2
+Wichita,319,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,319,"Justice, Supreme Court, Place 2",,,Under Votes,1,1,0
+Wichita,319,"Justice, Supreme Court, Place 4",,REP,John Devine,21,15,6
+Wichita,319,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,5,3,2
+Wichita,319,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,319,"Justice, Supreme Court, Place 4",,,Under Votes,3,3,0
+Wichita,319,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,18,12,6
+Wichita,319,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,6,4,2
+Wichita,319,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,319,"Justice, Supreme Court, Place 6",,,Under Votes,5,5,0
+Wichita,319,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,18,12,6
+Wichita,319,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,6,4,2
+Wichita,319,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,1,1,0
+Wichita,319,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,319,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,4,4,0
+Wichita,319,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,18,12,6
+Wichita,319,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,6,4,2
+Wichita,319,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,319,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,5,5,0
+Wichita,319,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,18,12,6
+Wichita,319,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,5,4,1
+Wichita,319,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,319,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,6,5,1
+Wichita,319,State Senator,30,REP,Pat Fallon,22,16,6
+Wichita,319,State Senator,30,DEM,Kevin Lopez,6,4,2
+Wichita,319,State Senator,30,,Over Votes,0,0,0
+Wichita,319,State Senator,30,,Under Votes,1,1,0
+Wichita,319,State Representative,69,REP,James Frank,21,14,7
+Wichita,319,State Representative,69,,Over Votes,0,0,0
+Wichita,319,State Representative,69,,Under Votes,8,7,1
+Wichita,319,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,24,17,7
+Wichita,319,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,319,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,5,4,1
+Wichita,319,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,23,16,7
+Wichita,319,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,319,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,6,5,1
+Wichita,319,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,20,14,6
+Wichita,319,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,6,4,2
+Wichita,319,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,319,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,3,3,0
+Wichita,319,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,21,14,7
+Wichita,319,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,319,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,8,7,1
+Wichita,319,"District Judge, 30th Judicial District",,REP,Jeff McKnight,19,12,7
+Wichita,319,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,319,"District Judge, 30th Judicial District",,,Under Votes,10,9,1
+Wichita,319,Criminal District Attorney,,REP,John Gillespie,19,12,7
+Wichita,319,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,319,Criminal District Attorney,,,Under Votes,10,9,1
+Wichita,319,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",18,11,7
+Wichita,319,County Judge,,,Over Votes,0,0,0
+Wichita,319,County Judge,,,Under Votes,11,10,1
+Wichita,319,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,19,12,7
+Wichita,319,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,319,"Judge, County Court at Law No. 1",,,Under Votes,10,9,1
+Wichita,319,"Judge, County Court at Law No. 2",,REP,Greg King,19,12,7
+Wichita,319,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,319,"Judge, County Court at Law No. 2",,,Under Votes,10,9,1
+Wichita,319,District Clerk,,REP,Patti Flores,18,11,7
+Wichita,319,District Clerk,,,Over Votes,0,0,0
+Wichita,319,District Clerk,,,Under Votes,11,10,1
+Wichita,319,County Clerk,,REP,Lori Bohannon,18,11,7
+Wichita,319,County Clerk,,,Over Votes,0,0,0
+Wichita,319,County Clerk,,,Under Votes,11,10,1
+Wichita,319,County Treasurer,,REP,R. J. Bob Hampton,19,12,7
+Wichita,319,County Treasurer,,,Over Votes,0,0,0
+Wichita,319,County Treasurer,,,Under Votes,10,9,1
+Wichita,319,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,23,16,7
+Wichita,319,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,319,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,6,5,1
+Wichita,319,City of Wichita Falls Mayor,,,Lowry W. Crane,5,3,2
+Wichita,319,City of Wichita Falls Mayor,,,Stephen L. Santellana,13,9,4
+Wichita,319,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,319,City of Wichita Falls Mayor,,,Under Votes,11,9,2
+Wichita,319,City of Wichita Falls Councilor District 4,,,Tim Brewer,15,11,4
+Wichita,319,City of Wichita Falls Councilor District 4,,,Nicholas J. Schreiber,4,1,3
+Wichita,319,City of Wichita Falls Councilor District 4,,,Over Votes,0,0,0
+Wichita,319,City of Wichita Falls Councilor District 4,,,Under Votes,10,9,1
+Wichita,319,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,16,10,6
+Wichita,319,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,319,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,13,11,2
+Wichita,319,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,16,11,5
+Wichita,319,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,7,5,2
+Wichita,319,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,319,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,6,5,1
+Wichita,319,Ballots Cast,,,,29,21,8
+Wichita,401,Straight Party,,REP,,609,488,121
+Wichita,401,Straight Party,,DEM,,142,120,22
+Wichita,401,Straight Party,,LIB,,2,2,0
+Wichita,401,Straight Party,,,Over Votes,0,0,0
+Wichita,401,Straight Party,,,Under Votes,649,518,131
+Wichita,401,U.S. Senate,,REP,Ted Cruz,1029,826,203
+Wichita,401,U.S. Senate,,DEM,Beto O'Rourke,346,278,68
+Wichita,401,U.S. Senate,,LIB,Neal M. Dikeman,8,5,3
+Wichita,401,U.S. Senate,,,Over Votes,0,0,0
+Wichita,401,U.S. Senate,,,Under Votes,17,17,0
+Wichita,401,U.S. House,13,REP,Mac Thornberry,1085,861,224
+Wichita,401,U.S. House,13,DEM,Greg Sagan,277,232,45
+Wichita,401,U.S. House,13,LIB,Calvin DeWeese,21,17,4
+Wichita,401,U.S. House,13,,Over Votes,0,0,0
+Wichita,401,U.S. House,13,,Under Votes,17,16,1
+Wichita,401,Governor,,REP,Greg Abbott,1085,865,220
+Wichita,401,Governor,,DEM,Lupe Valdez,282,232,50
+Wichita,401,Governor,,LIB,Mark Jay Tippetts,16,13,3
+Wichita,401,Governor,,,Over Votes,0,0,0
+Wichita,401,Governor,,,Under Votes,17,16,1
+Wichita,401,Lieutenant Governor,,REP,Dan Patrick,1007,810,197
+Wichita,401,Lieutenant Governor,,DEM,Mike Collier,332,271,61
+Wichita,401,Lieutenant Governor,,LIB,Kerry Douglas McKennon,34,22,12
+Wichita,401,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,401,Lieutenant Governor,,,Under Votes,27,23,4
+Wichita,401,Attorney General,,REP,Ken Paxton,1023,823,200
+Wichita,401,Attorney General,,DEM,Justin Nelson,317,261,56
+Wichita,401,Attorney General,,LIB,Michael Ray Harris,28,18,10
+Wichita,401,Attorney General,,,Over Votes,0,0,0
+Wichita,401,Attorney General,,,Under Votes,32,24,8
+Wichita,401,Comptroller of Public Accounts,,REP,Glenn Hegar,1018,814,204
+Wichita,401,Comptroller of Public Accounts,,DEM,Joi Chevalier,293,247,46
+Wichita,401,Comptroller of Public Accounts,,LIB,Ben Sanders,37,27,10
+Wichita,401,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,401,Comptroller of Public Accounts,,,Under Votes,52,38,14
+Wichita,401,Commissioner of the General Land Office,,REP,George P. Bush,1031,821,210
+Wichita,401,Commissioner of the General Land Office,,DEM,Miguel Suazo,282,235,47
+Wichita,401,Commissioner of the General Land Office,,LIB,Matt Pina,48,39,9
+Wichita,401,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,401,Commissioner of the General Land Office,,,Under Votes,39,31,8
+Wichita,401,Commissioner of Agriculture,,REP,Sid Miller,1001,801,200
+Wichita,401,Commissioner of Agriculture,,DEM,Kim Olson,311,260,51
+Wichita,401,Commissioner of Agriculture,,LIB,Richard Carpenter,28,20,8
+Wichita,401,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,401,Commissioner of Agriculture,,,Under Votes,60,45,15
+Wichita,401,Railroad Commissioner,,REP,Christi Craddick,1014,816,198
+Wichita,401,Railroad Commissioner,,DEM,Roman McAllen,289,239,50
+Wichita,401,Railroad Commissioner,,LIB,Mike Wright,38,29,9
+Wichita,401,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,401,Railroad Commissioner,,,Under Votes,59,42,17
+Wichita,401,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1033,825,208
+Wichita,401,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,321,265,56
+Wichita,401,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,401,"Justice, Supreme Court, Place 2",,,Under Votes,46,36,10
+Wichita,401,"Justice, Supreme Court, Place 4",,REP,John Devine,1049,838,211
+Wichita,401,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,303,251,52
+Wichita,401,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,401,"Justice, Supreme Court, Place 4",,,Under Votes,48,37,11
+Wichita,401,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1043,835,208
+Wichita,401,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,307,253,54
+Wichita,401,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,401,"Justice, Supreme Court, Place 6",,,Under Votes,50,38,12
+Wichita,401,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1013,818,195
+Wichita,401,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,299,246,53
+Wichita,401,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,36,25,11
+Wichita,401,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,401,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,52,37,15
+Wichita,401,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1043,837,206
+Wichita,401,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,300,247,53
+Wichita,401,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,401,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,57,42,15
+Wichita,401,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1075,866,209
+Wichita,401,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,123,96,27
+Wichita,401,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,401,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,202,164,38
+Wichita,401,State Senator,30,REP,Pat Fallon,1042,832,210
+Wichita,401,State Senator,30,DEM,Kevin Lopez,321,264,57
+Wichita,401,State Senator,30,,Over Votes,0,0,0
+Wichita,401,State Senator,30,,Under Votes,37,30,7
+Wichita,401,State Representative,69,REP,James Frank,1128,903,225
+Wichita,401,State Representative,69,,Over Votes,0,0,0
+Wichita,401,State Representative,69,,Under Votes,272,223,49
+Wichita,401,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,1113,895,218
+Wichita,401,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,401,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,287,231,56
+Wichita,401,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,1105,888,217
+Wichita,401,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,401,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,295,238,57
+Wichita,401,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,1016,814,202
+Wichita,401,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,312,259,53
+Wichita,401,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,401,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,72,53,19
+Wichita,401,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,1102,885,217
+Wichita,401,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,401,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,298,241,57
+Wichita,401,"District Judge, 30th Judicial District",,REP,Jeff McKnight,1118,894,224
+Wichita,401,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,401,"District Judge, 30th Judicial District",,,Under Votes,282,232,50
+Wichita,401,Criminal District Attorney,,REP,John Gillespie,1117,896,221
+Wichita,401,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,401,Criminal District Attorney,,,Under Votes,282,229,53
+Wichita,401,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",1131,904,227
+Wichita,401,County Judge,,,Over Votes,0,0,0
+Wichita,401,County Judge,,,Under Votes,269,222,47
+Wichita,401,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,1103,885,218
+Wichita,401,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,401,"Judge, County Court at Law No. 1",,,Under Votes,297,241,56
+Wichita,401,"Judge, County Court at Law No. 2",,REP,Greg King,1116,897,219
+Wichita,401,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,401,"Judge, County Court at Law No. 2",,,Under Votes,284,229,55
+Wichita,401,District Clerk,,REP,Patti Flores,1131,907,224
+Wichita,401,District Clerk,,,Over Votes,0,0,0
+Wichita,401,District Clerk,,,Under Votes,269,219,50
+Wichita,401,County Clerk,,REP,Lori Bohannon,1139,914,225
+Wichita,401,County Clerk,,,Over Votes,0,0,0
+Wichita,401,County Clerk,,,Under Votes,261,212,49
+Wichita,401,County Treasurer,,REP,R. J. Bob Hampton,1126,904,222
+Wichita,401,County Treasurer,,,Over Votes,0,0,0
+Wichita,401,County Treasurer,,,Under Votes,274,222,52
+Wichita,401,"County Commissioner, Precinct 4",,REP,Jeff Watts,1011,802,209
+Wichita,401,"County Commissioner, Precinct 4",,DEM,Catie Robinson,339,285,54
+Wichita,401,"County Commissioner, Precinct 4",,,Over Votes,0,0,0
+Wichita,401,"County Commissioner, Precinct 4",,,Under Votes,50,39,11
+Wichita,401,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,1118,895,223
+Wichita,401,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,401,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,282,231,51
+Wichita,401,City of Wichita Falls Mayor,,,Lowry W. Crane,328,270,58
+Wichita,401,City of Wichita Falls Mayor,,,Stephen L. Santellana,763,603,160
+Wichita,401,City of Wichita Falls Mayor,,,Over Votes,1,1,0
+Wichita,401,City of Wichita Falls Mayor,,,Under Votes,310,254,56
+Wichita,401,Wichita Falls ISD Single Member District 1,,,Bob Payton,864,691,173
+Wichita,401,Wichita Falls ISD Single Member District 1,,,Over Votes,0,0,0
+Wichita,401,Wichita Falls ISD Single Member District 1,,,Under Votes,538,437,101
+Wichita,401,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,869,690,179
+Wichita,401,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,401,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,533,438,95
+Wichita,401,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,644,507,137
+Wichita,401,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,398,325,73
+Wichita,401,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,401,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,361,297,64
+Wichita,401,Ballots Cast,,,,1403,1126,274
+Wichita,402,Straight Party,,REP,,178,137,41
+Wichita,402,Straight Party,,DEM,,44,31,13
+Wichita,402,Straight Party,,LIB,,0,0,0
+Wichita,402,Straight Party,,,Over Votes,1,1,0
+Wichita,402,Straight Party,,,Under Votes,185,138,47
+Wichita,402,U.S. Senate,,REP,Ted Cruz,293,221,72
+Wichita,402,U.S. Senate,,DEM,Beto O'Rourke,106,78,28
+Wichita,402,U.S. Senate,,LIB,Neal M. Dikeman,2,1,1
+Wichita,402,U.S. Senate,,,Over Votes,1,1,0
+Wichita,402,U.S. Senate,,,Under Votes,4,4,0
+Wichita,402,U.S. House,13,REP,Mac Thornberry,310,234,76
+Wichita,402,U.S. House,13,DEM,Greg Sagan,87,65,22
+Wichita,402,U.S. House,13,LIB,Calvin DeWeese,7,4,3
+Wichita,402,U.S. House,13,,Over Votes,0,0,0
+Wichita,402,U.S. House,13,,Under Votes,2,2,0
+Wichita,402,Governor,,REP,Greg Abbott,304,230,74
+Wichita,402,Governor,,DEM,Lupe Valdez,89,65,24
+Wichita,402,Governor,,LIB,Mark Jay Tippetts,9,6,3
+Wichita,402,Governor,,,Over Votes,0,0,0
+Wichita,402,Governor,,,Under Votes,4,4,0
+Wichita,402,Lieutenant Governor,,REP,Dan Patrick,280,209,71
+Wichita,402,Lieutenant Governor,,DEM,Mike Collier,107,81,26
+Wichita,402,Lieutenant Governor,,LIB,Kerry Douglas McKennon,11,8,3
+Wichita,402,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,402,Lieutenant Governor,,,Under Votes,8,7,1
+Wichita,402,Attorney General,,REP,Ken Paxton,287,215,72
+Wichita,402,Attorney General,,DEM,Justin Nelson,100,76,24
+Wichita,402,Attorney General,,LIB,Michael Ray Harris,15,10,5
+Wichita,402,Attorney General,,,Over Votes,0,0,0
+Wichita,402,Attorney General,,,Under Votes,4,4,0
+Wichita,402,Comptroller of Public Accounts,,REP,Glenn Hegar,287,219,68
+Wichita,402,Comptroller of Public Accounts,,DEM,Joi Chevalier,93,69,24
+Wichita,402,Comptroller of Public Accounts,,LIB,Ben Sanders,19,12,7
+Wichita,402,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,402,Comptroller of Public Accounts,,,Under Votes,7,5,2
+Wichita,402,Commissioner of the General Land Office,,REP,George P. Bush,295,224,71
+Wichita,402,Commissioner of the General Land Office,,DEM,Miguel Suazo,87,64,23
+Wichita,402,Commissioner of the General Land Office,,LIB,Matt Pina,18,12,6
+Wichita,402,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,402,Commissioner of the General Land Office,,,Under Votes,6,5,1
+Wichita,402,Commissioner of Agriculture,,REP,Sid Miller,285,217,68
+Wichita,402,Commissioner of Agriculture,,DEM,Kim Olson,105,80,25
+Wichita,402,Commissioner of Agriculture,,LIB,Richard Carpenter,10,4,6
+Wichita,402,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,402,Commissioner of Agriculture,,,Under Votes,6,4,2
+Wichita,402,Railroad Commissioner,,REP,Christi Craddick,293,220,73
+Wichita,402,Railroad Commissioner,,DEM,Roman McAllen,91,69,22
+Wichita,402,Railroad Commissioner,,LIB,Mike Wright,16,10,6
+Wichita,402,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,402,Railroad Commissioner,,,Under Votes,6,6,0
+Wichita,402,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,296,223,73
+Wichita,402,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,102,75,27
+Wichita,402,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,402,"Justice, Supreme Court, Place 2",,,Under Votes,8,7,1
+Wichita,402,"Justice, Supreme Court, Place 4",,REP,John Devine,296,222,74
+Wichita,402,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,102,75,27
+Wichita,402,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,402,"Justice, Supreme Court, Place 4",,,Under Votes,8,8,0
+Wichita,402,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,294,221,73
+Wichita,402,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,104,76,28
+Wichita,402,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,402,"Justice, Supreme Court, Place 6",,,Under Votes,8,8,0
+Wichita,402,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,288,217,71
+Wichita,402,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,99,73,26
+Wichita,402,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,10,6,4
+Wichita,402,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,402,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,9,9,0
+Wichita,402,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,291,218,73
+Wichita,402,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,107,79,28
+Wichita,402,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,402,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,8,8,0
+Wichita,402,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,307,231,76
+Wichita,402,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,50,36,14
+Wichita,402,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,402,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,49,38,11
+Wichita,402,State Senator,30,REP,Pat Fallon,298,222,76
+Wichita,402,State Senator,30,DEM,Kevin Lopez,104,79,25
+Wichita,402,State Senator,30,,Over Votes,0,0,0
+Wichita,402,State Senator,30,,Under Votes,4,4,0
+Wichita,402,State Representative,69,REP,James Frank,334,249,85
+Wichita,402,State Representative,69,,Over Votes,0,0,0
+Wichita,402,State Representative,69,,Under Votes,72,56,16
+Wichita,402,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,329,243,86
+Wichita,402,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,402,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,77,62,15
+Wichita,402,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,322,241,81
+Wichita,402,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,402,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,84,64,20
+Wichita,402,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,287,213,74
+Wichita,402,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,106,79,27
+Wichita,402,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,1,1,0
+Wichita,402,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,12,12,0
+Wichita,402,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,323,242,81
+Wichita,402,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,402,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,83,63,20
+Wichita,402,"District Judge, 30th Judicial District",,REP,Jeff McKnight,328,245,83
+Wichita,402,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,402,"District Judge, 30th Judicial District",,,Under Votes,78,60,18
+Wichita,402,Criminal District Attorney,,REP,John Gillespie,331,247,84
+Wichita,402,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,402,Criminal District Attorney,,,Under Votes,75,58,17
+Wichita,402,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",330,247,83
+Wichita,402,County Judge,,,Over Votes,0,0,0
+Wichita,402,County Judge,,,Under Votes,76,58,18
+Wichita,402,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,330,246,84
+Wichita,402,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,402,"Judge, County Court at Law No. 1",,,Under Votes,76,59,17
+Wichita,402,"Judge, County Court at Law No. 2",,REP,Greg King,328,246,82
+Wichita,402,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,402,"Judge, County Court at Law No. 2",,,Under Votes,78,59,19
+Wichita,402,District Clerk,,REP,Patti Flores,331,248,83
+Wichita,402,District Clerk,,,Over Votes,0,0,0
+Wichita,402,District Clerk,,,Under Votes,75,57,18
+Wichita,402,County Clerk,,REP,Lori Bohannon,330,246,84
+Wichita,402,County Clerk,,,Over Votes,0,0,0
+Wichita,402,County Clerk,,,Under Votes,76,59,17
+Wichita,402,County Treasurer,,REP,R. J. Bob Hampton,332,248,84
+Wichita,402,County Treasurer,,,Over Votes,0,0,0
+Wichita,402,County Treasurer,,,Under Votes,74,57,17
+Wichita,402,"County Commissioner, Precinct 4",,REP,Jeff Watts,289,214,75
+Wichita,402,"County Commissioner, Precinct 4",,DEM,Catie Robinson,115,89,26
+Wichita,402,"County Commissioner, Precinct 4",,,Over Votes,0,0,0
+Wichita,402,"County Commissioner, Precinct 4",,,Under Votes,2,2,0
+Wichita,402,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,330,247,83
+Wichita,402,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,402,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,76,58,18
+Wichita,402,City of Wichita Falls Mayor,,,Lowry W. Crane,89,69,20
+Wichita,402,City of Wichita Falls Mayor,,,Stephen L. Santellana,248,183,65
+Wichita,402,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,402,City of Wichita Falls Mayor,,,Under Votes,69,53,16
+Wichita,402,Wichita Falls ISD Single Member District 1,,,Bob Payton,271,203,68
+Wichita,402,Wichita Falls ISD Single Member District 1,,,Over Votes,0,0,0
+Wichita,402,Wichita Falls ISD Single Member District 1,,,Under Votes,135,102,33
+Wichita,402,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,277,205,72
+Wichita,402,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,402,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,129,100,29
+Wichita,402,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,207,149,58
+Wichita,402,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,121,95,26
+Wichita,402,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,402,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,78,61,17
+Wichita,402,Ballots Cast,,,,408,307,101
+Wichita,403,Straight Party,,REP,,437,317,120
+Wichita,403,Straight Party,,DEM,,148,118,30
+Wichita,403,Straight Party,,LIB,,6,5,1
+Wichita,403,Straight Party,,,Over Votes,0,0,0
+Wichita,403,Straight Party,,,Under Votes,568,428,140
+Wichita,403,U.S. Senate,,REP,Ted Cruz,778,573,205
+Wichita,403,U.S. Senate,,DEM,Beto O'Rourke,360,279,81
+Wichita,403,U.S. Senate,,LIB,Neal M. Dikeman,8,6,2
+Wichita,403,U.S. Senate,,,Over Votes,1,1,0
+Wichita,403,U.S. Senate,,,Under Votes,12,9,3
+Wichita,403,U.S. House,13,REP,Mac Thornberry,827,603,224
+Wichita,403,U.S. House,13,DEM,Greg Sagan,284,227,57
+Wichita,403,U.S. House,13,LIB,Calvin DeWeese,37,27,10
+Wichita,403,U.S. House,13,,Over Votes,0,0,0
+Wichita,403,U.S. House,13,,Under Votes,11,11,0
+Wichita,403,Governor,,REP,Greg Abbott,835,613,222
+Wichita,403,Governor,,DEM,Lupe Valdez,292,232,60
+Wichita,403,Governor,,LIB,Mark Jay Tippetts,20,14,6
+Wichita,403,Governor,,,Over Votes,0,0,0
+Wichita,403,Governor,,,Under Votes,12,9,3
+Wichita,403,Lieutenant Governor,,REP,Dan Patrick,771,567,204
+Wichita,403,Lieutenant Governor,,DEM,Mike Collier,335,262,73
+Wichita,403,Lieutenant Governor,,LIB,Kerry Douglas McKennon,36,25,11
+Wichita,403,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,403,Lieutenant Governor,,,Under Votes,17,14,3
+Wichita,403,Attorney General,,REP,Ken Paxton,764,558,206
+Wichita,403,Attorney General,,DEM,Justin Nelson,338,266,72
+Wichita,403,Attorney General,,LIB,Michael Ray Harris,38,30,8
+Wichita,403,Attorney General,,,Over Votes,0,0,0
+Wichita,403,Attorney General,,,Under Votes,19,14,5
+Wichita,403,Comptroller of Public Accounts,,REP,Glenn Hegar,785,572,213
+Wichita,403,Comptroller of Public Accounts,,DEM,Joi Chevalier,296,236,60
+Wichita,403,Comptroller of Public Accounts,,LIB,Ben Sanders,51,40,11
+Wichita,403,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,403,Comptroller of Public Accounts,,,Under Votes,27,20,7
+Wichita,403,Commissioner of the General Land Office,,REP,George P. Bush,782,571,211
+Wichita,403,Commissioner of the General Land Office,,DEM,Miguel Suazo,286,227,59
+Wichita,403,Commissioner of the General Land Office,,LIB,Matt Pina,65,50,15
+Wichita,403,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,403,Commissioner of the General Land Office,,,Under Votes,26,20,6
+Wichita,403,Commissioner of Agriculture,,REP,Sid Miller,774,567,207
+Wichita,403,Commissioner of Agriculture,,DEM,Kim Olson,323,255,68
+Wichita,403,Commissioner of Agriculture,,LIB,Richard Carpenter,35,28,7
+Wichita,403,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,403,Commissioner of Agriculture,,,Under Votes,27,18,9
+Wichita,403,Railroad Commissioner,,REP,Christi Craddick,801,588,213
+Wichita,403,Railroad Commissioner,,DEM,Roman McAllen,285,229,56
+Wichita,403,Railroad Commissioner,,LIB,Mike Wright,46,31,15
+Wichita,403,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,403,Railroad Commissioner,,,Under Votes,27,20,7
+Wichita,403,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,798,587,211
+Wichita,403,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,332,260,72
+Wichita,403,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,403,"Justice, Supreme Court, Place 2",,,Under Votes,29,21,8
+Wichita,403,"Justice, Supreme Court, Place 4",,REP,John Devine,814,596,218
+Wichita,403,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,313,247,66
+Wichita,403,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,403,"Justice, Supreme Court, Place 4",,,Under Votes,32,25,7
+Wichita,403,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,809,593,216
+Wichita,403,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,316,248,68
+Wichita,403,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,403,"Justice, Supreme Court, Place 6",,,Under Votes,34,27,7
+Wichita,403,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,790,579,211
+Wichita,403,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,300,236,64
+Wichita,403,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,37,26,11
+Wichita,403,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,403,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,32,27,5
+Wichita,403,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,804,587,217
+Wichita,403,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,320,254,66
+Wichita,403,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,403,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,35,27,8
+Wichita,403,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,836,612,224
+Wichita,403,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,171,139,32
+Wichita,403,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,403,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,152,117,35
+Wichita,403,State Senator,30,REP,Pat Fallon,804,588,216
+Wichita,403,State Senator,30,DEM,Kevin Lopez,332,262,70
+Wichita,403,State Senator,30,,Over Votes,0,0,0
+Wichita,403,State Senator,30,,Under Votes,23,18,5
+Wichita,403,State Representative,69,REP,James Frank,906,671,235
+Wichita,403,State Representative,69,,Over Votes,0,0,0
+Wichita,403,State Representative,69,,Under Votes,253,197,56
+Wichita,403,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,897,664,233
+Wichita,403,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,403,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,262,204,58
+Wichita,403,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,884,653,231
+Wichita,403,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,403,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,275,215,60
+Wichita,403,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,789,581,208
+Wichita,403,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,316,245,71
+Wichita,403,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,403,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,54,42,12
+Wichita,403,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,889,657,232
+Wichita,403,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,403,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,270,211,59
+Wichita,403,"District Judge, 30th Judicial District",,REP,Jeff McKnight,903,666,237
+Wichita,403,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,403,"District Judge, 30th Judicial District",,,Under Votes,256,202,54
+Wichita,403,Criminal District Attorney,,REP,John Gillespie,898,662,236
+Wichita,403,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,403,Criminal District Attorney,,,Under Votes,261,206,55
+Wichita,403,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",891,653,238
+Wichita,403,County Judge,,,Over Votes,0,0,0
+Wichita,403,County Judge,,,Under Votes,268,215,53
+Wichita,403,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,897,661,236
+Wichita,403,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,403,"Judge, County Court at Law No. 1",,,Under Votes,262,207,55
+Wichita,403,"Judge, County Court at Law No. 2",,REP,Greg King,901,663,238
+Wichita,403,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,403,"Judge, County Court at Law No. 2",,,Under Votes,258,205,53
+Wichita,403,District Clerk,,REP,Patti Flores,910,671,239
+Wichita,403,District Clerk,,,Over Votes,0,0,0
+Wichita,403,District Clerk,,,Under Votes,249,197,52
+Wichita,403,County Clerk,,REP,Lori Bohannon,908,672,236
+Wichita,403,County Clerk,,,Over Votes,0,0,0
+Wichita,403,County Clerk,,,Under Votes,251,196,55
+Wichita,403,County Treasurer,,REP,R. J. Bob Hampton,905,669,236
+Wichita,403,County Treasurer,,,Over Votes,0,0,0
+Wichita,403,County Treasurer,,,Under Votes,254,199,55
+Wichita,403,"County Commissioner, Precinct 4",,REP,Jeff Watts,767,564,203
+Wichita,403,"County Commissioner, Precinct 4",,DEM,Catie Robinson,359,276,83
+Wichita,403,"County Commissioner, Precinct 4",,,Over Votes,0,0,0
+Wichita,403,"County Commissioner, Precinct 4",,,Under Votes,33,28,5
+Wichita,403,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,897,661,236
+Wichita,403,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,403,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,262,207,55
+Wichita,403,City of Wichita Falls Mayor,,,Lowry W. Crane,296,226,70
+Wichita,403,City of Wichita Falls Mayor,,,Stephen L. Santellana,664,486,178
+Wichita,403,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,403,City of Wichita Falls Mayor,,,Under Votes,199,156,43
+Wichita,403,City of Wichita Falls Councilor District 3,,,Jeff L. Browning,751,548,203
+Wichita,403,City of Wichita Falls Councilor District 3,,,Over Votes,0,0,0
+Wichita,403,City of Wichita Falls Councilor District 3,,,Under Votes,408,320,88
+Wichita,403,Wichita Falls ISD Single Member District 3,,,Mark Lukert,598,450,148
+Wichita,403,Wichita Falls ISD Single Member District 3,,,Adam W. Groves,238,175,63
+Wichita,403,Wichita Falls ISD Single Member District 3,,,Over Votes,0,0,0
+Wichita,403,Wichita Falls ISD Single Member District 3,,,Under Votes,323,243,80
+Wichita,403,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,770,570,200
+Wichita,403,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,403,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,389,298,91
+Wichita,403,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,570,423,147
+Wichita,403,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,322,237,85
+Wichita,403,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,403,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,267,208,59
+Wichita,403,Ballots Cast,,,,1159,868,291
+Wichita,404,Straight Party,,REP,,704,573,131
+Wichita,404,Straight Party,,DEM,,167,139,28
+Wichita,404,Straight Party,,LIB,,6,3,3
+Wichita,404,Straight Party,,,Over Votes,0,0,0
+Wichita,404,Straight Party,,,Under Votes,822,624,198
+Wichita,404,U.S. Senate,,REP,Ted Cruz,1254,994,260
+Wichita,404,U.S. Senate,,DEM,Beto O'Rourke,417,327,90
+Wichita,404,U.S. Senate,,LIB,Neal M. Dikeman,17,10,7
+Wichita,404,U.S. Senate,,,Over Votes,0,0,0
+Wichita,404,U.S. Senate,,,Under Votes,8,5,3
+Wichita,404,U.S. House,13,REP,Mac Thornberry,1334,1050,284
+Wichita,404,U.S. House,13,DEM,Greg Sagan,313,254,59
+Wichita,404,U.S. House,13,LIB,Calvin DeWeese,27,18,9
+Wichita,404,U.S. House,13,,Over Votes,0,0,0
+Wichita,404,U.S. House,13,,Under Votes,22,14,8
+Wichita,404,Governor,,REP,Greg Abbott,1330,1051,279
+Wichita,404,Governor,,DEM,Lupe Valdez,336,264,72
+Wichita,404,Governor,,LIB,Mark Jay Tippetts,19,14,5
+Wichita,404,Governor,,,Over Votes,0,0,0
+Wichita,404,Governor,,,Under Votes,11,7,4
+Wichita,404,Lieutenant Governor,,REP,Dan Patrick,1234,981,253
+Wichita,404,Lieutenant Governor,,DEM,Mike Collier,388,304,84
+Wichita,404,Lieutenant Governor,,LIB,Kerry Douglas McKennon,40,25,15
+Wichita,404,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,404,Lieutenant Governor,,,Under Votes,34,26,8
+Wichita,404,Attorney General,,REP,Ken Paxton,1268,1001,267
+Wichita,404,Attorney General,,DEM,Justin Nelson,367,291,76
+Wichita,404,Attorney General,,LIB,Michael Ray Harris,24,15,9
+Wichita,404,Attorney General,,,Over Votes,0,0,0
+Wichita,404,Attorney General,,,Under Votes,36,28,8
+Wichita,404,Comptroller of Public Accounts,,REP,Glenn Hegar,1275,1009,266
+Wichita,404,Comptroller of Public Accounts,,DEM,Joi Chevalier,322,254,68
+Wichita,404,Comptroller of Public Accounts,,LIB,Ben Sanders,47,30,17
+Wichita,404,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,404,Comptroller of Public Accounts,,,Under Votes,51,42,9
+Wichita,404,Commissioner of the General Land Office,,REP,George P. Bush,1263,995,268
+Wichita,404,Commissioner of the General Land Office,,DEM,Miguel Suazo,335,261,74
+Wichita,404,Commissioner of the General Land Office,,LIB,Matt Pina,57,48,9
+Wichita,404,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,404,Commissioner of the General Land Office,,,Under Votes,40,31,9
+Wichita,404,Commissioner of Agriculture,,REP,Sid Miller,1239,985,254
+Wichita,404,Commissioner of Agriculture,,DEM,Kim Olson,365,287,78
+Wichita,404,Commissioner of Agriculture,,LIB,Richard Carpenter,36,22,14
+Wichita,404,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,404,Commissioner of Agriculture,,,Under Votes,55,41,14
+Wichita,404,Railroad Commissioner,,REP,Christi Craddick,1278,1015,263
+Wichita,404,Railroad Commissioner,,DEM,Roman McAllen,325,256,69
+Wichita,404,Railroad Commissioner,,LIB,Mike Wright,39,24,15
+Wichita,404,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,404,Railroad Commissioner,,,Under Votes,53,40,13
+Wichita,404,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1285,1016,269
+Wichita,404,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,362,282,80
+Wichita,404,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,404,"Justice, Supreme Court, Place 2",,,Under Votes,48,37,11
+Wichita,404,"Justice, Supreme Court, Place 4",,REP,John Devine,1290,1018,272
+Wichita,404,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,346,274,72
+Wichita,404,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,404,"Justice, Supreme Court, Place 4",,,Under Votes,59,43,16
+Wichita,404,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1283,1013,270
+Wichita,404,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,359,282,77
+Wichita,404,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,404,"Justice, Supreme Court, Place 6",,,Under Votes,53,40,13
+Wichita,404,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1262,999,263
+Wichita,404,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,344,274,70
+Wichita,404,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,34,19,15
+Wichita,404,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,404,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,55,43,12
+Wichita,404,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1290,1021,269
+Wichita,404,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,347,270,77
+Wichita,404,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,404,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,58,44,14
+Wichita,404,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1332,1056,276
+Wichita,404,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,158,116,42
+Wichita,404,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,404,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,207,165,42
+Wichita,404,State Senator,30,REP,Pat Fallon,1276,1013,263
+Wichita,404,State Senator,30,DEM,Kevin Lopez,386,299,87
+Wichita,404,State Senator,30,,Over Votes,0,0,0
+Wichita,404,State Senator,30,,Under Votes,33,23,10
+Wichita,404,State Representative,69,REP,James Frank,1432,1127,305
+Wichita,404,State Representative,69,,Over Votes,0,0,0
+Wichita,404,State Representative,69,,Under Votes,263,208,55
+Wichita,404,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,1400,1100,300
+Wichita,404,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,404,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,295,235,60
+Wichita,404,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,1393,1097,296
+Wichita,404,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,404,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,302,238,64
+Wichita,404,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,1271,1002,269
+Wichita,404,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,356,282,74
+Wichita,404,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,404,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,68,51,17
+Wichita,404,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,1400,1105,295
+Wichita,404,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,404,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,295,230,65
+Wichita,404,"District Judge, 30th Judicial District",,REP,Jeff McKnight,1414,1117,297
+Wichita,404,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,404,"District Judge, 30th Judicial District",,,Under Votes,281,218,63
+Wichita,404,Criminal District Attorney,,REP,John Gillespie,1409,1116,293
+Wichita,404,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,404,Criminal District Attorney,,,Under Votes,286,219,67
+Wichita,404,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",1429,1122,307
+Wichita,404,County Judge,,,Over Votes,0,0,0
+Wichita,404,County Judge,,,Under Votes,266,213,53
+Wichita,404,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,1417,1119,298
+Wichita,404,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,404,"Judge, County Court at Law No. 1",,,Under Votes,278,216,62
+Wichita,404,"Judge, County Court at Law No. 2",,REP,Greg King,1422,1122,300
+Wichita,404,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,404,"Judge, County Court at Law No. 2",,,Under Votes,273,213,60
+Wichita,404,District Clerk,,REP,Patti Flores,1417,1117,300
+Wichita,404,District Clerk,,,Over Votes,0,0,0
+Wichita,404,District Clerk,,,Under Votes,278,218,60
+Wichita,404,County Clerk,,REP,Lori Bohannon,1422,1122,300
+Wichita,404,County Clerk,,,Over Votes,0,0,0
+Wichita,404,County Clerk,,,Under Votes,274,214,60
+Wichita,404,County Treasurer,,REP,R. J. Bob Hampton,1418,1117,301
+Wichita,404,County Treasurer,,,Over Votes,0,0,0
+Wichita,404,County Treasurer,,,Under Votes,277,218,59
+Wichita,404,"County Commissioner, Precinct 4",,REP,Jeff Watts,1262,996,266
+Wichita,404,"County Commissioner, Precinct 4",,DEM,Catie Robinson,392,308,84
+Wichita,404,"County Commissioner, Precinct 4",,,Over Votes,0,0,0
+Wichita,404,"County Commissioner, Precinct 4",,,Under Votes,41,31,10
+Wichita,404,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,1418,1115,303
+Wichita,404,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,404,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,277,220,57
+Wichita,404,City of Wichita Falls Mayor,,,Lowry W. Crane,387,312,75
+Wichita,404,City of Wichita Falls Mayor,,,Stephen L. Santellana,1017,784,233
+Wichita,404,City of Wichita Falls Mayor,,,Over Votes,1,1,0
+Wichita,404,City of Wichita Falls Mayor,,,Under Votes,295,243,52
+Wichita,404,Wichita Falls ISD Single Member District 1,,,Bob Payton,1123,871,252
+Wichita,404,Wichita Falls ISD Single Member District 1,,,Over Votes,0,0,0
+Wichita,404,Wichita Falls ISD Single Member District 1,,,Under Votes,573,465,108
+Wichita,404,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,1131,875,256
+Wichita,404,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,404,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,565,461,104
+Wichita,404,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,703,531,172
+Wichita,404,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,669,540,129
+Wichita,404,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,404,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,326,267,59
+Wichita,404,Ballots Cast,,,,1700,1340,360
+Wichita,405,Straight Party,,REP,,314,233,81
+Wichita,405,Straight Party,,DEM,,176,115,61
+Wichita,405,Straight Party,,LIB,,7,6,1
+Wichita,405,Straight Party,,,Over Votes,0,0,0
+Wichita,405,Straight Party,,,Under Votes,380,272,108
+Wichita,405,U.S. Senate,,REP,Ted Cruz,510,381,129
+Wichita,405,U.S. Senate,,DEM,Beto O'Rourke,348,234,114
+Wichita,405,U.S. Senate,,LIB,Neal M. Dikeman,10,7,3
+Wichita,405,U.S. Senate,,,Over Votes,0,0,0
+Wichita,405,U.S. Senate,,,Under Votes,9,4,5
+Wichita,405,U.S. House,13,REP,Mac Thornberry,539,391,148
+Wichita,405,U.S. House,13,DEM,Greg Sagan,301,210,91
+Wichita,405,U.S. House,13,LIB,Calvin DeWeese,24,17,7
+Wichita,405,U.S. House,13,,Over Votes,0,0,0
+Wichita,405,U.S. House,13,,Under Votes,13,8,5
+Wichita,405,Governor,,REP,Greg Abbott,534,391,143
+Wichita,405,Governor,,DEM,Lupe Valdez,316,215,101
+Wichita,405,Governor,,LIB,Mark Jay Tippetts,13,12,1
+Wichita,405,Governor,,,Over Votes,0,0,0
+Wichita,405,Governor,,,Under Votes,14,8,6
+Wichita,405,Lieutenant Governor,,REP,Dan Patrick,507,371,136
+Wichita,405,Lieutenant Governor,,DEM,Mike Collier,333,231,102
+Wichita,405,Lieutenant Governor,,LIB,Kerry Douglas McKennon,25,18,7
+Wichita,405,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,405,Lieutenant Governor,,,Under Votes,12,6,6
+Wichita,405,Attorney General,,REP,Ken Paxton,511,377,134
+Wichita,405,Attorney General,,DEM,Justin Nelson,330,228,102
+Wichita,405,Attorney General,,LIB,Michael Ray Harris,22,15,7
+Wichita,405,Attorney General,,,Over Votes,0,0,0
+Wichita,405,Attorney General,,,Under Votes,14,6,8
+Wichita,405,Comptroller of Public Accounts,,REP,Glenn Hegar,508,376,132
+Wichita,405,Comptroller of Public Accounts,,DEM,Joi Chevalier,308,212,96
+Wichita,405,Comptroller of Public Accounts,,LIB,Ben Sanders,34,23,11
+Wichita,405,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,405,Comptroller of Public Accounts,,,Under Votes,27,15,12
+Wichita,405,Commissioner of the General Land Office,,REP,George P. Bush,516,379,137
+Wichita,405,Commissioner of the General Land Office,,DEM,Miguel Suazo,304,207,97
+Wichita,405,Commissioner of the General Land Office,,LIB,Matt Pina,38,27,11
+Wichita,405,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,405,Commissioner of the General Land Office,,,Under Votes,19,13,6
+Wichita,405,Commissioner of Agriculture,,REP,Sid Miller,494,363,131
+Wichita,405,Commissioner of Agriculture,,DEM,Kim Olson,335,231,104
+Wichita,405,Commissioner of Agriculture,,LIB,Richard Carpenter,25,17,8
+Wichita,405,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,405,Commissioner of Agriculture,,,Under Votes,23,15,8
+Wichita,405,Railroad Commissioner,,REP,Christi Craddick,523,383,140
+Wichita,405,Railroad Commissioner,,DEM,Roman McAllen,300,205,95
+Wichita,405,Railroad Commissioner,,LIB,Mike Wright,33,24,9
+Wichita,405,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,405,Railroad Commissioner,,,Under Votes,21,14,7
+Wichita,405,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,516,380,136
+Wichita,405,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,338,232,106
+Wichita,405,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,405,"Justice, Supreme Court, Place 2",,,Under Votes,23,14,9
+Wichita,405,"Justice, Supreme Court, Place 4",,REP,John Devine,514,378,136
+Wichita,405,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,332,228,104
+Wichita,405,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,405,"Justice, Supreme Court, Place 4",,,Under Votes,31,20,11
+Wichita,405,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,523,384,139
+Wichita,405,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,327,226,101
+Wichita,405,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,405,"Justice, Supreme Court, Place 6",,,Under Votes,27,16,11
+Wichita,405,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,503,368,135
+Wichita,405,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,325,223,102
+Wichita,405,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,25,20,5
+Wichita,405,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,405,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,24,15,9
+Wichita,405,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,518,381,137
+Wichita,405,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,331,229,102
+Wichita,405,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,1,1,0
+Wichita,405,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,27,15,12
+Wichita,405,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,556,407,149
+Wichita,405,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,136,94,42
+Wichita,405,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,405,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,185,125,60
+Wichita,405,State Senator,30,REP,Pat Fallon,520,380,140
+Wichita,405,State Senator,30,DEM,Kevin Lopez,336,233,103
+Wichita,405,State Senator,30,,Over Votes,0,0,0
+Wichita,405,State Senator,30,,Under Votes,21,13,8
+Wichita,405,State Representative,69,REP,James Frank,615,447,168
+Wichita,405,State Representative,69,,Over Votes,0,0,0
+Wichita,405,State Representative,69,,Under Votes,262,179,83
+Wichita,405,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,602,437,165
+Wichita,405,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,405,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,275,189,86
+Wichita,405,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,595,430,165
+Wichita,405,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,405,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,282,196,86
+Wichita,405,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,507,371,136
+Wichita,405,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,330,228,102
+Wichita,405,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,1,1,0
+Wichita,405,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,39,26,13
+Wichita,405,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,604,437,167
+Wichita,405,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,405,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,273,189,84
+Wichita,405,"District Judge, 30th Judicial District",,REP,Jeff McKnight,607,439,168
+Wichita,405,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,405,"District Judge, 30th Judicial District",,,Under Votes,270,187,83
+Wichita,405,Criminal District Attorney,,REP,John Gillespie,610,441,169
+Wichita,405,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,405,Criminal District Attorney,,,Under Votes,267,185,82
+Wichita,405,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",616,442,174
+Wichita,405,County Judge,,,Over Votes,0,0,0
+Wichita,405,County Judge,,,Under Votes,261,184,77
+Wichita,405,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,609,439,170
+Wichita,405,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,405,"Judge, County Court at Law No. 1",,,Under Votes,268,187,81
+Wichita,405,"Judge, County Court at Law No. 2",,REP,Greg King,605,437,168
+Wichita,405,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,405,"Judge, County Court at Law No. 2",,,Under Votes,272,189,83
+Wichita,405,District Clerk,,REP,Patti Flores,621,449,172
+Wichita,405,District Clerk,,,Over Votes,0,0,0
+Wichita,405,District Clerk,,,Under Votes,256,177,79
+Wichita,405,County Clerk,,REP,Lori Bohannon,623,450,173
+Wichita,405,County Clerk,,,Over Votes,0,0,0
+Wichita,405,County Clerk,,,Under Votes,254,176,78
+Wichita,405,County Treasurer,,REP,R. J. Bob Hampton,613,446,167
+Wichita,405,County Treasurer,,,Over Votes,0,0,0
+Wichita,405,County Treasurer,,,Under Votes,264,180,84
+Wichita,405,"County Commissioner, Precinct 4",,REP,Jeff Watts,508,373,135
+Wichita,405,"County Commissioner, Precinct 4",,DEM,Catie Robinson,339,235,104
+Wichita,405,"County Commissioner, Precinct 4",,,Over Votes,0,0,0
+Wichita,405,"County Commissioner, Precinct 4",,,Under Votes,30,18,12
+Wichita,405,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,614,442,172
+Wichita,405,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,405,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,263,184,79
+Wichita,405,City of Wichita Falls Mayor,,,Lowry W. Crane,226,149,77
+Wichita,405,City of Wichita Falls Mayor,,,Stephen L. Santellana,468,345,123
+Wichita,405,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,405,City of Wichita Falls Mayor,,,Under Votes,183,132,51
+Wichita,405,Wichita Falls ISD Single Member District 5,,,Tom Bursey,482,352,130
+Wichita,405,Wichita Falls ISD Single Member District 5,,,Over Votes,0,0,0
+Wichita,405,Wichita Falls ISD Single Member District 5,,,Under Votes,350,261,89
+Wichita,405,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,508,372,136
+Wichita,405,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,405,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,324,241,83
+Wichita,405,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,378,279,99
+Wichita,405,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,237,171,66
+Wichita,405,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,405,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,217,163,54
+Wichita,405,Ballots Cast,,,,877,626,251
+Wichita,406,Straight Party,,REP,,596,455,141
+Wichita,406,Straight Party,,DEM,,190,131,59
+Wichita,406,Straight Party,,LIB,,4,2,2
+Wichita,406,Straight Party,,,Over Votes,0,0,0
+Wichita,406,Straight Party,,,Under Votes,757,557,200
+Wichita,406,U.S. Senate,,REP,Ted Cruz,1072,794,278
+Wichita,406,U.S. Senate,,DEM,Beto O'Rourke,437,322,115
+Wichita,406,U.S. Senate,,LIB,Neal M. Dikeman,14,10,4
+Wichita,406,U.S. Senate,,,Over Votes,1,1,0
+Wichita,406,U.S. Senate,,,Under Votes,15,10,5
+Wichita,406,U.S. House,13,REP,Mac Thornberry,1116,828,288
+Wichita,406,U.S. House,13,DEM,Greg Sagan,375,279,96
+Wichita,406,U.S. House,13,LIB,Calvin DeWeese,33,23,10
+Wichita,406,U.S. House,13,,Over Votes,0,0,0
+Wichita,406,U.S. House,13,,Under Votes,15,7,8
+Wichita,406,Governor,,REP,Greg Abbott,1119,834,285
+Wichita,406,Governor,,DEM,Lupe Valdez,383,282,101
+Wichita,406,Governor,,LIB,Mark Jay Tippetts,26,17,9
+Wichita,406,Governor,,,Over Votes,0,0,0
+Wichita,406,Governor,,,Under Votes,11,4,7
+Wichita,406,Lieutenant Governor,,REP,Dan Patrick,1033,779,254
+Wichita,406,Lieutenant Governor,,DEM,Mike Collier,440,322,118
+Wichita,406,Lieutenant Governor,,LIB,Kerry Douglas McKennon,43,28,15
+Wichita,406,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,406,Lieutenant Governor,,,Under Votes,23,8,15
+Wichita,406,Attorney General,,REP,Ken Paxton,1065,793,272
+Wichita,406,Attorney General,,DEM,Justin Nelson,411,310,101
+Wichita,406,Attorney General,,LIB,Michael Ray Harris,33,21,12
+Wichita,406,Attorney General,,,Over Votes,0,0,0
+Wichita,406,Attorney General,,,Under Votes,30,13,17
+Wichita,406,Comptroller of Public Accounts,,REP,Glenn Hegar,1074,808,266
+Wichita,406,Comptroller of Public Accounts,,DEM,Joi Chevalier,375,280,95
+Wichita,406,Comptroller of Public Accounts,,LIB,Ben Sanders,51,29,22
+Wichita,406,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,406,Comptroller of Public Accounts,,,Under Votes,39,20,19
+Wichita,406,Commissioner of the General Land Office,,REP,George P. Bush,1058,788,270
+Wichita,406,Commissioner of the General Land Office,,DEM,Miguel Suazo,381,281,100
+Wichita,406,Commissioner of the General Land Office,,LIB,Matt Pina,62,46,16
+Wichita,406,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,406,Commissioner of the General Land Office,,,Under Votes,38,22,16
+Wichita,406,Commissioner of Agriculture,,REP,Sid Miller,1057,794,263
+Wichita,406,Commissioner of Agriculture,,DEM,Kim Olson,413,308,105
+Wichita,406,Commissioner of Agriculture,,LIB,Richard Carpenter,29,15,14
+Wichita,406,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,406,Commissioner of Agriculture,,,Under Votes,40,20,20
+Wichita,406,Railroad Commissioner,,REP,Christi Craddick,1072,804,268
+Wichita,406,Railroad Commissioner,,DEM,Roman McAllen,372,274,98
+Wichita,406,Railroad Commissioner,,LIB,Mike Wright,51,34,17
+Wichita,406,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,406,Railroad Commissioner,,,Under Votes,44,25,19
+Wichita,406,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1085,813,272
+Wichita,406,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,414,305,109
+Wichita,406,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,406,"Justice, Supreme Court, Place 2",,,Under Votes,40,19,21
+Wichita,406,"Justice, Supreme Court, Place 4",,REP,John Devine,1094,814,280
+Wichita,406,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,406,302,104
+Wichita,406,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,406,"Justice, Supreme Court, Place 4",,,Under Votes,39,21,18
+Wichita,406,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1086,809,277
+Wichita,406,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,412,306,106
+Wichita,406,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,406,"Justice, Supreme Court, Place 6",,,Under Votes,41,22,19
+Wichita,406,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1064,798,266
+Wichita,406,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,394,291,103
+Wichita,406,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,34,21,13
+Wichita,406,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,406,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,47,27,20
+Wichita,406,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1078,808,270
+Wichita,406,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,411,300,111
+Wichita,406,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,406,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,50,29,21
+Wichita,406,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1144,857,287
+Wichita,406,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,178,124,54
+Wichita,406,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,406,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,217,156,61
+Wichita,406,State Senator,30,REP,Pat Fallon,1081,806,275
+Wichita,406,State Senator,30,DEM,Kevin Lopez,427,316,111
+Wichita,406,State Senator,30,,Over Votes,0,0,0
+Wichita,406,State Senator,30,,Under Votes,31,15,16
+Wichita,406,State Representative,69,REP,James Frank,1216,913,303
+Wichita,406,State Representative,69,,Over Votes,0,0,0
+Wichita,406,State Representative,69,,Under Votes,323,224,99
+Wichita,406,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,1194,896,298
+Wichita,406,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,406,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,345,241,104
+Wichita,406,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,1184,890,294
+Wichita,406,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,406,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,355,247,108
+Wichita,406,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,1064,795,269
+Wichita,406,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,412,305,107
+Wichita,406,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,406,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,63,37,26
+Wichita,406,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,1184,892,292
+Wichita,406,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,406,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,355,245,110
+Wichita,406,"District Judge, 30th Judicial District",,REP,Jeff McKnight,1203,903,300
+Wichita,406,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,406,"District Judge, 30th Judicial District",,,Under Votes,336,234,102
+Wichita,406,Criminal District Attorney,,REP,John Gillespie,1216,910,306
+Wichita,406,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,406,Criminal District Attorney,,,Under Votes,323,227,96
+Wichita,406,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",1204,899,305
+Wichita,406,County Judge,,,Over Votes,0,0,0
+Wichita,406,County Judge,,,Under Votes,335,238,97
+Wichita,406,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,1205,906,299
+Wichita,406,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,406,"Judge, County Court at Law No. 1",,,Under Votes,334,231,103
+Wichita,406,"Judge, County Court at Law No. 2",,REP,Greg King,1209,907,302
+Wichita,406,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,406,"Judge, County Court at Law No. 2",,,Under Votes,330,230,100
+Wichita,406,District Clerk,,REP,Patti Flores,1206,901,305
+Wichita,406,District Clerk,,,Over Votes,0,0,0
+Wichita,406,District Clerk,,,Under Votes,333,236,97
+Wichita,406,County Clerk,,REP,Lori Bohannon,1224,916,308
+Wichita,406,County Clerk,,,Over Votes,0,0,0
+Wichita,406,County Clerk,,,Under Votes,315,221,94
+Wichita,406,County Treasurer,,REP,R. J. Bob Hampton,1219,917,302
+Wichita,406,County Treasurer,,,Over Votes,0,0,0
+Wichita,406,County Treasurer,,,Under Votes,320,220,100
+Wichita,406,"County Commissioner, Precinct 4",,REP,Jeff Watts,1053,786,267
+Wichita,406,"County Commissioner, Precinct 4",,DEM,Catie Robinson,452,333,119
+Wichita,406,"County Commissioner, Precinct 4",,,Over Votes,0,0,0
+Wichita,406,"County Commissioner, Precinct 4",,,Under Votes,34,18,16
+Wichita,406,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,1198,898,300
+Wichita,406,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,406,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,341,239,102
+Wichita,406,City of Wichita Falls Mayor,,,Lowry W. Crane,356,277,79
+Wichita,406,City of Wichita Falls Mayor,,,Stephen L. Santellana,863,628,235
+Wichita,406,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,406,City of Wichita Falls Mayor,,,Under Votes,295,225,70
+Wichita,406,City of Wichita Falls Councilor District 3,,,Jeff L. Browning,954,710,244
+Wichita,406,City of Wichita Falls Councilor District 3,,,Over Votes,0,0,0
+Wichita,406,City of Wichita Falls Councilor District 3,,,Under Votes,558,418,140
+Wichita,406,Wichita Falls ISD Single Member District 1,,,Bob Payton,956,712,244
+Wichita,406,Wichita Falls ISD Single Member District 1,,,Over Votes,0,0,0
+Wichita,406,Wichita Falls ISD Single Member District 1,,,Under Votes,574,420,154
+Wichita,406,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,991,746,245
+Wichita,406,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,406,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,539,386,153
+Wichita,406,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,710,527,183
+Wichita,406,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,447,329,118
+Wichita,406,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,406,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,375,278,97
+Wichita,406,Ballots Cast,,,,1547,1145,402
+Wichita,407,Straight Party,,REP,,260,192,68
+Wichita,407,Straight Party,,DEM,,143,102,41
+Wichita,407,Straight Party,,LIB,,3,1,2
+Wichita,407,Straight Party,,,Over Votes,0,0,0
+Wichita,407,Straight Party,,,Under Votes,374,258,116
+Wichita,407,U.S. Senate,,REP,Ted Cruz,441,311,130
+Wichita,407,U.S. Senate,,DEM,Beto O'Rourke,313,223,90
+Wichita,407,U.S. Senate,,LIB,Neal M. Dikeman,12,7,5
+Wichita,407,U.S. Senate,,,Over Votes,0,0,0
+Wichita,407,U.S. Senate,,,Under Votes,9,7,2
+Wichita,407,U.S. House,13,REP,Mac Thornberry,476,338,138
+Wichita,407,U.S. House,13,DEM,Greg Sagan,259,184,75
+Wichita,407,U.S. House,13,LIB,Calvin DeWeese,23,15,8
+Wichita,407,U.S. House,13,,Over Votes,0,0,0
+Wichita,407,U.S. House,13,,Under Votes,17,11,6
+Wichita,407,Governor,,REP,Greg Abbott,461,328,133
+Wichita,407,Governor,,DEM,Lupe Valdez,283,204,79
+Wichita,407,Governor,,LIB,Mark Jay Tippetts,17,7,10
+Wichita,407,Governor,,,Over Votes,0,0,0
+Wichita,407,Governor,,,Under Votes,14,9,5
+Wichita,407,Lieutenant Governor,,REP,Dan Patrick,429,303,126
+Wichita,407,Lieutenant Governor,,DEM,Mike Collier,296,214,82
+Wichita,407,Lieutenant Governor,,LIB,Kerry Douglas McKennon,31,18,13
+Wichita,407,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,407,Lieutenant Governor,,,Under Votes,19,13,6
+Wichita,407,Attorney General,,REP,Ken Paxton,433,304,129
+Wichita,407,Attorney General,,DEM,Justin Nelson,298,216,82
+Wichita,407,Attorney General,,LIB,Michael Ray Harris,26,15,11
+Wichita,407,Attorney General,,,Over Votes,0,0,0
+Wichita,407,Attorney General,,,Under Votes,18,13,5
+Wichita,407,Comptroller of Public Accounts,,REP,Glenn Hegar,442,315,127
+Wichita,407,Comptroller of Public Accounts,,DEM,Joi Chevalier,272,199,73
+Wichita,407,Comptroller of Public Accounts,,LIB,Ben Sanders,38,18,20
+Wichita,407,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,407,Comptroller of Public Accounts,,,Under Votes,23,16,7
+Wichita,407,Commissioner of the General Land Office,,REP,George P. Bush,434,315,119
+Wichita,407,Commissioner of the General Land Office,,DEM,Miguel Suazo,276,194,82
+Wichita,407,Commissioner of the General Land Office,,LIB,Matt Pina,43,23,20
+Wichita,407,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,407,Commissioner of the General Land Office,,,Under Votes,22,16,6
+Wichita,407,Commissioner of Agriculture,,REP,Sid Miller,426,303,123
+Wichita,407,Commissioner of Agriculture,,DEM,Kim Olson,290,205,85
+Wichita,407,Commissioner of Agriculture,,LIB,Richard Carpenter,32,21,11
+Wichita,407,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,407,Commissioner of Agriculture,,,Under Votes,27,19,8
+Wichita,407,Railroad Commissioner,,REP,Christi Craddick,445,310,135
+Wichita,407,Railroad Commissioner,,DEM,Roman McAllen,272,201,71
+Wichita,407,Railroad Commissioner,,LIB,Mike Wright,32,19,13
+Wichita,407,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,407,Railroad Commissioner,,,Under Votes,26,18,8
+Wichita,407,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,455,321,134
+Wichita,407,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,293,207,86
+Wichita,407,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,407,"Justice, Supreme Court, Place 2",,,Under Votes,27,20,7
+Wichita,407,"Justice, Supreme Court, Place 4",,REP,John Devine,455,322,133
+Wichita,407,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,290,205,85
+Wichita,407,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,407,"Justice, Supreme Court, Place 4",,,Under Votes,30,21,9
+Wichita,407,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,452,320,132
+Wichita,407,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,296,210,86
+Wichita,407,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,407,"Justice, Supreme Court, Place 6",,,Under Votes,27,18,9
+Wichita,407,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,442,313,129
+Wichita,407,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,279,203,76
+Wichita,407,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,28,15,13
+Wichita,407,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,407,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,26,17,9
+Wichita,407,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,458,325,133
+Wichita,407,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,289,204,85
+Wichita,407,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,407,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,28,19,9
+Wichita,407,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,485,339,146
+Wichita,407,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,132,97,35
+Wichita,407,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,407,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,158,112,46
+Wichita,407,State Senator,30,REP,Pat Fallon,453,321,132
+Wichita,407,State Senator,30,DEM,Kevin Lopez,302,213,89
+Wichita,407,State Senator,30,,Over Votes,0,0,0
+Wichita,407,State Senator,30,,Under Votes,20,14,6
+Wichita,407,State Representative,69,REP,James Frank,544,381,163
+Wichita,407,State Representative,69,,Over Votes,0,0,0
+Wichita,407,State Representative,69,,Under Votes,231,167,64
+Wichita,407,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,535,372,163
+Wichita,407,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,407,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,240,176,64
+Wichita,407,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,522,367,155
+Wichita,407,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,407,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,253,181,72
+Wichita,407,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,450,323,127
+Wichita,407,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,296,204,92
+Wichita,407,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,407,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,29,21,8
+Wichita,407,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,519,363,156
+Wichita,407,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,407,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,256,185,71
+Wichita,407,"District Judge, 30th Judicial District",,REP,Jeff McKnight,528,371,157
+Wichita,407,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,407,"District Judge, 30th Judicial District",,,Under Votes,247,177,70
+Wichita,407,Criminal District Attorney,,REP,John Gillespie,540,380,160
+Wichita,407,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,407,Criminal District Attorney,,,Under Votes,235,168,67
+Wichita,407,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",557,395,162
+Wichita,407,County Judge,,,Over Votes,0,0,0
+Wichita,407,County Judge,,,Under Votes,218,153,65
+Wichita,407,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,536,378,158
+Wichita,407,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,407,"Judge, County Court at Law No. 1",,,Under Votes,239,170,69
+Wichita,407,"Judge, County Court at Law No. 2",,REP,Greg King,536,379,157
+Wichita,407,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,407,"Judge, County Court at Law No. 2",,,Under Votes,239,169,70
+Wichita,407,District Clerk,,REP,Patti Flores,545,383,162
+Wichita,407,District Clerk,,,Over Votes,0,0,0
+Wichita,407,District Clerk,,,Under Votes,230,165,65
+Wichita,407,County Clerk,,REP,Lori Bohannon,553,390,163
+Wichita,407,County Clerk,,,Over Votes,0,0,0
+Wichita,407,County Clerk,,,Under Votes,222,158,64
+Wichita,407,County Treasurer,,REP,R. J. Bob Hampton,546,388,158
+Wichita,407,County Treasurer,,,Over Votes,0,0,0
+Wichita,407,County Treasurer,,,Under Votes,229,160,69
+Wichita,407,"County Commissioner, Precinct 4",,REP,Jeff Watts,442,315,127
+Wichita,407,"County Commissioner, Precinct 4",,DEM,Catie Robinson,305,213,92
+Wichita,407,"County Commissioner, Precinct 4",,,Over Votes,0,0,0
+Wichita,407,"County Commissioner, Precinct 4",,,Under Votes,28,20,8
+Wichita,407,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,529,374,155
+Wichita,407,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,407,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,246,174,72
+Wichita,407,City of Wichita Falls Mayor,,,Lowry W. Crane,178,117,61
+Wichita,407,City of Wichita Falls Mayor,,,Stephen L. Santellana,416,300,116
+Wichita,407,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,407,City of Wichita Falls Mayor,,,Under Votes,183,133,50
+Wichita,407,Wichita Falls ISD Single Member District 5,,,Tom Bursey,422,290,132
+Wichita,407,Wichita Falls ISD Single Member District 5,,,Over Votes,0,0,0
+Wichita,407,Wichita Falls ISD Single Member District 5,,,Under Votes,354,259,95
+Wichita,407,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,450,316,134
+Wichita,407,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,407,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,326,233,93
+Wichita,407,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,357,257,100
+Wichita,407,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,212,143,69
+Wichita,407,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,407,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,208,150,58
+Wichita,407,Ballots Cast,,,,780,553,227
+Wichita,408,Straight Party,,REP,,2,1,1
+Wichita,408,Straight Party,,DEM,,0,0,0
+Wichita,408,Straight Party,,LIB,,0,0,0
+Wichita,408,Straight Party,,,Over Votes,0,0,0
+Wichita,408,Straight Party,,,Under Votes,6,5,1
+Wichita,408,U.S. Senate,,REP,Ted Cruz,7,5,2
+Wichita,408,U.S. Senate,,DEM,Beto O'Rourke,1,1,0
+Wichita,408,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0
+Wichita,408,U.S. Senate,,,Over Votes,0,0,0
+Wichita,408,U.S. Senate,,,Under Votes,0,0,0
+Wichita,408,U.S. House,13,REP,Mac Thornberry,8,6,2
+Wichita,408,U.S. House,13,DEM,Greg Sagan,0,0,0
+Wichita,408,U.S. House,13,LIB,Calvin DeWeese,0,0,0
+Wichita,408,U.S. House,13,,Over Votes,0,0,0
+Wichita,408,U.S. House,13,,Under Votes,0,0,0
+Wichita,408,Governor,,REP,Greg Abbott,8,6,2
+Wichita,408,Governor,,DEM,Lupe Valdez,0,0,0
+Wichita,408,Governor,,LIB,Mark Jay Tippetts,0,0,0
+Wichita,408,Governor,,,Over Votes,0,0,0
+Wichita,408,Governor,,,Under Votes,0,0,0
+Wichita,408,Lieutenant Governor,,REP,Dan Patrick,7,5,2
+Wichita,408,Lieutenant Governor,,DEM,Mike Collier,1,1,0
+Wichita,408,Lieutenant Governor,,LIB,Kerry Douglas McKennon,0,0,0
+Wichita,408,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,408,Lieutenant Governor,,,Under Votes,0,0,0
+Wichita,408,Attorney General,,REP,Ken Paxton,7,5,2
+Wichita,408,Attorney General,,DEM,Justin Nelson,1,1,0
+Wichita,408,Attorney General,,LIB,Michael Ray Harris,0,0,0
+Wichita,408,Attorney General,,,Over Votes,0,0,0
+Wichita,408,Attorney General,,,Under Votes,0,0,0
+Wichita,408,Comptroller of Public Accounts,,REP,Glenn Hegar,7,5,2
+Wichita,408,Comptroller of Public Accounts,,DEM,Joi Chevalier,1,1,0
+Wichita,408,Comptroller of Public Accounts,,LIB,Ben Sanders,0,0,0
+Wichita,408,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,408,Comptroller of Public Accounts,,,Under Votes,0,0,0
+Wichita,408,Commissioner of the General Land Office,,REP,George P. Bush,7,5,2
+Wichita,408,Commissioner of the General Land Office,,DEM,Miguel Suazo,1,1,0
+Wichita,408,Commissioner of the General Land Office,,LIB,Matt Pina,0,0,0
+Wichita,408,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,408,Commissioner of the General Land Office,,,Under Votes,0,0,0
+Wichita,408,Commissioner of Agriculture,,REP,Sid Miller,7,5,2
+Wichita,408,Commissioner of Agriculture,,DEM,Kim Olson,1,1,0
+Wichita,408,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0
+Wichita,408,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,408,Commissioner of Agriculture,,,Under Votes,0,0,0
+Wichita,408,Railroad Commissioner,,REP,Christi Craddick,7,5,2
+Wichita,408,Railroad Commissioner,,DEM,Roman McAllen,1,1,0
+Wichita,408,Railroad Commissioner,,LIB,Mike Wright,0,0,0
+Wichita,408,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,408,Railroad Commissioner,,,Under Votes,0,0,0
+Wichita,408,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,7,5,2
+Wichita,408,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,1,1,0
+Wichita,408,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,408,"Justice, Supreme Court, Place 2",,,Under Votes,0,0,0
+Wichita,408,"Justice, Supreme Court, Place 4",,REP,John Devine,7,5,2
+Wichita,408,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,1,1,0
+Wichita,408,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,408,"Justice, Supreme Court, Place 4",,,Under Votes,0,0,0
+Wichita,408,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,7,5,2
+Wichita,408,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,1,1,0
+Wichita,408,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,408,"Justice, Supreme Court, Place 6",,,Under Votes,0,0,0
+Wichita,408,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,7,5,2
+Wichita,408,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,1,1,0
+Wichita,408,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,0,0,0
+Wichita,408,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,408,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,0,0,0
+Wichita,408,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,7,5,2
+Wichita,408,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,1,1,0
+Wichita,408,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,408,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,0,0,0
+Wichita,408,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,7,5,2
+Wichita,408,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,1,1,0
+Wichita,408,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,408,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,0,0,0
+Wichita,408,State Senator,30,REP,Pat Fallon,7,5,2
+Wichita,408,State Senator,30,DEM,Kevin Lopez,1,1,0
+Wichita,408,State Senator,30,,Over Votes,0,0,0
+Wichita,408,State Senator,30,,Under Votes,0,0,0
+Wichita,408,State Representative,69,REP,James Frank,7,5,2
+Wichita,408,State Representative,69,,Over Votes,0,0,0
+Wichita,408,State Representative,69,,Under Votes,1,1,0
+Wichita,408,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,7,5,2
+Wichita,408,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,408,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,1,1,0
+Wichita,408,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,7,5,2
+Wichita,408,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,408,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,1,1,0
+Wichita,408,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,7,5,2
+Wichita,408,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,1,1,0
+Wichita,408,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,408,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,0,0,0
+Wichita,408,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,7,5,2
+Wichita,408,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,408,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,1,1,0
+Wichita,408,"District Judge, 30th Judicial District",,REP,Jeff McKnight,7,5,2
+Wichita,408,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,408,"District Judge, 30th Judicial District",,,Under Votes,1,1,0
+Wichita,408,Criminal District Attorney,,REP,John Gillespie,7,5,2
+Wichita,408,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,408,Criminal District Attorney,,,Under Votes,1,1,0
+Wichita,408,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",5,4,1
+Wichita,408,County Judge,,,Over Votes,0,0,0
+Wichita,408,County Judge,,,Under Votes,3,2,1
+Wichita,408,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,7,5,2
+Wichita,408,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,408,"Judge, County Court at Law No. 1",,,Under Votes,1,1,0
+Wichita,408,"Judge, County Court at Law No. 2",,REP,Greg King,7,5,2
+Wichita,408,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,408,"Judge, County Court at Law No. 2",,,Under Votes,1,1,0
+Wichita,408,District Clerk,,REP,Patti Flores,7,5,2
+Wichita,408,District Clerk,,,Over Votes,0,0,0
+Wichita,408,District Clerk,,,Under Votes,1,1,0
+Wichita,408,County Clerk,,REP,Lori Bohannon,7,5,2
+Wichita,408,County Clerk,,,Over Votes,0,0,0
+Wichita,408,County Clerk,,,Under Votes,1,1,0
+Wichita,408,County Treasurer,,REP,R. J. Bob Hampton,7,5,2
+Wichita,408,County Treasurer,,,Over Votes,0,0,0
+Wichita,408,County Treasurer,,,Under Votes,1,1,0
+Wichita,408,"County Commissioner, Precinct 4",,REP,Jeff Watts,7,5,2
+Wichita,408,"County Commissioner, Precinct 4",,DEM,Catie Robinson,1,1,0
+Wichita,408,"County Commissioner, Precinct 4",,,Over Votes,0,0,0
+Wichita,408,"County Commissioner, Precinct 4",,,Under Votes,0,0,0
+Wichita,408,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,7,5,2
+Wichita,408,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,408,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,1,1,0
+Wichita,408,City of Wichita Falls Mayor,,,Lowry W. Crane,5,5,0
+Wichita,408,City of Wichita Falls Mayor,,,Stephen L. Santellana,3,1,2
+Wichita,408,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,408,City of Wichita Falls Mayor,,,Under Votes,0,0,0
+Wichita,408,Ballots Cast,,,,8,6,2
+Wichita,409,Straight Party,,REP,,6,4,2
+Wichita,409,Straight Party,,DEM,,1,1,0
+Wichita,409,Straight Party,,LIB,,0,0,0
+Wichita,409,Straight Party,,,Over Votes,0,0,0
+Wichita,409,Straight Party,,,Under Votes,8,8,0
+Wichita,409,U.S. Senate,,REP,Ted Cruz,12,10,2
+Wichita,409,U.S. Senate,,DEM,Beto O'Rourke,2,2,0
+Wichita,409,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0
+Wichita,409,U.S. Senate,,,Over Votes,0,0,0
+Wichita,409,U.S. Senate,,,Under Votes,1,1,0
+Wichita,409,U.S. House,13,REP,Mac Thornberry,11,9,2
+Wichita,409,U.S. House,13,DEM,Greg Sagan,2,2,0
+Wichita,409,U.S. House,13,LIB,Calvin DeWeese,0,0,0
+Wichita,409,U.S. House,13,,Over Votes,0,0,0
+Wichita,409,U.S. House,13,,Under Votes,2,2,0
+Wichita,409,Governor,,REP,Greg Abbott,11,9,2
+Wichita,409,Governor,,DEM,Lupe Valdez,3,3,0
+Wichita,409,Governor,,LIB,Mark Jay Tippetts,0,0,0
+Wichita,409,Governor,,,Over Votes,0,0,0
+Wichita,409,Governor,,,Under Votes,1,1,0
+Wichita,409,Lieutenant Governor,,REP,Dan Patrick,12,10,2
+Wichita,409,Lieutenant Governor,,DEM,Mike Collier,3,3,0
+Wichita,409,Lieutenant Governor,,LIB,Kerry Douglas McKennon,0,0,0
+Wichita,409,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,409,Lieutenant Governor,,,Under Votes,0,0,0
+Wichita,409,Attorney General,,REP,Ken Paxton,11,9,2
+Wichita,409,Attorney General,,DEM,Justin Nelson,3,3,0
+Wichita,409,Attorney General,,LIB,Michael Ray Harris,0,0,0
+Wichita,409,Attorney General,,,Over Votes,0,0,0
+Wichita,409,Attorney General,,,Under Votes,1,1,0
+Wichita,409,Comptroller of Public Accounts,,REP,Glenn Hegar,11,9,2
+Wichita,409,Comptroller of Public Accounts,,DEM,Joi Chevalier,2,2,0
+Wichita,409,Comptroller of Public Accounts,,LIB,Ben Sanders,0,0,0
+Wichita,409,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,409,Comptroller of Public Accounts,,,Under Votes,2,2,0
+Wichita,409,Commissioner of the General Land Office,,REP,George P. Bush,11,9,2
+Wichita,409,Commissioner of the General Land Office,,DEM,Miguel Suazo,2,2,0
+Wichita,409,Commissioner of the General Land Office,,LIB,Matt Pina,1,1,0
+Wichita,409,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,409,Commissioner of the General Land Office,,,Under Votes,1,1,0
+Wichita,409,Commissioner of Agriculture,,REP,Sid Miller,11,9,2
+Wichita,409,Commissioner of Agriculture,,DEM,Kim Olson,2,2,0
+Wichita,409,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0
+Wichita,409,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,409,Commissioner of Agriculture,,,Under Votes,2,2,0
+Wichita,409,Railroad Commissioner,,REP,Christi Craddick,11,9,2
+Wichita,409,Railroad Commissioner,,DEM,Roman McAllen,2,2,0
+Wichita,409,Railroad Commissioner,,LIB,Mike Wright,0,0,0
+Wichita,409,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,409,Railroad Commissioner,,,Under Votes,2,2,0
+Wichita,409,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,12,10,2
+Wichita,409,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,2,2,0
+Wichita,409,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,409,"Justice, Supreme Court, Place 2",,,Under Votes,1,1,0
+Wichita,409,"Justice, Supreme Court, Place 4",,REP,John Devine,11,9,2
+Wichita,409,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,2,2,0
+Wichita,409,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,409,"Justice, Supreme Court, Place 4",,,Under Votes,2,2,0
+Wichita,409,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,12,10,2
+Wichita,409,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,1,1,0
+Wichita,409,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,409,"Justice, Supreme Court, Place 6",,,Under Votes,2,2,0
+Wichita,409,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,11,9,2
+Wichita,409,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,2,2,0
+Wichita,409,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,0,0,0
+Wichita,409,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,409,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,2,2,0
+Wichita,409,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,12,10,2
+Wichita,409,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,1,1,0
+Wichita,409,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,409,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,2,2,0
+Wichita,409,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,12,10,2
+Wichita,409,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,1,1,0
+Wichita,409,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,409,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,2,2,0
+Wichita,409,State Senator,30,REP,Pat Fallon,13,11,2
+Wichita,409,State Senator,30,DEM,Kevin Lopez,1,1,0
+Wichita,409,State Senator,30,,Over Votes,0,0,0
+Wichita,409,State Senator,30,,Under Votes,1,1,0
+Wichita,409,State Representative,69,REP,James Frank,12,10,2
+Wichita,409,State Representative,69,,Over Votes,0,0,0
+Wichita,409,State Representative,69,,Under Votes,3,3,0
+Wichita,409,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,13,11,2
+Wichita,409,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,409,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,2,2,0
+Wichita,409,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,13,11,2
+Wichita,409,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,409,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,2,2,0
+Wichita,409,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,12,10,2
+Wichita,409,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,2,2,0
+Wichita,409,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,409,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,1,1,0
+Wichita,409,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,13,11,2
+Wichita,409,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,409,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,2,2,0
+Wichita,409,"District Judge, 30th Judicial District",,REP,Jeff McKnight,13,11,2
+Wichita,409,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,409,"District Judge, 30th Judicial District",,,Under Votes,2,2,0
+Wichita,409,Criminal District Attorney,,REP,John Gillespie,14,12,2
+Wichita,409,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,409,Criminal District Attorney,,,Under Votes,1,1,0
+Wichita,409,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",13,11,2
+Wichita,409,County Judge,,,Over Votes,0,0,0
+Wichita,409,County Judge,,,Under Votes,2,2,0
+Wichita,409,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,14,12,2
+Wichita,409,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,409,"Judge, County Court at Law No. 1",,,Under Votes,1,1,0
+Wichita,409,"Judge, County Court at Law No. 2",,REP,Greg King,13,11,2
+Wichita,409,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,409,"Judge, County Court at Law No. 2",,,Under Votes,2,2,0
+Wichita,409,District Clerk,,REP,Patti Flores,13,11,2
+Wichita,409,District Clerk,,,Over Votes,0,0,0
+Wichita,409,District Clerk,,,Under Votes,2,2,0
+Wichita,409,County Clerk,,REP,Lori Bohannon,13,11,2
+Wichita,409,County Clerk,,,Over Votes,0,0,0
+Wichita,409,County Clerk,,,Under Votes,2,2,0
+Wichita,409,County Treasurer,,REP,R. J. Bob Hampton,13,11,2
+Wichita,409,County Treasurer,,,Over Votes,0,0,0
+Wichita,409,County Treasurer,,,Under Votes,2,2,0
+Wichita,409,"County Commissioner, Precinct 4",,REP,Jeff Watts,11,9,2
+Wichita,409,"County Commissioner, Precinct 4",,DEM,Catie Robinson,2,2,0
+Wichita,409,"County Commissioner, Precinct 4",,,Over Votes,0,0,0
+Wichita,409,"County Commissioner, Precinct 4",,,Under Votes,2,2,0
+Wichita,409,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,13,11,2
+Wichita,409,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,409,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,2,2,0
+Wichita,409,City of Wichita Falls Mayor,,,Lowry W. Crane,2,2,0
+Wichita,409,City of Wichita Falls Mayor,,,Stephen L. Santellana,11,10,1
+Wichita,409,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,409,City of Wichita Falls Mayor,,,Under Votes,1,0,1
+Wichita,409,Wichita Falls ISD Single Member District 3,,,Mark Lukert,9,9,0
+Wichita,409,Wichita Falls ISD Single Member District 3,,,Adam W. Groves,3,1,2
+Wichita,409,Wichita Falls ISD Single Member District 3,,,Over Votes,0,0,0
+Wichita,409,Wichita Falls ISD Single Member District 3,,,Under Votes,3,3,0
+Wichita,409,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,11,9,2
+Wichita,409,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,409,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,4,4,0
+Wichita,409,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,7,6,1
+Wichita,409,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,5,4,1
+Wichita,409,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,409,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,3,3,0
+Wichita,409,Ballots Cast,,,,15,13,2
+Wichita,410,Straight Party,,REP,,80,60,20
+Wichita,410,Straight Party,,DEM,,9,3,6
+Wichita,410,Straight Party,,LIB,,0,0,0
+Wichita,410,Straight Party,,,Over Votes,0,0,0
+Wichita,410,Straight Party,,,Under Votes,66,52,14
+Wichita,410,U.S. Senate,,REP,Ted Cruz,123,92,31
+Wichita,410,U.S. Senate,,DEM,Beto O'Rourke,30,21,9
+Wichita,410,U.S. Senate,,LIB,Neal M. Dikeman,1,1,0
+Wichita,410,U.S. Senate,,,Over Votes,0,0,0
+Wichita,410,U.S. Senate,,,Under Votes,0,0,0
+Wichita,410,U.S. House,13,REP,Mac Thornberry,126,94,32
+Wichita,410,U.S. House,13,DEM,Greg Sagan,26,18,8
+Wichita,410,U.S. House,13,LIB,Calvin DeWeese,0,0,0
+Wichita,410,U.S. House,13,,Over Votes,0,0,0
+Wichita,410,U.S. House,13,,Under Votes,2,2,0
+Wichita,410,Governor,,REP,Greg Abbott,127,95,32
+Wichita,410,Governor,,DEM,Lupe Valdez,27,19,8
+Wichita,410,Governor,,LIB,Mark Jay Tippetts,0,0,0
+Wichita,410,Governor,,,Over Votes,0,0,0
+Wichita,410,Governor,,,Under Votes,0,0,0
+Wichita,410,Lieutenant Governor,,REP,Dan Patrick,121,90,31
+Wichita,410,Lieutenant Governor,,DEM,Mike Collier,29,21,8
+Wichita,410,Lieutenant Governor,,LIB,Kerry Douglas McKennon,3,2,1
+Wichita,410,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,410,Lieutenant Governor,,,Under Votes,1,1,0
+Wichita,410,Attorney General,,REP,Ken Paxton,120,89,31
+Wichita,410,Attorney General,,DEM,Justin Nelson,32,24,8
+Wichita,410,Attorney General,,LIB,Michael Ray Harris,1,0,1
+Wichita,410,Attorney General,,,Over Votes,0,0,0
+Wichita,410,Attorney General,,,Under Votes,1,1,0
+Wichita,410,Comptroller of Public Accounts,,REP,Glenn Hegar,123,93,30
+Wichita,410,Comptroller of Public Accounts,,DEM,Joi Chevalier,25,17,8
+Wichita,410,Comptroller of Public Accounts,,LIB,Ben Sanders,1,1,0
+Wichita,410,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,410,Comptroller of Public Accounts,,,Under Votes,5,3,2
+Wichita,410,Commissioner of the General Land Office,,REP,George P. Bush,119,93,26
+Wichita,410,Commissioner of the General Land Office,,DEM,Miguel Suazo,26,17,9
+Wichita,410,Commissioner of the General Land Office,,LIB,Matt Pina,6,3,3
+Wichita,410,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,410,Commissioner of the General Land Office,,,Under Votes,3,1,2
+Wichita,410,Commissioner of Agriculture,,REP,Sid Miller,118,89,29
+Wichita,410,Commissioner of Agriculture,,DEM,Kim Olson,29,21,8
+Wichita,410,Commissioner of Agriculture,,LIB,Richard Carpenter,3,2,1
+Wichita,410,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,410,Commissioner of Agriculture,,,Under Votes,4,2,2
+Wichita,410,Railroad Commissioner,,REP,Christi Craddick,121,95,26
+Wichita,410,Railroad Commissioner,,DEM,Roman McAllen,25,17,8
+Wichita,410,Railroad Commissioner,,LIB,Mike Wright,5,1,4
+Wichita,410,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,410,Railroad Commissioner,,,Under Votes,3,1,2
+Wichita,410,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,122,92,30
+Wichita,410,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,28,20,8
+Wichita,410,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,410,"Justice, Supreme Court, Place 2",,,Under Votes,4,2,2
+Wichita,410,"Justice, Supreme Court, Place 4",,REP,John Devine,122,93,29
+Wichita,410,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,28,19,9
+Wichita,410,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,410,"Justice, Supreme Court, Place 4",,,Under Votes,4,2,2
+Wichita,410,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,122,93,29
+Wichita,410,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,26,17,9
+Wichita,410,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,410,"Justice, Supreme Court, Place 6",,,Under Votes,6,4,2
+Wichita,410,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,118,91,27
+Wichita,410,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,29,20,9
+Wichita,410,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,2,0,2
+Wichita,410,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,410,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,5,3,2
+Wichita,410,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,121,92,29
+Wichita,410,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,28,19,9
+Wichita,410,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,410,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,5,3,2
+Wichita,410,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,128,96,32
+Wichita,410,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,13,11,2
+Wichita,410,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,410,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,13,7,6
+Wichita,410,State Senator,30,REP,Pat Fallon,119,90,29
+Wichita,410,State Senator,30,DEM,Kevin Lopez,30,21,9
+Wichita,410,State Senator,30,,Over Votes,0,0,0
+Wichita,410,State Senator,30,,Under Votes,5,3,2
+Wichita,410,State Representative,69,REP,James Frank,135,102,33
+Wichita,410,State Representative,69,,Over Votes,0,0,0
+Wichita,410,State Representative,69,,Under Votes,19,12,7
+Wichita,410,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,132,99,33
+Wichita,410,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,410,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,22,15,7
+Wichita,410,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,130,98,32
+Wichita,410,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,410,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,24,16,8
+Wichita,410,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,122,92,30
+Wichita,410,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,25,17,8
+Wichita,410,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,410,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,7,5,2
+Wichita,410,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,133,100,33
+Wichita,410,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,410,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,21,14,7
+Wichita,410,"District Judge, 30th Judicial District",,REP,Jeff McKnight,133,100,33
+Wichita,410,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,410,"District Judge, 30th Judicial District",,,Under Votes,21,14,7
+Wichita,410,Criminal District Attorney,,REP,John Gillespie,130,97,33
+Wichita,410,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,410,Criminal District Attorney,,,Under Votes,24,17,7
+Wichita,410,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",133,101,32
+Wichita,410,County Judge,,,Over Votes,0,0,0
+Wichita,410,County Judge,,,Under Votes,21,13,8
+Wichita,410,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,131,98,33
+Wichita,410,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,410,"Judge, County Court at Law No. 1",,,Under Votes,23,16,7
+Wichita,410,"Judge, County Court at Law No. 2",,REP,Greg King,130,97,33
+Wichita,410,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,410,"Judge, County Court at Law No. 2",,,Under Votes,24,17,7
+Wichita,410,District Clerk,,REP,Patti Flores,133,100,33
+Wichita,410,District Clerk,,,Over Votes,0,0,0
+Wichita,410,District Clerk,,,Under Votes,21,14,7
+Wichita,410,County Clerk,,REP,Lori Bohannon,133,100,33
+Wichita,410,County Clerk,,,Over Votes,0,0,0
+Wichita,410,County Clerk,,,Under Votes,21,14,7
+Wichita,410,County Treasurer,,REP,R. J. Bob Hampton,133,100,33
+Wichita,410,County Treasurer,,,Over Votes,0,0,0
+Wichita,410,County Treasurer,,,Under Votes,21,14,7
+Wichita,410,"County Commissioner, Precinct 4",,REP,Jeff Watts,123,93,30
+Wichita,410,"County Commissioner, Precinct 4",,DEM,Catie Robinson,26,18,8
+Wichita,410,"County Commissioner, Precinct 4",,,Over Votes,0,0,0
+Wichita,410,"County Commissioner, Precinct 4",,,Under Votes,5,3,2
+Wichita,410,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,131,98,33
+Wichita,410,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,410,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,23,16,7
+Wichita,410,City of Wichita Falls Mayor,,,Lowry W. Crane,43,31,12
+Wichita,410,City of Wichita Falls Mayor,,,Stephen L. Santellana,80,60,20
+Wichita,410,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,410,City of Wichita Falls Mayor,,,Under Votes,26,21,5
+Wichita,410,City of Wichita Falls Councilor District 3,,,Jeff L. Browning,95,72,23
+Wichita,410,City of Wichita Falls Councilor District 3,,,Over Votes,0,0,0
+Wichita,410,City of Wichita Falls Councilor District 3,,,Under Votes,54,40,14
+Wichita,410,Wichita Falls ISD Single Member District 3,,,Mark Lukert,93,69,24
+Wichita,410,Wichita Falls ISD Single Member District 3,,,Adam W. Groves,24,18,6
+Wichita,410,Wichita Falls ISD Single Member District 3,,,Over Votes,0,0,0
+Wichita,410,Wichita Falls ISD Single Member District 3,,,Under Votes,38,28,10
+Wichita,410,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,106,79,27
+Wichita,410,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,410,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,49,36,13
+Wichita,410,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,63,51,12
+Wichita,410,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,55,38,17
+Wichita,410,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,410,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,37,26,11
+Wichita,410,Ballots Cast,,,,155,115,40
+Wichita,411,Straight Party,,REP,,150,116,34
+Wichita,411,Straight Party,,DEM,,60,44,16
+Wichita,411,Straight Party,,LIB,,1,1,0
+Wichita,411,Straight Party,,,Over Votes,0,0,0
+Wichita,411,Straight Party,,,Under Votes,183,130,53
+Wichita,411,U.S. Senate,,REP,Ted Cruz,244,183,61
+Wichita,411,U.S. Senate,,DEM,Beto O'Rourke,142,102,40
+Wichita,411,U.S. Senate,,LIB,Neal M. Dikeman,5,4,1
+Wichita,411,U.S. Senate,,,Over Votes,0,0,0
+Wichita,411,U.S. Senate,,,Under Votes,3,2,1
+Wichita,411,U.S. House,13,REP,Mac Thornberry,268,199,69
+Wichita,411,U.S. House,13,DEM,Greg Sagan,115,86,29
+Wichita,411,U.S. House,13,LIB,Calvin DeWeese,9,5,4
+Wichita,411,U.S. House,13,,Over Votes,0,0,0
+Wichita,411,U.S. House,13,,Under Votes,2,1,1
+Wichita,411,Governor,,REP,Greg Abbott,259,191,68
+Wichita,411,Governor,,DEM,Lupe Valdez,122,92,30
+Wichita,411,Governor,,LIB,Mark Jay Tippetts,9,5,4
+Wichita,411,Governor,,,Over Votes,0,0,0
+Wichita,411,Governor,,,Under Votes,4,3,1
+Wichita,411,Lieutenant Governor,,REP,Dan Patrick,254,189,65
+Wichita,411,Lieutenant Governor,,DEM,Mike Collier,126,95,31
+Wichita,411,Lieutenant Governor,,LIB,Kerry Douglas McKennon,10,6,4
+Wichita,411,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,411,Lieutenant Governor,,,Under Votes,4,1,3
+Wichita,411,Attorney General,,REP,Ken Paxton,249,188,61
+Wichita,411,Attorney General,,DEM,Justin Nelson,129,97,32
+Wichita,411,Attorney General,,LIB,Michael Ray Harris,10,4,6
+Wichita,411,Attorney General,,,Over Votes,0,0,0
+Wichita,411,Attorney General,,,Under Votes,6,2,4
+Wichita,411,Comptroller of Public Accounts,,REP,Glenn Hegar,245,185,60
+Wichita,411,Comptroller of Public Accounts,,DEM,Joi Chevalier,121,94,27
+Wichita,411,Comptroller of Public Accounts,,LIB,Ben Sanders,17,9,8
+Wichita,411,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,411,Comptroller of Public Accounts,,,Under Votes,11,3,8
+Wichita,411,Commissioner of the General Land Office,,REP,George P. Bush,242,180,62
+Wichita,411,Commissioner of the General Land Office,,DEM,Miguel Suazo,119,89,30
+Wichita,411,Commissioner of the General Land Office,,LIB,Matt Pina,24,18,6
+Wichita,411,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,411,Commissioner of the General Land Office,,,Under Votes,9,4,5
+Wichita,411,Commissioner of Agriculture,,REP,Sid Miller,241,182,59
+Wichita,411,Commissioner of Agriculture,,DEM,Kim Olson,126,94,32
+Wichita,411,Commissioner of Agriculture,,LIB,Richard Carpenter,15,11,4
+Wichita,411,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,411,Commissioner of Agriculture,,,Under Votes,12,4,8
+Wichita,411,Railroad Commissioner,,REP,Christi Craddick,241,182,59
+Wichita,411,Railroad Commissioner,,DEM,Roman McAllen,119,88,31
+Wichita,411,Railroad Commissioner,,LIB,Mike Wright,21,16,5
+Wichita,411,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,411,Railroad Commissioner,,,Under Votes,13,5,8
+Wichita,411,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,255,193,62
+Wichita,411,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,129,95,34
+Wichita,411,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,411,"Justice, Supreme Court, Place 2",,,Under Votes,10,3,7
+Wichita,411,"Justice, Supreme Court, Place 4",,REP,John Devine,249,187,62
+Wichita,411,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,132,97,35
+Wichita,411,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,411,"Justice, Supreme Court, Place 4",,,Under Votes,13,7,6
+Wichita,411,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,249,187,62
+Wichita,411,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,132,97,35
+Wichita,411,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,411,"Justice, Supreme Court, Place 6",,,Under Votes,13,7,6
+Wichita,411,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,245,185,60
+Wichita,411,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,121,90,31
+Wichita,411,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,15,10,5
+Wichita,411,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,411,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,13,6,7
+Wichita,411,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,253,191,62
+Wichita,411,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,128,94,34
+Wichita,411,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,411,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,13,6,7
+Wichita,411,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,273,208,65
+Wichita,411,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,61,43,18
+Wichita,411,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,411,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,60,40,20
+Wichita,411,State Senator,30,REP,Pat Fallon,253,188,65
+Wichita,411,State Senator,30,DEM,Kevin Lopez,135,101,34
+Wichita,411,State Senator,30,,Over Votes,0,0,0
+Wichita,411,State Senator,30,,Under Votes,6,2,4
+Wichita,411,State Representative,69,REP,James Frank,297,222,75
+Wichita,411,State Representative,69,,Over Votes,0,0,0
+Wichita,411,State Representative,69,,Under Votes,97,69,28
+Wichita,411,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,295,221,74
+Wichita,411,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,411,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,99,70,29
+Wichita,411,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,287,215,72
+Wichita,411,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,411,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,107,76,31
+Wichita,411,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,245,185,60
+Wichita,411,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,135,99,36
+Wichita,411,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,411,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,14,7,7
+Wichita,411,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,290,216,74
+Wichita,411,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,411,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,104,75,29
+Wichita,411,"District Judge, 30th Judicial District",,REP,Jeff McKnight,291,216,75
+Wichita,411,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,411,"District Judge, 30th Judicial District",,,Under Votes,103,75,28
+Wichita,411,Criminal District Attorney,,REP,John Gillespie,294,217,77
+Wichita,411,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,411,Criminal District Attorney,,,Under Votes,100,74,26
+Wichita,411,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",295,217,78
+Wichita,411,County Judge,,,Over Votes,0,0,0
+Wichita,411,County Judge,,,Under Votes,99,74,25
+Wichita,411,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,292,216,76
+Wichita,411,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,411,"Judge, County Court at Law No. 1",,,Under Votes,102,75,27
+Wichita,411,"Judge, County Court at Law No. 2",,REP,Greg King,289,215,74
+Wichita,411,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,411,"Judge, County Court at Law No. 2",,,Under Votes,105,76,29
+Wichita,411,District Clerk,,REP,Patti Flores,294,218,76
+Wichita,411,District Clerk,,,Over Votes,0,0,0
+Wichita,411,District Clerk,,,Under Votes,100,73,27
+Wichita,411,County Clerk,,REP,Lori Bohannon,295,219,76
+Wichita,411,County Clerk,,,Over Votes,0,0,0
+Wichita,411,County Clerk,,,Under Votes,99,72,27
+Wichita,411,County Treasurer,,REP,R. J. Bob Hampton,291,214,77
+Wichita,411,County Treasurer,,,Over Votes,0,0,0
+Wichita,411,County Treasurer,,,Under Votes,103,77,26
+Wichita,411,"County Commissioner, Precinct 4",,REP,Jeff Watts,249,184,65
+Wichita,411,"County Commissioner, Precinct 4",,DEM,Catie Robinson,135,101,34
+Wichita,411,"County Commissioner, Precinct 4",,,Over Votes,0,0,0
+Wichita,411,"County Commissioner, Precinct 4",,,Under Votes,10,6,4
+Wichita,411,"Justice of the Peace, Precinct 1 Place 2",,REP,Robert Woodruff,289,215,74
+Wichita,411,"Justice of the Peace, Precinct 1 Place 2",,,Over Votes,0,0,0
+Wichita,411,"Justice of the Peace, Precinct 1 Place 2",,,Under Votes,105,76,29
+Wichita,411,City of Wichita Falls Mayor,,,Lowry W. Crane,93,69,24
+Wichita,411,City of Wichita Falls Mayor,,,Stephen L. Santellana,217,157,60
+Wichita,411,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,411,City of Wichita Falls Mayor,,,Under Votes,84,65,19
+Wichita,411,City of Wichita Falls Councilor District 3,,,Jeff L. Browning,243,180,63
+Wichita,411,City of Wichita Falls Councilor District 3,,,Over Votes,0,0,0
+Wichita,411,City of Wichita Falls Councilor District 3,,,Under Votes,151,111,40
+Wichita,411,Wichita Falls ISD Single Member District 1,,,Bob Payton,246,181,65
+Wichita,411,Wichita Falls ISD Single Member District 1,,,Over Votes,0,0,0
+Wichita,411,Wichita Falls ISD Single Member District 1,,,Under Votes,148,110,38
+Wichita,411,"Wichita Falls ISD At-Large, 2-Year",,,Katherine McGregor,245,180,65
+Wichita,411,"Wichita Falls ISD At-Large, 2-Year",,,Over Votes,0,0,0
+Wichita,411,"Wichita Falls ISD At-Large, 2-Year",,,Under Votes,149,111,38
+Wichita,411,"Wichita Falls ISD At-Large, 4-Year",,,Elizabeth Yeager,187,142,45
+Wichita,411,"Wichita Falls ISD At-Large, 4-Year",,,Susan Grisél,101,71,30
+Wichita,411,"Wichita Falls ISD At-Large, 4-Year",,,Over Votes,0,0,0
+Wichita,411,"Wichita Falls ISD At-Large, 4-Year",,,Under Votes,106,78,28
+Wichita,411,Ballots Cast,,,,394,291,103
+Wichita,412,Straight Party,,REP,,221,171,50
+Wichita,412,Straight Party,,DEM,,20,16,4
+Wichita,412,Straight Party,,LIB,,0,0,0
+Wichita,412,Straight Party,,,Over Votes,0,0,0
+Wichita,412,Straight Party,,,Under Votes,161,109,52
+Wichita,412,U.S. Senate,,REP,Ted Cruz,353,267,86
+Wichita,412,U.S. Senate,,DEM,Beto O'Rourke,46,28,18
+Wichita,412,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0
+Wichita,412,U.S. Senate,,,Over Votes,0,0,0
+Wichita,412,U.S. Senate,,,Under Votes,3,1,2
+Wichita,412,U.S. House,13,REP,Mac Thornberry,361,270,91
+Wichita,412,U.S. House,13,DEM,Greg Sagan,33,22,11
+Wichita,412,U.S. House,13,LIB,Calvin DeWeese,6,2,4
+Wichita,412,U.S. House,13,,Over Votes,0,0,0
+Wichita,412,U.S. House,13,,Under Votes,2,2,0
+Wichita,412,Governor,,REP,Greg Abbott,357,268,89
+Wichita,412,Governor,,DEM,Lupe Valdez,39,26,13
+Wichita,412,Governor,,LIB,Mark Jay Tippetts,6,2,4
+Wichita,412,Governor,,,Over Votes,0,0,0
+Wichita,412,Governor,,,Under Votes,0,0,0
+Wichita,412,Lieutenant Governor,,REP,Dan Patrick,346,254,92
+Wichita,412,Lieutenant Governor,,DEM,Mike Collier,44,31,13
+Wichita,412,Lieutenant Governor,,LIB,Kerry Douglas McKennon,9,8,1
+Wichita,412,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,412,Lieutenant Governor,,,Under Votes,3,3,0
+Wichita,412,Attorney General,,REP,Ken Paxton,347,262,85
+Wichita,412,Attorney General,,DEM,Justin Nelson,44,26,18
+Wichita,412,Attorney General,,LIB,Michael Ray Harris,7,4,3
+Wichita,412,Attorney General,,,Over Votes,0,0,0
+Wichita,412,Attorney General,,,Under Votes,4,4,0
+Wichita,412,Comptroller of Public Accounts,,REP,Glenn Hegar,350,262,88
+Wichita,412,Comptroller of Public Accounts,,DEM,Joi Chevalier,37,22,15
+Wichita,412,Comptroller of Public Accounts,,LIB,Ben Sanders,9,6,3
+Wichita,412,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,412,Comptroller of Public Accounts,,,Under Votes,6,6,0
+Wichita,412,Commissioner of the General Land Office,,REP,George P. Bush,348,260,88
+Wichita,412,Commissioner of the General Land Office,,DEM,Miguel Suazo,39,24,15
+Wichita,412,Commissioner of the General Land Office,,LIB,Matt Pina,10,8,2
+Wichita,412,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,412,Commissioner of the General Land Office,,,Under Votes,5,4,1
+Wichita,412,Commissioner of Agriculture,,REP,Sid Miller,354,265,89
+Wichita,412,Commissioner of Agriculture,,DEM,Kim Olson,40,25,15
+Wichita,412,Commissioner of Agriculture,,LIB,Richard Carpenter,3,1,2
+Wichita,412,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,412,Commissioner of Agriculture,,,Under Votes,5,5,0
+Wichita,412,Railroad Commissioner,,REP,Christi Craddick,357,266,91
+Wichita,412,Railroad Commissioner,,DEM,Roman McAllen,33,20,13
+Wichita,412,Railroad Commissioner,,LIB,Mike Wright,5,3,2
+Wichita,412,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,412,Railroad Commissioner,,,Under Votes,7,7,0
+Wichita,412,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,355,265,90
+Wichita,412,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,42,26,16
+Wichita,412,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,412,"Justice, Supreme Court, Place 2",,,Under Votes,5,5,0
+Wichita,412,"Justice, Supreme Court, Place 4",,REP,John Devine,356,266,90
+Wichita,412,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,41,25,16
+Wichita,412,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,412,"Justice, Supreme Court, Place 4",,,Under Votes,5,5,0
+Wichita,412,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,354,266,88
+Wichita,412,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,43,27,16
+Wichita,412,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,412,"Justice, Supreme Court, Place 6",,,Under Votes,5,3,2
+Wichita,412,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,349,264,85
+Wichita,412,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,37,22,15
+Wichita,412,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,8,4,4
+Wichita,412,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,412,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,8,6,2
+Wichita,412,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,353,266,87
+Wichita,412,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,42,25,17
+Wichita,412,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,412,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,7,5,2
+Wichita,412,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,360,269,91
+Wichita,412,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,18,8,10
+Wichita,412,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,412,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,24,19,5
+Wichita,412,State Senator,30,REP,Pat Fallon,350,263,87
+Wichita,412,State Senator,30,DEM,Kevin Lopez,49,31,18
+Wichita,412,State Senator,30,,Over Votes,0,0,0
+Wichita,412,State Senator,30,,Under Votes,3,2,1
+Wichita,412,State Representative,69,REP,James Frank,370,272,98
+Wichita,412,State Representative,69,,Over Votes,0,0,0
+Wichita,412,State Representative,69,,Under Votes,32,24,8
+Wichita,412,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,365,270,95
+Wichita,412,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,412,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,37,26,11
+Wichita,412,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,361,268,93
+Wichita,412,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,412,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,41,28,13
+Wichita,412,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,348,262,86
+Wichita,412,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,47,28,19
+Wichita,412,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,412,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,7,6,1
+Wichita,412,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,365,270,95
+Wichita,412,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,412,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,37,26,11
+Wichita,412,"District Judge, 30th Judicial District",,REP,Jeff McKnight,367,271,96
+Wichita,412,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,412,"District Judge, 30th Judicial District",,,Under Votes,35,25,10
+Wichita,412,Criminal District Attorney,,REP,John Gillespie,366,271,95
+Wichita,412,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,412,Criminal District Attorney,,,Under Votes,36,25,11
+Wichita,412,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",362,266,96
+Wichita,412,County Judge,,,Over Votes,0,0,0
+Wichita,412,County Judge,,,Under Votes,40,30,10
+Wichita,412,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,366,271,95
+Wichita,412,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,412,"Judge, County Court at Law No. 1",,,Under Votes,36,25,11
+Wichita,412,"Judge, County Court at Law No. 2",,REP,Greg King,365,270,95
+Wichita,412,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,412,"Judge, County Court at Law No. 2",,,Under Votes,37,26,11
+Wichita,412,District Clerk,,REP,Patti Flores,364,269,95
+Wichita,412,District Clerk,,,Over Votes,0,0,0
+Wichita,412,District Clerk,,,Under Votes,38,27,11
+Wichita,412,County Clerk,,REP,Lori Bohannon,365,270,95
+Wichita,412,County Clerk,,,Over Votes,0,0,0
+Wichita,412,County Clerk,,,Under Votes,37,26,11
+Wichita,412,County Treasurer,,REP,R. J. Bob Hampton,366,270,96
+Wichita,412,County Treasurer,,,Over Votes,0,0,0
+Wichita,412,County Treasurer,,,Under Votes,36,26,10
+Wichita,412,"County Commissioner, Precinct 4",,REP,Jeff Watts,342,254,88
+Wichita,412,"County Commissioner, Precinct 4",,DEM,Catie Robinson,57,40,17
+Wichita,412,"County Commissioner, Precinct 4",,,Over Votes,0,0,0
+Wichita,412,"County Commissioner, Precinct 4",,,Under Votes,3,2,1
+Wichita,412,"Justice of the Peace, Precinct 3",,REP,Robert Johnson,369,273,96
+Wichita,412,"Justice of the Peace, Precinct 3",,,Over Votes,0,0,0
+Wichita,412,"Justice of the Peace, Precinct 3",,,Under Votes,33,23,10
+Wichita,412,Ballots Cast,,,,402,296,106
+Wichita,413,Straight Party,,REP,,269,168,101
+Wichita,413,Straight Party,,DEM,,44,26,18
+Wichita,413,Straight Party,,LIB,,2,2,0
+Wichita,413,Straight Party,,,Over Votes,0,0,0
+Wichita,413,Straight Party,,,Under Votes,177,99,78
+Wichita,413,U.S. Senate,,REP,Ted Cruz,401,241,160
+Wichita,413,U.S. Senate,,DEM,Beto O'Rourke,79,48,31
+Wichita,413,U.S. Senate,,LIB,Neal M. Dikeman,7,2,5
+Wichita,413,U.S. Senate,,,Over Votes,0,0,0
+Wichita,413,U.S. Senate,,,Under Votes,4,3,1
+Wichita,413,U.S. House,13,REP,Mac Thornberry,403,241,162
+Wichita,413,U.S. House,13,DEM,Greg Sagan,68,43,25
+Wichita,413,U.S. House,13,LIB,Calvin DeWeese,9,4,5
+Wichita,413,U.S. House,13,,Over Votes,0,0,0
+Wichita,413,U.S. House,13,,Under Votes,11,6,5
+Wichita,413,Governor,,REP,Greg Abbott,408,244,164
+Wichita,413,Governor,,DEM,Lupe Valdez,69,44,25
+Wichita,413,Governor,,LIB,Mark Jay Tippetts,3,2,1
+Wichita,413,Governor,,,Over Votes,0,0,0
+Wichita,413,Governor,,,Under Votes,11,4,7
+Wichita,413,Lieutenant Governor,,REP,Dan Patrick,373,224,149
+Wichita,413,Lieutenant Governor,,DEM,Mike Collier,93,54,39
+Wichita,413,Lieutenant Governor,,LIB,Kerry Douglas McKennon,10,5,5
+Wichita,413,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,413,Lieutenant Governor,,,Under Votes,15,11,4
+Wichita,413,Attorney General,,REP,Ken Paxton,390,234,156
+Wichita,413,Attorney General,,DEM,Justin Nelson,80,49,31
+Wichita,413,Attorney General,,LIB,Michael Ray Harris,10,5,5
+Wichita,413,Attorney General,,,Over Votes,0,0,0
+Wichita,413,Attorney General,,,Under Votes,11,6,5
+Wichita,413,Comptroller of Public Accounts,,REP,Glenn Hegar,390,237,153
+Wichita,413,Comptroller of Public Accounts,,DEM,Joi Chevalier,69,42,27
+Wichita,413,Comptroller of Public Accounts,,LIB,Ben Sanders,13,6,7
+Wichita,413,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,413,Comptroller of Public Accounts,,,Under Votes,19,9,10
+Wichita,413,Commissioner of the General Land Office,,REP,George P. Bush,369,218,151
+Wichita,413,Commissioner of the General Land Office,,DEM,Miguel Suazo,85,53,32
+Wichita,413,Commissioner of the General Land Office,,LIB,Matt Pina,19,13,6
+Wichita,413,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,413,Commissioner of the General Land Office,,,Under Votes,18,10,8
+Wichita,413,Commissioner of Agriculture,,REP,Sid Miller,390,229,161
+Wichita,413,Commissioner of Agriculture,,DEM,Kim Olson,77,50,27
+Wichita,413,Commissioner of Agriculture,,LIB,Richard Carpenter,7,6,1
+Wichita,413,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,413,Commissioner of Agriculture,,,Under Votes,17,9,8
+Wichita,413,Railroad Commissioner,,REP,Christi Craddick,387,232,155
+Wichita,413,Railroad Commissioner,,DEM,Roman McAllen,76,48,28
+Wichita,413,Railroad Commissioner,,LIB,Mike Wright,9,4,5
+Wichita,413,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,413,Railroad Commissioner,,,Under Votes,19,10,9
+Wichita,413,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,397,237,160
+Wichita,413,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,79,48,31
+Wichita,413,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,413,"Justice, Supreme Court, Place 2",,,Under Votes,15,9,6
+Wichita,413,"Justice, Supreme Court, Place 4",,REP,John Devine,392,233,159
+Wichita,413,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,78,47,31
+Wichita,413,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,413,"Justice, Supreme Court, Place 4",,,Under Votes,21,14,7
+Wichita,413,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,394,231,163
+Wichita,413,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,76,50,26
+Wichita,413,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,413,"Justice, Supreme Court, Place 6",,,Under Votes,21,13,8
+Wichita,413,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,386,231,155
+Wichita,413,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,74,44,30
+Wichita,413,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,10,5,5
+Wichita,413,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,413,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,21,14,7
+Wichita,413,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,389,233,156
+Wichita,413,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,78,47,31
+Wichita,413,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,413,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,24,14,10
+Wichita,413,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,403,238,165
+Wichita,413,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,27,18,9
+Wichita,413,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,413,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,61,38,23
+Wichita,413,State Senator,30,REP,Pat Fallon,399,239,160
+Wichita,413,State Senator,30,DEM,Kevin Lopez,82,50,32
+Wichita,413,State Senator,30,,Over Votes,0,0,0
+Wichita,413,State Senator,30,,Under Votes,10,5,5
+Wichita,413,State Representative,69,REP,James Frank,410,244,166
+Wichita,413,State Representative,69,,Over Votes,0,0,0
+Wichita,413,State Representative,69,,Under Votes,81,50,31
+Wichita,413,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,407,241,166
+Wichita,413,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,413,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,84,53,31
+Wichita,413,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,409,242,167
+Wichita,413,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,413,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,82,52,30
+Wichita,413,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,385,230,155
+Wichita,413,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,81,49,32
+Wichita,413,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,413,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,25,15,10
+Wichita,413,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,408,243,165
+Wichita,413,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,413,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,83,51,32
+Wichita,413,"District Judge, 30th Judicial District",,REP,Jeff McKnight,414,244,170
+Wichita,413,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,413,"District Judge, 30th Judicial District",,,Under Votes,77,50,27
+Wichita,413,Criminal District Attorney,,REP,John Gillespie,413,245,168
+Wichita,413,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,413,Criminal District Attorney,,,Under Votes,78,49,29
+Wichita,413,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",415,245,170
+Wichita,413,County Judge,,,Over Votes,0,0,0
+Wichita,413,County Judge,,,Under Votes,76,49,27
+Wichita,413,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,411,245,166
+Wichita,413,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,413,"Judge, County Court at Law No. 1",,,Under Votes,80,49,31
+Wichita,413,"Judge, County Court at Law No. 2",,REP,Greg King,410,243,167
+Wichita,413,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,413,"Judge, County Court at Law No. 2",,,Under Votes,81,51,30
+Wichita,413,District Clerk,,REP,Patti Flores,419,248,171
+Wichita,413,District Clerk,,,Over Votes,0,0,0
+Wichita,413,District Clerk,,,Under Votes,72,46,26
+Wichita,413,County Clerk,,REP,Lori Bohannon,415,247,168
+Wichita,413,County Clerk,,,Over Votes,0,0,0
+Wichita,413,County Clerk,,,Under Votes,76,47,29
+Wichita,413,County Treasurer,,REP,R. J. Bob Hampton,414,244,170
+Wichita,413,County Treasurer,,,Over Votes,0,0,0
+Wichita,413,County Treasurer,,,Under Votes,77,50,27
+Wichita,413,"County Commissioner, Precinct 4",,REP,Jeff Watts,369,218,151
+Wichita,413,"County Commissioner, Precinct 4",,DEM,Catie Robinson,109,68,41
+Wichita,413,"County Commissioner, Precinct 4",,,Over Votes,1,1,0
+Wichita,413,"County Commissioner, Precinct 4",,,Under Votes,12,7,5
+Wichita,413,"Justice of the Peace, Precinct 4",,REP,Judy Baker,426,250,176
+Wichita,413,"Justice of the Peace, Precinct 4",,,Over Votes,0,0,0
+Wichita,413,"Justice of the Peace, Precinct 4",,,Under Votes,65,44,21
+Wichita,413,City of Wichita Falls Mayor,,,Lowry W. Crane,0,0,0
+Wichita,413,City of Wichita Falls Mayor,,,Stephen L. Santellana,3,0,3
+Wichita,413,City of Wichita Falls Mayor,,,Over Votes,0,0,0
+Wichita,413,City of Wichita Falls Mayor,,,Under Votes,8,8,0
+Wichita,413,Ballots Cast,,,,492,295,197
+Wichita,414,Straight Party,,REP,,159,107,52
+Wichita,414,Straight Party,,DEM,,21,12,9
+Wichita,414,Straight Party,,LIB,,0,0,0
+Wichita,414,Straight Party,,,Over Votes,0,0,0
+Wichita,414,Straight Party,,,Under Votes,118,81,37
+Wichita,414,U.S. Senate,,REP,Ted Cruz,244,164,80
+Wichita,414,U.S. Senate,,DEM,Beto O'Rourke,48,32,16
+Wichita,414,U.S. Senate,,LIB,Neal M. Dikeman,1,1,0
+Wichita,414,U.S. Senate,,,Over Votes,0,0,0
+Wichita,414,U.S. Senate,,,Under Votes,5,3,2
+Wichita,414,U.S. House,13,REP,Mac Thornberry,253,168,85
+Wichita,414,U.S. House,13,DEM,Greg Sagan,40,28,12
+Wichita,414,U.S. House,13,LIB,Calvin DeWeese,4,3,1
+Wichita,414,U.S. House,13,,Over Votes,0,0,0
+Wichita,414,U.S. House,13,,Under Votes,1,1,0
+Wichita,414,Governor,,REP,Greg Abbott,258,173,85
+Wichita,414,Governor,,DEM,Lupe Valdez,39,26,13
+Wichita,414,Governor,,LIB,Mark Jay Tippetts,0,0,0
+Wichita,414,Governor,,,Over Votes,0,0,0
+Wichita,414,Governor,,,Under Votes,1,1,0
+Wichita,414,Lieutenant Governor,,REP,Dan Patrick,243,164,79
+Wichita,414,Lieutenant Governor,,DEM,Mike Collier,50,33,17
+Wichita,414,Lieutenant Governor,,LIB,Kerry Douglas McKennon,1,0,1
+Wichita,414,Lieutenant Governor,,,Over Votes,0,0,0
+Wichita,414,Lieutenant Governor,,,Under Votes,4,3,1
+Wichita,414,Attorney General,,REP,Ken Paxton,251,166,85
+Wichita,414,Attorney General,,DEM,Justin Nelson,42,30,12
+Wichita,414,Attorney General,,LIB,Michael Ray Harris,1,1,0
+Wichita,414,Attorney General,,,Over Votes,0,0,0
+Wichita,414,Attorney General,,,Under Votes,4,3,1
+Wichita,414,Comptroller of Public Accounts,,REP,Glenn Hegar,248,165,83
+Wichita,414,Comptroller of Public Accounts,,DEM,Joi Chevalier,39,27,12
+Wichita,414,Comptroller of Public Accounts,,LIB,Ben Sanders,4,2,2
+Wichita,414,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Wichita,414,Comptroller of Public Accounts,,,Under Votes,7,6,1
+Wichita,414,Commissioner of the General Land Office,,REP,George P. Bush,241,161,80
+Wichita,414,Commissioner of the General Land Office,,DEM,Miguel Suazo,43,30,13
+Wichita,414,Commissioner of the General Land Office,,LIB,Matt Pina,9,6,3
+Wichita,414,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Wichita,414,Commissioner of the General Land Office,,,Under Votes,5,3,2
+Wichita,414,Commissioner of Agriculture,,REP,Sid Miller,247,164,83
+Wichita,414,Commissioner of Agriculture,,DEM,Kim Olson,42,29,13
+Wichita,414,Commissioner of Agriculture,,LIB,Richard Carpenter,4,3,1
+Wichita,414,Commissioner of Agriculture,,,Over Votes,0,0,0
+Wichita,414,Commissioner of Agriculture,,,Under Votes,5,4,1
+Wichita,414,Railroad Commissioner,,REP,Christi Craddick,251,166,85
+Wichita,414,Railroad Commissioner,,DEM,Roman McAllen,39,27,12
+Wichita,414,Railroad Commissioner,,LIB,Mike Wright,1,1,0
+Wichita,414,Railroad Commissioner,,,Over Votes,0,0,0
+Wichita,414,Railroad Commissioner,,,Under Votes,7,6,1
+Wichita,414,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,248,165,83
+Wichita,414,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,40,27,13
+Wichita,414,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Wichita,414,"Justice, Supreme Court, Place 2",,,Under Votes,10,8,2
+Wichita,414,"Justice, Supreme Court, Place 4",,REP,John Devine,246,163,83
+Wichita,414,"Justice, Supreme Court, Place 4",,DEM,R. K. Sandill,42,29,13
+Wichita,414,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Wichita,414,"Justice, Supreme Court, Place 4",,,Under Votes,10,8,2
+Wichita,414,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,249,165,84
+Wichita,414,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,39,26,13
+Wichita,414,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Wichita,414,"Justice, Supreme Court, Place 6",,,Under Votes,10,9,1
+Wichita,414,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,240,159,81
+Wichita,414,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,41,29,12
+Wichita,414,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,5,2,3
+Wichita,414,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Wichita,414,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,12,10,2
+Wichita,414,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,245,162,83
+Wichita,414,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,41,28,13
+Wichita,414,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Wichita,414,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,12,10,2
+Wichita,414,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,248,166,82
+Wichita,414,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,19,13,6
+Wichita,414,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Wichita,414,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,31,21,10
+Wichita,414,State Senator,30,REP,Pat Fallon,250,166,84
+Wichita,414,State Senator,30,DEM,Kevin Lopez,41,28,13
+Wichita,414,State Senator,30,,Over Votes,0,0,0
+Wichita,414,State Senator,30,,Under Votes,7,6,1
+Wichita,414,State Representative,69,REP,James Frank,253,168,85
+Wichita,414,State Representative,69,,Over Votes,0,0,0
+Wichita,414,State Representative,69,,Under Votes,45,32,13
+Wichita,414,"Chief Justice, 2nd Court of Appeals District",,REP,Bonnie Sudderth,250,165,85
+Wichita,414,"Chief Justice, 2nd Court of Appeals District",,,Over Votes,0,0,0
+Wichita,414,"Chief Justice, 2nd Court of Appeals District",,,Under Votes,48,35,13
+Wichita,414,"Justice, 2nd Court of Appeals District, Place 4",,REP,Wade Birdwell,251,167,84
+Wichita,414,"Justice, 2nd Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Wichita,414,"Justice, 2nd Court of Appeals District, Place 4",,,Under Votes,47,33,14
+Wichita,414,"Justice, 2nd Court of Appeals District, Place 5",,REP,Dabney Bassel,239,155,84
+Wichita,414,"Justice, 2nd Court of Appeals District, Place 5",,DEM,Delonia A. Watson,44,31,13
+Wichita,414,"Justice, 2nd Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Wichita,414,"Justice, 2nd Court of Appeals District, Place 5",,,Under Votes,15,14,1
+Wichita,414,"Justice, 2nd Court of Appeals District, Place 6",,REP,Mark Pittman,249,164,85
+Wichita,414,"Justice, 2nd Court of Appeals District, Place 6",,,Over Votes,0,0,0
+Wichita,414,"Justice, 2nd Court of Appeals District, Place 6",,,Under Votes,49,36,13
+Wichita,414,"District Judge, 30th Judicial District",,REP,Jeff McKnight,252,167,85
+Wichita,414,"District Judge, 30th Judicial District",,,Over Votes,0,0,0
+Wichita,414,"District Judge, 30th Judicial District",,,Under Votes,46,33,13
+Wichita,414,Criminal District Attorney,,REP,John Gillespie,248,163,85
+Wichita,414,Criminal District Attorney,,,Over Votes,0,0,0
+Wichita,414,Criminal District Attorney,,,Under Votes,50,37,13
+Wichita,414,County Judge,,REP,"Woodrow W. ""Woody"" Gossom, Jr.",249,165,84
+Wichita,414,County Judge,,,Over Votes,0,0,0
+Wichita,414,County Judge,,,Under Votes,49,35,14
+Wichita,414,"Judge, County Court at Law No. 1",,REP,Gary W. Butler,247,164,83
+Wichita,414,"Judge, County Court at Law No. 1",,,Over Votes,0,0,0
+Wichita,414,"Judge, County Court at Law No. 1",,,Under Votes,51,36,15
+Wichita,414,"Judge, County Court at Law No. 2",,REP,Greg King,250,167,83
+Wichita,414,"Judge, County Court at Law No. 2",,,Over Votes,0,0,0
+Wichita,414,"Judge, County Court at Law No. 2",,,Under Votes,48,33,15
+Wichita,414,District Clerk,,REP,Patti Flores,253,169,84
+Wichita,414,District Clerk,,,Over Votes,0,0,0
+Wichita,414,District Clerk,,,Under Votes,45,31,14
+Wichita,414,County Clerk,,REP,Lori Bohannon,255,171,84
+Wichita,414,County Clerk,,,Over Votes,0,0,0
+Wichita,414,County Clerk,,,Under Votes,43,29,14
+Wichita,414,County Treasurer,,REP,R. J. Bob Hampton,251,167,84
+Wichita,414,County Treasurer,,,Over Votes,0,0,0
+Wichita,414,County Treasurer,,,Under Votes,47,33,14
+Wichita,414,"County Commissioner, Precinct 4",,REP,Jeff Watts,227,148,79
+Wichita,414,"County Commissioner, Precinct 4",,DEM,Catie Robinson,67,50,17
+Wichita,414,"County Commissioner, Precinct 4",,,Over Votes,0,0,0
+Wichita,414,"County Commissioner, Precinct 4",,,Under Votes,4,2,2
+Wichita,414,"Justice of the Peace, Precinct 4",,REP,Judy Baker,262,176,86
+Wichita,414,"Justice of the Peace, Precinct 4",,,Over Votes,0,0,0
+Wichita,414,"Justice of the Peace, Precinct 4",,,Under Votes,36,24,12
+Wichita,414,Ballots Cast,,,,298,200,98


### PR DESCRIPTION
How troublesome.

This was a old-style Hart precinct PDF, parsed using Ghostscript and `pdf.py`.

Ballots cast + overvotes + undervotes did not equal the listed "Ballots Cast" number for precincts 302 and 401. For those precincts, I listed the calculated EV/ED ballots cast, but it does not sum to the total ballots cast (in the `votes` field).