### PR TITLE
Add precinct-level results for the 2018 general election in Randall County

### DIFF
--- a/2018/20181106__tx__general__randall__precinct.csv
+++ b/2018/20181106__tx__general__randall__precinct.csv
@@ -1,0 +1,1620 @@
+county,precinct,office,district,party,candidate,votes,early_voting,election_day
+Randall,110 CISD,Registered Voters,,,,4916,,
+Randall,110 CISD,Provisional Ballots,,,,20,,
+Randall,110 CISD,Provisional Ballots Counted,,,,10,,
+Randall,110 CISD,Straight Party,,REP,Republican Party,1888,1385,503
+Randall,110 CISD,Straight Party,,DEM,Democratic Party,209,161,48
+Randall,110 CISD,Straight Party,,LIB,Libertarian Party,9,5,4
+Randall,110 CISD,U.S. Senate,,REP,Ted Cruz,2426,1790,636
+Randall,110 CISD,U.S. Senate,,DEM,Beto O'Rourke,369,279,90
+Randall,110 CISD,U.S. Senate,,LIB,Neal M. Dikeman,20,13,7
+Randall,110 CISD,U.S. House,13,REP,Mac Thornberry,2431,1784,647
+Randall,110 CISD,U.S. House,13,DEM,Greg Sagan,329,262,67
+Randall,110 CISD,U.S. House,13,LIB,Calvin DeWeese,36,22,14
+Randall,110 CISD,Governor,,REP,Greg Abbott,2463,1808,655
+Randall,110 CISD,Governor,,DEM,Lupe Valdez,320,260,60
+Randall,110 CISD,Governor,,LIB,Mark Jay Tippetts,25,12,13
+Randall,110 CISD,Lieutenant Governor,,REP,Dan Patrick,2384,1756,628
+Randall,110 CISD,Lieutenant Governor,,DEM,Mike Collier,375,291,84
+Randall,110 CISD,Lieutenant Governor,,LIB,Kerry Douglas McKennon,42,27,15
+Randall,110 CISD,Attorney General,,REP,Ken Paxton,2380,1750,630
+Randall,110 CISD,Attorney General,,DEM,Justin Nelson,373,291,82
+Randall,110 CISD,Attorney General,,LIB,Michael Ray Harris,46,33,13
+Randall,110 CISD,Comptroller of Public Accounts,,REP,Glenn Hegar,2419,1787,632
+Randall,110 CISD,Comptroller of Public Accounts,,DEM,Joi Chevalier,318,251,67
+Randall,110 CISD,Comptroller of Public Accounts,,LIB,Ben Sanders,60,36,24
+Randall,110 CISD,Commissioner of the General Land Office,,REP,George P. Bush,2380,1749,631
+Randall,110 CISD,Commissioner of the General Land Office,,DEM,Miguel Suazo,323,255,68
+Randall,110 CISD,Commissioner of the General Land Office,,LIB,Matt Pina,87,62,25
+Randall,110 CISD,Commissioner of Agriculture,,REP,Sid Miller,2384,1759,625
+Randall,110 CISD,Commissioner of Agriculture,,DEM,Kim Olson,365,282,83
+Randall,110 CISD,Commissioner of Agriculture,,LIB,Richard Carpenter,47,33,14
+Randall,110 CISD,Railroad Commissioner,,REP,Christi Craddick,2414,1776,638
+Randall,110 CISD,Railroad Commissioner,,DEM,Roman McAllen,326,259,67
+Randall,110 CISD,Railroad Commissioner,,LIB,Mike Wright,49,31,18
+Randall,110 CISD,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,2433,1791,642
+Randall,110 CISD,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,359,279,80
+Randall,110 CISD,"Justice, Supreme Court, Place 4",,REP,John Devine,2435,1795,640
+Randall,110 CISD,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,352,270,82
+Randall,110 CISD,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,2445,1796,649
+Randall,110 CISD,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,342,269,73
+Randall,110 CISD,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,2414,1779,635
+Randall,110 CISD,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,340,264,76
+Randall,110 CISD,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,39,26,13
+Randall,110 CISD,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,2455,1810,645
+Randall,110 CISD,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,334,255,79
+Randall,110 CISD,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,2474,1823,651
+Randall,110 CISD,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,218,160,58
+Randall,110 CISD,State Senator,31,REP,Kel Seliger,2428,1785,643
+Randall,110 CISD,State Senator,31,LIB,Jack B. Westbrook,276,206,70
+Randall,110 CISD,State Representative,86,REP,John Smithee,2438,1796,642
+Randall,110 CISD,State Representative,86,DEM,Mike Purcell,348,265,83
+Randall,110 CISD,"Justice, 7th Court of Appeals District, Place 2",,REP,Judy Parker,2545,1870,675
+Randall,110 CISD,"Justice, 7th Court of Appeals District, Place 3",,REP,Pat Pirtle,2536,1864,672
+Randall,110 CISD,"District Judge, 47th Judicial District",,REP,Dan L. Schaap,2533,1864,669
+Randall,110 CISD,"District Judge, 181st Judicial District",,REP,John B. Board,2528,1859,669
+Randall,110 CISD,"District Judge, 251st Judicial District",,REP,Ana Elizabeth Estevez,2533,1859,674
+Randall,110 CISD,Criminal District Attorney,,REP,Robert Love,2527,1857,670
+Randall,110 CISD,County Judge,,REP,Ernie Houdashell,2538,1865,673
+Randall,110 CISD,"Judge, County Court at Law 1",,REP,James W. Anderson,2532,1861,671
+Randall,110 CISD,"Judge, County Court at Law 2",,REP,Matt Martindale,2531,1860,671
+Randall,110 CISD,District Clerk,,REP,Joel Forbis,2525,1855,670
+Randall,110 CISD,County Clerk,,REP,Susan Allen,2526,1856,670
+Randall,110 CISD,County Treasurer,,REP,Angie Parker,2526,1858,668
+Randall,110 CISD,"Justice of the Peace, Precinct 4",,REP,Clay Houdashell,2524,1852,672
+Randall,111,Registered Voters,,,,4845,,
+Randall,111,Provisional Ballots,,,,11,,
+Randall,111,Provisional Ballots Counted,,,,5,,
+Randall,111,Straight Party,,REP,Republican Party,1073,803,270
+Randall,111,Straight Party,,DEM,Democratic Party,423,267,156
+Randall,111,Straight Party,,LIB,Libertarian Party,11,6,5
+Randall,111,U.S. Senate,,REP,Ted Cruz,1354,1016,338
+Randall,111,U.S. Senate,,DEM,Beto O'Rourke,656,420,236
+Randall,111,U.S. Senate,,LIB,Neal M. Dikeman,17,8,9
+Randall,111,U.S. House,13,REP,Mac Thornberry,1443,1057,386
+Randall,111,U.S. House,13,DEM,Greg Sagan,544,358,186
+Randall,111,U.S. House,13,LIB,Calvin DeWeese,32,22,10
+Randall,111,Governor,,REP,Greg Abbott,1440,1056,384
+Randall,111,Governor,,DEM,Lupe Valdez,554,370,184
+Randall,111,Governor,,LIB,Mark Jay Tippetts,33,18,15
+Randall,111,Lieutenant Governor,,REP,Dan Patrick,1368,1020,348
+Randall,111,Lieutenant Governor,,DEM,Mike Collier,601,390,211
+Randall,111,Lieutenant Governor,,LIB,Kerry Douglas McKennon,49,28,21
+Randall,111,Attorney General,,REP,Ken Paxton,1349,990,359
+Randall,111,Attorney General,,DEM,Justin Nelson,623,418,205
+Randall,111,Attorney General,,LIB,Michael Ray Harris,41,25,16
+Randall,111,Comptroller of Public Accounts,,REP,Glenn Hegar,1376,1023,353
+Randall,111,Comptroller of Public Accounts,,DEM,Joi Chevalier,565,368,197
+Randall,111,Comptroller of Public Accounts,,LIB,Ben Sanders,69,41,28
+Randall,111,Commissioner of the General Land Office,,REP,George P. Bush,1387,1025,362
+Randall,111,Commissioner of the General Land Office,,DEM,Miguel Suazo,564,368,196
+Randall,111,Commissioner of the General Land Office,,LIB,Matt Pina,68,44,24
+Randall,111,Commissioner of Agriculture,,REP,Sid Miller,1374,1016,358
+Randall,111,Commissioner of Agriculture,,DEM,Kim Olson,591,389,202
+Randall,111,Commissioner of Agriculture,,LIB,Richard Carpenter,45,28,17
+Randall,111,Railroad Commissioner,,REP,Christi Craddick,1373,1013,360
+Randall,111,Railroad Commissioner,,DEM,Roman McAllen,585,387,198
+Randall,111,Railroad Commissioner,,LIB,Mike Wright,48,29,19
+Randall,111,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1385,1017,368
+Randall,111,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,626,418,208
+Randall,111,"Justice, Supreme Court, Place 4",,REP,John Devine,1397,1026,371
+Randall,111,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,614,408,206
+Randall,111,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1396,1032,364
+Randall,111,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,614,401,213
+Randall,111,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1365,1011,354
+Randall,111,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,584,383,201
+Randall,111,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,60,38,22
+Randall,111,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1384,1021,363
+Randall,111,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,622,410,212
+Randall,111,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1484,1081,403
+Randall,111,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,354,232,122
+Randall,111,State Senator,31,REP,Kel Seliger,1498,1086,412
+Randall,111,State Senator,31,LIB,Jack B. Westbrook,358,236,122
+Randall,111,State Representative,86,REP,John Smithee,1397,1025,372
+Randall,111,State Representative,86,DEM,Mike Purcell,613,405,208
+Randall,111,"Justice, 7th Court of Appeals District, Place 2",,REP,Judy Parker,1644,1176,468
+Randall,111,"Justice, 7th Court of Appeals District, Place 3",,REP,Pat Pirtle,1627,1164,463
+Randall,111,"District Judge, 47th Judicial District",,REP,Dan L. Schaap,1621,1160,461
+Randall,111,"District Judge, 181st Judicial District",,REP,John B. Board,1621,1160,461
+Randall,111,"District Judge, 251st Judicial District",,REP,Ana Elizabeth Estevez,1641,1175,466
+Randall,111,Criminal District Attorney,,REP,Robert Love,1614,1153,461
+Randall,111,County Judge,,REP,Ernie Houdashell,1622,1161,461
+Randall,111,"Judge, County Court at Law 1",,REP,James W. Anderson,1616,1154,462
+Randall,111,"Judge, County Court at Law 2",,REP,Matt Martindale,1621,1162,459
+Randall,111,District Clerk,,REP,Joel Forbis,1608,1152,456
+Randall,111,County Clerk,,REP,Susan Allen,1617,1154,463
+Randall,111,County Treasurer,,REP,Angie Parker,1613,1155,458
+Randall,111,"Justice of the Peace, Precinct 4",,REP,Clay Houdashell,1618,1159,459
+Randall,112,Registered Voters,,,,4009,,
+Randall,112,Provisional Ballots,,,,13,,
+Randall,112,Provisional Ballots Counted,,,,3,,
+Randall,112,Straight Party,,REP,Republican Party,749,518,231
+Randall,112,Straight Party,,DEM,Democratic Party,271,184,87
+Randall,112,Straight Party,,LIB,Libertarian Party,9,5,4
+Randall,112,U.S. Senate,,REP,Ted Cruz,1012,705,307
+Randall,112,U.S. Senate,,DEM,Beto O'Rourke,440,303,137
+Randall,112,U.S. Senate,,LIB,Neal M. Dikeman,19,12,7
+Randall,112,U.S. House,13,REP,Mac Thornberry,1044,721,323
+Randall,112,U.S. House,13,DEM,Greg Sagan,390,278,112
+Randall,112,U.S. House,13,LIB,Calvin DeWeese,32,18,14
+Randall,112,Governor,,REP,Greg Abbott,1034,718,316
+Randall,112,Governor,,DEM,Lupe Valdez,395,274,121
+Randall,112,Governor,,LIB,Mark Jay Tippetts,37,25,12
+Randall,112,Lieutenant Governor,,REP,Dan Patrick,999,699,300
+Randall,112,Lieutenant Governor,,DEM,Mike Collier,418,286,132
+Randall,112,Lieutenant Governor,,LIB,Kerry Douglas McKennon,45,29,16
+Randall,112,Attorney General,,REP,Ken Paxton,989,692,297
+Randall,112,Attorney General,,DEM,Justin Nelson,418,284,134
+Randall,112,Attorney General,,LIB,Michael Ray Harris,54,37,17
+Randall,112,Comptroller of Public Accounts,,REP,Glenn Hegar,992,691,301
+Randall,112,Comptroller of Public Accounts,,DEM,Joi Chevalier,388,273,115
+Randall,112,Comptroller of Public Accounts,,LIB,Ben Sanders,77,47,30
+Randall,112,Commissioner of the General Land Office,,REP,George P. Bush,994,690,304
+Randall,112,Commissioner of the General Land Office,,DEM,Miguel Suazo,393,278,115
+Randall,112,Commissioner of the General Land Office,,LIB,Matt Pina,70,44,26
+Randall,112,Commissioner of Agriculture,,REP,Sid Miller,989,688,301
+Randall,112,Commissioner of Agriculture,,DEM,Kim Olson,407,288,119
+Randall,112,Commissioner of Agriculture,,LIB,Richard Carpenter,62,36,26
+Randall,112,Railroad Commissioner,,REP,Christi Craddick,1014,711,303
+Randall,112,Railroad Commissioner,,DEM,Roman McAllen,378,267,111
+Randall,112,Railroad Commissioner,,LIB,Mike Wright,68,36,32
+Randall,112,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1016,708,308
+Randall,112,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,439,300,139
+Randall,112,"Justice, Supreme Court, Place 4",,REP,John Devine,1027,711,316
+Randall,112,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,430,300,130
+Randall,112,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1025,713,312
+Randall,112,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,430,296,134
+Randall,112,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,991,697,294
+Randall,112,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,400,275,125
+Randall,112,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,67,39,28
+Randall,112,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1026,715,311
+Randall,112,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,428,294,134
+Randall,112,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1052,730,322
+Randall,112,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,291,198,93
+Randall,112,State Senator,31,REP,Kel Seliger,1050,726,324
+Randall,112,State Senator,31,LIB,Jack B. Westbrook,313,220,93
+Randall,112,State Representative,86,REP,John Smithee,1037,724,313
+Randall,112,State Representative,86,DEM,Mike Purcell,413,284,129
+Randall,112,"Justice, 7th Court of Appeals District, Place 2",,REP,Judy Parker,1164,801,363
+Randall,112,"Justice, 7th Court of Appeals District, Place 3",,REP,Pat Pirtle,1161,803,358
+Randall,112,"District Judge, 47th Judicial District",,REP,Dan L. Schaap,1162,801,361
+Randall,112,"District Judge, 181st Judicial District",,REP,John B. Board,1162,800,362
+Randall,112,"District Judge, 251st Judicial District",,REP,Ana Elizabeth Estevez,1166,802,364
+Randall,112,Criminal District Attorney,,REP,Robert Love,1151,791,360
+Randall,112,County Judge,,REP,Ernie Houdashell,1156,797,359
+Randall,112,"Judge, County Court at Law 1",,REP,James W. Anderson,1145,786,359
+Randall,112,"Judge, County Court at Law 2",,REP,Matt Martindale,1152,791,361
+Randall,112,District Clerk,,REP,Joel Forbis,1143,786,357
+Randall,112,County Clerk,,REP,Susan Allen,1147,790,357
+Randall,112,County Treasurer,,REP,Angie Parker,1144,787,357
+Randall,112,"Justice of the Peace, Precinct 4",,REP,Clay Houdashell,1145,788,357
+Randall,114,Registered Voters,,,,3236,,
+Randall,114,Provisional Ballots,,,,12,,
+Randall,114,Provisional Ballots Counted,,,,4,,
+Randall,114,Straight Party,,REP,Republican Party,769,526,243
+Randall,114,Straight Party,,DEM,Democratic Party,242,171,71
+Randall,114,Straight Party,,LIB,Libertarian Party,11,6,5
+Randall,114,U.S. Senate,,REP,Ted Cruz,1059,744,315
+Randall,114,U.S. Senate,,DEM,Beto O'Rourke,396,286,110
+Randall,114,U.S. Senate,,LIB,Neal M. Dikeman,16,9,7
+Randall,114,U.S. House,13,REP,Mac Thornberry,1102,772,330
+Randall,114,U.S. House,13,DEM,Greg Sagan,342,250,92
+Randall,114,U.S. House,13,LIB,Calvin DeWeese,28,16,12
+Randall,114,Governor,,REP,Greg Abbott,1100,765,335
+Randall,114,Governor,,DEM,Lupe Valdez,349,260,89
+Randall,114,Governor,,LIB,Mark Jay Tippetts,26,16,10
+Randall,114,Lieutenant Governor,,REP,Dan Patrick,1029,719,310
+Randall,114,Lieutenant Governor,,DEM,Mike Collier,396,285,111
+Randall,114,Lieutenant Governor,,LIB,Kerry Douglas McKennon,41,30,11
+Randall,114,Attorney General,,REP,Ken Paxton,1041,720,321
+Randall,114,Attorney General,,DEM,Justin Nelson,389,288,101
+Randall,114,Attorney General,,LIB,Michael Ray Harris,40,29,11
+Randall,114,Comptroller of Public Accounts,,REP,Glenn Hegar,1048,733,315
+Randall,114,Comptroller of Public Accounts,,DEM,Joi Chevalier,348,259,89
+Randall,114,Comptroller of Public Accounts,,LIB,Ben Sanders,66,39,27
+Randall,114,Commissioner of the General Land Office,,REP,George P. Bush,1061,743,318
+Randall,114,Commissioner of the General Land Office,,DEM,Miguel Suazo,357,259,98
+Randall,114,Commissioner of the General Land Office,,LIB,Matt Pina,46,30,16
+Randall,114,Commissioner of Agriculture,,REP,Sid Miller,1046,728,318
+Randall,114,Commissioner of Agriculture,,DEM,Kim Olson,381,279,102
+Randall,114,Commissioner of Agriculture,,LIB,Richard Carpenter,34,22,12
+Randall,114,Railroad Commissioner,,REP,Christi Craddick,1062,743,319
+Randall,114,Railroad Commissioner,,DEM,Roman McAllen,354,258,96
+Randall,114,Railroad Commissioner,,LIB,Mike Wright,41,25,16
+Randall,114,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1078,751,327
+Randall,114,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,386,284,102
+Randall,114,"Justice, Supreme Court, Place 4",,REP,John Devine,1074,750,324
+Randall,114,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,380,278,102
+Randall,114,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1073,746,327
+Randall,114,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,386,284,102
+Randall,114,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1042,727,315
+Randall,114,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,366,268,98
+Randall,114,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,48,33,15
+Randall,114,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1085,761,324
+Randall,114,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,366,262,104
+Randall,114,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1120,784,336
+Randall,114,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,233,161,72
+Randall,114,State Senator,31,REP,Kel Seliger,1130,790,340
+Randall,114,State Senator,31,LIB,Jack B. Westbrook,259,182,77
+Randall,114,State Representative,86,REP,John Smithee,1086,759,327
+Randall,114,State Representative,86,DEM,Mike Purcell,376,273,103
+Randall,114,"Justice, 7th Court of Appeals District, Place 2",,REP,Judy Parker,1228,856,372
+Randall,114,"Justice, 7th Court of Appeals District, Place 3",,REP,Pat Pirtle,1222,851,371
+Randall,114,"District Judge, 47th Judicial District",,REP,Dan L. Schaap,1206,838,368
+Randall,114,"District Judge, 181st Judicial District",,REP,John B. Board,1204,835,369
+Randall,114,"District Judge, 251st Judicial District",,REP,Ana Elizabeth Estevez,1214,841,373
+Randall,114,Criminal District Attorney,,REP,Robert Love,1203,834,369
+Randall,114,County Judge,,REP,Ernie Houdashell,1207,840,367
+Randall,114,"Judge, County Court at Law 1",,REP,James W. Anderson,1193,829,364
+Randall,114,"Judge, County Court at Law 2",,REP,Matt Martindale,1207,840,367
+Randall,114,District Clerk,,REP,Joel Forbis,1194,829,365
+Randall,114,County Clerk,,REP,Susan Allen,1192,826,366
+Randall,114,County Treasurer,,REP,Angie Parker,1191,826,365
+Randall,114,"Justice of the Peace, Precinct 4",,REP,Clay Houdashell,1200,836,364
+Randall,123 CISD,Registered Voters,,,,1561,,
+Randall,123 CISD,Provisional Ballots,,,,24,,
+Randall,123 CISD,Provisional Ballots Counted,,,,2,,
+Randall,123 CISD,Straight Party,,REP,Republican Party,438,336,102
+Randall,123 CISD,Straight Party,,DEM,Democratic Party,152,107,45
+Randall,123 CISD,Straight Party,,LIB,Libertarian Party,10,6,4
+Randall,123 CISD,U.S. Senate,,REP,Ted Cruz,620,484,136
+Randall,123 CISD,U.S. Senate,,DEM,Beto O'Rourke,257,185,72
+Randall,123 CISD,U.S. Senate,,LIB,Neal M. Dikeman,6,4,2
+Randall,123 CISD,U.S. House,13,REP,Mac Thornberry,628,485,143
+Randall,123 CISD,U.S. House,13,DEM,Greg Sagan,200,142,58
+Randall,123 CISD,U.S. House,13,LIB,Calvin DeWeese,24,18,6
+Randall,123 CISD,Governor,,REP,Greg Abbott,639,496,143
+Randall,123 CISD,Governor,,DEM,Lupe Valdez,222,164,58
+Randall,123 CISD,Governor,,LIB,Mark Jay Tippetts,20,13,7
+Randall,123 CISD,Lieutenant Governor,,REP,Dan Patrick,598,464,134
+Randall,123 CISD,Lieutenant Governor,,DEM,Mike Collier,242,177,65
+Randall,123 CISD,Lieutenant Governor,,LIB,Kerry Douglas McKennon,33,24,9
+Randall,123 CISD,Attorney General,,REP,Ken Paxton,610,474,136
+Randall,123 CISD,Attorney General,,DEM,Justin Nelson,232,172,60
+Randall,123 CISD,Attorney General,,LIB,Michael Ray Harris,33,21,12
+Randall,123 CISD,Comptroller of Public Accounts,,REP,Glenn Hegar,636,495,141
+Randall,123 CISD,Comptroller of Public Accounts,,DEM,Joi Chevalier,202,147,55
+Randall,123 CISD,Comptroller of Public Accounts,,LIB,Ben Sanders,36,25,11
+Randall,123 CISD,Commissioner of the General Land Office,,REP,George P. Bush,625,486,139
+Randall,123 CISD,Commissioner of the General Land Office,,DEM,Miguel Suazo,214,155,59
+Randall,123 CISD,Commissioner of the General Land Office,,LIB,Matt Pina,36,27,9
+Randall,123 CISD,Commissioner of Agriculture,,REP,Sid Miller,622,480,142
+Randall,123 CISD,Commissioner of Agriculture,,DEM,Kim Olson,224,167,57
+Randall,123 CISD,Commissioner of Agriculture,,LIB,Richard Carpenter,23,15,8
+Randall,123 CISD,Railroad Commissioner,,REP,Christi Craddick,637,493,144
+Randall,123 CISD,Railroad Commissioner,,DEM,Roman McAllen,202,149,53
+Randall,123 CISD,Railroad Commissioner,,LIB,Mike Wright,32,23,9
+Randall,123 CISD,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,625,486,139
+Randall,123 CISD,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,242,175,67
+Randall,123 CISD,"Justice, Supreme Court, Place 4",,REP,John Devine,633,492,141
+Randall,123 CISD,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,237,172,65
+Randall,123 CISD,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,637,497,140
+Randall,123 CISD,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,231,166,65
+Randall,123 CISD,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,620,482,138
+Randall,123 CISD,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,214,155,59
+Randall,123 CISD,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,35,24,11
+Randall,123 CISD,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,636,494,142
+Randall,123 CISD,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,229,166,63
+Randall,123 CISD,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,673,518,155
+Randall,123 CISD,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,153,110,43
+Randall,123 CISD,State Senator,31,REP,Kel Seliger,652,501,151
+Randall,123 CISD,State Senator,31,LIB,Jack B. Westbrook,163,115,48
+Randall,123 CISD,State Representative,86,REP,John Smithee,631,488,143
+Randall,123 CISD,State Representative,86,DEM,Mike Purcell,219,156,63
+Randall,123 CISD,"Justice, 7th Court of Appeals District, Place 2",,REP,Judy Parker,744,566,178
+Randall,123 CISD,"Justice, 7th Court of Appeals District, Place 3",,REP,Pat Pirtle,733,558,175
+Randall,123 CISD,"District Judge, 47th Judicial District",,REP,Dan L. Schaap,724,550,174
+Randall,123 CISD,"District Judge, 181st Judicial District",,REP,John B. Board,724,550,174
+Randall,123 CISD,"District Judge, 251st Judicial District",,REP,Ana Elizabeth Estevez,728,553,175
+Randall,123 CISD,Criminal District Attorney,,REP,Robert Love,724,553,171
+Randall,123 CISD,County Judge,,REP,Ernie Houdashell,720,547,173
+Randall,123 CISD,"Judge, County Court at Law 1",,REP,James W. Anderson,724,551,173
+Randall,123 CISD,"Judge, County Court at Law 2",,REP,Matt Martindale,722,549,173
+Randall,123 CISD,District Clerk,,REP,Joel Forbis,717,542,175
+Randall,123 CISD,County Clerk,,REP,Susan Allen,725,551,174
+Randall,123 CISD,County Treasurer,,REP,Angie Parker,723,548,175
+Randall,123 CISD,"Justice of the Peace, Precinct 1",,REP,J. Tracy Byrd,723,549,174
+Randall,123 CISD,"Constable, Precinct 1, Unexpired Term",,REP,Richard Beals,698,528,170
+Randall,123 CISD,"Constable, Precinct 1, Unexpired Term",,,"Patrick ""Tinsley"" Tinsley",9,7,2
+Randall,123 CISD,"Constable, Precinct 1, Unexpired Term",,,Rejected write-ins,10,8,2
+Randall,123 CISD,"Constable, Precinct 1, Unexpired Term",,,Unassigned write-ins,0,0,0
+Randall,208,Registered Voters,,,,1025,,
+Randall,208,Provisional Ballots,,,,6,,
+Randall,208,Provisional Ballots Counted,,,,4,,
+Randall,208,Straight Party,,REP,Republican Party,427,289,138
+Randall,208,Straight Party,,DEM,Democratic Party,24,22,2
+Randall,208,Straight Party,,LIB,Libertarian Party,1,0,1
+Randall,208,U.S. Senate,,REP,Ted Cruz,589,407,182
+Randall,208,U.S. Senate,,DEM,Beto O'Rourke,49,43,6
+Randall,208,U.S. Senate,,LIB,Neal M. Dikeman,2,2,0
+Randall,208,U.S. House,13,REP,Mac Thornberry,588,406,182
+Randall,208,U.S. House,13,DEM,Greg Sagan,39,35,4
+Randall,208,U.S. House,13,LIB,Calvin DeWeese,8,6,2
+Randall,208,Governor,,REP,Greg Abbott,591,409,182
+Randall,208,Governor,,DEM,Lupe Valdez,42,38,4
+Randall,208,Governor,,LIB,Mark Jay Tippetts,6,4,2
+Randall,208,Lieutenant Governor,,REP,Dan Patrick,554,385,169
+Randall,208,Lieutenant Governor,,DEM,Mike Collier,69,57,12
+Randall,208,Lieutenant Governor,,LIB,Kerry Douglas McKennon,14,7,7
+Randall,208,Attorney General,,REP,Ken Paxton,572,396,176
+Randall,208,Attorney General,,DEM,Justin Nelson,52,48,4
+Randall,208,Attorney General,,LIB,Michael Ray Harris,11,4,7
+Randall,208,Comptroller of Public Accounts,,REP,Glenn Hegar,582,404,178
+Randall,208,Comptroller of Public Accounts,,DEM,Joi Chevalier,40,37,3
+Randall,208,Comptroller of Public Accounts,,LIB,Ben Sanders,13,8,5
+Randall,208,Commissioner of the General Land Office,,REP,George P. Bush,579,400,179
+Randall,208,Commissioner of the General Land Office,,DEM,Miguel Suazo,40,37,3
+Randall,208,Commissioner of the General Land Office,,LIB,Matt Pina,19,13,6
+Randall,208,Commissioner of Agriculture,,REP,Sid Miller,575,399,176
+Randall,208,Commissioner of Agriculture,,DEM,Kim Olson,49,44,5
+Randall,208,Commissioner of Agriculture,,LIB,Richard Carpenter,12,6,6
+Randall,208,Railroad Commissioner,,REP,Christi Craddick,580,403,177
+Randall,208,Railroad Commissioner,,DEM,Roman McAllen,39,36,3
+Randall,208,Railroad Commissioner,,LIB,Mike Wright,15,8,7
+Randall,208,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,583,402,181
+Randall,208,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,50,45,5
+Randall,208,"Justice, Supreme Court, Place 4",,REP,John Devine,587,405,182
+Randall,208,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,45,41,4
+Randall,208,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,583,401,182
+Randall,208,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,48,44,4
+Randall,208,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,579,403,176
+Randall,208,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,42,38,4
+Randall,208,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,11,5,6
+Randall,208,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,585,403,182
+Randall,208,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,45,41,4
+Randall,208,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,583,407,176
+Randall,208,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,34,25,9
+Randall,208,State Senator,31,REP,Kel Seliger,574,399,175
+Randall,208,State Senator,31,LIB,Jack B. Westbrook,46,36,10
+Randall,208,State Representative,86,REP,John Smithee,582,401,181
+Randall,208,State Representative,86,DEM,Mike Purcell,49,43,6
+Randall,208,"Justice, 7th Court of Appeals District, Place 2",,REP,Judy Parker,602,417,185
+Randall,208,"Justice, 7th Court of Appeals District, Place 3",,REP,Pat Pirtle,602,417,185
+Randall,208,"District Judge, 47th Judicial District",,REP,Dan L. Schaap,600,415,185
+Randall,208,"District Judge, 181st Judicial District",,REP,John B. Board,599,414,185
+Randall,208,"District Judge, 251st Judicial District",,REP,Ana Elizabeth Estevez,599,414,185
+Randall,208,Criminal District Attorney,,REP,Robert Love,598,413,185
+Randall,208,County Judge,,REP,Ernie Houdashell,597,412,185
+Randall,208,"Judge, County Court at Law 1",,REP,James W. Anderson,595,410,185
+Randall,208,"Judge, County Court at Law 2",,REP,Matt Martindale,595,411,184
+Randall,208,District Clerk,,REP,Joel Forbis,596,411,185
+Randall,208,County Clerk,,REP,Susan Allen,596,411,185
+Randall,208,County Treasurer,,REP,Angie Parker,596,411,185
+Randall,208,"County Commissioner, Precinct 2",,REP,Mark C. Benton,596,410,186
+Randall,208,"Justice of the Peace, Precinct 4",,REP,Clay Houdashell,600,415,185
+Randall,208 CISD,Registered Voters,,,,4844,,
+Randall,208 CISD,Provisional Ballots,,,,22,,
+Randall,208 CISD,Provisional Ballots Counted,,,,9,,
+Randall,208 CISD,Straight Party,,REP,Republican Party,1604,1234,370
+Randall,208 CISD,Straight Party,,DEM,Democratic Party,326,243,83
+Randall,208 CISD,Straight Party,,LIB,Libertarian Party,12,5,7
+Randall,208 CISD,U.S. Senate,,REP,Ted Cruz,2161,1661,500
+Randall,208 CISD,U.S. Senate,,DEM,Beto O'Rourke,616,452,164
+Randall,208 CISD,U.S. Senate,,LIB,Neal M. Dikeman,24,8,16
+Randall,208 CISD,U.S. House,13,REP,Mac Thornberry,2260,1711,549
+Randall,208 CISD,U.S. House,13,DEM,Greg Sagan,481,372,109
+Randall,208 CISD,U.S. House,13,LIB,Calvin DeWeese,39,22,17
+Randall,208 CISD,Governor,,REP,Greg Abbott,2241,1703,538
+Randall,208 CISD,Governor,,DEM,Lupe Valdez,519,394,125
+Randall,208 CISD,Governor,,LIB,Mark Jay Tippetts,33,18,15
+Randall,208 CISD,Lieutenant Governor,,REP,Dan Patrick,2096,1612,484
+Randall,208 CISD,Lieutenant Governor,,DEM,Mike Collier,614,455,159
+Randall,208 CISD,Lieutenant Governor,,LIB,Kerry Douglas McKennon,69,38,31
+Randall,208 CISD,Attorney General,,REP,Ken Paxton,2131,1636,495
+Randall,208 CISD,Attorney General,,DEM,Justin Nelson,571,426,145
+Randall,208 CISD,Attorney General,,LIB,Michael Ray Harris,71,33,38
+Randall,208 CISD,Comptroller of Public Accounts,,REP,Glenn Hegar,2197,1679,518
+Randall,208 CISD,Comptroller of Public Accounts,,DEM,Joi Chevalier,502,380,122
+Randall,208 CISD,Comptroller of Public Accounts,,LIB,Ben Sanders,68,36,32
+Randall,208 CISD,Commissioner of the General Land Office,,REP,George P. Bush,2209,1675,534
+Randall,208 CISD,Commissioner of the General Land Office,,DEM,Miguel Suazo,500,382,118
+Randall,208 CISD,Commissioner of the General Land Office,,LIB,Matt Pina,63,39,24
+Randall,208 CISD,Commissioner of Agriculture,,REP,Sid Miller,2150,1645,505
+Randall,208 CISD,Commissioner of Agriculture,,DEM,Kim Olson,554,416,138
+Randall,208 CISD,Commissioner of Agriculture,,LIB,Richard Carpenter,53,25,28
+Randall,208 CISD,Railroad Commissioner,,REP,Christi Craddick,2184,1673,511
+Randall,208 CISD,Railroad Commissioner,,DEM,Roman McAllen,505,381,124
+Randall,208 CISD,Railroad Commissioner,,LIB,Mike Wright,73,36,37
+Randall,208 CISD,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,2209,1677,532
+Randall,208 CISD,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,555,416,139
+Randall,208 CISD,"Justice, Supreme Court, Place 4",,REP,John Devine,2215,1680,535
+Randall,208 CISD,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,547,411,136
+Randall,208 CISD,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,2217,1683,534
+Randall,208 CISD,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,551,414,137
+Randall,208 CISD,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,2183,1665,518
+Randall,208 CISD,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,531,403,128
+Randall,208 CISD,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,53,24,29
+Randall,208 CISD,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,2228,1690,538
+Randall,208 CISD,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,534,401,133
+Randall,208 CISD,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,2319,1756,563
+Randall,208 CISD,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,323,233,90
+Randall,208 CISD,State Senator,31,REP,Kel Seliger,2289,1739,550
+Randall,208 CISD,State Senator,31,LIB,Jack B. Westbrook,382,272,110
+Randall,208 CISD,State Representative,86,REP,John Smithee,2238,1703,535
+Randall,208 CISD,State Representative,86,DEM,Mike Purcell,527,385,142
+Randall,208 CISD,"Justice, 7th Court of Appeals District, Place 2",,REP,Judy Parker,2456,1853,603
+Randall,208 CISD,"Justice, 7th Court of Appeals District, Place 3",,REP,Pat Pirtle,2450,1849,601
+Randall,208 CISD,"District Judge, 47th Judicial District",,REP,Dan L. Schaap,2429,1830,599
+Randall,208 CISD,"District Judge, 181st Judicial District",,REP,John B. Board,2420,1827,593
+Randall,208 CISD,"District Judge, 251st Judicial District",,REP,Ana Elizabeth Estevez,2420,1825,595
+Randall,208 CISD,Criminal District Attorney,,REP,Robert Love,2412,1818,594
+Randall,208 CISD,County Judge,,REP,Ernie Houdashell,2417,1821,596
+Randall,208 CISD,"Judge, County Court at Law 1",,REP,James W. Anderson,2409,1816,593
+Randall,208 CISD,"Judge, County Court at Law 2",,REP,Matt Martindale,2418,1821,597
+Randall,208 CISD,District Clerk,,REP,Joel Forbis,2402,1812,590
+Randall,208 CISD,County Clerk,,REP,Susan Allen,2403,1810,593
+Randall,208 CISD,County Treasurer,,REP,Angie Parker,2398,1804,594
+Randall,208 CISD,"County Commissioner, Precinct 2",,REP,Mark C. Benton,2396,1806,590
+Randall,208 CISD,"Justice of the Peace, Precinct 4",,REP,Clay Houdashell,2404,1815,589
+Randall,220,Registered Voters,,,,2023,,
+Randall,220,Provisional Ballots,,,,6,,
+Randall,220,Provisional Ballots Counted,,,,3,,
+Randall,220,Straight Party,,REP,Republican Party,654,514,140
+Randall,220,Straight Party,,DEM,Democratic Party,122,92,30
+Randall,220,Straight Party,,LIB,Libertarian Party,5,2,3
+Randall,220,U.S. Senate,,REP,Ted Cruz,896,703,193
+Randall,220,U.S. Senate,,DEM,Beto O'Rourke,222,169,53
+Randall,220,U.S. Senate,,LIB,Neal M. Dikeman,6,2,4
+Randall,220,U.S. House,13,REP,Mac Thornberry,909,709,200
+Randall,220,U.S. House,13,DEM,Greg Sagan,184,141,43
+Randall,220,U.S. House,13,LIB,Calvin DeWeese,22,16,6
+Randall,220,Governor,,REP,Greg Abbott,919,715,204
+Randall,220,Governor,,DEM,Lupe Valdez,192,149,43
+Randall,220,Governor,,LIB,Mark Jay Tippetts,14,10,4
+Randall,220,Lieutenant Governor,,REP,Dan Patrick,874,684,190
+Randall,220,Lieutenant Governor,,DEM,Mike Collier,222,171,51
+Randall,220,Lieutenant Governor,,LIB,Kerry Douglas McKennon,26,17,9
+Randall,220,Attorney General,,REP,Ken Paxton,869,674,195
+Randall,220,Attorney General,,DEM,Justin Nelson,227,179,48
+Randall,220,Attorney General,,LIB,Michael Ray Harris,24,16,8
+Randall,220,Comptroller of Public Accounts,,REP,Glenn Hegar,873,683,190
+Randall,220,Comptroller of Public Accounts,,DEM,Joi Chevalier,199,153,46
+Randall,220,Comptroller of Public Accounts,,LIB,Ben Sanders,38,26,12
+Randall,220,Commissioner of the General Land Office,,REP,George P. Bush,873,680,193
+Randall,220,Commissioner of the General Land Office,,DEM,Miguel Suazo,199,157,42
+Randall,220,Commissioner of the General Land Office,,LIB,Matt Pina,40,27,13
+Randall,220,Commissioner of Agriculture,,REP,Sid Miller,861,673,188
+Randall,220,Commissioner of Agriculture,,DEM,Kim Olson,212,165,47
+Randall,220,Commissioner of Agriculture,,LIB,Richard Carpenter,38,25,13
+Randall,220,Railroad Commissioner,,REP,Christi Craddick,876,682,194
+Randall,220,Railroad Commissioner,,DEM,Roman McAllen,200,158,42
+Randall,220,Railroad Commissioner,,LIB,Mike Wright,39,26,13
+Randall,220,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,893,695,198
+Randall,220,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,219,168,51
+Randall,220,"Justice, Supreme Court, Place 4",,REP,John Devine,892,694,198
+Randall,220,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,217,167,50
+Randall,220,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,889,692,197
+Randall,220,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,219,168,51
+Randall,220,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,881,688,193
+Randall,220,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,196,154,42
+Randall,220,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,36,22,14
+Randall,220,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,900,699,201
+Randall,220,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,209,162,47
+Randall,220,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,932,724,208
+Randall,220,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,122,90,32
+Randall,220,State Senator,31,REP,Kel Seliger,942,729,213
+Randall,220,State Senator,31,LIB,Jack B. Westbrook,131,98,33
+Randall,220,State Representative,86,REP,John Smithee,909,708,201
+Randall,220,State Representative,86,DEM,Mike Purcell,207,160,47
+Randall,220,"Justice, 7th Court of Appeals District, Place 2",,REP,Judy Parker,978,754,224
+Randall,220,"Justice, 7th Court of Appeals District, Place 3",,REP,Pat Pirtle,981,755,226
+Randall,220,"District Judge, 47th Judicial District",,REP,Dan L. Schaap,974,751,223
+Randall,220,"District Judge, 181st Judicial District",,REP,John B. Board,975,750,225
+Randall,220,"District Judge, 251st Judicial District",,REP,Ana Elizabeth Estevez,975,750,225
+Randall,220,Criminal District Attorney,,REP,Robert Love,970,745,225
+Randall,220,County Judge,,REP,Ernie Houdashell,976,750,226
+Randall,220,"Judge, County Court at Law 1",,REP,James W. Anderson,964,741,223
+Randall,220,"Judge, County Court at Law 2",,REP,Matt Martindale,976,752,224
+Randall,220,District Clerk,,REP,Joel Forbis,963,741,222
+Randall,220,County Clerk,,REP,Susan Allen,968,748,220
+Randall,220,County Treasurer,,REP,Angie Parker,966,744,222
+Randall,220,"County Commissioner, Precinct 2",,REP,Mark C. Benton,960,740,220
+Randall,220,"Justice of the Peace, Precinct 4",,REP,Clay Houdashell,971,748,223
+Randall,222,Registered Voters,,,,4300,,
+Randall,222,Provisional Ballots,,,,14,,
+Randall,222,Provisional Ballots Counted,,,,6,,
+Randall,222,Straight Party,,REP,Republican Party,1482,1166,316
+Randall,222,Straight Party,,DEM,Democratic Party,216,171,45
+Randall,222,Straight Party,,LIB,Libertarian Party,10,4,6
+Randall,222,U.S. Senate,,REP,Ted Cruz,2138,1673,465
+Randall,222,U.S. Senate,,DEM,Beto O'Rourke,482,379,103
+Randall,222,U.S. Senate,,LIB,Neal M. Dikeman,23,13,10
+Randall,222,U.S. House,13,REP,Mac Thornberry,2219,1724,495
+Randall,222,U.S. House,13,DEM,Greg Sagan,370,303,67
+Randall,222,U.S. House,13,LIB,Calvin DeWeese,53,35,18
+Randall,222,Governor,,REP,Greg Abbott,2208,1715,493
+Randall,222,Governor,,DEM,Lupe Valdez,388,314,74
+Randall,222,Governor,,LIB,Mark Jay Tippetts,43,30,13
+Randall,222,Lieutenant Governor,,REP,Dan Patrick,2053,1602,451
+Randall,222,Lieutenant Governor,,DEM,Mike Collier,501,396,105
+Randall,222,Lieutenant Governor,,LIB,Kerry Douglas McKennon,75,55,20
+Randall,222,Attorney General,,REP,Ken Paxton,2077,1617,460
+Randall,222,Attorney General,,DEM,Justin Nelson,481,383,98
+Randall,222,Attorney General,,LIB,Michael Ray Harris,67,50,17
+Randall,222,Comptroller of Public Accounts,,REP,Glenn Hegar,2151,1683,468
+Randall,222,Comptroller of Public Accounts,,DEM,Joi Chevalier,385,311,74
+Randall,222,Comptroller of Public Accounts,,LIB,Ben Sanders,76,51,25
+Randall,222,Commissioner of the General Land Office,,REP,George P. Bush,2155,1680,475
+Randall,222,Commissioner of the General Land Office,,DEM,Miguel Suazo,386,317,69
+Randall,222,Commissioner of the General Land Office,,LIB,Matt Pina,79,56,23
+Randall,222,Commissioner of Agriculture,,REP,Sid Miller,2093,1631,462
+Randall,222,Commissioner of Agriculture,,DEM,Kim Olson,457,368,89
+Randall,222,Commissioner of Agriculture,,LIB,Richard Carpenter,61,42,19
+Randall,222,Railroad Commissioner,,REP,Christi Craddick,2167,1697,470
+Randall,222,Railroad Commissioner,,DEM,Roman McAllen,385,312,73
+Randall,222,Railroad Commissioner,,LIB,Mike Wright,60,34,26
+Randall,222,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,2175,1698,477
+Randall,222,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,440,349,91
+Randall,222,"Justice, Supreme Court, Place 4",,REP,John Devine,2184,1706,478
+Randall,222,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,426,339,87
+Randall,222,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,2182,1703,479
+Randall,222,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,433,345,88
+Randall,222,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,2141,1676,465
+Randall,222,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,420,334,86
+Randall,222,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,51,32,19
+Randall,222,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,2175,1696,479
+Randall,222,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,429,343,86
+Randall,222,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,2253,1758,495
+Randall,222,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,248,190,58
+Randall,222,State Senator,31,REP,Kel Seliger,2256,1750,506
+Randall,222,State Senator,31,LIB,Jack B. Westbrook,278,220,58
+Randall,222,State Representative,86,REP,John Smithee,2236,1736,500
+Randall,222,State Representative,86,DEM,Mike Purcell,392,317,75
+Randall,222,"Justice, 7th Court of Appeals District, Place 2",,REP,Judy Parker,2342,1812,530
+Randall,222,"Justice, 7th Court of Appeals District, Place 3",,REP,Pat Pirtle,2344,1811,533
+Randall,222,"District Judge, 47th Judicial District",,REP,Dan L. Schaap,2334,1805,529
+Randall,222,"District Judge, 181st Judicial District",,REP,John B. Board,2332,1804,528
+Randall,222,"District Judge, 251st Judicial District",,REP,Ana Elizabeth Estevez,2339,1814,525
+Randall,222,Criminal District Attorney,,REP,Robert Love,2323,1794,529
+Randall,222,County Judge,,REP,Ernie Houdashell,2332,1805,527
+Randall,222,"Judge, County Court at Law 1",,REP,James W. Anderson,2326,1796,530
+Randall,222,"Judge, County Court at Law 2",,REP,Matt Martindale,2342,1809,533
+Randall,222,District Clerk,,REP,Joel Forbis,2325,1795,530
+Randall,222,County Clerk,,REP,Susan Allen,2326,1796,530
+Randall,222,County Treasurer,,REP,Angie Parker,2321,1793,528
+Randall,222,"County Commissioner, Precinct 2",,REP,Mark C. Benton,2315,1786,529
+Randall,222,"Justice of the Peace, Precinct 4",,REP,Clay Houdashell,2322,1794,528
+Randall,227,Registered Voters,,,,5208,,
+Randall,227,Provisional Ballots,,,,20,,
+Randall,227,Provisional Ballots Counted,,,,12,,
+Randall,227,Straight Party,,REP,Republican Party,1899,1499,400
+Randall,227,Straight Party,,DEM,Democratic Party,270,201,69
+Randall,227,Straight Party,,LIB,Libertarian Party,4,4,0
+Randall,227,U.S. Senate,,REP,Ted Cruz,2568,2023,545
+Randall,227,U.S. Senate,,DEM,Beto O'Rourke,555,422,133
+Randall,227,U.S. Senate,,LIB,Neal M. Dikeman,17,8,9
+Randall,227,U.S. House,13,REP,Mac Thornberry,2665,2083,582
+Randall,227,U.S. House,13,DEM,Greg Sagan,432,341,91
+Randall,227,U.S. House,13,LIB,Calvin DeWeese,41,28,13
+Randall,227,Governor,,REP,Greg Abbott,2653,2078,575
+Randall,227,Governor,,DEM,Lupe Valdez,447,348,99
+Randall,227,Governor,,LIB,Mark Jay Tippetts,42,29,13
+Randall,227,Lieutenant Governor,,REP,Dan Patrick,2524,1989,535
+Randall,227,Lieutenant Governor,,DEM,Mike Collier,549,422,127
+Randall,227,Lieutenant Governor,,LIB,Kerry Douglas McKennon,51,34,17
+Randall,227,Attorney General,,REP,Ken Paxton,2521,1976,545
+Randall,227,Attorney General,,DEM,Justin Nelson,543,423,120
+Randall,227,Attorney General,,LIB,Michael Ray Harris,54,39,15
+Randall,227,Comptroller of Public Accounts,,REP,Glenn Hegar,2577,2029,548
+Randall,227,Comptroller of Public Accounts,,DEM,Joi Chevalier,446,345,101
+Randall,227,Comptroller of Public Accounts,,LIB,Ben Sanders,82,55,27
+Randall,227,Commissioner of the General Land Office,,REP,George P. Bush,2580,2018,562
+Randall,227,Commissioner of the General Land Office,,DEM,Miguel Suazo,446,349,97
+Randall,227,Commissioner of the General Land Office,,LIB,Matt Pina,98,74,24
+Randall,227,Commissioner of Agriculture,,REP,Sid Miller,2522,1982,540
+Randall,227,Commissioner of Agriculture,,DEM,Kim Olson,525,407,118
+Randall,227,Commissioner of Agriculture,,LIB,Richard Carpenter,59,40,19
+Randall,227,Railroad Commissioner,,REP,Christi Craddick,2585,2031,554
+Randall,227,Railroad Commissioner,,DEM,Roman McAllen,461,358,103
+Randall,227,Railroad Commissioner,,LIB,Mike Wright,55,36,19
+Randall,227,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,2597,2042,555
+Randall,227,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,512,391,121
+Randall,227,"Justice, Supreme Court, Place 4",,REP,John Devine,2610,2042,568
+Randall,227,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,493,383,110
+Randall,227,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,2604,2044,560
+Randall,227,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,498,382,116
+Randall,227,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,2579,2029,550
+Randall,227,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,472,364,108
+Randall,227,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,49,30,19
+Randall,227,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,2599,2040,559
+Randall,227,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,492,377,115
+Randall,227,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,2682,2104,578
+Randall,227,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,279,205,74
+Randall,227,State Senator,31,REP,Kel Seliger,2731,2142,589
+Randall,227,State Senator,31,LIB,Jack B. Westbrook,290,212,78
+Randall,227,State Representative,86,REP,John Smithee,2627,2060,567
+Randall,227,State Representative,86,DEM,Mike Purcell,480,367,113
+Randall,227,"Justice, 7th Court of Appeals District, Place 2",,REP,Judy Parker,2797,2179,618
+Randall,227,"Justice, 7th Court of Appeals District, Place 3",,REP,Pat Pirtle,2797,2181,616
+Randall,227,"District Judge, 47th Judicial District",,REP,Dan L. Schaap,2787,2174,613
+Randall,227,"District Judge, 181st Judicial District",,REP,John B. Board,2784,2172,612
+Randall,227,"District Judge, 251st Judicial District",,REP,Ana Elizabeth Estevez,2792,2177,615
+Randall,227,Criminal District Attorney,,REP,Robert Love,2765,2156,609
+Randall,227,County Judge,,REP,Ernie Houdashell,2786,2175,611
+Randall,227,"Judge, County Court at Law 1",,REP,James W. Anderson,2768,2158,610
+Randall,227,"Judge, County Court at Law 2",,REP,Matt Martindale,2788,2175,613
+Randall,227,District Clerk,,REP,Joel Forbis,2763,2153,610
+Randall,227,County Clerk,,REP,Susan Allen,2772,2160,612
+Randall,227,County Treasurer,,REP,Angie Parker,2761,2153,608
+Randall,227,"County Commissioner, Precinct 2",,REP,Mark C. Benton,2761,2152,609
+Randall,227,"Justice of the Peace, Precinct 4",,REP,Clay Houdashell,2773,2163,610
+Randall,228,Registered Voters,,,,4956,,
+Randall,228,Provisional Ballots,,,,17,,
+Randall,228,Provisional Ballots Counted,,,,12,,
+Randall,228,Straight Party,,REP,Republican Party,1793,1358,435
+Randall,228,Straight Party,,DEM,Democratic Party,305,224,81
+Randall,228,Straight Party,,LIB,Libertarian Party,9,5,4
+Randall,228,U.S. Senate,,REP,Ted Cruz,2442,1832,610
+Randall,228,U.S. Senate,,DEM,Beto O'Rourke,614,447,167
+Randall,228,U.S. Senate,,LIB,Neal M. Dikeman,29,15,14
+Randall,228,U.S. House,13,REP,Mac Thornberry,2562,1914,648
+Randall,228,U.S. House,13,DEM,Greg Sagan,473,348,125
+Randall,228,U.S. House,13,LIB,Calvin DeWeese,45,30,15
+Randall,228,Governor,,REP,Greg Abbott,2528,1878,650
+Randall,228,Governor,,DEM,Lupe Valdez,511,383,128
+Randall,228,Governor,,LIB,Mark Jay Tippetts,41,29,12
+Randall,228,Lieutenant Governor,,REP,Dan Patrick,2390,1796,594
+Randall,228,Lieutenant Governor,,DEM,Mike Collier,609,449,160
+Randall,228,Lieutenant Governor,,LIB,Kerry Douglas McKennon,76,47,29
+Randall,228,Attorney General,,REP,Ken Paxton,2415,1802,613
+Randall,228,Attorney General,,DEM,Justin Nelson,602,449,153
+Randall,228,Attorney General,,LIB,Michael Ray Harris,58,40,18
+Randall,228,Comptroller of Public Accounts,,REP,Glenn Hegar,2490,1861,629
+Randall,228,Comptroller of Public Accounts,,DEM,Joi Chevalier,489,371,118
+Randall,228,Comptroller of Public Accounts,,LIB,Ben Sanders,80,49,31
+Randall,228,Commissioner of the General Land Office,,REP,George P. Bush,2499,1867,632
+Randall,228,Commissioner of the General Land Office,,DEM,Miguel Suazo,490,362,128
+Randall,228,Commissioner of the General Land Office,,LIB,Matt Pina,79,57,22
+Randall,228,Commissioner of Agriculture,,REP,Sid Miller,2457,1839,618
+Randall,228,Commissioner of Agriculture,,DEM,Kim Olson,540,401,139
+Randall,228,Commissioner of Agriculture,,LIB,Richard Carpenter,59,39,20
+Randall,228,Railroad Commissioner,,REP,Christi Craddick,2487,1851,636
+Randall,228,Railroad Commissioner,,DEM,Roman McAllen,503,380,123
+Randall,228,Railroad Commissioner,,LIB,Mike Wright,65,45,20
+Randall,228,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,2509,1874,635
+Randall,228,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,544,403,141
+Randall,228,"Justice, Supreme Court, Place 4",,REP,John Devine,2519,1882,637
+Randall,228,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,530,393,137
+Randall,228,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,2507,1873,634
+Randall,228,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,545,404,141
+Randall,228,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,2463,1841,622
+Randall,228,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,522,390,132
+Randall,228,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,64,45,19
+Randall,228,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,2519,1880,639
+Randall,228,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,525,392,133
+Randall,228,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,2590,1939,651
+Randall,228,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,323,225,98
+Randall,228,State Senator,31,REP,Kel Seliger,2615,1952,663
+Randall,228,State Senator,31,LIB,Jack B. Westbrook,344,240,104
+Randall,228,State Representative,86,REP,John Smithee,2562,1903,659
+Randall,228,State Representative,86,DEM,Mike Purcell,504,377,127
+Randall,228,"Justice, 7th Court of Appeals District, Place 2",,REP,Judy Parker,2727,2023,704
+Randall,228,"Justice, 7th Court of Appeals District, Place 3",,REP,Pat Pirtle,2726,2017,709
+Randall,228,"District Judge, 47th Judicial District",,REP,Dan L. Schaap,2720,2017,703
+Randall,228,"District Judge, 181st Judicial District",,REP,John B. Board,2729,2022,707
+Randall,228,"District Judge, 251st Judicial District",,REP,Ana Elizabeth Estevez,2737,2031,706
+Randall,228,Criminal District Attorney,,REP,Robert Love,2709,2008,701
+Randall,228,County Judge,,REP,Ernie Houdashell,2705,2005,700
+Randall,228,"Judge, County Court at Law 1",,REP,James W. Anderson,2700,2001,699
+Randall,228,"Judge, County Court at Law 2",,REP,Matt Martindale,2713,2008,705
+Randall,228,District Clerk,,REP,Joel Forbis,2697,1999,698
+Randall,228,County Clerk,,REP,Susan Allen,2707,2010,697
+Randall,228,County Treasurer,,REP,Angie Parker,2701,2004,697
+Randall,228,"County Commissioner, Precinct 2",,REP,Mark C. Benton,2695,1997,698
+Randall,228,"Justice of the Peace, Precinct 4",,REP,Clay Houdashell,2693,1998,695
+Randall,230,Registered Voters,,,,3034,,
+Randall,230,Provisional Ballots,,,,8,,
+Randall,230,Provisional Ballots Counted,,,,2,,
+Randall,230,Straight Party,,REP,Republican Party,1159,952,207
+Randall,230,Straight Party,,DEM,Democratic Party,154,126,28
+Randall,230,Straight Party,,LIB,Libertarian Party,8,4,4
+Randall,230,U.S. Senate,,REP,Ted Cruz,1591,1289,302
+Randall,230,U.S. Senate,,DEM,Beto O'Rourke,332,265,67
+Randall,230,U.S. Senate,,LIB,Neal M. Dikeman,11,6,5
+Randall,230,U.S. House,13,REP,Mac Thornberry,1630,1317,313
+Randall,230,U.S. House,13,DEM,Greg Sagan,262,210,52
+Randall,230,U.S. House,13,LIB,Calvin DeWeese,34,24,10
+Randall,230,Governor,,REP,Greg Abbott,1627,1317,310
+Randall,230,Governor,,DEM,Lupe Valdez,280,226,54
+Randall,230,Governor,,LIB,Mark Jay Tippetts,22,11,11
+Randall,230,Lieutenant Governor,,REP,Dan Patrick,1529,1238,291
+Randall,230,Lieutenant Governor,,DEM,Mike Collier,353,278,75
+Randall,230,Lieutenant Governor,,LIB,Kerry Douglas McKennon,38,31,7
+Randall,230,Attorney General,,REP,Ken Paxton,1569,1265,304
+Randall,230,Attorney General,,DEM,Justin Nelson,313,255,58
+Randall,230,Attorney General,,LIB,Michael Ray Harris,38,28,10
+Randall,230,Comptroller of Public Accounts,,REP,Glenn Hegar,1581,1280,301
+Randall,230,Comptroller of Public Accounts,,DEM,Joi Chevalier,270,221,49
+Randall,230,Comptroller of Public Accounts,,LIB,Ben Sanders,57,37,20
+Randall,230,Commissioner of the General Land Office,,REP,George P. Bush,1600,1297,303
+Randall,230,Commissioner of the General Land Office,,DEM,Miguel Suazo,260,208,52
+Randall,230,Commissioner of the General Land Office,,LIB,Matt Pina,53,36,17
+Randall,230,Commissioner of Agriculture,,REP,Sid Miller,1558,1263,295
+Randall,230,Commissioner of Agriculture,,DEM,Kim Olson,312,249,63
+Randall,230,Commissioner of Agriculture,,LIB,Richard Carpenter,39,27,12
+Randall,230,Railroad Commissioner,,REP,Christi Craddick,1583,1286,297
+Randall,230,Railroad Commissioner,,DEM,Roman McAllen,281,224,57
+Randall,230,Railroad Commissioner,,LIB,Mike Wright,49,30,19
+Randall,230,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1612,1303,309
+Randall,230,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,302,240,62
+Randall,230,"Justice, Supreme Court, Place 4",,REP,John Devine,1601,1298,303
+Randall,230,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,314,245,69
+Randall,230,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1601,1293,308
+Randall,230,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,306,243,63
+Randall,230,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1589,1292,297
+Randall,230,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,286,225,61
+Randall,230,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,38,23,15
+Randall,230,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1610,1298,312
+Randall,230,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,293,232,61
+Randall,230,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1658,1340,318
+Randall,230,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,178,133,45
+Randall,230,State Senator,31,REP,Kel Seliger,1661,1343,318
+Randall,230,State Senator,31,LIB,Jack B. Westbrook,189,139,50
+Randall,230,State Representative,86,REP,John Smithee,1623,1311,312
+Randall,230,State Representative,86,DEM,Mike Purcell,291,229,62
+Randall,230,"Justice, 7th Court of Appeals District, Place 2",,REP,Judy Parker,1720,1378,342
+Randall,230,"Justice, 7th Court of Appeals District, Place 3",,REP,Pat Pirtle,1713,1373,340
+Randall,230,"District Judge, 47th Judicial District",,REP,Dan L. Schaap,1707,1365,342
+Randall,230,"District Judge, 181st Judicial District",,REP,John B. Board,1705,1368,337
+Randall,230,"District Judge, 251st Judicial District",,REP,Ana Elizabeth Estevez,1711,1373,338
+Randall,230,Criminal District Attorney,,REP,Robert Love,1701,1366,335
+Randall,230,County Judge,,REP,Ernie Houdashell,1713,1374,339
+Randall,230,"Judge, County Court at Law 1",,REP,James W. Anderson,1693,1357,336
+Randall,230,"Judge, County Court at Law 2",,REP,Matt Martindale,1710,1373,337
+Randall,230,District Clerk,,REP,Joel Forbis,1697,1361,336
+Randall,230,County Clerk,,REP,Susan Allen,1702,1366,336
+Randall,230,County Treasurer,,REP,Angie Parker,1699,1363,336
+Randall,230,"County Commissioner, Precinct 2",,REP,Mark C. Benton,1698,1362,336
+Randall,230,"Justice of the Peace, Precinct 4",,REP,Clay Houdashell,1701,1365,336
+Randall,305,Registered Voters,,,,25,,
+Randall,305,Provisional Ballots,,,,0,,
+Randall,305,Provisional Ballots Counted,,,,0,,
+Randall,305,Straight Party,,REP,Republican Party,8,5,3
+Randall,305,Straight Party,,DEM,Democratic Party,3,3,0
+Randall,305,Straight Party,,LIB,Libertarian Party,0,0,0
+Randall,305,U.S. Senate,,REP,Ted Cruz,11,8,3
+Randall,305,U.S. Senate,,DEM,Beto O'Rourke,3,3,0
+Randall,305,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0
+Randall,305,U.S. House,13,REP,Mac Thornberry,10,7,3
+Randall,305,U.S. House,13,DEM,Greg Sagan,3,3,0
+Randall,305,U.S. House,13,LIB,Calvin DeWeese,0,0,0
+Randall,305,Governor,,REP,Greg Abbott,11,8,3
+Randall,305,Governor,,DEM,Lupe Valdez,3,3,0
+Randall,305,Governor,,LIB,Mark Jay Tippetts,0,0,0
+Randall,305,Lieutenant Governor,,REP,Dan Patrick,11,8,3
+Randall,305,Lieutenant Governor,,DEM,Mike Collier,3,3,0
+Randall,305,Lieutenant Governor,,LIB,Kerry Douglas McKennon,0,0,0
+Randall,305,Attorney General,,REP,Ken Paxton,8,5,3
+Randall,305,Attorney General,,DEM,Justin Nelson,4,4,0
+Randall,305,Attorney General,,LIB,Michael Ray Harris,1,1,0
+Randall,305,Comptroller of Public Accounts,,REP,Glenn Hegar,11,8,3
+Randall,305,Comptroller of Public Accounts,,DEM,Joi Chevalier,3,3,0
+Randall,305,Comptroller of Public Accounts,,LIB,Ben Sanders,0,0,0
+Randall,305,Commissioner of the General Land Office,,REP,George P. Bush,11,8,3
+Randall,305,Commissioner of the General Land Office,,DEM,Miguel Suazo,3,3,0
+Randall,305,Commissioner of the General Land Office,,LIB,Matt Pina,0,0,0
+Randall,305,Commissioner of Agriculture,,REP,Sid Miller,11,8,3
+Randall,305,Commissioner of Agriculture,,DEM,Kim Olson,3,3,0
+Randall,305,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0
+Randall,305,Railroad Commissioner,,REP,Christi Craddick,11,8,3
+Randall,305,Railroad Commissioner,,DEM,Roman McAllen,3,3,0
+Randall,305,Railroad Commissioner,,LIB,Mike Wright,0,0,0
+Randall,305,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,11,8,3
+Randall,305,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,3,3,0
+Randall,305,"Justice, Supreme Court, Place 4",,REP,John Devine,11,8,3
+Randall,305,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,3,3,0
+Randall,305,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,11,8,3
+Randall,305,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,3,3,0
+Randall,305,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,11,8,3
+Randall,305,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,3,3,0
+Randall,305,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,0,0,0
+Randall,305,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,11,8,3
+Randall,305,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,3,3,0
+Randall,305,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,11,8,3
+Randall,305,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,0,0,0
+Randall,305,State Senator,31,REP,Kel Seliger,11,8,3
+Randall,305,State Senator,31,LIB,Jack B. Westbrook,0,0,0
+Randall,305,State Representative,86,REP,John Smithee,10,7,3
+Randall,305,State Representative,86,DEM,Mike Purcell,3,3,0
+Randall,305,"Justice, 7th Court of Appeals District, Place 2",,REP,Judy Parker,11,8,3
+Randall,305,"Justice, 7th Court of Appeals District, Place 3",,REP,Pat Pirtle,11,8,3
+Randall,305,"District Judge, 47th Judicial District",,REP,Dan L. Schaap,10,7,3
+Randall,305,"District Judge, 181st Judicial District",,REP,John B. Board,10,7,3
+Randall,305,"District Judge, 251st Judicial District",,REP,Ana Elizabeth Estevez,10,7,3
+Randall,305,Criminal District Attorney,,REP,Robert Love,10,7,3
+Randall,305,County Judge,,REP,Ernie Houdashell,10,7,3
+Randall,305,"Judge, County Court at Law 1",,REP,James W. Anderson,10,7,3
+Randall,305,"Judge, County Court at Law 2",,REP,Matt Martindale,10,7,3
+Randall,305,District Clerk,,REP,Joel Forbis,10,7,3
+Randall,305,County Clerk,,REP,Susan Allen,10,7,3
+Randall,305,County Treasurer,,REP,Angie Parker,10,7,3
+Randall,305,"Justice of the Peace, Precinct 1",,REP,J. Tracy Byrd,10,7,3
+Randall,305,"Constable, Precinct 1, Unexpired Term",,REP,Richard Beals,10,7,3
+Randall,305,"Constable, Precinct 1, Unexpired Term",,,"Patrick ""Tinsley"" Tinsley",0,0,0
+Randall,305,"Constable, Precinct 1, Unexpired Term",,,Rejected write-ins,0,0,0
+Randall,305,"Constable, Precinct 1, Unexpired Term",,,Unassigned write-ins,0,0,0
+Randall,305 CISD,Registered Voters,,,,2728,,
+Randall,305 CISD,Provisional Ballots,,,,14,,
+Randall,305 CISD,Provisional Ballots Counted,,,,1,,
+Randall,305 CISD,Straight Party,,REP,Republican Party,833,610,223
+Randall,305 CISD,Straight Party,,DEM,Democratic Party,126,88,38
+Randall,305 CISD,Straight Party,,LIB,Libertarian Party,8,5,3
+Randall,305 CISD,U.S. Senate,,REP,Ted Cruz,1238,904,334
+Randall,305 CISD,U.S. Senate,,DEM,Beto O'Rourke,282,201,81
+Randall,305 CISD,U.S. Senate,,LIB,Neal M. Dikeman,11,9,2
+Randall,305 CISD,U.S. House,13,REP,Mac Thornberry,1279,934,345
+Randall,305 CISD,U.S. House,13,DEM,Greg Sagan,203,148,55
+Randall,305 CISD,U.S. House,13,LIB,Calvin DeWeese,36,22,14
+Randall,305 CISD,Governor,,REP,Greg Abbott,1265,920,345
+Randall,305 CISD,Governor,,DEM,Lupe Valdez,234,175,59
+Randall,305 CISD,Governor,,LIB,Mark Jay Tippetts,30,19,11
+Randall,305 CISD,Lieutenant Governor,,REP,Dan Patrick,1152,849,303
+Randall,305 CISD,Lieutenant Governor,,DEM,Mike Collier,318,226,92
+Randall,305 CISD,Lieutenant Governor,,LIB,Kerry Douglas McKennon,51,31,20
+Randall,305 CISD,Attorney General,,REP,Ken Paxton,1201,876,325
+Randall,305 CISD,Attorney General,,DEM,Justin Nelson,272,201,71
+Randall,305 CISD,Attorney General,,LIB,Michael Ray Harris,44,28,16
+Randall,305 CISD,Comptroller of Public Accounts,,REP,Glenn Hegar,1241,902,339
+Randall,305 CISD,Comptroller of Public Accounts,,DEM,Joi Chevalier,221,164,57
+Randall,305 CISD,Comptroller of Public Accounts,,LIB,Ben Sanders,53,35,18
+Randall,305 CISD,Commissioner of the General Land Office,,REP,George P. Bush,1238,904,334
+Randall,305 CISD,Commissioner of the General Land Office,,DEM,Miguel Suazo,223,166,57
+Randall,305 CISD,Commissioner of the General Land Office,,LIB,Matt Pina,62,39,23
+Randall,305 CISD,Commissioner of Agriculture,,REP,Sid Miller,1221,889,332
+Randall,305 CISD,Commissioner of Agriculture,,DEM,Kim Olson,257,190,67
+Randall,305 CISD,Commissioner of Agriculture,,LIB,Richard Carpenter,36,22,14
+Randall,305 CISD,Railroad Commissioner,,REP,Christi Craddick,1251,912,339
+Randall,305 CISD,Railroad Commissioner,,DEM,Roman McAllen,218,163,55
+Randall,305 CISD,Railroad Commissioner,,LIB,Mike Wright,44,29,15
+Randall,305 CISD,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1262,915,347
+Randall,305 CISD,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,250,184,66
+Randall,305 CISD,"Justice, Supreme Court, Place 4",,REP,John Devine,1260,919,341
+Randall,305 CISD,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,250,181,69
+Randall,305 CISD,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1257,918,339
+Randall,305 CISD,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,253,182,71
+Randall,305 CISD,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1227,900,327
+Randall,305 CISD,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,236,173,63
+Randall,305 CISD,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,46,25,21
+Randall,305 CISD,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1264,917,347
+Randall,305 CISD,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,244,181,63
+Randall,305 CISD,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1299,947,352
+Randall,305 CISD,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,163,114,49
+Randall,305 CISD,State Senator,31,REP,Kel Seliger,1288,937,351
+Randall,305 CISD,State Senator,31,LIB,Jack B. Westbrook,177,124,53
+Randall,305 CISD,State Representative,86,REP,John Smithee,1270,925,345
+Randall,305 CISD,State Representative,86,DEM,Mike Purcell,239,174,65
+Randall,305 CISD,"Justice, 7th Court of Appeals District, Place 2",,REP,Judy Parker,1361,982,379
+Randall,305 CISD,"Justice, 7th Court of Appeals District, Place 3",,REP,Pat Pirtle,1362,984,378
+Randall,305 CISD,"District Judge, 47th Judicial District",,REP,Dan L. Schaap,1349,974,375
+Randall,305 CISD,"District Judge, 181st Judicial District",,REP,John B. Board,1349,976,373
+Randall,305 CISD,"District Judge, 251st Judicial District",,REP,Ana Elizabeth Estevez,1351,977,374
+Randall,305 CISD,Criminal District Attorney,,REP,Robert Love,1345,973,372
+Randall,305 CISD,County Judge,,REP,Ernie Houdashell,1351,974,377
+Randall,305 CISD,"Judge, County Court at Law 1",,REP,James W. Anderson,1343,970,373
+Randall,305 CISD,"Judge, County Court at Law 2",,REP,Matt Martindale,1344,971,373
+Randall,305 CISD,District Clerk,,REP,Joel Forbis,1338,967,371
+Randall,305 CISD,County Clerk,,REP,Susan Allen,1346,972,374
+Randall,305 CISD,County Treasurer,,REP,Angie Parker,1349,975,374
+Randall,305 CISD,"Justice of the Peace, Precinct 1",,REP,J. Tracy Byrd,1354,978,376
+Randall,305 CISD,"Constable, Precinct 1, Unexpired Term",,REP,Richard Beals,1314,948,366
+Randall,305 CISD,"Constable, Precinct 1, Unexpired Term",,,"Patrick ""Tinsley"" Tinsley",28,23,5
+Randall,305 CISD,"Constable, Precinct 1, Unexpired Term",,,Rejected write-ins,8,5,3
+Randall,305 CISD,"Constable, Precinct 1, Unexpired Term",,,Unassigned write-ins,0,0,0
+Randall,306,Registered Voters,,,,158,,
+Randall,306,Provisional Ballots,,,,1,,
+Randall,306,Provisional Ballots Counted,,,,0,,
+Randall,306,Straight Party,,REP,Republican Party,58,50,8
+Randall,306,Straight Party,,DEM,Democratic Party,2,1,1
+Randall,306,Straight Party,,LIB,Libertarian Party,0,0,0
+Randall,306,U.S. Senate,,REP,Ted Cruz,84,69,15
+Randall,306,U.S. Senate,,DEM,Beto O'Rourke,8,3,5
+Randall,306,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0
+Randall,306,U.S. House,13,REP,Mac Thornberry,89,70,19
+Randall,306,U.S. House,13,DEM,Greg Sagan,3,2,1
+Randall,306,U.S. House,13,LIB,Calvin DeWeese,0,0,0
+Randall,306,Governor,,REP,Greg Abbott,86,70,16
+Randall,306,Governor,,DEM,Lupe Valdez,3,2,1
+Randall,306,Governor,,LIB,Mark Jay Tippetts,2,0,2
+Randall,306,Lieutenant Governor,,REP,Dan Patrick,77,63,14
+Randall,306,Lieutenant Governor,,DEM,Mike Collier,13,7,6
+Randall,306,Lieutenant Governor,,LIB,Kerry Douglas McKennon,0,0,0
+Randall,306,Attorney General,,REP,Ken Paxton,81,66,15
+Randall,306,Attorney General,,DEM,Justin Nelson,9,4,5
+Randall,306,Attorney General,,LIB,Michael Ray Harris,1,1,0
+Randall,306,Comptroller of Public Accounts,,REP,Glenn Hegar,83,68,15
+Randall,306,Comptroller of Public Accounts,,DEM,Joi Chevalier,5,2,3
+Randall,306,Comptroller of Public Accounts,,LIB,Ben Sanders,1,0,1
+Randall,306,Commissioner of the General Land Office,,REP,George P. Bush,88,71,17
+Randall,306,Commissioner of the General Land Office,,DEM,Miguel Suazo,4,1,3
+Randall,306,Commissioner of the General Land Office,,LIB,Matt Pina,0,0,0
+Randall,306,Commissioner of Agriculture,,REP,Sid Miller,87,70,17
+Randall,306,Commissioner of Agriculture,,DEM,Kim Olson,5,2,3
+Randall,306,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0
+Randall,306,Railroad Commissioner,,REP,Christi Craddick,86,71,15
+Randall,306,Railroad Commissioner,,DEM,Roman McAllen,5,1,4
+Randall,306,Railroad Commissioner,,LIB,Mike Wright,1,0,1
+Randall,306,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,86,70,16
+Randall,306,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,6,2,4
+Randall,306,"Justice, Supreme Court, Place 4",,REP,John Devine,88,70,18
+Randall,306,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,4,2,2
+Randall,306,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,88,70,18
+Randall,306,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,4,2,2
+Randall,306,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,88,70,18
+Randall,306,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,4,2,2
+Randall,306,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,0,0,0
+Randall,306,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,87,70,17
+Randall,306,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,5,2,3
+Randall,306,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,89,70,19
+Randall,306,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,3,2,1
+Randall,306,State Senator,31,REP,Kel Seliger,86,68,18
+Randall,306,State Senator,31,LIB,Jack B. Westbrook,3,2,1
+Randall,306,State Representative,86,REP,John Smithee,89,70,19
+Randall,306,State Representative,86,DEM,Mike Purcell,3,2,1
+Randall,306,"Justice, 7th Court of Appeals District, Place 2",,REP,Judy Parker,89,70,19
+Randall,306,"Justice, 7th Court of Appeals District, Place 3",,REP,Pat Pirtle,87,70,17
+Randall,306,"District Judge, 47th Judicial District",,REP,Dan L. Schaap,87,69,18
+Randall,306,"District Judge, 181st Judicial District",,REP,John B. Board,88,70,18
+Randall,306,"District Judge, 251st Judicial District",,REP,Ana Elizabeth Estevez,87,69,18
+Randall,306,Criminal District Attorney,,REP,Robert Love,87,69,18
+Randall,306,County Judge,,REP,Ernie Houdashell,89,70,19
+Randall,306,"Judge, County Court at Law 1",,REP,James W. Anderson,87,69,18
+Randall,306,"Judge, County Court at Law 2",,REP,Matt Martindale,88,70,18
+Randall,306,District Clerk,,REP,Joel Forbis,87,69,18
+Randall,306,County Clerk,,REP,Susan Allen,87,68,19
+Randall,306,County Treasurer,,REP,Angie Parker,87,69,18
+Randall,306,"Justice of the Peace, Precinct 1",,REP,J. Tracy Byrd,88,70,18
+Randall,306,"Constable, Precinct 1, Unexpired Term",,REP,Richard Beals,87,69,18
+Randall,306,"Constable, Precinct 1, Unexpired Term",,,"Patrick ""Tinsley"" Tinsley",0,0,0
+Randall,306,"Constable, Precinct 1, Unexpired Term",,,Rejected write-ins,0,0,0
+Randall,306,"Constable, Precinct 1, Unexpired Term",,,Unassigned write-ins,0,0,0
+Randall,306 CISD,Registered Voters,,,,3712,,
+Randall,306 CISD,Provisional Ballots,,,,17,,
+Randall,306 CISD,Provisional Ballots Counted,,,,7,,
+Randall,306 CISD,Straight Party,,REP,Republican Party,1119,868,251
+Randall,306 CISD,Straight Party,,DEM,Democratic Party,231,166,65
+Randall,306 CISD,Straight Party,,LIB,Libertarian Party,9,4,5
+Randall,306 CISD,U.S. Senate,,REP,Ted Cruz,1716,1323,393
+Randall,306 CISD,U.S. Senate,,DEM,Beto O'Rourke,469,349,120
+Randall,306 CISD,U.S. Senate,,LIB,Neal M. Dikeman,21,11,10
+Randall,306 CISD,U.S. House,13,REP,Mac Thornberry,1754,1346,408
+Randall,306 CISD,U.S. House,13,DEM,Greg Sagan,381,286,95
+Randall,306 CISD,U.S. House,13,LIB,Calvin DeWeese,55,40,15
+Randall,306 CISD,Governor,,REP,Greg Abbott,1751,1340,411
+Randall,306 CISD,Governor,,DEM,Lupe Valdez,396,305,91
+Randall,306 CISD,Governor,,LIB,Mark Jay Tippetts,49,31,18
+Randall,306 CISD,Lieutenant Governor,,REP,Dan Patrick,1561,1197,364
+Randall,306 CISD,Lieutenant Governor,,DEM,Mike Collier,548,412,136
+Randall,306 CISD,Lieutenant Governor,,LIB,Kerry Douglas McKennon,71,53,18
+Randall,306 CISD,Attorney General,,REP,Ken Paxton,1644,1269,375
+Randall,306 CISD,Attorney General,,DEM,Justin Nelson,464,348,116
+Randall,306 CISD,Attorney General,,LIB,Michael Ray Harris,63,41,22
+Randall,306 CISD,Comptroller of Public Accounts,,REP,Glenn Hegar,1706,1313,393
+Randall,306 CISD,Comptroller of Public Accounts,,DEM,Joi Chevalier,383,287,96
+Randall,306 CISD,Comptroller of Public Accounts,,LIB,Ben Sanders,78,56,22
+Randall,306 CISD,Commissioner of the General Land Office,,REP,George P. Bush,1699,1300,399
+Randall,306 CISD,Commissioner of the General Land Office,,DEM,Miguel Suazo,399,305,94
+Randall,306 CISD,Commissioner of the General Land Office,,LIB,Matt Pina,75,55,20
+Randall,306 CISD,Commissioner of Agriculture,,REP,Sid Miller,1683,1296,387
+Randall,306 CISD,Commissioner of Agriculture,,DEM,Kim Olson,422,322,100
+Randall,306 CISD,Commissioner of Agriculture,,LIB,Richard Carpenter,66,44,22
+Randall,306 CISD,Railroad Commissioner,,REP,Christi Craddick,1710,1321,389
+Randall,306 CISD,Railroad Commissioner,,DEM,Roman McAllen,382,285,97
+Randall,306 CISD,Railroad Commissioner,,LIB,Mike Wright,74,49,25
+Randall,306 CISD,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1744,1335,409
+Randall,306 CISD,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,415,314,101
+Randall,306 CISD,"Justice, Supreme Court, Place 4",,REP,John Devine,1736,1332,404
+Randall,306 CISD,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,413,307,106
+Randall,306 CISD,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1734,1329,405
+Randall,306 CISD,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,421,315,106
+Randall,306 CISD,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1714,1324,390
+Randall,306 CISD,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,386,289,97
+Randall,306 CISD,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,62,40,22
+Randall,306 CISD,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1744,1336,408
+Randall,306 CISD,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,405,306,99
+Randall,306 CISD,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1787,1368,419
+Randall,306 CISD,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,260,192,68
+Randall,306 CISD,State Senator,31,REP,Kel Seliger,1791,1366,425
+Randall,306 CISD,State Senator,31,LIB,Jack B. Westbrook,300,229,71
+Randall,306 CISD,State Representative,86,REP,John Smithee,1762,1351,411
+Randall,306 CISD,State Representative,86,DEM,Mike Purcell,410,304,106
+Randall,306 CISD,"Justice, 7th Court of Appeals District, Place 2",,REP,Judy Parker,1890,1429,461
+Randall,306 CISD,"Justice, 7th Court of Appeals District, Place 3",,REP,Pat Pirtle,1879,1428,451
+Randall,306 CISD,"District Judge, 47th Judicial District",,REP,Dan L. Schaap,1868,1412,456
+Randall,306 CISD,"District Judge, 181st Judicial District",,REP,John B. Board,1864,1409,455
+Randall,306 CISD,"District Judge, 251st Judicial District",,REP,Ana Elizabeth Estevez,1877,1419,458
+Randall,306 CISD,Criminal District Attorney,,REP,Robert Love,1856,1403,453
+Randall,306 CISD,County Judge,,REP,Ernie Houdashell,1872,1413,459
+Randall,306 CISD,"Judge, County Court at Law 1",,REP,James W. Anderson,1863,1408,455
+Randall,306 CISD,"Judge, County Court at Law 2",,REP,Matt Martindale,1865,1410,455
+Randall,306 CISD,District Clerk,,REP,Joel Forbis,1856,1404,452
+Randall,306 CISD,County Clerk,,REP,Susan Allen,1861,1402,459
+Randall,306 CISD,County Treasurer,,REP,Angie Parker,1864,1408,456
+Randall,306 CISD,"Justice of the Peace, Precinct 1",,REP,J. Tracy Byrd,1882,1421,461
+Randall,306 CISD,"Constable, Precinct 1, Unexpired Term",,REP,Richard Beals,1834,1389,445
+Randall,306 CISD,"Constable, Precinct 1, Unexpired Term",,,"Patrick ""Tinsley"" Tinsley",35,28,7
+Randall,306 CISD,"Constable, Precinct 1, Unexpired Term",,,Rejected write-ins,7,5,2
+Randall,306 CISD,"Constable, Precinct 1, Unexpired Term",,,Unassigned write-ins,0,0,0
+Randall,307 CISD,Registered Voters,,,,3482,,
+Randall,307 CISD,Provisional Ballots,,,,10,,
+Randall,307 CISD,Provisional Ballots Counted,,,,6,,
+Randall,307 CISD,Straight Party,,REP,Republican Party,1247,999,248
+Randall,307 CISD,Straight Party,,DEM,Democratic Party,183,138,45
+Randall,307 CISD,Straight Party,,LIB,Libertarian Party,9,4,5
+Randall,307 CISD,U.S. Senate,,REP,Ted Cruz,1805,1455,350
+Randall,307 CISD,U.S. Senate,,DEM,Beto O'Rourke,393,296,97
+Randall,307 CISD,U.S. Senate,,LIB,Neal M. Dikeman,16,9,7
+Randall,307 CISD,U.S. House,13,REP,Mac Thornberry,1863,1497,366
+Randall,307 CISD,U.S. House,13,DEM,Greg Sagan,295,229,66
+Randall,307 CISD,U.S. House,13,LIB,Calvin DeWeese,45,27,18
+Randall,307 CISD,Governor,,REP,Greg Abbott,1856,1486,370
+Randall,307 CISD,Governor,,DEM,Lupe Valdez,305,236,69
+Randall,307 CISD,Governor,,LIB,Mark Jay Tippetts,41,27,14
+Randall,307 CISD,Lieutenant Governor,,REP,Dan Patrick,1665,1336,329
+Randall,307 CISD,Lieutenant Governor,,DEM,Mike Collier,472,371,101
+Randall,307 CISD,Lieutenant Governor,,LIB,Kerry Douglas McKennon,61,39,22
+Randall,307 CISD,Attorney General,,REP,Ken Paxton,1766,1418,348
+Randall,307 CISD,Attorney General,,DEM,Justin Nelson,366,287,79
+Randall,307 CISD,Attorney General,,LIB,Michael Ray Harris,61,38,23
+Randall,307 CISD,Comptroller of Public Accounts,,REP,Glenn Hegar,1817,1463,354
+Randall,307 CISD,Comptroller of Public Accounts,,DEM,Joi Chevalier,293,226,67
+Randall,307 CISD,Comptroller of Public Accounts,,LIB,Ben Sanders,67,41,26
+Randall,307 CISD,Commissioner of the General Land Office,,REP,George P. Bush,1805,1451,354
+Randall,307 CISD,Commissioner of the General Land Office,,DEM,Miguel Suazo,316,242,74
+Randall,307 CISD,Commissioner of the General Land Office,,LIB,Matt Pina,71,49,22
+Randall,307 CISD,Commissioner of Agriculture,,REP,Sid Miller,1766,1424,342
+Randall,307 CISD,Commissioner of Agriculture,,DEM,Kim Olson,370,282,88
+Randall,307 CISD,Commissioner of Agriculture,,LIB,Richard Carpenter,51,32,19
+Randall,307 CISD,Railroad Commissioner,,REP,Christi Craddick,1818,1459,359
+Randall,307 CISD,Railroad Commissioner,,DEM,Roman McAllen,304,236,68
+Randall,307 CISD,Railroad Commissioner,,LIB,Mike Wright,58,37,21
+Randall,307 CISD,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1826,1465,361
+Randall,307 CISD,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,351,270,81
+Randall,307 CISD,"Justice, Supreme Court, Place 4",,REP,John Devine,1826,1461,365
+Randall,307 CISD,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,351,271,80
+Randall,307 CISD,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1830,1467,363
+Randall,307 CISD,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,349,267,82
+Randall,307 CISD,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1796,1444,352
+Randall,307 CISD,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,318,250,68
+Randall,307 CISD,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,58,35,23
+Randall,307 CISD,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1841,1468,373
+Randall,307 CISD,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,329,256,73
+Randall,307 CISD,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1900,1519,381
+Randall,307 CISD,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,209,153,56
+Randall,307 CISD,State Senator,31,REP,Kel Seliger,1892,1524,368
+Randall,307 CISD,State Senator,31,LIB,Jack B. Westbrook,254,180,74
+Randall,307 CISD,State Representative,86,REP,John Smithee,1872,1507,365
+Randall,307 CISD,State Representative,86,DEM,Mike Purcell,326,242,84
+Randall,307 CISD,"Justice, 7th Court of Appeals District, Place 2",,REP,Judy Parker,1993,1583,410
+Randall,307 CISD,"Justice, 7th Court of Appeals District, Place 3",,REP,Pat Pirtle,1991,1582,409
+Randall,307 CISD,"District Judge, 47th Judicial District",,REP,Dan L. Schaap,1976,1569,407
+Randall,307 CISD,"District Judge, 181st Judicial District",,REP,John B. Board,1971,1565,406
+Randall,307 CISD,"District Judge, 251st Judicial District",,REP,Ana Elizabeth Estevez,1977,1570,407
+Randall,307 CISD,Criminal District Attorney,,REP,Robert Love,1970,1564,406
+Randall,307 CISD,County Judge,,REP,Ernie Houdashell,1978,1576,402
+Randall,307 CISD,"Judge, County Court at Law 1",,REP,James W. Anderson,1975,1571,404
+Randall,307 CISD,"Judge, County Court at Law 2",,REP,Matt Martindale,1979,1576,403
+Randall,307 CISD,District Clerk,,REP,Joel Forbis,1966,1561,405
+Randall,307 CISD,County Clerk,,REP,Susan Allen,1972,1568,404
+Randall,307 CISD,County Treasurer,,REP,Angie Parker,1975,1567,408
+Randall,307 CISD,"Justice of the Peace, Precinct 1",,REP,J. Tracy Byrd,1984,1577,407
+Randall,307 CISD,"Constable, Precinct 1, Unexpired Term",,REP,Richard Beals,1927,1533,394
+Randall,307 CISD,"Constable, Precinct 1, Unexpired Term",,,"Patrick ""Tinsley"" Tinsley",27,21,6
+Randall,307 CISD,"Constable, Precinct 1, Unexpired Term",,,Rejected write-ins,10,7,3
+Randall,307 CISD,"Constable, Precinct 1, Unexpired Term",,,Unassigned write-ins,0,0,0
+Randall,309 CISD,Registered Voters,,,,4007,,
+Randall,309 CISD,Provisional Ballots,,,,14,,
+Randall,309 CISD,Provisional Ballots Counted,,,,3,,
+Randall,309 CISD,Straight Party,,REP,Republican Party,1292,920,372
+Randall,309 CISD,Straight Party,,DEM,Democratic Party,119,86,33
+Randall,309 CISD,Straight Party,,LIB,Libertarian Party,4,2,2
+Randall,309 CISD,U.S. Senate,,REP,Ted Cruz,1660,1195,465
+Randall,309 CISD,U.S. Senate,,DEM,Beto O'Rourke,213,143,70
+Randall,309 CISD,U.S. Senate,,LIB,Neal M. Dikeman,11,6,5
+Randall,309 CISD,U.S. House,13,REP,Mac Thornberry,1684,1204,480
+Randall,309 CISD,U.S. House,13,DEM,Greg Sagan,177,125,52
+Randall,309 CISD,U.S. House,13,LIB,Calvin DeWeese,22,14,8
+Randall,309 CISD,Governor,,REP,Greg Abbott,1679,1202,477
+Randall,309 CISD,Governor,,DEM,Lupe Valdez,187,132,55
+Randall,309 CISD,Governor,,LIB,Mark Jay Tippetts,21,13,8
+Randall,309 CISD,Lieutenant Governor,,REP,Dan Patrick,1625,1165,460
+Randall,309 CISD,Lieutenant Governor,,DEM,Mike Collier,225,159,66
+Randall,309 CISD,Lieutenant Governor,,LIB,Kerry Douglas McKennon,35,20,15
+Randall,309 CISD,Attorney General,,REP,Ken Paxton,1629,1172,457
+Randall,309 CISD,Attorney General,,DEM,Justin Nelson,211,146,65
+Randall,309 CISD,Attorney General,,LIB,Michael Ray Harris,40,21,19
+Randall,309 CISD,Comptroller of Public Accounts,,REP,Glenn Hegar,1655,1191,464
+Randall,309 CISD,Comptroller of Public Accounts,,DEM,Joi Chevalier,180,127,53
+Randall,309 CISD,Comptroller of Public Accounts,,LIB,Ben Sanders,43,23,20
+Randall,309 CISD,Commissioner of the General Land Office,,REP,George P. Bush,1637,1171,466
+Randall,309 CISD,Commissioner of the General Land Office,,DEM,Miguel Suazo,178,125,53
+Randall,309 CISD,Commissioner of the General Land Office,,LIB,Matt Pina,63,42,21
+Randall,309 CISD,Commissioner of Agriculture,,REP,Sid Miller,1639,1175,464
+Randall,309 CISD,Commissioner of Agriculture,,DEM,Kim Olson,200,139,61
+Randall,309 CISD,Commissioner of Agriculture,,LIB,Richard Carpenter,35,22,13
+Randall,309 CISD,Railroad Commissioner,,REP,Christi Craddick,1645,1179,466
+Randall,309 CISD,Railroad Commissioner,,DEM,Roman McAllen,183,126,57
+Randall,309 CISD,Railroad Commissioner,,LIB,Mike Wright,47,32,15
+Randall,309 CISD,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1667,1196,471
+Randall,309 CISD,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,209,143,66
+Randall,309 CISD,"Justice, Supreme Court, Place 4",,REP,John Devine,1676,1201,475
+Randall,309 CISD,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,197,138,59
+Randall,309 CISD,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1666,1196,470
+Randall,309 CISD,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,212,146,66
+Randall,309 CISD,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1649,1183,466
+Randall,309 CISD,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,191,136,55
+Randall,309 CISD,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,36,22,14
+Randall,309 CISD,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1672,1198,474
+Randall,309 CISD,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,200,141,59
+Randall,309 CISD,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1686,1210,476
+Randall,309 CISD,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,134,90,44
+Randall,309 CISD,State Senator,31,REP,Kel Seliger,1647,1180,467
+Randall,309 CISD,State Senator,31,LIB,Jack B. Westbrook,189,126,63
+Randall,309 CISD,State Representative,86,REP,John Smithee,1673,1199,474
+Randall,309 CISD,State Representative,86,DEM,Mike Purcell,201,137,64
+Randall,309 CISD,"Justice, 7th Court of Appeals District, Place 2",,REP,Judy Parker,1746,1246,500
+Randall,309 CISD,"Justice, 7th Court of Appeals District, Place 3",,REP,Pat Pirtle,1742,1243,499
+Randall,309 CISD,"District Judge, 47th Judicial District",,REP,Dan L. Schaap,1736,1238,498
+Randall,309 CISD,"District Judge, 181st Judicial District",,REP,John B. Board,1734,1237,497
+Randall,309 CISD,"District Judge, 251st Judicial District",,REP,Ana Elizabeth Estevez,1737,1238,499
+Randall,309 CISD,Criminal District Attorney,,REP,Robert Love,1731,1233,498
+Randall,309 CISD,County Judge,,REP,Ernie Houdashell,1725,1225,500
+Randall,309 CISD,"Judge, County Court at Law 1",,REP,James W. Anderson,1727,1230,497
+Randall,309 CISD,"Judge, County Court at Law 2",,REP,Matt Martindale,1738,1236,502
+Randall,309 CISD,District Clerk,,REP,Joel Forbis,1730,1231,499
+Randall,309 CISD,County Clerk,,REP,Susan Allen,1728,1231,497
+Randall,309 CISD,County Treasurer,,REP,Angie Parker,1733,1232,501
+Randall,309 CISD,"Justice of the Peace, Precinct 1",,REP,J. Tracy Byrd,1733,1231,502
+Randall,309 CISD,"Constable, Precinct 1, Unexpired Term",,REP,Richard Beals,1718,1222,496
+Randall,309 CISD,"Constable, Precinct 1, Unexpired Term",,,"Patrick ""Tinsley"" Tinsley",10,7,3
+Randall,309 CISD,"Constable, Precinct 1, Unexpired Term",,,Rejected write-ins,4,4,0
+Randall,309 CISD,"Constable, Precinct 1, Unexpired Term",,,Unassigned write-ins,0,0,0
+Randall,324 CISD,Registered Voters,,,,5114,,
+Randall,324 CISD,Provisional Ballots,,,,29,,
+Randall,324 CISD,Provisional Ballots Counted,,,,11,,
+Randall,324 CISD,Straight Party,,REP,Republican Party,1914,1544,370
+Randall,324 CISD,Straight Party,,DEM,Democratic Party,280,217,63
+Randall,324 CISD,Straight Party,,LIB,Libertarian Party,8,4,4
+Randall,324 CISD,U.S. Senate,,REP,Ted Cruz,2603,2071,532
+Randall,324 CISD,U.S. Senate,,DEM,Beto O'Rourke,574,435,139
+Randall,324 CISD,U.S. Senate,,LIB,Neal M. Dikeman,22,15,7
+Randall,324 CISD,U.S. House,13,REP,Mac Thornberry,2701,2141,560
+Randall,324 CISD,U.S. House,13,DEM,Greg Sagan,446,347,99
+Randall,324 CISD,U.S. House,13,LIB,Calvin DeWeese,48,28,20
+Randall,324 CISD,Governor,,REP,Greg Abbott,2673,2116,557
+Randall,324 CISD,Governor,,DEM,Lupe Valdez,480,369,111
+Randall,324 CISD,Governor,,LIB,Mark Jay Tippetts,43,31,12
+Randall,324 CISD,Lieutenant Governor,,REP,Dan Patrick,2517,2001,516
+Randall,324 CISD,Lieutenant Governor,,DEM,Mike Collier,599,461,138
+Randall,324 CISD,Lieutenant Governor,,LIB,Kerry Douglas McKennon,75,50,25
+Randall,324 CISD,Attorney General,,REP,Ken Paxton,2521,2013,508
+Randall,324 CISD,Attorney General,,DEM,Justin Nelson,574,440,134
+Randall,324 CISD,Attorney General,,LIB,Michael Ray Harris,71,46,25
+Randall,324 CISD,Comptroller of Public Accounts,,REP,Glenn Hegar,2591,2074,517
+Randall,324 CISD,Comptroller of Public Accounts,,DEM,Joi Chevalier,475,365,110
+Randall,324 CISD,Comptroller of Public Accounts,,LIB,Ben Sanders,89,52,37
+Randall,324 CISD,Commissioner of the General Land Office,,REP,George P. Bush,2584,2056,528
+Randall,324 CISD,Commissioner of the General Land Office,,DEM,Miguel Suazo,468,362,106
+Randall,324 CISD,Commissioner of the General Land Office,,LIB,Matt Pina,117,84,33
+Randall,324 CISD,Commissioner of Agriculture,,REP,Sid Miller,2544,2031,513
+Randall,324 CISD,Commissioner of Agriculture,,DEM,Kim Olson,541,410,131
+Randall,324 CISD,Commissioner of Agriculture,,LIB,Richard Carpenter,70,49,21
+Randall,324 CISD,Railroad Commissioner,,REP,Christi Craddick,2625,2088,537
+Randall,324 CISD,Railroad Commissioner,,DEM,Roman McAllen,461,359,102
+Randall,324 CISD,Railroad Commissioner,,LIB,Mike Wright,73,48,25
+Randall,324 CISD,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,2619,2087,532
+Randall,324 CISD,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,536,408,128
+Randall,324 CISD,"Justice, Supreme Court, Place 4",,REP,John Devine,2625,2086,539
+Randall,324 CISD,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,525,403,122
+Randall,324 CISD,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,2621,2092,529
+Randall,324 CISD,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,537,405,132
+Randall,324 CISD,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,2597,2075,522
+Randall,324 CISD,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,498,377,121
+Randall,324 CISD,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,61,42,19
+Randall,324 CISD,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,2640,2101,539
+Randall,324 CISD,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,503,384,119
+Randall,324 CISD,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,2715,2156,559
+Randall,324 CISD,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,313,231,82
+Randall,324 CISD,State Senator,31,REP,Kel Seliger,2731,2165,566
+Randall,324 CISD,State Senator,31,LIB,Jack B. Westbrook,344,252,92
+Randall,324 CISD,State Representative,86,REP,John Smithee,2675,2123,552
+Randall,324 CISD,State Representative,86,DEM,Mike Purcell,492,373,119
+Randall,324 CISD,"Justice, 7th Court of Appeals District, Place 2",,REP,Judy Parker,2837,2231,606
+Randall,324 CISD,"Justice, 7th Court of Appeals District, Place 3",,REP,Pat Pirtle,2832,2226,606
+Randall,324 CISD,"District Judge, 47th Judicial District",,REP,Dan L. Schaap,2826,2226,600
+Randall,324 CISD,"District Judge, 181st Judicial District",,REP,John B. Board,2822,2222,600
+Randall,324 CISD,"District Judge, 251st Judicial District",,REP,Ana Elizabeth Estevez,2818,2214,604
+Randall,324 CISD,Criminal District Attorney,,REP,Robert Love,2812,2213,599
+Randall,324 CISD,County Judge,,REP,Ernie Houdashell,2833,2227,606
+Randall,324 CISD,"Judge, County Court at Law 1",,REP,James W. Anderson,2812,2212,600
+Randall,324 CISD,"Judge, County Court at Law 2",,REP,Matt Martindale,2821,2218,603
+Randall,324 CISD,District Clerk,,REP,Joel Forbis,2825,2224,601
+Randall,324 CISD,County Clerk,,REP,Susan Allen,2825,2224,601
+Randall,324 CISD,County Treasurer,,REP,Angie Parker,2824,2223,601
+Randall,324 CISD,"Justice of the Peace, Precinct 4",,REP,Clay Houdashell,2818,2215,603
+Randall,325 CISD,Registered Voters,,,,3726,,
+Randall,325 CISD,Provisional Ballots,,,,10,,
+Randall,325 CISD,Provisional Ballots Counted,,,,3,,
+Randall,325 CISD,Straight Party,,REP,Republican Party,1504,1093,411
+Randall,325 CISD,Straight Party,,DEM,Democratic Party,145,100,45
+Randall,325 CISD,Straight Party,,LIB,Libertarian Party,8,5,3
+Randall,325 CISD,U.S. Senate,,REP,Ted Cruz,2036,1506,530
+Randall,325 CISD,U.S. Senate,,DEM,Beto O'Rourke,280,200,80
+Randall,325 CISD,U.S. Senate,,LIB,Neal M. Dikeman,13,7,6
+Randall,325 CISD,U.S. House,13,REP,Mac Thornberry,2057,1523,534
+Randall,325 CISD,U.S. House,13,DEM,Greg Sagan,228,158,70
+Randall,325 CISD,U.S. House,13,LIB,Calvin DeWeese,32,19,13
+Randall,325 CISD,Governor,,REP,Greg Abbott,2077,1535,542
+Randall,325 CISD,Governor,,DEM,Lupe Valdez,230,161,69
+Randall,325 CISD,Governor,,LIB,Mark Jay Tippetts,19,14,5
+Randall,325 CISD,Lieutenant Governor,,REP,Dan Patrick,1946,1452,494
+Randall,325 CISD,Lieutenant Governor,,DEM,Mike Collier,327,227,100
+Randall,325 CISD,Lieutenant Governor,,LIB,Kerry Douglas McKennon,43,27,16
+Randall,325 CISD,Attorney General,,REP,Ken Paxton,2010,1488,522
+Randall,325 CISD,Attorney General,,DEM,Justin Nelson,270,193,77
+Randall,325 CISD,Attorney General,,LIB,Michael Ray Harris,35,24,11
+Randall,325 CISD,Comptroller of Public Accounts,,REP,Glenn Hegar,2031,1507,524
+Randall,325 CISD,Comptroller of Public Accounts,,DEM,Joi Chevalier,228,159,69
+Randall,325 CISD,Comptroller of Public Accounts,,LIB,Ben Sanders,43,31,12
+Randall,325 CISD,Commissioner of the General Land Office,,REP,George P. Bush,2005,1482,523
+Randall,325 CISD,Commissioner of the General Land Office,,DEM,Miguel Suazo,233,167,66
+Randall,325 CISD,Commissioner of the General Land Office,,LIB,Matt Pina,67,46,21
+Randall,325 CISD,Commissioner of Agriculture,,REP,Sid Miller,2000,1484,516
+Randall,325 CISD,Commissioner of Agriculture,,DEM,Kim Olson,266,184,82
+Randall,325 CISD,Commissioner of Agriculture,,LIB,Richard Carpenter,40,29,11
+Randall,325 CISD,Railroad Commissioner,,REP,Christi Craddick,2014,1488,526
+Randall,325 CISD,Railroad Commissioner,,DEM,Roman McAllen,231,164,67
+Randall,325 CISD,Railroad Commissioner,,LIB,Mike Wright,56,40,16
+Randall,325 CISD,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,2031,1506,525
+Randall,325 CISD,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,264,187,77
+Randall,325 CISD,"Justice, Supreme Court, Place 4",,REP,John Devine,2033,1510,523
+Randall,325 CISD,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,263,182,81
+Randall,325 CISD,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,2034,1510,524
+Randall,325 CISD,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,265,184,81
+Randall,325 CISD,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,2016,1496,520
+Randall,325 CISD,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,244,169,75
+Randall,325 CISD,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,39,26,13
+Randall,325 CISD,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,2041,1513,528
+Randall,325 CISD,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,253,177,76
+Randall,325 CISD,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,2071,1530,541
+Randall,325 CISD,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,167,119,48
+Randall,325 CISD,State Senator,31,REP,Kel Seliger,2062,1522,540
+Randall,325 CISD,State Senator,31,LIB,Jack B. Westbrook,198,139,59
+Randall,325 CISD,State Representative,86,REP,John Smithee,2049,1518,531
+Randall,325 CISD,State Representative,86,DEM,Mike Purcell,254,177,77
+Randall,325 CISD,"Justice, 7th Court of Appeals District, Place 2",,REP,Judy Parker,2137,1565,572
+Randall,325 CISD,"Justice, 7th Court of Appeals District, Place 3",,REP,Pat Pirtle,2135,1563,572
+Randall,325 CISD,"District Judge, 47th Judicial District",,REP,Dan L. Schaap,2129,1562,567
+Randall,325 CISD,"District Judge, 181st Judicial District",,REP,John B. Board,2129,1558,571
+Randall,325 CISD,"District Judge, 251st Judicial District",,REP,Ana Elizabeth Estevez,2129,1559,570
+Randall,325 CISD,Criminal District Attorney,,REP,Robert Love,2125,1559,566
+Randall,325 CISD,County Judge,,REP,Ernie Houdashell,2125,1556,569
+Randall,325 CISD,"Judge, County Court at Law 1",,REP,James W. Anderson,2117,1552,565
+Randall,325 CISD,"Judge, County Court at Law 2",,REP,Matt Martindale,2130,1563,567
+Randall,325 CISD,District Clerk,,REP,Joel Forbis,2121,1559,562
+Randall,325 CISD,County Clerk,,REP,Susan Allen,2125,1558,567
+Randall,325 CISD,County Treasurer,,REP,Angie Parker,2120,1555,565
+Randall,325 CISD,"Justice of the Peace, Precinct 1",,REP,J. Tracy Byrd,2130,1561,569
+Randall,325 CISD,"Constable, Precinct 1, Unexpired Term",,REP,Richard Beals,2105,1541,564
+Randall,325 CISD,"Constable, Precinct 1, Unexpired Term",,,"Patrick ""Tinsley"" Tinsley",18,15,3
+Randall,325 CISD,"Constable, Precinct 1, Unexpired Term",,,Rejected write-ins,4,4,0
+Randall,325 CISD,"Constable, Precinct 1, Unexpired Term",,,Unassigned write-ins,0,0,0
+Randall,415 CISD,Registered Voters,,,,4668,,
+Randall,415 CISD,Provisional Ballots,,,,30,,
+Randall,415 CISD,Provisional Ballots Counted,,,,7,,
+Randall,415 CISD,Straight Party,,REP,Republican Party,1375,970,405
+Randall,415 CISD,Straight Party,,DEM,Democratic Party,280,201,79
+Randall,415 CISD,Straight Party,,LIB,Libertarian Party,8,5,3
+Randall,415 CISD,U.S. Senate,,REP,Ted Cruz,1823,1298,525
+Randall,415 CISD,U.S. Senate,,DEM,Beto O'Rourke,515,351,164
+Randall,415 CISD,U.S. Senate,,LIB,Neal M. Dikeman,13,8,5
+Randall,415 CISD,U.S. House,13,REP,Mac Thornberry,1889,1338,551
+Randall,415 CISD,U.S. House,13,DEM,Greg Sagan,415,292,123
+Randall,415 CISD,U.S. House,13,LIB,Calvin DeWeese,31,16,15
+Randall,415 CISD,Governor,,REP,Greg Abbott,1893,1334,559
+Randall,415 CISD,Governor,,DEM,Lupe Valdez,428,302,126
+Randall,415 CISD,Governor,,LIB,Mark Jay Tippetts,23,16,7
+Randall,415 CISD,Lieutenant Governor,,REP,Dan Patrick,1757,1259,498
+Randall,415 CISD,Lieutenant Governor,,DEM,Mike Collier,525,357,168
+Randall,415 CISD,Lieutenant Governor,,LIB,Kerry Douglas McKennon,48,28,20
+Randall,415 CISD,Attorney General,,REP,Ken Paxton,1803,1278,525
+Randall,415 CISD,Attorney General,,DEM,Justin Nelson,475,331,144
+Randall,415 CISD,Attorney General,,LIB,Michael Ray Harris,48,31,17
+Randall,415 CISD,Comptroller of Public Accounts,,REP,Glenn Hegar,1818,1294,524
+Randall,415 CISD,Comptroller of Public Accounts,,DEM,Joi Chevalier,430,299,131
+Randall,415 CISD,Comptroller of Public Accounts,,LIB,Ben Sanders,69,41,28
+Randall,415 CISD,Commissioner of the General Land Office,,REP,George P. Bush,1807,1279,528
+Randall,415 CISD,Commissioner of the General Land Office,,DEM,Miguel Suazo,442,304,138
+Randall,415 CISD,Commissioner of the General Land Office,,LIB,Matt Pina,78,58,20
+Randall,415 CISD,Commissioner of Agriculture,,REP,Sid Miller,1820,1295,525
+Randall,415 CISD,Commissioner of Agriculture,,DEM,Kim Olson,459,317,142
+Randall,415 CISD,Commissioner of Agriculture,,LIB,Richard Carpenter,40,26,14
+Randall,415 CISD,Railroad Commissioner,,REP,Christi Craddick,1830,1304,526
+Randall,415 CISD,Railroad Commissioner,,DEM,Roman McAllen,433,304,129
+Randall,415 CISD,Railroad Commissioner,,LIB,Mike Wright,56,29,27
+Randall,415 CISD,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1837,1311,526
+Randall,415 CISD,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,483,328,155
+Randall,415 CISD,"Justice, Supreme Court, Place 4",,REP,John Devine,1838,1309,529
+Randall,415 CISD,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,480,327,153
+Randall,415 CISD,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1836,1306,530
+Randall,415 CISD,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,480,329,151
+Randall,415 CISD,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1820,1298,522
+Randall,415 CISD,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,449,308,141
+Randall,415 CISD,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,46,28,18
+Randall,415 CISD,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1855,1316,539
+Randall,415 CISD,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,458,317,141
+Randall,415 CISD,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1920,1363,557
+Randall,415 CISD,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,293,193,100
+Randall,415 CISD,State Senator,31,REP,Kel Seliger,1909,1352,557
+Randall,415 CISD,State Senator,31,LIB,Jack B. Westbrook,326,218,108
+Randall,415 CISD,State Representative,86,REP,John Smithee,1869,1318,551
+Randall,415 CISD,State Representative,86,DEM,Mike Purcell,452,318,134
+Randall,415 CISD,"Justice, 7th Court of Appeals District, Place 2",,REP,Judy Parker,2047,1433,614
+Randall,415 CISD,"Justice, 7th Court of Appeals District, Place 3",,REP,Pat Pirtle,2042,1428,614
+Randall,415 CISD,"District Judge, 47th Judicial District",,REP,Dan L. Schaap,2033,1423,610
+Randall,415 CISD,"District Judge, 181st Judicial District",,REP,John B. Board,2036,1425,611
+Randall,415 CISD,"District Judge, 251st Judicial District",,REP,Ana Elizabeth Estevez,2042,1428,614
+Randall,415 CISD,Criminal District Attorney,,REP,Robert Love,2028,1415,613
+Randall,415 CISD,County Judge,,REP,Ernie Houdashell,2026,1417,609
+Randall,415 CISD,"Judge, County Court at Law 1",,REP,James W. Anderson,2026,1416,610
+Randall,415 CISD,"Judge, County Court at Law 2",,REP,Matt Martindale,2025,1415,610
+Randall,415 CISD,District Clerk,,REP,Joel Forbis,2022,1414,608
+Randall,415 CISD,County Clerk,,REP,Susan Allen,2021,1413,608
+Randall,415 CISD,County Treasurer,,REP,Angie Parker,2022,1412,610
+Randall,415 CISD,"County Commissioner, Precinct 4",,REP,Buddy DeFord,2010,1404,606
+Randall,415 CISD,"Justice of the Peace, Precinct 4",,REP,Clay Houdashell,2009,1406,603
+Randall,418,Registered Voters,,,,5237,,
+Randall,418,Provisional Ballots,,,,34,,
+Randall,418,Provisional Ballots Counted,,,,13,,
+Randall,418,Straight Party,,REP,Republican Party,1624,1282,342
+Randall,418,Straight Party,,DEM,Democratic Party,317,230,87
+Randall,418,Straight Party,,LIB,Libertarian Party,17,14,3
+Randall,418,U.S. Senate,,REP,Ted Cruz,2193,1715,478
+Randall,418,U.S. Senate,,DEM,Beto O'Rourke,624,455,169
+Randall,418,U.S. Senate,,LIB,Neal M. Dikeman,24,16,8
+Randall,418,U.S. House,13,REP,Mac Thornberry,2286,1771,515
+Randall,418,U.S. House,13,DEM,Greg Sagan,478,358,120
+Randall,418,U.S. House,13,LIB,Calvin DeWeese,61,46,15
+Randall,418,Governor,,REP,Greg Abbott,2260,1754,506
+Randall,418,Governor,,DEM,Lupe Valdez,520,393,127
+Randall,418,Governor,,LIB,Mark Jay Tippetts,53,36,17
+Randall,418,Lieutenant Governor,,REP,Dan Patrick,2121,1654,467
+Randall,418,Lieutenant Governor,,DEM,Mike Collier,608,454,154
+Randall,418,Lieutenant Governor,,LIB,Kerry Douglas McKennon,93,69,24
+Randall,418,Attorney General,,REP,Ken Paxton,2158,1673,485
+Randall,418,Attorney General,,DEM,Justin Nelson,595,448,147
+Randall,418,Attorney General,,LIB,Michael Ray Harris,76,59,17
+Randall,418,Comptroller of Public Accounts,,REP,Glenn Hegar,2179,1698,481
+Randall,418,Comptroller of Public Accounts,,DEM,Joi Chevalier,518,388,130
+Randall,418,Comptroller of Public Accounts,,LIB,Ben Sanders,115,80,35
+Randall,418,Commissioner of the General Land Office,,REP,George P. Bush,2196,1705,491
+Randall,418,Commissioner of the General Land Office,,DEM,Miguel Suazo,507,375,132
+Randall,418,Commissioner of the General Land Office,,LIB,Matt Pina,116,89,27
+Randall,418,Commissioner of Agriculture,,REP,Sid Miller,2137,1662,475
+Randall,418,Commissioner of Agriculture,,DEM,Kim Olson,572,431,141
+Randall,418,Commissioner of Agriculture,,LIB,Richard Carpenter,100,73,27
+Randall,418,Railroad Commissioner,,REP,Christi Craddick,2208,1725,483
+Randall,418,Railroad Commissioner,,DEM,Roman McAllen,495,367,128
+Randall,418,Railroad Commissioner,,LIB,Mike Wright,99,70,29
+Randall,418,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,2238,1739,499
+Randall,418,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,564,422,142
+Randall,418,"Justice, Supreme Court, Place 4",,REP,John Devine,2244,1749,495
+Randall,418,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,561,415,146
+Randall,418,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,2235,1742,493
+Randall,418,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,575,426,149
+Randall,418,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,2185,1706,479
+Randall,418,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,524,389,135
+Randall,418,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,94,67,27
+Randall,418,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,2247,1748,499
+Randall,418,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,553,411,142
+Randall,418,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,2324,1804,520
+Randall,418,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,333,249,84
+Randall,418,State Senator,31,REP,Kel Seliger,2333,1817,516
+Randall,418,State Senator,31,LIB,Jack B. Westbrook,368,264,104
+Randall,418,State Representative,86,REP,John Smithee,2274,1768,506
+Randall,418,State Representative,86,DEM,Mike Purcell,539,398,141
+Randall,418,"Justice, 7th Court of Appeals District, Place 2",,REP,Judy Parker,2443,1884,559
+Randall,418,"Justice, 7th Court of Appeals District, Place 3",,REP,Pat Pirtle,2431,1876,555
+Randall,418,"District Judge, 47th Judicial District",,REP,Dan L. Schaap,2426,1872,554
+Randall,418,"District Judge, 181st Judicial District",,REP,John B. Board,2423,1871,552
+Randall,418,"District Judge, 251st Judicial District",,REP,Ana Elizabeth Estevez,2441,1885,556
+Randall,418,Criminal District Attorney,,REP,Robert Love,2403,1853,550
+Randall,418,County Judge,,REP,Ernie Houdashell,2423,1866,557
+Randall,418,"Judge, County Court at Law 1",,REP,James W. Anderson,2417,1862,555
+Randall,418,"Judge, County Court at Law 2",,REP,Matt Martindale,2437,1881,556
+Randall,418,District Clerk,,REP,Joel Forbis,2406,1855,551
+Randall,418,County Clerk,,REP,Susan Allen,2416,1861,555
+Randall,418,County Treasurer,,REP,Angie Parker,2411,1858,553
+Randall,418,"County Commissioner, Precinct 4",,REP,Buddy DeFord,2414,1864,550
+Randall,418,"Justice of the Peace, Precinct 4",,REP,Clay Houdashell,2413,1857,556
+Randall,421,Registered Voters,,,,3534,,
+Randall,421,Provisional Ballots,,,,9,,
+Randall,421,Provisional Ballots Counted,,,,1,,
+Randall,421,Straight Party,,REP,Republican Party,963,724,239
+Randall,421,Straight Party,,DEM,Democratic Party,214,152,62
+Randall,421,Straight Party,,LIB,Libertarian Party,7,5,2
+Randall,421,U.S. Senate,,REP,Ted Cruz,1291,972,319
+Randall,421,U.S. Senate,,DEM,Beto O'Rourke,404,284,120
+Randall,421,U.S. Senate,,LIB,Neal M. Dikeman,14,9,5
+Randall,421,U.S. House,13,REP,Mac Thornberry,1348,1011,337
+Randall,421,U.S. House,13,DEM,Greg Sagan,333,236,97
+Randall,421,U.S. House,13,LIB,Calvin DeWeese,24,15,9
+Randall,421,Governor,,REP,Greg Abbott,1329,993,336
+Randall,421,Governor,,DEM,Lupe Valdez,341,249,92
+Randall,421,Governor,,LIB,Mark Jay Tippetts,36,22,14
+Randall,421,Lieutenant Governor,,REP,Dan Patrick,1274,955,319
+Randall,421,Lieutenant Governor,,DEM,Mike Collier,390,278,112
+Randall,421,Lieutenant Governor,,LIB,Kerry Douglas McKennon,37,26,11
+Randall,421,Attorney General,,REP,Ken Paxton,1274,960,314
+Randall,421,Attorney General,,DEM,Justin Nelson,377,270,107
+Randall,421,Attorney General,,LIB,Michael Ray Harris,47,29,18
+Randall,421,Comptroller of Public Accounts,,REP,Glenn Hegar,1290,969,321
+Randall,421,Comptroller of Public Accounts,,DEM,Joi Chevalier,336,242,94
+Randall,421,Comptroller of Public Accounts,,LIB,Ben Sanders,65,45,20
+Randall,421,Commissioner of the General Land Office,,REP,George P. Bush,1298,964,334
+Randall,421,Commissioner of the General Land Office,,DEM,Miguel Suazo,327,238,89
+Randall,421,Commissioner of the General Land Office,,LIB,Matt Pina,68,51,17
+Randall,421,Commissioner of Agriculture,,REP,Sid Miller,1275,956,319
+Randall,421,Commissioner of Agriculture,,DEM,Kim Olson,373,261,112
+Randall,421,Commissioner of Agriculture,,LIB,Richard Carpenter,44,35,9
+Randall,421,Railroad Commissioner,,REP,Christi Craddick,1295,969,326
+Randall,421,Railroad Commissioner,,DEM,Roman McAllen,325,234,91
+Randall,421,Railroad Commissioner,,LIB,Mike Wright,68,49,19
+Randall,421,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1309,979,330
+Randall,421,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,381,274,107
+Randall,421,"Justice, Supreme Court, Place 4",,REP,John Devine,1320,989,331
+Randall,421,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,367,261,106
+Randall,421,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1305,980,325
+Randall,421,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,384,271,113
+Randall,421,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1286,967,319
+Randall,421,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,359,255,104
+Randall,421,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,42,29,13
+Randall,421,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1316,986,330
+Randall,421,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,371,264,107
+Randall,421,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1372,1021,351
+Randall,421,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,223,154,69
+Randall,421,State Senator,31,REP,Kel Seliger,1371,1021,350
+Randall,421,State Senator,31,LIB,Jack B. Westbrook,261,181,80
+Randall,421,State Representative,86,REP,John Smithee,1338,995,343
+Randall,421,State Representative,86,DEM,Mike Purcell,358,258,100
+Randall,421,"Justice, 7th Court of Appeals District, Place 2",,REP,Judy Parker,1481,1090,391
+Randall,421,"Justice, 7th Court of Appeals District, Place 3",,REP,Pat Pirtle,1471,1086,385
+Randall,421,"District Judge, 47th Judicial District",,REP,Dan L. Schaap,1463,1078,385
+Randall,421,"District Judge, 181st Judicial District",,REP,John B. Board,1465,1082,383
+Randall,421,"District Judge, 251st Judicial District",,REP,Ana Elizabeth Estevez,1471,1085,386
+Randall,421,Criminal District Attorney,,REP,Robert Love,1458,1075,383
+Randall,421,County Judge,,REP,Ernie Houdashell,1458,1076,382
+Randall,421,"Judge, County Court at Law 1",,REP,James W. Anderson,1451,1074,377
+Randall,421,"Judge, County Court at Law 2",,REP,Matt Martindale,1465,1083,382
+Randall,421,District Clerk,,REP,Joel Forbis,1456,1078,378
+Randall,421,County Clerk,,REP,Susan Allen,1464,1078,386
+Randall,421,County Treasurer,,REP,Angie Parker,1457,1076,381
+Randall,421,"County Commissioner, Precinct 4",,REP,Buddy DeFord,1449,1075,374
+Randall,421,"Justice of the Peace, Precinct 4",,REP,Clay Houdashell,1457,1079,378
+Randall,426 CISD,Registered Voters,,,,2878,,
+Randall,426 CISD,Provisional Ballots,,,,7,,
+Randall,426 CISD,Provisional Ballots Counted,,,,3,,
+Randall,426 CISD,Straight Party,,REP,Republican Party,1075,831,244
+Randall,426 CISD,Straight Party,,DEM,Democratic Party,110,87,23
+Randall,426 CISD,Straight Party,,LIB,Libertarian Party,8,2,6
+Randall,426 CISD,U.S. Senate,,REP,Ted Cruz,1472,1116,356
+Randall,426 CISD,U.S. Senate,,DEM,Beto O'Rourke,227,180,47
+Randall,426 CISD,U.S. Senate,,LIB,Neal M. Dikeman,15,9,6
+Randall,426 CISD,U.S. House,13,REP,Mac Thornberry,1487,1126,361
+Randall,426 CISD,U.S. House,13,DEM,Greg Sagan,188,158,30
+Randall,426 CISD,U.S. House,13,LIB,Calvin DeWeese,31,17,14
+Randall,426 CISD,Governor,,REP,Greg Abbott,1497,1128,369
+Randall,426 CISD,Governor,,DEM,Lupe Valdez,189,158,31
+Randall,426 CISD,Governor,,LIB,Mark Jay Tippetts,22,16,6
+Randall,426 CISD,Lieutenant Governor,,REP,Dan Patrick,1430,1090,340
+Randall,426 CISD,Lieutenant Governor,,DEM,Mike Collier,245,192,53
+Randall,426 CISD,Lieutenant Governor,,LIB,Kerry Douglas McKennon,35,22,13
+Randall,426 CISD,Attorney General,,REP,Ken Paxton,1432,1091,341
+Randall,426 CISD,Attorney General,,DEM,Justin Nelson,233,186,47
+Randall,426 CISD,Attorney General,,LIB,Michael Ray Harris,41,26,15
+Randall,426 CISD,Comptroller of Public Accounts,,REP,Glenn Hegar,1449,1107,342
+Randall,426 CISD,Comptroller of Public Accounts,,DEM,Joi Chevalier,200,161,39
+Randall,426 CISD,Comptroller of Public Accounts,,LIB,Ben Sanders,49,30,19
+Randall,426 CISD,Commissioner of the General Land Office,,REP,George P. Bush,1447,1104,343
+Randall,426 CISD,Commissioner of the General Land Office,,DEM,Miguel Suazo,192,153,39
+Randall,426 CISD,Commissioner of the General Land Office,,LIB,Matt Pina,66,44,22
+Randall,426 CISD,Commissioner of Agriculture,,REP,Sid Miller,1447,1107,340
+Randall,426 CISD,Commissioner of Agriculture,,DEM,Kim Olson,212,165,47
+Randall,426 CISD,Commissioner of Agriculture,,LIB,Richard Carpenter,47,30,17
+Randall,426 CISD,Railroad Commissioner,,REP,Christi Craddick,1460,1118,342
+Randall,426 CISD,Railroad Commissioner,,DEM,Roman McAllen,189,146,43
+Randall,426 CISD,Railroad Commissioner,,LIB,Mike Wright,52,34,18
+Randall,426 CISD,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1477,1124,353
+Randall,426 CISD,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,217,171,46
+Randall,426 CISD,"Justice, Supreme Court, Place 4",,REP,John Devine,1486,1127,359
+Randall,426 CISD,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,206,166,40
+Randall,426 CISD,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1473,1123,350
+Randall,426 CISD,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,221,173,48
+Randall,426 CISD,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1451,1114,337
+Randall,426 CISD,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,208,158,50
+Randall,426 CISD,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,36,22,14
+Randall,426 CISD,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1479,1127,352
+Randall,426 CISD,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,215,167,48
+Randall,426 CISD,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1509,1148,361
+Randall,426 CISD,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,140,110,30
+Randall,426 CISD,State Senator,31,REP,Kel Seliger,1491,1136,355
+Randall,426 CISD,State Senator,31,LIB,Jack B. Westbrook,178,134,44
+Randall,426 CISD,State Representative,86,REP,John Smithee,1490,1129,361
+Randall,426 CISD,State Representative,86,DEM,Mike Purcell,212,170,42
+Randall,426 CISD,"Justice, 7th Court of Appeals District, Place 2",,REP,Judy Parker,1564,1189,375
+Randall,426 CISD,"Justice, 7th Court of Appeals District, Place 3",,REP,Pat Pirtle,1560,1185,375
+Randall,426 CISD,"District Judge, 47th Judicial District",,REP,Dan L. Schaap,1550,1178,372
+Randall,426 CISD,"District Judge, 181st Judicial District",,REP,John B. Board,1552,1180,372
+Randall,426 CISD,"District Judge, 251st Judicial District",,REP,Ana Elizabeth Estevez,1552,1181,371
+Randall,426 CISD,Criminal District Attorney,,REP,Robert Love,1550,1178,372
+Randall,426 CISD,County Judge,,REP,Ernie Houdashell,1558,1182,376
+Randall,426 CISD,"Judge, County Court at Law 1",,REP,James W. Anderson,1553,1181,372
+Randall,426 CISD,"Judge, County Court at Law 2",,REP,Matt Martindale,1556,1184,372
+Randall,426 CISD,District Clerk,,REP,Joel Forbis,1550,1181,369
+Randall,426 CISD,County Clerk,,REP,Susan Allen,1546,1179,367
+Randall,426 CISD,County Treasurer,,REP,Angie Parker,1550,1180,370
+Randall,426 CISD,"County Commissioner, Precinct 4",,REP,Buddy DeFord,1552,1182,370
+Randall,426 CISD,"Justice of the Peace, Precinct 4",,REP,Clay Houdashell,1549,1177,372
+Randall,429,Registered Voters,,,,4446,,
+Randall,429,Provisional Ballots,,,,21,,
+Randall,429,Provisional Ballots Counted,,,,11,,
+Randall,429,Straight Party,,REP,Republican Party,1189,976,213
+Randall,429,Straight Party,,DEM,Democratic Party,315,233,82
+Randall,429,Straight Party,,LIB,Libertarian Party,11,10,1
+Randall,429,U.S. Senate,,REP,Ted Cruz,1691,1366,325
+Randall,429,U.S. Senate,,DEM,Beto O'Rourke,633,476,157
+Randall,429,U.S. Senate,,LIB,Neal M. Dikeman,13,12,1
+Randall,429,U.S. House,13,REP,Mac Thornberry,1773,1422,351
+Randall,429,U.S. House,13,DEM,Greg Sagan,509,394,115
+Randall,429,U.S. House,13,LIB,Calvin DeWeese,44,29,15
+Randall,429,Governor,,REP,Greg Abbott,1766,1415,351
+Randall,429,Governor,,DEM,Lupe Valdez,530,409,121
+Randall,429,Governor,,LIB,Mark Jay Tippetts,36,27,9
+Randall,429,Lieutenant Governor,,REP,Dan Patrick,1641,1328,313
+Randall,429,Lieutenant Governor,,DEM,Mike Collier,612,463,149
+Randall,429,Lieutenant Governor,,LIB,Kerry Douglas McKennon,65,53,12
+Randall,429,Attorney General,,REP,Ken Paxton,1636,1323,313
+Randall,429,Attorney General,,DEM,Justin Nelson,621,473,148
+Randall,429,Attorney General,,LIB,Michael Ray Harris,67,49,18
+Randall,429,Comptroller of Public Accounts,,REP,Glenn Hegar,1705,1373,332
+Randall,429,Comptroller of Public Accounts,,DEM,Joi Chevalier,523,399,124
+Randall,429,Comptroller of Public Accounts,,LIB,Ben Sanders,73,53,20
+Randall,429,Commissioner of the General Land Office,,REP,George P. Bush,1699,1365,334
+Randall,429,Commissioner of the General Land Office,,DEM,Miguel Suazo,509,390,119
+Randall,429,Commissioner of the General Land Office,,LIB,Matt Pina,101,77,24
+Randall,429,Commissioner of Agriculture,,REP,Sid Miller,1631,1318,313
+Randall,429,Commissioner of Agriculture,,DEM,Kim Olson,588,448,140
+Randall,429,Commissioner of Agriculture,,LIB,Richard Carpenter,73,55,18
+Randall,429,Railroad Commissioner,,REP,Christi Craddick,1731,1396,335
+Randall,429,Railroad Commissioner,,DEM,Roman McAllen,519,390,129
+Randall,429,Railroad Commissioner,,LIB,Mike Wright,56,45,11
+Randall,429,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1721,1390,331
+Randall,429,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,582,442,140
+Randall,429,"Justice, Supreme Court, Place 4",,REP,John Devine,1732,1394,338
+Randall,429,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,566,431,135
+Randall,429,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1718,1383,335
+Randall,429,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,584,446,138
+Randall,429,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1687,1366,321
+Randall,429,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,556,417,139
+Randall,429,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,66,51,15
+Randall,429,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1730,1399,331
+Randall,429,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,566,426,140
+Randall,429,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1814,1462,352
+Randall,429,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,332,240,92
+Randall,429,State Senator,31,REP,Kel Seliger,1844,1477,367
+Randall,429,State Senator,31,LIB,Jack B. Westbrook,346,255,91
+Randall,429,State Representative,86,REP,John Smithee,1777,1431,346
+Randall,429,State Representative,86,DEM,Mike Purcell,537,404,133
+Randall,429,"Justice, 7th Court of Appeals District, Place 2",,REP,Judy Parker,1930,1539,391
+Randall,429,"Justice, 7th Court of Appeals District, Place 3",,REP,Pat Pirtle,1936,1547,389
+Randall,429,"District Judge, 47th Judicial District",,REP,Dan L. Schaap,1917,1528,389
+Randall,429,"District Judge, 181st Judicial District",,REP,John B. Board,1934,1543,391
+Randall,429,"District Judge, 251st Judicial District",,REP,Ana Elizabeth Estevez,1938,1545,393
+Randall,429,Criminal District Attorney,,REP,Robert Love,1909,1524,385
+Randall,429,County Judge,,REP,Ernie Houdashell,1928,1539,389
+Randall,429,"Judge, County Court at Law 1",,REP,James W. Anderson,1910,1526,384
+Randall,429,"Judge, County Court at Law 2",,REP,Matt Martindale,1943,1552,391
+Randall,429,District Clerk,,REP,Joel Forbis,1906,1522,384
+Randall,429,County Clerk,,REP,Susan Allen,1906,1519,387
+Randall,429,County Treasurer,,REP,Angie Parker,1907,1520,387
+Randall,429,"County Commissioner, Precinct 4",,REP,Buddy DeFord,1906,1523,383
+Randall,429,"Justice of the Peace, Precinct 4",,REP,Clay Houdashell,1912,1522,390


### PR DESCRIPTION
How strange.

This was a CSV file reminiscent of the `csv-a.py` format, but with some notable exceptions:
- No over/undervote information
- No information on ballots cast
- Statistics on provisionals cast and accepted ("Provisional Ballots{, Counted}")
- No total vote numbers (Can be derived, but not verified)