### PR TITLE
Add precinct-level results for the 2018 general election in Kerr County

### DIFF
--- a/2018/20181106__tx__general__kerr__precinct.csv
+++ b/2018/20181106__tx__general__kerr__precinct.csv
@@ -1,0 +1,2141 @@
+county,precinct,office,district,party,candidate,votes,early_voting,election_day
+Kerr,101,Ballots Cast,,,,3232,2593,639
+Kerr,101,Straight Party,,,Over Votes,0,0,0
+Kerr,101,Straight Party,,,Under Votes,626,503,123
+Kerr,101,Straight Party,,REP,Republican Party,1024,832,192
+Kerr,101,Straight Party,,DEM,Democratic Party,176,140,36
+Kerr,101,Straight Party,,LIB,Libertarian Party,2,1,1
+Kerr,101,U.S. Senate,,,Over Votes,0,0,0
+Kerr,101,U.S. Senate,,,Under Votes,14,12,2
+Kerr,101,U.S. Senate,,REP,Ted Cruz,1428,1151,277
+Kerr,101,U.S. Senate,,DEM,Beto O'Rourke,373,303,70
+Kerr,101,U.S. Senate,,LIB,Neal M. Dikeman,13,10,3
+Kerr,101,U.S. House,21,,Over Votes,1,1,0
+Kerr,101,U.S. House,21,,Under Votes,23,22,1
+Kerr,101,U.S. House,21,REP,Chip Roy,1411,1137,274
+Kerr,101,U.S. House,21,DEM,Joseph Kopser,377,307,70
+Kerr,101,U.S. House,21,LIB,Lee Santos,16,9,7
+Kerr,101,Governor,,,Over Votes,0,0,0
+Kerr,101,Governor,,,Under Votes,16,14,2
+Kerr,101,Governor,,REP,Greg Abbott,1489,1199,290
+Kerr,101,Governor,,DEM,Lupe Valdez,305,248,57
+Kerr,101,Governor,,LIB,Mark Jay Tippetts,18,15,3
+Kerr,101,Lieutenant Governor,,,Over Votes,0,0,0
+Kerr,101,Lieutenant Governor,,,Under Votes,8,8,0
+Kerr,101,Lieutenant Governor,,REP,Dan Patrick,1421,1145,276
+Kerr,101,Lieutenant Governor,,DEM,Mike Collier,378,314,64
+Kerr,101,Lieutenant Governor,,LIB,Kerry Douglas McKennon,21,9,12
+Kerr,101,Attorney General,,,Over Votes,0,0,0
+Kerr,101,Attorney General,,,Under Votes,14,11,3
+Kerr,101,Attorney General,,REP,Ken Paxton,1401,1135,266
+Kerr,101,Attorney General,,DEM,Justin Nelson,385,311,74
+Kerr,101,Attorney General,,LIB,Michael Ray Harris,28,19,9
+Kerr,101,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Kerr,101,Comptroller of Public Accounts,,,Under Votes,33,29,4
+Kerr,101,Comptroller of Public Accounts,,REP,Glenn Hegar,1435,1166,269
+Kerr,101,Comptroller of Public Accounts,,DEM,Joi Chevalier,320,255,65
+Kerr,101,Comptroller of Public Accounts,,LIB,Ben Sanders,40,26,14
+Kerr,101,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Kerr,101,Commissioner of the General Land Office,,,Under Votes,37,30,7
+Kerr,101,Commissioner of the General Land Office,,REP,George P. Bush,1399,1130,269
+Kerr,101,Commissioner of the General Land Office,,DEM,Miguel Suazo,325,265,60
+Kerr,101,Commissioner of the General Land Office,,LIB,Matt Piña,67,51,16
+Kerr,101,Commissioner of Agriculture,,,Over Votes,0,0,0
+Kerr,101,Commissioner of Agriculture,,,Under Votes,30,25,5
+Kerr,101,Commissioner of Agriculture,,REP,Sid Miller,1407,1137,270
+Kerr,101,Commissioner of Agriculture,,DEM,Kim Olson,358,289,69
+Kerr,101,Commissioner of Agriculture,,LIB,Richard Carpenter,33,25,8
+Kerr,101,Railroad Commissioner,,,Over Votes,1,1,0
+Kerr,101,Railroad Commissioner,,,Under Votes,32,26,6
+Kerr,101,Railroad Commissioner,,REP,Christi Craddick,1432,1157,275
+Kerr,101,Railroad Commissioner,,DEM,Roman McAllen,325,266,59
+Kerr,101,Railroad Commissioner,,LIB,Mike Wright,38,26,12
+Kerr,101,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Kerr,101,"Justice, Supreme Court, Place 2",,,Under Votes,37,29,8
+Kerr,101,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1434,1159,275
+Kerr,101,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,357,288,69
+Kerr,101,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Kerr,101,"Justice, Supreme Court, Place 4",,,Under Votes,38,31,7
+Kerr,101,"Justice, Supreme Court, Place 4",,REP,John Devine,1446,1170,276
+Kerr,101,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,344,275,69
+Kerr,101,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Kerr,101,"Justice, Supreme Court, Place 6",,,Under Votes,33,27,6
+Kerr,101,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1443,1169,274
+Kerr,101,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,352,280,72
+Kerr,101,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Kerr,101,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,36,30,6
+Kerr,101,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1430,1157,273
+Kerr,101,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,334,271,63
+Kerr,101,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,28,18,10
+Kerr,101,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,1,1,0
+Kerr,101,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,36,31,5
+Kerr,101,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1454,1180,274
+Kerr,101,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,337,264,73
+Kerr,101,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Kerr,101,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,208,171,37
+Kerr,101,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1487,1204,283
+Kerr,101,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,133,101,32
+Kerr,101,State Representative,53,,Over Votes,0,0,0
+Kerr,101,State Representative,53,,Under Votes,34,29,5
+Kerr,101,State Representative,53,REP,Andrew S. Murr,1446,1167,279
+Kerr,101,State Representative,53,DEM,Stephanie Lochte Ertel,348,280,68
+Kerr,101,"Justice, 4th Court of Appeals District, Place 2",,,Over Votes,0,0,0
+Kerr,101,"Justice, 4th Court of Appeals District, Place 2",,,Under Votes,44,36,8
+Kerr,101,"Justice, 4th Court of Appeals District, Place 2",,REP,Marialyn Barnard,1443,1169,274
+Kerr,101,"Justice, 4th Court of Appeals District, Place 2",,DEM,Beth Watkins,341,271,70
+Kerr,101,"Justice, 4th Court of Appeals District, Place 3",,,Over Votes,0,0,0
+Kerr,101,"Justice, 4th Court of Appeals District, Place 3",,,Under Votes,40,33,7
+Kerr,101,"Justice, 4th Court of Appeals District, Place 3",,REP,Jason Pulliam,1428,1158,270
+Kerr,101,"Justice, 4th Court of Appeals District, Place 3",,DEM,Patricia O'Connell Alvarez,360,285,75
+Kerr,101,"Justice, 4th Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Kerr,101,"Justice, 4th Court of Appeals District, Place 4",,,Under Votes,42,36,6
+Kerr,101,"Justice, 4th Court of Appeals District, Place 4",,REP,Patrick Ballantyne,1427,1157,270
+Kerr,101,"Justice, 4th Court of Appeals District, Place 4",,DEM,Luz Elena Chapa,359,283,76
+Kerr,101,"Justice, 4th Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Kerr,101,"Justice, 4th Court of Appeals District, Place 5",,,Under Votes,44,37,7
+Kerr,101,"Justice, 4th Court of Appeals District, Place 5",,REP,Rebecca Simmons,1452,1178,274
+Kerr,101,"Justice, 4th Court of Appeals District, Place 5",,DEM,Liza Rodriguez,332,261,71
+Kerr,101,"Justice, 4th Court of Appeals District, Place 7",,,Over Votes,0,0,0
+Kerr,101,"Justice, 4th Court of Appeals District, Place 7",,,Under Votes,41,33,8
+Kerr,101,"Justice, 4th Court of Appeals District, Place 7",,REP,Shane Stolarczyk,1433,1164,269
+Kerr,101,"Justice, 4th Court of Appeals District, Place 7",,DEM,Rebeca Martinez,354,279,75
+Kerr,101,"District Judge, 198th Judicial District",,,Over Votes,0,0,0
+Kerr,101,"District Judge, 198th Judicial District",,,Under Votes,281,233,48
+Kerr,101,"District Judge, 198th Judicial District",,REP,Rex Emerson,1547,1243,304
+Kerr,101,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,Over Votes,1,1,0
+Kerr,101,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,Under Votes,2,2,0
+Kerr,101,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,FOR,876,684,192
+Kerr,101,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,AGAINST,525,430,95
+Kerr,107,Ballots Cast,,,,1024,761,263
+Kerr,107,Straight Party,,,Over Votes,0,0,0
+Kerr,107,Straight Party,,,Under Votes,205,136,69
+Kerr,107,Straight Party,,REP,Republican Party,347,264,83
+Kerr,107,Straight Party,,DEM,Democratic Party,50,41,9
+Kerr,107,Straight Party,,LIB,Libertarian Party,2,2,0
+Kerr,107,U.S. Senate,,,Over Votes,0,0,0
+Kerr,107,U.S. Senate,,,Under Votes,2,2,0
+Kerr,107,U.S. Senate,,REP,Ted Cruz,491,360,131
+Kerr,107,U.S. Senate,,DEM,Beto O'Rourke,108,79,29
+Kerr,107,U.S. Senate,,LIB,Neal M. Dikeman,3,2,1
+Kerr,107,U.S. House,21,,Over Votes,0,0,0
+Kerr,107,U.S. House,21,,Under Votes,5,3,2
+Kerr,107,U.S. House,21,REP,Chip Roy,489,357,132
+Kerr,107,U.S. House,21,DEM,Joseph Kopser,102,78,24
+Kerr,107,U.S. House,21,LIB,Lee Santos,8,5,3
+Kerr,107,Governor,,,Over Votes,0,0,0
+Kerr,107,Governor,,,Under Votes,2,1,1
+Kerr,107,Governor,,REP,Greg Abbott,501,367,134
+Kerr,107,Governor,,DEM,Lupe Valdez,93,69,24
+Kerr,107,Governor,,LIB,Mark Jay Tippetts,8,6,2
+Kerr,107,Lieutenant Governor,,,Over Votes,0,0,0
+Kerr,107,Lieutenant Governor,,,Under Votes,1,1,0
+Kerr,107,Lieutenant Governor,,REP,Dan Patrick,493,361,132
+Kerr,107,Lieutenant Governor,,DEM,Mike Collier,102,74,28
+Kerr,107,Lieutenant Governor,,LIB,Kerry Douglas McKennon,7,6,1
+Kerr,107,Attorney General,,,Over Votes,0,0,0
+Kerr,107,Attorney General,,,Under Votes,1,0,1
+Kerr,107,Attorney General,,REP,Ken Paxton,487,359,128
+Kerr,107,Attorney General,,DEM,Justin Nelson,101,76,25
+Kerr,107,Attorney General,,LIB,Michael Ray Harris,15,8,7
+Kerr,107,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Kerr,107,Comptroller of Public Accounts,,,Under Votes,8,6,2
+Kerr,107,Comptroller of Public Accounts,,REP,Glenn Hegar,488,359,129
+Kerr,107,Comptroller of Public Accounts,,DEM,Joi Chevalier,91,69,22
+Kerr,107,Comptroller of Public Accounts,,LIB,Ben Sanders,17,9,8
+Kerr,107,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Kerr,107,Commissioner of the General Land Office,,,Under Votes,6,5,1
+Kerr,107,Commissioner of the General Land Office,,REP,George P. Bush,465,344,121
+Kerr,107,Commissioner of the General Land Office,,DEM,Miguel Suazo,99,74,25
+Kerr,107,Commissioner of the General Land Office,,LIB,Matt Piña,34,20,14
+Kerr,107,Commissioner of Agriculture,,,Over Votes,0,0,0
+Kerr,107,Commissioner of Agriculture,,,Under Votes,5,4,1
+Kerr,107,Commissioner of Agriculture,,REP,Sid Miller,479,356,123
+Kerr,107,Commissioner of Agriculture,,DEM,Kim Olson,104,73,31
+Kerr,107,Commissioner of Agriculture,,LIB,Richard Carpenter,16,10,6
+Kerr,107,Railroad Commissioner,,,Over Votes,0,0,0
+Kerr,107,Railroad Commissioner,,,Under Votes,6,5,1
+Kerr,107,Railroad Commissioner,,REP,Christi Craddick,486,357,129
+Kerr,107,Railroad Commissioner,,DEM,Roman McAllen,95,72,23
+Kerr,107,Railroad Commissioner,,LIB,Mike Wright,17,9,8
+Kerr,107,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Kerr,107,"Justice, Supreme Court, Place 2",,,Under Votes,12,9,3
+Kerr,107,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,489,359,130
+Kerr,107,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,103,75,28
+Kerr,107,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Kerr,107,"Justice, Supreme Court, Place 4",,,Under Votes,9,6,3
+Kerr,107,"Justice, Supreme Court, Place 4",,REP,John Devine,500,368,132
+Kerr,107,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,95,69,26
+Kerr,107,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Kerr,107,"Justice, Supreme Court, Place 6",,,Under Votes,12,9,3
+Kerr,107,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,493,364,129
+Kerr,107,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,99,70,29
+Kerr,107,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Kerr,107,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,8,8,0
+Kerr,107,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,478,352,126
+Kerr,107,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,96,71,25
+Kerr,107,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,22,12,10
+Kerr,107,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Kerr,107,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,7,6,1
+Kerr,107,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,498,365,133
+Kerr,107,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,99,72,27
+Kerr,107,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Kerr,107,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,53,43,10
+Kerr,107,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,503,366,137
+Kerr,107,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,48,34,14
+Kerr,107,State Representative,53,,Over Votes,0,0,0
+Kerr,107,State Representative,53,,Under Votes,3,2,1
+Kerr,107,State Representative,53,REP,Andrew S. Murr,498,365,133
+Kerr,107,State Representative,53,DEM,Stephanie Lochte Ertel,103,76,27
+Kerr,107,"Justice, 4th Court of Appeals District, Place 2",,,Over Votes,0,0,0
+Kerr,107,"Justice, 4th Court of Appeals District, Place 2",,,Under Votes,12,10,2
+Kerr,107,"Justice, 4th Court of Appeals District, Place 2",,REP,Marialyn Barnard,496,362,134
+Kerr,107,"Justice, 4th Court of Appeals District, Place 2",,DEM,Beth Watkins,96,71,25
+Kerr,107,"Justice, 4th Court of Appeals District, Place 3",,,Over Votes,0,0,0
+Kerr,107,"Justice, 4th Court of Appeals District, Place 3",,,Under Votes,13,9,4
+Kerr,107,"Justice, 4th Court of Appeals District, Place 3",,REP,Jason Pulliam,490,363,127
+Kerr,107,"Justice, 4th Court of Appeals District, Place 3",,DEM,Patricia O'Connell Alvarez,101,71,30
+Kerr,107,"Justice, 4th Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Kerr,107,"Justice, 4th Court of Appeals District, Place 4",,,Under Votes,12,9,3
+Kerr,107,"Justice, 4th Court of Appeals District, Place 4",,REP,Patrick Ballantyne,494,361,133
+Kerr,107,"Justice, 4th Court of Appeals District, Place 4",,DEM,Luz Elena Chapa,98,73,25
+Kerr,107,"Justice, 4th Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Kerr,107,"Justice, 4th Court of Appeals District, Place 5",,,Under Votes,12,10,2
+Kerr,107,"Justice, 4th Court of Appeals District, Place 5",,REP,Rebecca Simmons,494,361,133
+Kerr,107,"Justice, 4th Court of Appeals District, Place 5",,DEM,Liza Rodriguez,98,72,26
+Kerr,107,"Justice, 4th Court of Appeals District, Place 7",,,Over Votes,0,0,0
+Kerr,107,"Justice, 4th Court of Appeals District, Place 7",,,Under Votes,12,9,3
+Kerr,107,"Justice, 4th Court of Appeals District, Place 7",,REP,Shane Stolarczyk,488,358,130
+Kerr,107,"Justice, 4th Court of Appeals District, Place 7",,DEM,Rebeca Martinez,104,76,28
+Kerr,107,"District Judge, 198th Judicial District",,,Over Votes,0,0,0
+Kerr,107,"District Judge, 198th Judicial District",,,Under Votes,89,68,21
+Kerr,107,"District Judge, 198th Judicial District",,REP,Rex Emerson,515,375,140
+Kerr,107,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,Over Votes,0,0,0
+Kerr,107,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,Under Votes,2,2,0
+Kerr,107,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,FOR,241,180,61
+Kerr,107,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,AGAINST,177,136,41
+Kerr,109,Ballots Cast,,,,1647,1311,336
+Kerr,109,Straight Party,,,Over Votes,0,0,0
+Kerr,109,Straight Party,,,Under Votes,329,238,91
+Kerr,109,Straight Party,,REP,Republican Party,512,442,70
+Kerr,109,Straight Party,,DEM,Democratic Party,87,71,16
+Kerr,109,Straight Party,,LIB,Libertarian Party,3,1,2
+Kerr,109,U.S. Senate,,,Over Votes,0,0,0
+Kerr,109,U.S. Senate,,,Under Votes,6,4,2
+Kerr,109,U.S. Senate,,REP,Ted Cruz,723,592,131
+Kerr,109,U.S. Senate,,DEM,Beto O'Rourke,189,147,42
+Kerr,109,U.S. Senate,,LIB,Neal M. Dikeman,13,9,4
+Kerr,109,U.S. House,21,,Over Votes,0,0,0
+Kerr,109,U.S. House,21,,Under Votes,12,8,4
+Kerr,109,U.S. House,21,REP,Chip Roy,711,583,128
+Kerr,109,U.S. House,21,DEM,Joseph Kopser,192,152,40
+Kerr,109,U.S. House,21,LIB,Lee Santos,16,9,7
+Kerr,109,Governor,,,Over Votes,0,0,0
+Kerr,109,Governor,,,Under Votes,10,8,2
+Kerr,109,Governor,,REP,Greg Abbott,750,614,136
+Kerr,109,Governor,,DEM,Lupe Valdez,155,121,34
+Kerr,109,Governor,,LIB,Mark Jay Tippetts,16,9,7
+Kerr,109,Lieutenant Governor,,,Over Votes,0,0,0
+Kerr,109,Lieutenant Governor,,,Under Votes,8,5,3
+Kerr,109,Lieutenant Governor,,REP,Dan Patrick,725,592,133
+Kerr,109,Lieutenant Governor,,DEM,Mike Collier,186,148,38
+Kerr,109,Lieutenant Governor,,LIB,Kerry Douglas McKennon,12,7,5
+Kerr,109,Attorney General,,,Over Votes,0,0,0
+Kerr,109,Attorney General,,,Under Votes,15,10,5
+Kerr,109,Attorney General,,REP,Ken Paxton,711,584,127
+Kerr,109,Attorney General,,DEM,Justin Nelson,182,144,38
+Kerr,109,Attorney General,,LIB,Michael Ray Harris,23,14,9
+Kerr,109,Comptroller of Public Accounts,,,Over Votes,1,1,0
+Kerr,109,Comptroller of Public Accounts,,,Under Votes,20,15,5
+Kerr,109,Comptroller of Public Accounts,,REP,Glenn Hegar,731,596,135
+Kerr,109,Comptroller of Public Accounts,,DEM,Joi Chevalier,157,128,29
+Kerr,109,Comptroller of Public Accounts,,LIB,Ben Sanders,22,12,10
+Kerr,109,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Kerr,109,Commissioner of the General Land Office,,,Under Votes,23,18,5
+Kerr,109,Commissioner of the General Land Office,,REP,George P. Bush,710,582,128
+Kerr,109,Commissioner of the General Land Office,,DEM,Miguel Suazo,158,127,31
+Kerr,109,Commissioner of the General Land Office,,LIB,Matt Piña,40,25,15
+Kerr,109,Commissioner of Agriculture,,,Over Votes,0,0,0
+Kerr,109,Commissioner of Agriculture,,,Under Votes,20,15,5
+Kerr,109,Commissioner of Agriculture,,REP,Sid Miller,713,586,127
+Kerr,109,Commissioner of Agriculture,,DEM,Kim Olson,176,138,38
+Kerr,109,Commissioner of Agriculture,,LIB,Richard Carpenter,22,13,9
+Kerr,109,Railroad Commissioner,,,Over Votes,0,0,0
+Kerr,109,Railroad Commissioner,,,Under Votes,23,17,6
+Kerr,109,Railroad Commissioner,,REP,Christi Craddick,731,598,133
+Kerr,109,Railroad Commissioner,,DEM,Roman McAllen,156,124,32
+Kerr,109,Railroad Commissioner,,LIB,Mike Wright,21,13,8
+Kerr,109,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Kerr,109,"Justice, Supreme Court, Place 2",,,Under Votes,30,21,9
+Kerr,109,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,729,597,132
+Kerr,109,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,172,134,38
+Kerr,109,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Kerr,109,"Justice, Supreme Court, Place 4",,,Under Votes,28,21,7
+Kerr,109,"Justice, Supreme Court, Place 4",,REP,John Devine,736,604,132
+Kerr,109,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,167,127,40
+Kerr,109,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Kerr,109,"Justice, Supreme Court, Place 6",,,Under Votes,27,20,7
+Kerr,109,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,733,601,132
+Kerr,109,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,171,131,40
+Kerr,109,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,1,1,0
+Kerr,109,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,25,20,5
+Kerr,109,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,726,594,132
+Kerr,109,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,163,127,36
+Kerr,109,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,16,10,6
+Kerr,109,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Kerr,109,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,32,24,8
+Kerr,109,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,736,599,137
+Kerr,109,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,163,129,34
+Kerr,109,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Kerr,109,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,106,86,20
+Kerr,109,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,734,602,132
+Kerr,109,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,91,64,27
+Kerr,109,State Representative,53,,Over Votes,0,0,0
+Kerr,109,State Representative,53,,Under Votes,26,19,7
+Kerr,109,State Representative,53,REP,Andrew S. Murr,740,604,136
+Kerr,109,State Representative,53,DEM,Stephanie Lochte Ertel,165,129,36
+Kerr,109,"Justice, 4th Court of Appeals District, Place 2",,,Over Votes,0,0,0
+Kerr,109,"Justice, 4th Court of Appeals District, Place 2",,,Under Votes,28,20,8
+Kerr,109,"Justice, 4th Court of Appeals District, Place 2",,REP,Marialyn Barnard,723,591,132
+Kerr,109,"Justice, 4th Court of Appeals District, Place 2",,DEM,Beth Watkins,180,141,39
+Kerr,109,"Justice, 4th Court of Appeals District, Place 3",,,Over Votes,0,0,0
+Kerr,109,"Justice, 4th Court of Appeals District, Place 3",,,Under Votes,30,22,8
+Kerr,109,"Justice, 4th Court of Appeals District, Place 3",,REP,Jason Pulliam,730,599,131
+Kerr,109,"Justice, 4th Court of Appeals District, Place 3",,DEM,Patricia O'Connell Alvarez,171,131,40
+Kerr,109,"Justice, 4th Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Kerr,109,"Justice, 4th Court of Appeals District, Place 4",,,Under Votes,31,23,8
+Kerr,109,"Justice, 4th Court of Appeals District, Place 4",,REP,Patrick Ballantyne,733,601,132
+Kerr,109,"Justice, 4th Court of Appeals District, Place 4",,DEM,Luz Elena Chapa,167,128,39
+Kerr,109,"Justice, 4th Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Kerr,109,"Justice, 4th Court of Appeals District, Place 5",,,Under Votes,30,23,7
+Kerr,109,"Justice, 4th Court of Appeals District, Place 5",,REP,Rebecca Simmons,736,598,138
+Kerr,109,"Justice, 4th Court of Appeals District, Place 5",,DEM,Liza Rodriguez,165,131,34
+Kerr,109,"Justice, 4th Court of Appeals District, Place 7",,,Over Votes,1,1,0
+Kerr,109,"Justice, 4th Court of Appeals District, Place 7",,,Under Votes,31,23,8
+Kerr,109,"Justice, 4th Court of Appeals District, Place 7",,REP,Shane Stolarczyk,723,594,129
+Kerr,109,"Justice, 4th Court of Appeals District, Place 7",,DEM,Rebeca Martinez,176,134,42
+Kerr,109,"District Judge, 198th Judicial District",,,Over Votes,0,0,0
+Kerr,109,"District Judge, 198th Judicial District",,,Under Votes,167,134,33
+Kerr,109,"District Judge, 198th Judicial District",,REP,Rex Emerson,764,618,146
+Kerr,109,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,Over Votes,0,0,0
+Kerr,109,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,Under Votes,3,3,0
+Kerr,109,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,FOR,419,324,95
+Kerr,109,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,AGAINST,294,232,62
+Kerr,113,Ballots Cast,,,,1953,1596,357
+Kerr,113,Straight Party,,,Over Votes,0,0,0
+Kerr,113,Straight Party,,,Under Votes,444,368,76
+Kerr,113,Straight Party,,REP,Republican Party,533,425,108
+Kerr,113,Straight Party,,DEM,Democratic Party,129,107,22
+Kerr,113,Straight Party,,LIB,Libertarian Party,5,3,2
+Kerr,113,U.S. Senate,,,Over Votes,0,0,0
+Kerr,113,U.S. Senate,,,Under Votes,3,3,0
+Kerr,113,U.S. Senate,,REP,Ted Cruz,808,651,157
+Kerr,113,U.S. Senate,,DEM,Beto O'Rourke,289,240,49
+Kerr,113,U.S. Senate,,LIB,Neal M. Dikeman,12,9,3
+Kerr,113,U.S. House,21,,Over Votes,0,0,0
+Kerr,113,U.S. House,21,,Under Votes,7,6,1
+Kerr,113,U.S. House,21,REP,Chip Roy,790,637,153
+Kerr,113,U.S. House,21,DEM,Joseph Kopser,299,249,50
+Kerr,113,U.S. House,21,LIB,Lee Santos,16,11,5
+Kerr,113,Governor,,,Over Votes,0,0,0
+Kerr,113,Governor,,,Under Votes,11,11,0
+Kerr,113,Governor,,REP,Greg Abbott,848,679,169
+Kerr,113,Governor,,DEM,Lupe Valdez,241,205,36
+Kerr,113,Governor,,LIB,Mark Jay Tippetts,12,8,4
+Kerr,113,Lieutenant Governor,,,Over Votes,0,0,0
+Kerr,113,Lieutenant Governor,,,Under Votes,14,12,2
+Kerr,113,Lieutenant Governor,,REP,Dan Patrick,784,633,151
+Kerr,113,Lieutenant Governor,,DEM,Mike Collier,294,245,49
+Kerr,113,Lieutenant Governor,,LIB,Kerry Douglas McKennon,20,13,7
+Kerr,113,Attorney General,,,Over Votes,0,0,0
+Kerr,113,Attorney General,,,Under Votes,19,15,4
+Kerr,113,Attorney General,,REP,Ken Paxton,779,629,150
+Kerr,113,Attorney General,,DEM,Justin Nelson,288,243,45
+Kerr,113,Attorney General,,LIB,Michael Ray Harris,26,16,10
+Kerr,113,Comptroller of Public Accounts,,,Over Votes,1,1,0
+Kerr,113,Comptroller of Public Accounts,,,Under Votes,31,25,6
+Kerr,113,Comptroller of Public Accounts,,REP,Glenn Hegar,811,657,154
+Kerr,113,Comptroller of Public Accounts,,DEM,Joi Chevalier,237,197,40
+Kerr,113,Comptroller of Public Accounts,,LIB,Ben Sanders,32,23,9
+Kerr,113,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Kerr,113,Commissioner of the General Land Office,,,Under Votes,21,18,3
+Kerr,113,Commissioner of the General Land Office,,REP,George P. Bush,804,655,149
+Kerr,113,Commissioner of the General Land Office,,DEM,Miguel Suazo,233,192,41
+Kerr,113,Commissioner of the General Land Office,,LIB,Matt Piña,54,38,16
+Kerr,113,Commissioner of Agriculture,,,Over Votes,0,0,0
+Kerr,113,Commissioner of Agriculture,,,Under Votes,32,26,6
+Kerr,113,Commissioner of Agriculture,,REP,Sid Miller,789,635,154
+Kerr,113,Commissioner of Agriculture,,DEM,Kim Olson,266,225,41
+Kerr,113,Commissioner of Agriculture,,LIB,Richard Carpenter,25,17,8
+Kerr,113,Railroad Commissioner,,,Over Votes,0,0,0
+Kerr,113,Railroad Commissioner,,,Under Votes,28,22,6
+Kerr,113,Railroad Commissioner,,REP,Christi Craddick,816,659,157
+Kerr,113,Railroad Commissioner,,DEM,Roman McAllen,240,202,38
+Kerr,113,Railroad Commissioner,,LIB,Mike Wright,28,20,8
+Kerr,113,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Kerr,113,"Justice, Supreme Court, Place 2",,,Under Votes,35,30,5
+Kerr,113,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,808,649,159
+Kerr,113,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,269,224,45
+Kerr,113,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Kerr,113,"Justice, Supreme Court, Place 4",,,Under Votes,37,30,7
+Kerr,113,"Justice, Supreme Court, Place 4",,REP,John Devine,815,657,158
+Kerr,113,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,260,216,44
+Kerr,113,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Kerr,113,"Justice, Supreme Court, Place 6",,,Under Votes,33,27,6
+Kerr,113,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,810,655,155
+Kerr,113,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,269,221,48
+Kerr,113,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Kerr,113,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,24,19,5
+Kerr,113,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,814,659,155
+Kerr,113,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,250,211,39
+Kerr,113,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,24,14,10
+Kerr,113,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Kerr,113,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,38,32,6
+Kerr,113,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,817,658,159
+Kerr,113,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,257,213,44
+Kerr,113,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Kerr,113,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,160,134,26
+Kerr,113,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,828,670,158
+Kerr,113,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,124,99,25
+Kerr,113,State Representative,53,,Over Votes,0,0,0
+Kerr,113,State Representative,53,,Under Votes,20,18,2
+Kerr,113,State Representative,53,REP,Andrew S. Murr,819,661,158
+Kerr,113,State Representative,53,DEM,Stephanie Lochte Ertel,273,224,49
+Kerr,113,"Justice, 4th Court of Appeals District, Place 2",,,Over Votes,0,0,0
+Kerr,113,"Justice, 4th Court of Appeals District, Place 2",,,Under Votes,38,32,6
+Kerr,113,"Justice, 4th Court of Appeals District, Place 2",,REP,Marialyn Barnard,813,655,158
+Kerr,113,"Justice, 4th Court of Appeals District, Place 2",,DEM,Beth Watkins,261,216,45
+Kerr,113,"Justice, 4th Court of Appeals District, Place 3",,,Over Votes,0,0,0
+Kerr,113,"Justice, 4th Court of Appeals District, Place 3",,,Under Votes,39,32,7
+Kerr,113,"Justice, 4th Court of Appeals District, Place 3",,REP,Jason Pulliam,806,652,154
+Kerr,113,"Justice, 4th Court of Appeals District, Place 3",,DEM,Patricia O'Connell Alvarez,267,219,48
+Kerr,113,"Justice, 4th Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Kerr,113,"Justice, 4th Court of Appeals District, Place 4",,,Under Votes,41,35,6
+Kerr,113,"Justice, 4th Court of Appeals District, Place 4",,REP,Patrick Ballantyne,814,654,160
+Kerr,113,"Justice, 4th Court of Appeals District, Place 4",,DEM,Luz Elena Chapa,257,214,43
+Kerr,113,"Justice, 4th Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Kerr,113,"Justice, 4th Court of Appeals District, Place 5",,,Under Votes,39,32,7
+Kerr,113,"Justice, 4th Court of Appeals District, Place 5",,REP,Rebecca Simmons,813,657,156
+Kerr,113,"Justice, 4th Court of Appeals District, Place 5",,DEM,Liza Rodriguez,260,214,46
+Kerr,113,"Justice, 4th Court of Appeals District, Place 7",,,Over Votes,0,0,0
+Kerr,113,"Justice, 4th Court of Appeals District, Place 7",,,Under Votes,36,30,6
+Kerr,113,"Justice, 4th Court of Appeals District, Place 7",,REP,Shane Stolarczyk,808,653,155
+Kerr,113,"Justice, 4th Court of Appeals District, Place 7",,DEM,Rebeca Martinez,268,220,48
+Kerr,113,"District Judge, 198th Judicial District",,,Over Votes,0,0,0
+Kerr,113,"District Judge, 198th Judicial District",,,Under Votes,226,191,35
+Kerr,113,"District Judge, 198th Judicial District",,REP,Rex Emerson,886,712,174
+Kerr,113,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,Over Votes,0,0,0
+Kerr,113,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,Under Votes,4,4,0
+Kerr,113,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,FOR,580,485,95
+Kerr,113,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,AGAINST,257,204,53
+Kerr,118,Ballots Cast,,,,408,338,70
+Kerr,118,Straight Party,,,Over Votes,0,0,0
+Kerr,118,Straight Party,,,Under Votes,79,63,16
+Kerr,118,Straight Party,,REP,Republican Party,132,113,19
+Kerr,118,Straight Party,,DEM,Democratic Party,34,24,10
+Kerr,118,Straight Party,,LIB,Libertarian Party,0,0,0
+Kerr,118,U.S. Senate,,,Over Votes,0,0,0
+Kerr,118,U.S. Senate,,,Under Votes,0,0,0
+Kerr,118,U.S. Senate,,REP,Ted Cruz,183,157,26
+Kerr,118,U.S. Senate,,DEM,Beto O'Rourke,59,41,18
+Kerr,118,U.S. Senate,,LIB,Neal M. Dikeman,3,2,1
+Kerr,118,U.S. House,21,,Over Votes,0,0,0
+Kerr,118,U.S. House,21,,Under Votes,4,4,0
+Kerr,118,U.S. House,21,REP,Chip Roy,173,145,28
+Kerr,118,U.S. House,21,DEM,Joseph Kopser,64,48,16
+Kerr,118,U.S. House,21,LIB,Lee Santos,4,3,1
+Kerr,118,Governor,,,Over Votes,0,0,0
+Kerr,118,Governor,,,Under Votes,2,2,0
+Kerr,118,Governor,,REP,Greg Abbott,187,158,29
+Kerr,118,Governor,,DEM,Lupe Valdez,52,38,14
+Kerr,118,Governor,,LIB,Mark Jay Tippetts,4,2,2
+Kerr,118,Lieutenant Governor,,,Over Votes,0,0,0
+Kerr,118,Lieutenant Governor,,,Under Votes,2,2,0
+Kerr,118,Lieutenant Governor,,REP,Dan Patrick,184,156,28
+Kerr,118,Lieutenant Governor,,DEM,Mike Collier,51,37,14
+Kerr,118,Lieutenant Governor,,LIB,Kerry Douglas McKennon,8,5,3
+Kerr,118,Attorney General,,,Over Votes,0,0,0
+Kerr,118,Attorney General,,,Under Votes,2,2,0
+Kerr,118,Attorney General,,REP,Ken Paxton,177,151,26
+Kerr,118,Attorney General,,DEM,Justin Nelson,60,42,18
+Kerr,118,Attorney General,,LIB,Michael Ray Harris,6,5,1
+Kerr,118,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Kerr,118,Comptroller of Public Accounts,,,Under Votes,8,7,1
+Kerr,118,Comptroller of Public Accounts,,REP,Glenn Hegar,182,154,28
+Kerr,118,Comptroller of Public Accounts,,DEM,Joi Chevalier,48,32,16
+Kerr,118,Comptroller of Public Accounts,,LIB,Ben Sanders,7,7,0
+Kerr,118,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Kerr,118,Commissioner of the General Land Office,,,Under Votes,6,4,2
+Kerr,118,Commissioner of the General Land Office,,REP,George P. Bush,178,153,25
+Kerr,118,Commissioner of the General Land Office,,DEM,Miguel Suazo,50,34,16
+Kerr,118,Commissioner of the General Land Office,,LIB,Matt Piña,11,9,2
+Kerr,118,Commissioner of Agriculture,,,Over Votes,0,0,0
+Kerr,118,Commissioner of Agriculture,,,Under Votes,7,6,1
+Kerr,118,Commissioner of Agriculture,,REP,Sid Miller,174,147,27
+Kerr,118,Commissioner of Agriculture,,DEM,Kim Olson,59,42,17
+Kerr,118,Commissioner of Agriculture,,LIB,Richard Carpenter,5,5,0
+Kerr,118,Railroad Commissioner,,,Over Votes,0,0,0
+Kerr,118,Railroad Commissioner,,,Under Votes,8,6,2
+Kerr,118,Railroad Commissioner,,REP,Christi Craddick,179,151,28
+Kerr,118,Railroad Commissioner,,DEM,Roman McAllen,48,34,14
+Kerr,118,Railroad Commissioner,,LIB,Mike Wright,10,9,1
+Kerr,118,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Kerr,118,"Justice, Supreme Court, Place 2",,,Under Votes,10,7,3
+Kerr,118,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,180,153,27
+Kerr,118,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,55,40,15
+Kerr,118,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Kerr,118,"Justice, Supreme Court, Place 4",,,Under Votes,9,7,2
+Kerr,118,"Justice, Supreme Court, Place 4",,REP,John Devine,182,155,27
+Kerr,118,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,54,38,16
+Kerr,118,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Kerr,118,"Justice, Supreme Court, Place 6",,,Under Votes,8,6,2
+Kerr,118,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,182,156,26
+Kerr,118,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,55,38,17
+Kerr,118,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Kerr,118,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,8,6,2
+Kerr,118,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,179,153,26
+Kerr,118,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,53,37,16
+Kerr,118,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,5,4,1
+Kerr,118,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Kerr,118,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,9,7,2
+Kerr,118,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,184,156,28
+Kerr,118,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,52,37,15
+Kerr,118,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Kerr,118,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,38,28,10
+Kerr,118,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,186,157,29
+Kerr,118,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,21,15,6
+Kerr,118,State Representative,53,,Over Votes,0,0,0
+Kerr,118,State Representative,53,,Under Votes,7,6,1
+Kerr,118,State Representative,53,REP,Andrew S. Murr,178,152,26
+Kerr,118,State Representative,53,DEM,Stephanie Lochte Ertel,60,42,18
+Kerr,118,"Justice, 4th Court of Appeals District, Place 2",,,Over Votes,0,0,0
+Kerr,118,"Justice, 4th Court of Appeals District, Place 2",,,Under Votes,12,10,2
+Kerr,118,"Justice, 4th Court of Appeals District, Place 2",,REP,Marialyn Barnard,180,152,28
+Kerr,118,"Justice, 4th Court of Appeals District, Place 2",,DEM,Beth Watkins,53,38,15
+Kerr,118,"Justice, 4th Court of Appeals District, Place 3",,,Over Votes,0,0,0
+Kerr,118,"Justice, 4th Court of Appeals District, Place 3",,,Under Votes,12,10,2
+Kerr,118,"Justice, 4th Court of Appeals District, Place 3",,REP,Jason Pulliam,177,150,27
+Kerr,118,"Justice, 4th Court of Appeals District, Place 3",,DEM,Patricia O'Connell Alvarez,56,40,16
+Kerr,118,"Justice, 4th Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Kerr,118,"Justice, 4th Court of Appeals District, Place 4",,,Under Votes,10,9,1
+Kerr,118,"Justice, 4th Court of Appeals District, Place 4",,REP,Patrick Ballantyne,178,151,27
+Kerr,118,"Justice, 4th Court of Appeals District, Place 4",,DEM,Luz Elena Chapa,57,40,17
+Kerr,118,"Justice, 4th Court of Appeals District, Place 5",,,Over Votes,1,1,0
+Kerr,118,"Justice, 4th Court of Appeals District, Place 5",,,Under Votes,11,10,1
+Kerr,118,"Justice, 4th Court of Appeals District, Place 5",,REP,Rebecca Simmons,178,152,26
+Kerr,118,"Justice, 4th Court of Appeals District, Place 5",,DEM,Liza Rodriguez,55,37,18
+Kerr,118,"Justice, 4th Court of Appeals District, Place 7",,,Over Votes,0,0,0
+Kerr,118,"Justice, 4th Court of Appeals District, Place 7",,,Under Votes,11,11,0
+Kerr,118,"Justice, 4th Court of Appeals District, Place 7",,REP,Shane Stolarczyk,176,148,28
+Kerr,118,"Justice, 4th Court of Appeals District, Place 7",,DEM,Rebeca Martinez,58,41,17
+Kerr,118,"District Judge, 198th Judicial District",,,Over Votes,0,0,0
+Kerr,118,"District Judge, 198th Judicial District",,,Under Votes,55,41,14
+Kerr,118,"District Judge, 198th Judicial District",,REP,Rex Emerson,190,159,31
+Kerr,118,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,Over Votes,0,0,0
+Kerr,118,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,Under Votes,2,2,0
+Kerr,118,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,FOR,107,87,20
+Kerr,118,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,AGAINST,54,49,5
+Kerr,119,Ballots Cast,,,,2328,1986,342
+Kerr,119,Straight Party,,,Over Votes,0,0,0
+Kerr,119,Straight Party,,,Under Votes,499,401,98
+Kerr,119,Straight Party,,REP,Republican Party,661,566,95
+Kerr,119,Straight Party,,DEM,Democratic Party,194,170,24
+Kerr,119,Straight Party,,LIB,Libertarian Party,2,2,0
+Kerr,119,U.S. Senate,,,Over Votes,0,0,0
+Kerr,119,U.S. Senate,,,Under Votes,14,12,2
+Kerr,119,U.S. Senate,,REP,Ted Cruz,910,771,139
+Kerr,119,U.S. Senate,,DEM,Beto O'Rourke,415,345,70
+Kerr,119,U.S. Senate,,LIB,Neal M. Dikeman,17,11,6
+Kerr,119,U.S. House,21,,Over Votes,0,0,0
+Kerr,119,U.S. House,21,,Under Votes,19,18,1
+Kerr,119,U.S. House,21,REP,Chip Roy,896,758,138
+Kerr,119,U.S. House,21,DEM,Joseph Kopser,418,347,71
+Kerr,119,U.S. House,21,LIB,Lee Santos,23,16,7
+Kerr,119,Governor,,,Over Votes,0,0,0
+Kerr,119,Governor,,,Under Votes,15,13,2
+Kerr,119,Governor,,REP,Greg Abbott,986,819,167
+Kerr,119,Governor,,DEM,Lupe Valdez,336,294,42
+Kerr,119,Governor,,LIB,Mark Jay Tippetts,19,13,6
+Kerr,119,Lieutenant Governor,,,Over Votes,0,0,0
+Kerr,119,Lieutenant Governor,,,Under Votes,13,10,3
+Kerr,119,Lieutenant Governor,,REP,Dan Patrick,922,772,150
+Kerr,119,Lieutenant Governor,,DEM,Mike Collier,395,337,58
+Kerr,119,Lieutenant Governor,,LIB,Kerry Douglas McKennon,26,20,6
+Kerr,119,Attorney General,,,Over Votes,0,0,0
+Kerr,119,Attorney General,,,Under Votes,17,13,4
+Kerr,119,Attorney General,,REP,Ken Paxton,900,759,141
+Kerr,119,Attorney General,,DEM,Justin Nelson,404,342,62
+Kerr,119,Attorney General,,LIB,Michael Ray Harris,35,25,10
+Kerr,119,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Kerr,119,Comptroller of Public Accounts,,,Under Votes,33,26,7
+Kerr,119,Comptroller of Public Accounts,,REP,Glenn Hegar,936,788,148
+Kerr,119,Comptroller of Public Accounts,,DEM,Joi Chevalier,348,296,52
+Kerr,119,Comptroller of Public Accounts,,LIB,Ben Sanders,39,29,10
+Kerr,119,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Kerr,119,Commissioner of the General Land Office,,,Under Votes,27,21,6
+Kerr,119,Commissioner of the General Land Office,,REP,George P. Bush,945,794,151
+Kerr,119,Commissioner of the General Land Office,,DEM,Miguel Suazo,346,294,52
+Kerr,119,Commissioner of the General Land Office,,LIB,Matt Piña,38,30,8
+Kerr,119,Commissioner of Agriculture,,,Over Votes,0,0,0
+Kerr,119,Commissioner of Agriculture,,,Under Votes,40,32,8
+Kerr,119,Commissioner of Agriculture,,REP,Sid Miller,905,768,137
+Kerr,119,Commissioner of Agriculture,,DEM,Kim Olson,372,310,62
+Kerr,119,Commissioner of Agriculture,,LIB,Richard Carpenter,37,27,10
+Kerr,119,Railroad Commissioner,,,Over Votes,1,1,0
+Kerr,119,Railroad Commissioner,,,Under Votes,38,29,9
+Kerr,119,Railroad Commissioner,,REP,Christi Craddick,926,780,146
+Kerr,119,Railroad Commissioner,,DEM,Roman McAllen,347,296,51
+Kerr,119,Railroad Commissioner,,LIB,Mike Wright,45,34,11
+Kerr,119,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Kerr,119,"Justice, Supreme Court, Place 2",,,Under Votes,52,41,11
+Kerr,119,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,924,777,147
+Kerr,119,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,380,321,59
+Kerr,119,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Kerr,119,"Justice, Supreme Court, Place 4",,,Under Votes,53,42,11
+Kerr,119,"Justice, Supreme Court, Place 4",,REP,John Devine,933,785,148
+Kerr,119,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,370,312,58
+Kerr,119,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Kerr,119,"Justice, Supreme Court, Place 6",,,Under Votes,53,41,12
+Kerr,119,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,923,777,146
+Kerr,119,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,380,321,59
+Kerr,119,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,1,1,0
+Kerr,119,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,44,34,10
+Kerr,119,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,914,771,143
+Kerr,119,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,356,302,54
+Kerr,119,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,41,31,10
+Kerr,119,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Kerr,119,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,43,35,8
+Kerr,119,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,933,786,147
+Kerr,119,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,380,318,62
+Kerr,119,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Kerr,119,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,216,189,27
+Kerr,119,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,961,807,154
+Kerr,119,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,179,143,36
+Kerr,119,State Representative,53,,Over Votes,0,0,0
+Kerr,119,State Representative,53,,Under Votes,41,35,6
+Kerr,119,State Representative,53,REP,Andrew S. Murr,944,790,154
+Kerr,119,State Representative,53,DEM,Stephanie Lochte Ertel,371,314,57
+Kerr,119,"Justice, 4th Court of Appeals District, Place 2",,,Over Votes,0,0,0
+Kerr,119,"Justice, 4th Court of Appeals District, Place 2",,,Under Votes,51,40,11
+Kerr,119,"Justice, 4th Court of Appeals District, Place 2",,REP,Marialyn Barnard,930,781,149
+Kerr,119,"Justice, 4th Court of Appeals District, Place 2",,DEM,Beth Watkins,375,318,57
+Kerr,119,"Justice, 4th Court of Appeals District, Place 3",,,Over Votes,0,0,0
+Kerr,119,"Justice, 4th Court of Appeals District, Place 3",,,Under Votes,58,46,12
+Kerr,119,"Justice, 4th Court of Appeals District, Place 3",,REP,Jason Pulliam,923,776,147
+Kerr,119,"Justice, 4th Court of Appeals District, Place 3",,DEM,Patricia O'Connell Alvarez,375,317,58
+Kerr,119,"Justice, 4th Court of Appeals District, Place 4",,,Over Votes,1,1,0
+Kerr,119,"Justice, 4th Court of Appeals District, Place 4",,,Under Votes,50,40,10
+Kerr,119,"Justice, 4th Court of Appeals District, Place 4",,REP,Patrick Ballantyne,927,781,146
+Kerr,119,"Justice, 4th Court of Appeals District, Place 4",,DEM,Luz Elena Chapa,378,317,61
+Kerr,119,"Justice, 4th Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Kerr,119,"Justice, 4th Court of Appeals District, Place 5",,,Under Votes,54,44,10
+Kerr,119,"Justice, 4th Court of Appeals District, Place 5",,REP,Rebecca Simmons,934,786,148
+Kerr,119,"Justice, 4th Court of Appeals District, Place 5",,DEM,Liza Rodriguez,368,309,59
+Kerr,119,"Justice, 4th Court of Appeals District, Place 7",,,Over Votes,0,0,0
+Kerr,119,"Justice, 4th Court of Appeals District, Place 7",,,Under Votes,49,40,9
+Kerr,119,"Justice, 4th Court of Appeals District, Place 7",,REP,Shane Stolarczyk,924,778,146
+Kerr,119,"Justice, 4th Court of Appeals District, Place 7",,DEM,Rebeca Martinez,383,321,62
+Kerr,119,"District Judge, 198th Judicial District",,,Over Votes,0,0,0
+Kerr,119,"District Judge, 198th Judicial District",,,Under Votes,323,283,40
+Kerr,119,"District Judge, 198th Judicial District",,REP,Rex Emerson,1033,856,177
+Kerr,119,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,Over Votes,0,0,0
+Kerr,119,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,Under Votes,5,5,0
+Kerr,119,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,FOR,690,608,82
+Kerr,119,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,AGAINST,276,233,43
+Kerr,202,Ballots Cast,,,,1399,881,518
+Kerr,202,Straight Party,,,Over Votes,0,0,0
+Kerr,202,Straight Party,,,Under Votes,495,296,199
+Kerr,202,Straight Party,,REP,Republican Party,791,506,285
+Kerr,202,Straight Party,,DEM,Democratic Party,107,75,32
+Kerr,202,Straight Party,,LIB,Libertarian Party,5,3,2
+Kerr,202,U.S. Senate,,,Over Votes,0,0,0
+Kerr,202,U.S. Senate,,,Under Votes,8,6,2
+Kerr,202,U.S. Senate,,REP,Ted Cruz,1143,724,419
+Kerr,202,U.S. Senate,,DEM,Beto O'Rourke,237,145,92
+Kerr,202,U.S. Senate,,LIB,Neal M. Dikeman,10,5,5
+Kerr,202,U.S. House,21,,Over Votes,0,0,0
+Kerr,202,U.S. House,21,,Under Votes,24,17,7
+Kerr,202,U.S. House,21,REP,Chip Roy,1119,707,412
+Kerr,202,U.S. House,21,DEM,Joseph Kopser,237,145,92
+Kerr,202,U.S. House,21,LIB,Lee Santos,18,11,7
+Kerr,202,Governor,,,Over Votes,0,0,0
+Kerr,202,Governor,,,Under Votes,7,4,3
+Kerr,202,Governor,,REP,Greg Abbott,1179,742,437
+Kerr,202,Governor,,DEM,Lupe Valdez,198,127,71
+Kerr,202,Governor,,LIB,Mark Jay Tippetts,14,7,7
+Kerr,202,Lieutenant Governor,,,Over Votes,0,0,0
+Kerr,202,Lieutenant Governor,,,Under Votes,12,8,4
+Kerr,202,Lieutenant Governor,,REP,Dan Patrick,1130,718,412
+Kerr,202,Lieutenant Governor,,DEM,Mike Collier,227,137,90
+Kerr,202,Lieutenant Governor,,LIB,Kerry Douglas McKennon,29,17,12
+Kerr,202,Attorney General,,,Over Votes,0,0,0
+Kerr,202,Attorney General,,,Under Votes,19,14,5
+Kerr,202,Attorney General,,REP,Ken Paxton,1124,704,420
+Kerr,202,Attorney General,,DEM,Justin Nelson,227,145,82
+Kerr,202,Attorney General,,LIB,Michael Ray Harris,28,17,11
+Kerr,202,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Kerr,202,Comptroller of Public Accounts,,,Under Votes,23,15,8
+Kerr,202,Comptroller of Public Accounts,,REP,Glenn Hegar,1145,720,425
+Kerr,202,Comptroller of Public Accounts,,DEM,Joi Chevalier,193,125,68
+Kerr,202,Comptroller of Public Accounts,,LIB,Ben Sanders,37,20,17
+Kerr,202,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Kerr,202,Commissioner of the General Land Office,,,Under Votes,19,13,6
+Kerr,202,Commissioner of the General Land Office,,REP,George P. Bush,1100,686,414
+Kerr,202,Commissioner of the General Land Office,,DEM,Miguel Suazo,210,137,73
+Kerr,202,Commissioner of the General Land Office,,LIB,Matt Piña,69,44,25
+Kerr,202,Commissioner of Agriculture,,,Over Votes,0,0,0
+Kerr,202,Commissioner of Agriculture,,,Under Votes,23,14,9
+Kerr,202,Commissioner of Agriculture,,REP,Sid Miller,1130,711,419
+Kerr,202,Commissioner of Agriculture,,DEM,Kim Olson,217,136,81
+Kerr,202,Commissioner of Agriculture,,LIB,Richard Carpenter,28,19,9
+Kerr,202,Railroad Commissioner,,,Over Votes,0,0,0
+Kerr,202,Railroad Commissioner,,,Under Votes,25,16,9
+Kerr,202,Railroad Commissioner,,REP,Christi Craddick,1137,720,417
+Kerr,202,Railroad Commissioner,,DEM,Roman McAllen,192,121,71
+Kerr,202,Railroad Commissioner,,LIB,Mike Wright,44,23,21
+Kerr,202,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Kerr,202,"Justice, Supreme Court, Place 2",,,Under Votes,37,23,14
+Kerr,202,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1137,722,415
+Kerr,202,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,224,135,89
+Kerr,202,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Kerr,202,"Justice, Supreme Court, Place 4",,,Under Votes,38,25,13
+Kerr,202,"Justice, Supreme Court, Place 4",,REP,John Devine,1144,720,424
+Kerr,202,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,216,135,81
+Kerr,202,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Kerr,202,"Justice, Supreme Court, Place 6",,,Under Votes,38,22,16
+Kerr,202,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1140,724,416
+Kerr,202,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,220,134,86
+Kerr,202,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Kerr,202,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,34,18,16
+Kerr,202,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1129,718,411
+Kerr,202,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,203,127,76
+Kerr,202,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,32,17,15
+Kerr,202,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Kerr,202,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,36,24,12
+Kerr,202,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1147,724,423
+Kerr,202,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,215,132,83
+Kerr,202,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Kerr,202,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,126,90,36
+Kerr,202,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1161,729,432
+Kerr,202,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,111,61,50
+Kerr,202,State Representative,53,,Over Votes,0,0,0
+Kerr,202,State Representative,53,,Under Votes,31,26,5
+Kerr,202,State Representative,53,REP,Andrew S. Murr,1146,718,428
+Kerr,202,State Representative,53,DEM,Stephanie Lochte Ertel,221,136,85
+Kerr,202,"Justice, 4th Court of Appeals District, Place 2",,,Over Votes,0,0,0
+Kerr,202,"Justice, 4th Court of Appeals District, Place 2",,,Under Votes,43,29,14
+Kerr,202,"Justice, 4th Court of Appeals District, Place 2",,REP,Marialyn Barnard,1130,713,417
+Kerr,202,"Justice, 4th Court of Appeals District, Place 2",,DEM,Beth Watkins,225,138,87
+Kerr,202,"Justice, 4th Court of Appeals District, Place 3",,,Over Votes,0,0,0
+Kerr,202,"Justice, 4th Court of Appeals District, Place 3",,,Under Votes,42,29,13
+Kerr,202,"Justice, 4th Court of Appeals District, Place 3",,REP,Jason Pulliam,1140,714,426
+Kerr,202,"Justice, 4th Court of Appeals District, Place 3",,DEM,Patricia O'Connell Alvarez,216,137,79
+Kerr,202,"Justice, 4th Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Kerr,202,"Justice, 4th Court of Appeals District, Place 4",,,Under Votes,43,29,14
+Kerr,202,"Justice, 4th Court of Appeals District, Place 4",,REP,Patrick Ballantyne,1140,717,423
+Kerr,202,"Justice, 4th Court of Appeals District, Place 4",,DEM,Luz Elena Chapa,215,134,81
+Kerr,202,"Justice, 4th Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Kerr,202,"Justice, 4th Court of Appeals District, Place 5",,,Under Votes,42,27,15
+Kerr,202,"Justice, 4th Court of Appeals District, Place 5",,REP,Rebecca Simmons,1147,722,425
+Kerr,202,"Justice, 4th Court of Appeals District, Place 5",,DEM,Liza Rodriguez,209,131,78
+Kerr,202,"Justice, 4th Court of Appeals District, Place 7",,,Over Votes,2,2,0
+Kerr,202,"Justice, 4th Court of Appeals District, Place 7",,,Under Votes,42,28,14
+Kerr,202,"Justice, 4th Court of Appeals District, Place 7",,REP,Shane Stolarczyk,1133,712,421
+Kerr,202,"Justice, 4th Court of Appeals District, Place 7",,DEM,Rebeca Martinez,221,138,83
+Kerr,202,"District Judge, 198th Judicial District",,,Over Votes,0,0,0
+Kerr,202,"District Judge, 198th Judicial District",,,Under Votes,213,143,70
+Kerr,202,"District Judge, 198th Judicial District",,REP,Rex Emerson,1185,737,448
+Kerr,202,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,Over Votes,0,0,0
+Kerr,202,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,Under Votes,0,0,0
+Kerr,202,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,FOR,1,1,0
+Kerr,202,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,AGAINST,0,0,0
+Kerr,211,Ballots Cast,,,,1121,865,256
+Kerr,211,Straight Party,,,Over Votes,0,0,0
+Kerr,211,Straight Party,,,Under Votes,217,168,49
+Kerr,211,Straight Party,,REP,Republican Party,342,274,68
+Kerr,211,Straight Party,,DEM,Democratic Party,93,55,38
+Kerr,211,Straight Party,,LIB,Libertarian Party,1,0,1
+Kerr,211,U.S. Senate,,,Over Votes,0,0,0
+Kerr,211,U.S. Senate,,,Under Votes,4,2,2
+Kerr,211,U.S. Senate,,REP,Ted Cruz,464,371,93
+Kerr,211,U.S. Senate,,DEM,Beto O'Rourke,179,119,60
+Kerr,211,U.S. Senate,,LIB,Neal M. Dikeman,6,5,1
+Kerr,211,U.S. House,21,,Over Votes,0,0,0
+Kerr,211,U.S. House,21,,Under Votes,15,11,4
+Kerr,211,U.S. House,21,REP,Chip Roy,461,370,91
+Kerr,211,U.S. House,21,DEM,Joseph Kopser,167,112,55
+Kerr,211,U.S. House,21,LIB,Lee Santos,10,4,6
+Kerr,211,Governor,,,Over Votes,0,0,0
+Kerr,211,Governor,,,Under Votes,6,3,3
+Kerr,211,Governor,,REP,Greg Abbott,489,391,98
+Kerr,211,Governor,,DEM,Lupe Valdez,148,98,50
+Kerr,211,Governor,,LIB,Mark Jay Tippetts,10,5,5
+Kerr,211,Lieutenant Governor,,,Over Votes,0,0,0
+Kerr,211,Lieutenant Governor,,,Under Votes,12,7,5
+Kerr,211,Lieutenant Governor,,REP,Dan Patrick,470,378,92
+Kerr,211,Lieutenant Governor,,DEM,Mike Collier,165,111,54
+Kerr,211,Lieutenant Governor,,LIB,Kerry Douglas McKennon,6,1,5
+Kerr,211,Attorney General,,,Over Votes,0,0,0
+Kerr,211,Attorney General,,,Under Votes,9,4,5
+Kerr,211,Attorney General,,REP,Ken Paxton,466,377,89
+Kerr,211,Attorney General,,DEM,Justin Nelson,162,107,55
+Kerr,211,Attorney General,,LIB,Michael Ray Harris,16,9,7
+Kerr,211,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Kerr,211,Comptroller of Public Accounts,,,Under Votes,11,6,5
+Kerr,211,Comptroller of Public Accounts,,REP,Glenn Hegar,472,377,95
+Kerr,211,Comptroller of Public Accounts,,DEM,Joi Chevalier,152,103,49
+Kerr,211,Comptroller of Public Accounts,,LIB,Ben Sanders,18,11,7
+Kerr,211,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Kerr,211,Commissioner of the General Land Office,,,Under Votes,10,6,4
+Kerr,211,Commissioner of the General Land Office,,REP,George P. Bush,461,370,91
+Kerr,211,Commissioner of the General Land Office,,DEM,Miguel Suazo,158,104,54
+Kerr,211,Commissioner of the General Land Office,,LIB,Matt Piña,24,17,7
+Kerr,211,Commissioner of Agriculture,,,Over Votes,0,0,0
+Kerr,211,Commissioner of Agriculture,,,Under Votes,12,5,7
+Kerr,211,Commissioner of Agriculture,,REP,Sid Miller,457,366,91
+Kerr,211,Commissioner of Agriculture,,DEM,Kim Olson,167,114,53
+Kerr,211,Commissioner of Agriculture,,LIB,Richard Carpenter,17,12,5
+Kerr,211,Railroad Commissioner,,,Over Votes,0,0,0
+Kerr,211,Railroad Commissioner,,,Under Votes,14,6,8
+Kerr,211,Railroad Commissioner,,REP,Christi Craddick,470,377,93
+Kerr,211,Railroad Commissioner,,DEM,Roman McAllen,147,98,49
+Kerr,211,Railroad Commissioner,,LIB,Mike Wright,22,16,6
+Kerr,211,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Kerr,211,"Justice, Supreme Court, Place 2",,,Under Votes,23,14,9
+Kerr,211,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,465,375,90
+Kerr,211,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,165,108,57
+Kerr,211,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Kerr,211,"Justice, Supreme Court, Place 4",,,Under Votes,20,11,9
+Kerr,211,"Justice, Supreme Court, Place 4",,REP,John Devine,470,378,92
+Kerr,211,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,163,108,55
+Kerr,211,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Kerr,211,"Justice, Supreme Court, Place 6",,,Under Votes,19,9,10
+Kerr,211,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,468,380,88
+Kerr,211,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,166,108,58
+Kerr,211,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Kerr,211,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,21,13,8
+Kerr,211,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,459,370,89
+Kerr,211,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,159,107,52
+Kerr,211,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,14,7,7
+Kerr,211,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Kerr,211,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,22,12,10
+Kerr,211,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,471,379,92
+Kerr,211,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,160,106,54
+Kerr,211,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Kerr,211,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,87,57,30
+Kerr,211,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,493,396,97
+Kerr,211,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,73,44,29
+Kerr,211,State Representative,53,,Over Votes,0,0,0
+Kerr,211,State Representative,53,,Under Votes,23,14,9
+Kerr,211,State Representative,53,REP,Andrew S. Murr,472,382,90
+Kerr,211,State Representative,53,DEM,Stephanie Lochte Ertel,158,101,57
+Kerr,211,"Justice, 4th Court of Appeals District, Place 2",,,Over Votes,0,0,0
+Kerr,211,"Justice, 4th Court of Appeals District, Place 2",,,Under Votes,26,16,10
+Kerr,211,"Justice, 4th Court of Appeals District, Place 2",,REP,Marialyn Barnard,464,375,89
+Kerr,211,"Justice, 4th Court of Appeals District, Place 2",,DEM,Beth Watkins,163,106,57
+Kerr,211,"Justice, 4th Court of Appeals District, Place 3",,,Over Votes,0,0,0
+Kerr,211,"Justice, 4th Court of Appeals District, Place 3",,,Under Votes,25,15,10
+Kerr,211,"Justice, 4th Court of Appeals District, Place 3",,REP,Jason Pulliam,470,380,90
+Kerr,211,"Justice, 4th Court of Appeals District, Place 3",,DEM,Patricia O'Connell Alvarez,158,102,56
+Kerr,211,"Justice, 4th Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Kerr,211,"Justice, 4th Court of Appeals District, Place 4",,,Under Votes,25,15,10
+Kerr,211,"Justice, 4th Court of Appeals District, Place 4",,REP,Patrick Ballantyne,467,378,89
+Kerr,211,"Justice, 4th Court of Appeals District, Place 4",,DEM,Luz Elena Chapa,161,104,57
+Kerr,211,"Justice, 4th Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Kerr,211,"Justice, 4th Court of Appeals District, Place 5",,,Under Votes,25,15,10
+Kerr,211,"Justice, 4th Court of Appeals District, Place 5",,REP,Rebecca Simmons,476,383,93
+Kerr,211,"Justice, 4th Court of Appeals District, Place 5",,DEM,Liza Rodriguez,152,99,53
+Kerr,211,"Justice, 4th Court of Appeals District, Place 7",,,Over Votes,0,0,0
+Kerr,211,"Justice, 4th Court of Appeals District, Place 7",,,Under Votes,24,14,10
+Kerr,211,"Justice, 4th Court of Appeals District, Place 7",,REP,Shane Stolarczyk,463,375,88
+Kerr,211,"Justice, 4th Court of Appeals District, Place 7",,DEM,Rebeca Martinez,166,108,58
+Kerr,211,"District Judge, 198th Judicial District",,,Over Votes,0,0,0
+Kerr,211,"District Judge, 198th Judicial District",,,Under Votes,141,98,43
+Kerr,211,"District Judge, 198th Judicial District",,REP,Rex Emerson,512,399,113
+Kerr,211,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,Over Votes,0,0,0
+Kerr,211,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,Under Votes,1,1,0
+Kerr,211,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,FOR,320,241,79
+Kerr,211,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,AGAINST,147,126,21
+Kerr,215,Ballots Cast,,,,3243,2540,703
+Kerr,215,Straight Party,,,Over Votes,0,0,0
+Kerr,215,Straight Party,,,Under Votes,660,488,172
+Kerr,215,Straight Party,,REP,Republican Party,1041,835,206
+Kerr,215,Straight Party,,DEM,Democratic Party,172,138,34
+Kerr,215,Straight Party,,LIB,Libertarian Party,2,1,1
+Kerr,215,U.S. Senate,,,Over Votes,0,0,0
+Kerr,215,U.S. Senate,,,Under Votes,7,5,2
+Kerr,215,U.S. Senate,,REP,Ted Cruz,1477,1161,316
+Kerr,215,U.S. Senate,,DEM,Beto O'Rourke,380,290,90
+Kerr,215,U.S. Senate,,LIB,Neal M. Dikeman,11,6,5
+Kerr,215,U.S. House,21,,Over Votes,1,1,0
+Kerr,215,U.S. House,21,,Under Votes,20,16,4
+Kerr,215,U.S. House,21,REP,Chip Roy,1451,1138,313
+Kerr,215,U.S. House,21,DEM,Joseph Kopser,374,289,85
+Kerr,215,U.S. House,21,LIB,Lee Santos,29,18,11
+Kerr,215,Governor,,,Over Votes,0,0,0
+Kerr,215,Governor,,,Under Votes,12,10,2
+Kerr,215,Governor,,REP,Greg Abbott,1540,1206,334
+Kerr,215,Governor,,DEM,Lupe Valdez,303,239,64
+Kerr,215,Governor,,LIB,Mark Jay Tippetts,20,7,13
+Kerr,215,Lieutenant Governor,,,Over Votes,0,0,0
+Kerr,215,Lieutenant Governor,,,Under Votes,22,15,7
+Kerr,215,Lieutenant Governor,,REP,Dan Patrick,1452,1141,311
+Kerr,215,Lieutenant Governor,,DEM,Mike Collier,370,284,86
+Kerr,215,Lieutenant Governor,,LIB,Kerry Douglas McKennon,31,22,9
+Kerr,215,Attorney General,,,Over Votes,0,0,0
+Kerr,215,Attorney General,,,Under Votes,23,16,7
+Kerr,215,Attorney General,,REP,Ken Paxton,1448,1138,310
+Kerr,215,Attorney General,,DEM,Justin Nelson,365,283,82
+Kerr,215,Attorney General,,LIB,Michael Ray Harris,39,25,14
+Kerr,215,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Kerr,215,Comptroller of Public Accounts,,,Under Votes,32,25,7
+Kerr,215,Comptroller of Public Accounts,,REP,Glenn Hegar,1481,1170,311
+Kerr,215,Comptroller of Public Accounts,,DEM,Joi Chevalier,304,235,69
+Kerr,215,Comptroller of Public Accounts,,LIB,Ben Sanders,58,32,26
+Kerr,215,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Kerr,215,Commissioner of the General Land Office,,,Under Votes,31,27,4
+Kerr,215,Commissioner of the General Land Office,,REP,George P. Bush,1466,1155,311
+Kerr,215,Commissioner of the General Land Office,,DEM,Miguel Suazo,309,239,70
+Kerr,215,Commissioner of the General Land Office,,LIB,Matt Piña,69,41,28
+Kerr,215,Commissioner of Agriculture,,,Over Votes,0,0,0
+Kerr,215,Commissioner of Agriculture,,,Under Votes,24,20,4
+Kerr,215,Commissioner of Agriculture,,REP,Sid Miller,1440,1132,308
+Kerr,215,Commissioner of Agriculture,,DEM,Kim Olson,367,280,87
+Kerr,215,Commissioner of Agriculture,,LIB,Richard Carpenter,44,30,14
+Kerr,215,Railroad Commissioner,,,Over Votes,0,0,0
+Kerr,215,Railroad Commissioner,,,Under Votes,34,28,6
+Kerr,215,Railroad Commissioner,,REP,Christi Craddick,1496,1175,321
+Kerr,215,Railroad Commissioner,,DEM,Roman McAllen,301,232,69
+Kerr,215,Railroad Commissioner,,LIB,Mike Wright,44,27,17
+Kerr,215,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Kerr,215,"Justice, Supreme Court, Place 2",,,Under Votes,46,37,9
+Kerr,215,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1493,1164,329
+Kerr,215,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,336,261,75
+Kerr,215,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Kerr,215,"Justice, Supreme Court, Place 4",,,Under Votes,45,36,9
+Kerr,215,"Justice, Supreme Court, Place 4",,REP,John Devine,1499,1170,329
+Kerr,215,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,331,256,75
+Kerr,215,"Justice, Supreme Court, Place 6",,,Over Votes,1,1,0
+Kerr,215,"Justice, Supreme Court, Place 6",,,Under Votes,44,36,8
+Kerr,215,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1497,1168,329
+Kerr,215,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,333,257,76
+Kerr,215,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Kerr,215,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,41,34,7
+Kerr,215,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1470,1148,322
+Kerr,215,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,319,254,65
+Kerr,215,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,45,26,19
+Kerr,215,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,1,1,0
+Kerr,215,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,43,36,7
+Kerr,215,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1502,1172,330
+Kerr,215,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,329,253,76
+Kerr,215,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Kerr,215,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,186,159,27
+Kerr,215,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1540,1203,337
+Kerr,215,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,149,100,49
+Kerr,215,State Representative,53,,Over Votes,0,0,0
+Kerr,215,State Representative,53,,Under Votes,38,31,7
+Kerr,215,State Representative,53,REP,Andrew S. Murr,1491,1166,325
+Kerr,215,State Representative,53,DEM,Stephanie Lochte Ertel,346,265,81
+Kerr,215,"Justice, 4th Court of Appeals District, Place 2",,,Over Votes,0,0,0
+Kerr,215,"Justice, 4th Court of Appeals District, Place 2",,,Under Votes,48,41,7
+Kerr,215,"Justice, 4th Court of Appeals District, Place 2",,REP,Marialyn Barnard,1489,1158,331
+Kerr,215,"Justice, 4th Court of Appeals District, Place 2",,DEM,Beth Watkins,338,263,75
+Kerr,215,"Justice, 4th Court of Appeals District, Place 3",,,Over Votes,0,0,0
+Kerr,215,"Justice, 4th Court of Appeals District, Place 3",,,Under Votes,48,41,7
+Kerr,215,"Justice, 4th Court of Appeals District, Place 3",,REP,Jason Pulliam,1479,1156,323
+Kerr,215,"Justice, 4th Court of Appeals District, Place 3",,DEM,Patricia O'Connell Alvarez,348,265,83
+Kerr,215,"Justice, 4th Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Kerr,215,"Justice, 4th Court of Appeals District, Place 4",,,Under Votes,47,40,7
+Kerr,215,"Justice, 4th Court of Appeals District, Place 4",,REP,Patrick Ballantyne,1493,1166,327
+Kerr,215,"Justice, 4th Court of Appeals District, Place 4",,DEM,Luz Elena Chapa,335,256,79
+Kerr,215,"Justice, 4th Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Kerr,215,"Justice, 4th Court of Appeals District, Place 5",,,Under Votes,48,41,7
+Kerr,215,"Justice, 4th Court of Appeals District, Place 5",,REP,Rebecca Simmons,1503,1174,329
+Kerr,215,"Justice, 4th Court of Appeals District, Place 5",,DEM,Liza Rodriguez,324,247,77
+Kerr,215,"Justice, 4th Court of Appeals District, Place 7",,,Over Votes,0,0,0
+Kerr,215,"Justice, 4th Court of Appeals District, Place 7",,,Under Votes,49,41,8
+Kerr,215,"Justice, 4th Court of Appeals District, Place 7",,REP,Shane Stolarczyk,1478,1156,322
+Kerr,215,"Justice, 4th Court of Appeals District, Place 7",,DEM,Rebeca Martinez,348,265,83
+Kerr,215,"District Judge, 198th Judicial District",,,Over Votes,0,0,0
+Kerr,215,"District Judge, 198th Judicial District",,,Under Votes,282,235,47
+Kerr,215,"District Judge, 198th Judicial District",,REP,Rex Emerson,1593,1227,366
+Kerr,215,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,Over Votes,0,0,0
+Kerr,215,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,Under Votes,3,3,0
+Kerr,215,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,FOR,855,657,198
+Kerr,215,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,AGAINST,510,418,92
+Kerr,220,Ballots Cast,,,,3430,3022,408
+Kerr,220,Straight Party,,,Over Votes,0,0,0
+Kerr,220,Straight Party,,,Under Votes,657,552,105
+Kerr,220,Straight Party,,REP,Republican Party,1078,965,113
+Kerr,220,Straight Party,,DEM,Democratic Party,147,133,14
+Kerr,220,Straight Party,,LIB,Libertarian Party,5,2,3
+Kerr,220,U.S. Senate,,,Over Votes,0,0,0
+Kerr,220,U.S. Senate,,,Under Votes,6,6,0
+Kerr,220,U.S. Senate,,REP,Ted Cruz,1484,1313,171
+Kerr,220,U.S. Senate,,DEM,Beto O'Rourke,385,325,60
+Kerr,220,U.S. Senate,,LIB,Neal M. Dikeman,12,8,4
+Kerr,220,U.S. House,21,,Over Votes,1,1,0
+Kerr,220,U.S. House,21,,Under Votes,20,17,3
+Kerr,220,U.S. House,21,REP,Chip Roy,1456,1281,175
+Kerr,220,U.S. House,21,DEM,Joseph Kopser,395,344,51
+Kerr,220,U.S. House,21,LIB,Lee Santos,15,9,6
+Kerr,220,Governor,,,Over Votes,0,0,0
+Kerr,220,Governor,,,Under Votes,28,25,3
+Kerr,220,Governor,,REP,Greg Abbott,1558,1364,194
+Kerr,220,Governor,,DEM,Lupe Valdez,281,249,32
+Kerr,220,Governor,,LIB,Mark Jay Tippetts,20,14,6
+Kerr,220,Lieutenant Governor,,,Over Votes,0,0,0
+Kerr,220,Lieutenant Governor,,,Under Votes,26,23,3
+Kerr,220,Lieutenant Governor,,REP,Dan Patrick,1471,1294,177
+Kerr,220,Lieutenant Governor,,DEM,Mike Collier,357,312,45
+Kerr,220,Lieutenant Governor,,LIB,Kerry Douglas McKennon,33,23,10
+Kerr,220,Attorney General,,,Over Votes,0,0,0
+Kerr,220,Attorney General,,,Under Votes,28,25,3
+Kerr,220,Attorney General,,REP,Ken Paxton,1453,1281,172
+Kerr,220,Attorney General,,DEM,Justin Nelson,368,318,50
+Kerr,220,Attorney General,,LIB,Michael Ray Harris,38,28,10
+Kerr,220,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Kerr,220,Comptroller of Public Accounts,,,Under Votes,50,44,6
+Kerr,220,Comptroller of Public Accounts,,REP,Glenn Hegar,1516,1330,186
+Kerr,220,Comptroller of Public Accounts,,DEM,Joi Chevalier,273,245,28
+Kerr,220,Comptroller of Public Accounts,,LIB,Ben Sanders,48,33,15
+Kerr,220,Commissioner of the General Land Office,,,Over Votes,1,1,0
+Kerr,220,Commissioner of the General Land Office,,,Under Votes,39,35,4
+Kerr,220,Commissioner of the General Land Office,,REP,George P. Bush,1520,1328,192
+Kerr,220,Commissioner of the General Land Office,,DEM,Miguel Suazo,282,253,29
+Kerr,220,Commissioner of the General Land Office,,LIB,Matt Piña,45,35,10
+Kerr,220,Commissioner of Agriculture,,,Over Votes,0,0,0
+Kerr,220,Commissioner of Agriculture,,,Under Votes,52,44,8
+Kerr,220,Commissioner of Agriculture,,REP,Sid Miller,1468,1293,175
+Kerr,220,Commissioner of Agriculture,,DEM,Kim Olson,333,291,42
+Kerr,220,Commissioner of Agriculture,,LIB,Richard Carpenter,34,24,10
+Kerr,220,Railroad Commissioner,,,Over Votes,0,0,0
+Kerr,220,Railroad Commissioner,,,Under Votes,51,42,9
+Kerr,220,Railroad Commissioner,,REP,Christi Craddick,1520,1347,173
+Kerr,220,Railroad Commissioner,,DEM,Roman McAllen,273,239,34
+Kerr,220,Railroad Commissioner,,LIB,Mike Wright,43,24,19
+Kerr,220,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Kerr,220,"Justice, Supreme Court, Place 2",,,Under Votes,61,50,11
+Kerr,220,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1506,1326,180
+Kerr,220,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,320,276,44
+Kerr,220,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Kerr,220,"Justice, Supreme Court, Place 4",,,Under Votes,65,55,10
+Kerr,220,"Justice, Supreme Court, Place 4",,REP,John Devine,1522,1334,188
+Kerr,220,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,300,263,37
+Kerr,220,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Kerr,220,"Justice, Supreme Court, Place 6",,,Under Votes,63,53,10
+Kerr,220,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1513,1329,184
+Kerr,220,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,311,270,41
+Kerr,220,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Kerr,220,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,59,50,9
+Kerr,220,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1500,1324,176
+Kerr,220,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,301,264,37
+Kerr,220,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,27,14,13
+Kerr,220,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Kerr,220,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,69,57,12
+Kerr,220,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1528,1341,187
+Kerr,220,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,290,254,36
+Kerr,220,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,1,1,0
+Kerr,220,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,217,195,22
+Kerr,220,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1541,1353,188
+Kerr,220,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,128,103,25
+Kerr,220,State Representative,53,,Over Votes,0,0,0
+Kerr,220,State Representative,53,,Under Votes,51,40,11
+Kerr,220,State Representative,53,REP,Andrew S. Murr,1529,1344,185
+Kerr,220,State Representative,53,DEM,Stephanie Lochte Ertel,307,268,39
+Kerr,220,"Justice, 4th Court of Appeals District, Place 2",,,Over Votes,0,0,0
+Kerr,220,"Justice, 4th Court of Appeals District, Place 2",,,Under Votes,75,63,12
+Kerr,220,"Justice, 4th Court of Appeals District, Place 2",,REP,Marialyn Barnard,1504,1321,183
+Kerr,220,"Justice, 4th Court of Appeals District, Place 2",,DEM,Beth Watkins,308,268,40
+Kerr,220,"Justice, 4th Court of Appeals District, Place 3",,,Over Votes,0,0,0
+Kerr,220,"Justice, 4th Court of Appeals District, Place 3",,,Under Votes,75,63,12
+Kerr,220,"Justice, 4th Court of Appeals District, Place 3",,REP,Jason Pulliam,1500,1318,182
+Kerr,220,"Justice, 4th Court of Appeals District, Place 3",,DEM,Patricia O'Connell Alvarez,312,271,41
+Kerr,220,"Justice, 4th Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Kerr,220,"Justice, 4th Court of Appeals District, Place 4",,,Under Votes,73,62,11
+Kerr,220,"Justice, 4th Court of Appeals District, Place 4",,REP,Patrick Ballantyne,1507,1321,186
+Kerr,220,"Justice, 4th Court of Appeals District, Place 4",,DEM,Luz Elena Chapa,307,269,38
+Kerr,220,"Justice, 4th Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Kerr,220,"Justice, 4th Court of Appeals District, Place 5",,,Under Votes,74,63,11
+Kerr,220,"Justice, 4th Court of Appeals District, Place 5",,REP,Rebecca Simmons,1517,1330,187
+Kerr,220,"Justice, 4th Court of Appeals District, Place 5",,DEM,Liza Rodriguez,296,259,37
+Kerr,220,"Justice, 4th Court of Appeals District, Place 7",,,Over Votes,0,0,0
+Kerr,220,"Justice, 4th Court of Appeals District, Place 7",,,Under Votes,70,59,11
+Kerr,220,"Justice, 4th Court of Appeals District, Place 7",,REP,Shane Stolarczyk,1509,1322,187
+Kerr,220,"Justice, 4th Court of Appeals District, Place 7",,DEM,Rebeca Martinez,308,271,37
+Kerr,220,"District Judge, 198th Judicial District",,,Over Votes,0,0,0
+Kerr,220,"District Judge, 198th Judicial District",,,Under Votes,305,268,37
+Kerr,220,"District Judge, 198th Judicial District",,REP,Rex Emerson,1582,1384,198
+Kerr,220,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,Over Votes,0,0,0
+Kerr,220,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,Under Votes,5,4,1
+Kerr,220,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,FOR,1128,1009,119
+Kerr,220,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,AGAINST,410,357,53
+Kerr,303,Ballots Cast,,,,774,656,118
+Kerr,303,Straight Party,,,Over Votes,0,0,0
+Kerr,303,Straight Party,,,Under Votes,227,186,41
+Kerr,303,Straight Party,,REP,Republican Party,390,336,54
+Kerr,303,Straight Party,,DEM,Democratic Party,58,49,9
+Kerr,303,Straight Party,,LIB,Libertarian Party,1,1,0
+Kerr,303,U.S. Senate,,,Over Votes,0,0,0
+Kerr,303,U.S. Senate,,,Under Votes,0,0,0
+Kerr,303,U.S. Senate,,REP,Ted Cruz,547,465,82
+Kerr,303,U.S. Senate,,DEM,Beto O'Rourke,126,106,20
+Kerr,303,U.S. Senate,,LIB,Neal M. Dikeman,3,1,2
+Kerr,303,U.S. House,21,,Over Votes,0,0,0
+Kerr,303,U.S. House,21,,Under Votes,2,2,0
+Kerr,303,U.S. House,21,REP,Chip Roy,545,457,88
+Kerr,303,U.S. House,21,DEM,Joseph Kopser,125,110,15
+Kerr,303,U.S. House,21,LIB,Lee Santos,4,3,1
+Kerr,303,Governor,,,Over Votes,0,0,0
+Kerr,303,Governor,,,Under Votes,1,1,0
+Kerr,303,Governor,,REP,Greg Abbott,571,482,89
+Kerr,303,Governor,,DEM,Lupe Valdez,100,85,15
+Kerr,303,Governor,,LIB,Mark Jay Tippetts,4,4,0
+Kerr,303,Lieutenant Governor,,,Over Votes,0,0,0
+Kerr,303,Lieutenant Governor,,,Under Votes,4,3,1
+Kerr,303,Lieutenant Governor,,REP,Dan Patrick,541,459,82
+Kerr,303,Lieutenant Governor,,DEM,Mike Collier,123,104,19
+Kerr,303,Lieutenant Governor,,LIB,Kerry Douglas McKennon,8,6,2
+Kerr,303,Attorney General,,,Over Votes,0,0,0
+Kerr,303,Attorney General,,,Under Votes,3,3,0
+Kerr,303,Attorney General,,REP,Ken Paxton,543,461,82
+Kerr,303,Attorney General,,DEM,Justin Nelson,124,104,20
+Kerr,303,Attorney General,,LIB,Michael Ray Harris,6,4,2
+Kerr,303,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Kerr,303,Comptroller of Public Accounts,,,Under Votes,10,9,1
+Kerr,303,Comptroller of Public Accounts,,REP,Glenn Hegar,551,466,85
+Kerr,303,Comptroller of Public Accounts,,DEM,Joi Chevalier,106,91,15
+Kerr,303,Comptroller of Public Accounts,,LIB,Ben Sanders,9,6,3
+Kerr,303,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Kerr,303,Commissioner of the General Land Office,,,Under Votes,10,10,0
+Kerr,303,Commissioner of the General Land Office,,REP,George P. Bush,541,456,85
+Kerr,303,Commissioner of the General Land Office,,DEM,Miguel Suazo,112,96,16
+Kerr,303,Commissioner of the General Land Office,,LIB,Matt Piña,13,10,3
+Kerr,303,Commissioner of Agriculture,,,Over Votes,0,0,0
+Kerr,303,Commissioner of Agriculture,,,Under Votes,9,8,1
+Kerr,303,Commissioner of Agriculture,,REP,Sid Miller,535,457,78
+Kerr,303,Commissioner of Agriculture,,DEM,Kim Olson,124,101,23
+Kerr,303,Commissioner of Agriculture,,LIB,Richard Carpenter,8,6,2
+Kerr,303,Railroad Commissioner,,,Over Votes,0,0,0
+Kerr,303,Railroad Commissioner,,,Under Votes,7,6,1
+Kerr,303,Railroad Commissioner,,REP,Christi Craddick,552,468,84
+Kerr,303,Railroad Commissioner,,DEM,Roman McAllen,106,89,17
+Kerr,303,Railroad Commissioner,,LIB,Mike Wright,11,9,2
+Kerr,303,"Justice, Supreme Court, Place 2",,,Over Votes,1,1,0
+Kerr,303,"Justice, Supreme Court, Place 2",,,Under Votes,8,8,0
+Kerr,303,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,549,463,86
+Kerr,303,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,118,100,18
+Kerr,303,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Kerr,303,"Justice, Supreme Court, Place 4",,,Under Votes,11,11,0
+Kerr,303,"Justice, Supreme Court, Place 4",,REP,John Devine,551,466,85
+Kerr,303,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,114,95,19
+Kerr,303,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Kerr,303,"Justice, Supreme Court, Place 6",,,Under Votes,9,8,1
+Kerr,303,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,553,468,85
+Kerr,303,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,114,96,18
+Kerr,303,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,1,1,0
+Kerr,303,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,9,9,0
+Kerr,303,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,546,461,85
+Kerr,303,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,106,90,16
+Kerr,303,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,14,11,3
+Kerr,303,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Kerr,303,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,9,7,2
+Kerr,303,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,557,471,86
+Kerr,303,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,110,94,16
+Kerr,303,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Kerr,303,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,63,53,10
+Kerr,303,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,561,478,83
+Kerr,303,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,52,41,11
+Kerr,303,State Representative,53,,Over Votes,0,0,0
+Kerr,303,State Representative,53,,Under Votes,10,8,2
+Kerr,303,State Representative,53,REP,Andrew S. Murr,550,468,82
+Kerr,303,State Representative,53,DEM,Stephanie Lochte Ertel,116,96,20
+Kerr,303,"Justice, 4th Court of Appeals District, Place 2",,,Over Votes,0,0,0
+Kerr,303,"Justice, 4th Court of Appeals District, Place 2",,,Under Votes,13,12,1
+Kerr,303,"Justice, 4th Court of Appeals District, Place 2",,REP,Marialyn Barnard,550,465,85
+Kerr,303,"Justice, 4th Court of Appeals District, Place 2",,DEM,Beth Watkins,113,95,18
+Kerr,303,"Justice, 4th Court of Appeals District, Place 3",,,Over Votes,0,0,0
+Kerr,303,"Justice, 4th Court of Appeals District, Place 3",,,Under Votes,14,12,2
+Kerr,303,"Justice, 4th Court of Appeals District, Place 3",,REP,Jason Pulliam,549,464,85
+Kerr,303,"Justice, 4th Court of Appeals District, Place 3",,DEM,Patricia O'Connell Alvarez,113,96,17
+Kerr,303,"Justice, 4th Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Kerr,303,"Justice, 4th Court of Appeals District, Place 4",,,Under Votes,15,13,2
+Kerr,303,"Justice, 4th Court of Appeals District, Place 4",,REP,Patrick Ballantyne,554,468,86
+Kerr,303,"Justice, 4th Court of Appeals District, Place 4",,DEM,Luz Elena Chapa,107,91,16
+Kerr,303,"Justice, 4th Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Kerr,303,"Justice, 4th Court of Appeals District, Place 5",,,Under Votes,14,12,2
+Kerr,303,"Justice, 4th Court of Appeals District, Place 5",,REP,Rebecca Simmons,553,468,85
+Kerr,303,"Justice, 4th Court of Appeals District, Place 5",,DEM,Liza Rodriguez,109,92,17
+Kerr,303,"Justice, 4th Court of Appeals District, Place 7",,,Over Votes,0,0,0
+Kerr,303,"Justice, 4th Court of Appeals District, Place 7",,,Under Votes,13,11,2
+Kerr,303,"Justice, 4th Court of Appeals District, Place 7",,REP,Shane Stolarczyk,552,466,86
+Kerr,303,"Justice, 4th Court of Appeals District, Place 7",,DEM,Rebeca Martinez,111,95,16
+Kerr,303,"District Judge, 198th Judicial District",,,Over Votes,0,0,0
+Kerr,303,"District Judge, 198th Judicial District",,,Under Votes,103,90,13
+Kerr,303,"District Judge, 198th Judicial District",,REP,Rex Emerson,573,482,91
+Kerr,303,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,Over Votes,0,0,0
+Kerr,303,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,Under Votes,0,0,0
+Kerr,303,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,FOR,62,55,7
+Kerr,303,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,AGAINST,36,29,7
+Kerr,308,Registered Voters,,,,590,,
+Kerr,308,Ballots Cast,,,,342,198,144
+Kerr,308,Straight Party,,,Over Votes,0,0,0
+Kerr,308,Straight Party,,,Under Votes,117,70,47
+Kerr,308,Straight Party,,REP,Republican Party,166,99,67
+Kerr,308,Straight Party,,DEM,Democratic Party,58,29,29
+Kerr,308,Straight Party,,LIB,Libertarian Party,1,0,1
+Kerr,308,U.S. Senate,,,Over Votes,0,0,0
+Kerr,308,U.S. Senate,,,Under Votes,0,0,0
+Kerr,308,U.S. Senate,,REP,Ted Cruz,253,154,99
+Kerr,308,U.S. Senate,,DEM,Beto O'Rourke,88,44,44
+Kerr,308,U.S. Senate,,LIB,Neal M. Dikeman,1,0,1
+Kerr,308,U.S. House,21,,Over Votes,0,0,0
+Kerr,308,U.S. House,21,,Under Votes,0,0,0
+Kerr,308,U.S. House,21,REP,Chip Roy,250,151,99
+Kerr,308,U.S. House,21,DEM,Joseph Kopser,88,46,42
+Kerr,308,U.S. House,21,LIB,Lee Santos,4,1,3
+Kerr,308,Governor,,,Over Votes,0,0,0
+Kerr,308,Governor,,,Under Votes,1,1,0
+Kerr,308,Governor,,REP,Greg Abbott,256,154,102
+Kerr,308,Governor,,DEM,Lupe Valdez,84,43,41
+Kerr,308,Governor,,LIB,Mark Jay Tippetts,1,0,1
+Kerr,308,Lieutenant Governor,,,Over Votes,0,0,0
+Kerr,308,Lieutenant Governor,,,Under Votes,2,1,1
+Kerr,308,Lieutenant Governor,,REP,Dan Patrick,251,152,99
+Kerr,308,Lieutenant Governor,,DEM,Mike Collier,88,45,43
+Kerr,308,Lieutenant Governor,,LIB,Kerry Douglas McKennon,1,0,1
+Kerr,308,Attorney General,,,Over Votes,0,0,0
+Kerr,308,Attorney General,,,Under Votes,3,0,3
+Kerr,308,Attorney General,,REP,Ken Paxton,249,148,101
+Kerr,308,Attorney General,,DEM,Justin Nelson,86,47,39
+Kerr,308,Attorney General,,LIB,Michael Ray Harris,4,3,1
+Kerr,308,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Kerr,308,Comptroller of Public Accounts,,,Under Votes,4,0,4
+Kerr,308,Comptroller of Public Accounts,,REP,Glenn Hegar,249,151,98
+Kerr,308,Comptroller of Public Accounts,,DEM,Joi Chevalier,78,39,39
+Kerr,308,Comptroller of Public Accounts,,LIB,Ben Sanders,11,8,3
+Kerr,308,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Kerr,308,Commissioner of the General Land Office,,,Under Votes,2,1,1
+Kerr,308,Commissioner of the General Land Office,,REP,George P. Bush,240,141,99
+Kerr,308,Commissioner of the General Land Office,,DEM,Miguel Suazo,83,44,39
+Kerr,308,Commissioner of the General Land Office,,LIB,Matt Piña,17,12,5
+Kerr,308,Commissioner of Agriculture,,,Over Votes,0,0,0
+Kerr,308,Commissioner of Agriculture,,,Under Votes,3,1,2
+Kerr,308,Commissioner of Agriculture,,REP,Sid Miller,248,147,101
+Kerr,308,Commissioner of Agriculture,,DEM,Kim Olson,87,47,40
+Kerr,308,Commissioner of Agriculture,,LIB,Richard Carpenter,4,3,1
+Kerr,308,Railroad Commissioner,,,Over Votes,0,0,0
+Kerr,308,Railroad Commissioner,,,Under Votes,1,0,1
+Kerr,308,Railroad Commissioner,,REP,Christi Craddick,256,153,103
+Kerr,308,Railroad Commissioner,,DEM,Roman McAllen,80,42,38
+Kerr,308,Railroad Commissioner,,LIB,Mike Wright,5,3,2
+Kerr,308,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Kerr,308,"Justice, Supreme Court, Place 2",,,Under Votes,3,1,2
+Kerr,308,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,253,153,100
+Kerr,308,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,86,44,42
+Kerr,308,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Kerr,308,"Justice, Supreme Court, Place 4",,,Under Votes,5,1,4
+Kerr,308,"Justice, Supreme Court, Place 4",,REP,John Devine,253,154,99
+Kerr,308,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,84,43,41
+Kerr,308,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Kerr,308,"Justice, Supreme Court, Place 6",,,Under Votes,5,2,3
+Kerr,308,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,251,152,99
+Kerr,308,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,86,44,42
+Kerr,308,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Kerr,308,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,2,1,1
+Kerr,308,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,249,148,101
+Kerr,308,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,81,42,39
+Kerr,308,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,10,7,3
+Kerr,308,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Kerr,308,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,3,0,3
+Kerr,308,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,255,155,100
+Kerr,308,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,84,43,41
+Kerr,308,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Kerr,308,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,54,28,26
+Kerr,308,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,260,153,107
+Kerr,308,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,28,17,11
+Kerr,308,State Representative,53,,Over Votes,0,0,0
+Kerr,308,State Representative,53,,Under Votes,5,2,3
+Kerr,308,State Representative,53,REP,Andrew S. Murr,254,154,100
+Kerr,308,State Representative,53,DEM,Stephanie Lochte Ertel,83,42,41
+Kerr,308,"Justice, 4th Court of Appeals District, Place 2",,,Over Votes,0,0,0
+Kerr,308,"Justice, 4th Court of Appeals District, Place 2",,,Under Votes,4,1,3
+Kerr,308,"Justice, 4th Court of Appeals District, Place 2",,REP,Marialyn Barnard,256,154,102
+Kerr,308,"Justice, 4th Court of Appeals District, Place 2",,DEM,Beth Watkins,82,43,39
+Kerr,308,"Justice, 4th Court of Appeals District, Place 3",,,Over Votes,0,0,0
+Kerr,308,"Justice, 4th Court of Appeals District, Place 3",,,Under Votes,4,2,2
+Kerr,308,"Justice, 4th Court of Appeals District, Place 3",,REP,Jason Pulliam,251,154,97
+Kerr,308,"Justice, 4th Court of Appeals District, Place 3",,DEM,Patricia O'Connell Alvarez,87,42,45
+Kerr,308,"Justice, 4th Court of Appeals District, Place 4",,,Over Votes,1,1,0
+Kerr,308,"Justice, 4th Court of Appeals District, Place 4",,,Under Votes,2,1,1
+Kerr,308,"Justice, 4th Court of Appeals District, Place 4",,REP,Patrick Ballantyne,252,153,99
+Kerr,308,"Justice, 4th Court of Appeals District, Place 4",,DEM,Luz Elena Chapa,87,43,44
+Kerr,308,"Justice, 4th Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Kerr,308,"Justice, 4th Court of Appeals District, Place 5",,,Under Votes,3,0,3
+Kerr,308,"Justice, 4th Court of Appeals District, Place 5",,REP,Rebecca Simmons,257,155,102
+Kerr,308,"Justice, 4th Court of Appeals District, Place 5",,DEM,Liza Rodriguez,82,43,39
+Kerr,308,"Justice, 4th Court of Appeals District, Place 7",,,Over Votes,0,0,0
+Kerr,308,"Justice, 4th Court of Appeals District, Place 7",,,Under Votes,4,1,3
+Kerr,308,"Justice, 4th Court of Appeals District, Place 7",,REP,Shane Stolarczyk,254,154,100
+Kerr,308,"Justice, 4th Court of Appeals District, Place 7",,DEM,Rebeca Martinez,84,43,41
+Kerr,308,"District Judge, 198th Judicial District",,,Over Votes,0,0,0
+Kerr,308,"District Judge, 198th Judicial District",,,Under Votes,77,44,33
+Kerr,308,"District Judge, 198th Judicial District",,REP,Rex Emerson,265,154,111
+Kerr,312,Ballots Cast,,,,3834,3089,745
+Kerr,312,Straight Party,,,Over Votes,0,0,0
+Kerr,312,Straight Party,,,Under Votes,808,653,155
+Kerr,312,Straight Party,,REP,Republican Party,1027,843,184
+Kerr,312,Straight Party,,DEM,Democratic Party,364,277,87
+Kerr,312,Straight Party,,LIB,Libertarian Party,11,7,4
+Kerr,312,U.S. Senate,,,Over Votes,0,0,0
+Kerr,312,U.S. Senate,,,Under Votes,11,9,2
+Kerr,312,U.S. Senate,,REP,Ted Cruz,1488,1226,262
+Kerr,312,U.S. Senate,,DEM,Beto O'Rourke,695,535,160
+Kerr,312,U.S. Senate,,LIB,Neal M. Dikeman,16,10,6
+Kerr,312,U.S. House,21,,Over Votes,0,0,0
+Kerr,312,U.S. House,21,,Under Votes,30,26,4
+Kerr,312,U.S. House,21,REP,Chip Roy,1454,1188,266
+Kerr,312,U.S. House,21,DEM,Joseph Kopser,692,541,151
+Kerr,312,U.S. House,21,LIB,Lee Santos,34,25,9
+Kerr,312,Governor,,,Over Votes,0,0,0
+Kerr,312,Governor,,,Under Votes,21,19,2
+Kerr,312,Governor,,REP,Greg Abbott,1571,1278,293
+Kerr,312,Governor,,DEM,Lupe Valdez,580,457,123
+Kerr,312,Governor,,LIB,Mark Jay Tippetts,38,26,12
+Kerr,312,Lieutenant Governor,,,Over Votes,1,1,0
+Kerr,312,Lieutenant Governor,,,Under Votes,32,28,4
+Kerr,312,Lieutenant Governor,,REP,Dan Patrick,1487,1216,271
+Kerr,312,Lieutenant Governor,,DEM,Mike Collier,644,501,143
+Kerr,312,Lieutenant Governor,,LIB,Kerry Douglas McKennon,46,34,12
+Kerr,312,Attorney General,,,Over Votes,1,1,0
+Kerr,312,Attorney General,,,Under Votes,34,29,5
+Kerr,312,Attorney General,,REP,Ken Paxton,1470,1194,276
+Kerr,312,Attorney General,,DEM,Justin Nelson,646,510,136
+Kerr,312,Attorney General,,LIB,Michael Ray Harris,59,46,13
+Kerr,312,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Kerr,312,Comptroller of Public Accounts,,,Under Votes,54,46,8
+Kerr,312,Comptroller of Public Accounts,,REP,Glenn Hegar,1506,1230,276
+Kerr,312,Comptroller of Public Accounts,,DEM,Joi Chevalier,564,442,122
+Kerr,312,Comptroller of Public Accounts,,LIB,Ben Sanders,86,62,24
+Kerr,312,Commissioner of the General Land Office,,,Over Votes,1,1,0
+Kerr,312,Commissioner of the General Land Office,,,Under Votes,40,33,7
+Kerr,312,Commissioner of the General Land Office,,REP,George P. Bush,1490,1227,263
+Kerr,312,Commissioner of the General Land Office,,DEM,Miguel Suazo,582,449,133
+Kerr,312,Commissioner of the General Land Office,,LIB,Matt Piña,97,70,27
+Kerr,312,Commissioner of Agriculture,,,Over Votes,0,0,0
+Kerr,312,Commissioner of Agriculture,,,Under Votes,53,46,7
+Kerr,312,Commissioner of Agriculture,,REP,Sid Miller,1447,1185,262
+Kerr,312,Commissioner of Agriculture,,DEM,Kim Olson,638,496,142
+Kerr,312,Commissioner of Agriculture,,LIB,Richard Carpenter,72,53,19
+Kerr,312,Railroad Commissioner,,,Over Votes,0,0,0
+Kerr,312,Railroad Commissioner,,,Under Votes,53,46,7
+Kerr,312,Railroad Commissioner,,REP,Christi Craddick,1506,1237,269
+Kerr,312,Railroad Commissioner,,DEM,Roman McAllen,569,438,131
+Kerr,312,Railroad Commissioner,,LIB,Mike Wright,82,59,23
+Kerr,312,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Kerr,312,"Justice, Supreme Court, Place 2",,,Under Votes,68,58,10
+Kerr,312,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1506,1225,281
+Kerr,312,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,636,497,139
+Kerr,312,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Kerr,312,"Justice, Supreme Court, Place 4",,,Under Votes,68,59,9
+Kerr,312,"Justice, Supreme Court, Place 4",,REP,John Devine,1523,1241,282
+Kerr,312,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,619,480,139
+Kerr,312,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Kerr,312,"Justice, Supreme Court, Place 6",,,Under Votes,61,52,9
+Kerr,312,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1500,1227,273
+Kerr,312,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,649,501,148
+Kerr,312,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,1,1,0
+Kerr,312,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,49,42,7
+Kerr,312,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1499,1221,278
+Kerr,312,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,598,468,130
+Kerr,312,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,63,48,15
+Kerr,312,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,1,0,1
+Kerr,312,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,58,49,9
+Kerr,312,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1530,1245,285
+Kerr,312,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,621,486,135
+Kerr,312,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Kerr,312,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,332,262,70
+Kerr,312,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1583,1286,297
+Kerr,312,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,295,232,63
+Kerr,312,State Representative,53,,Over Votes,0,0,0
+Kerr,312,State Representative,53,,Under Votes,48,41,7
+Kerr,312,State Representative,53,REP,Andrew S. Murr,1532,1248,284
+Kerr,312,State Representative,53,DEM,Stephanie Lochte Ertel,630,491,139
+Kerr,312,"Justice, 4th Court of Appeals District, Place 2",,,Over Votes,1,1,0
+Kerr,312,"Justice, 4th Court of Appeals District, Place 2",,,Under Votes,64,53,11
+Kerr,312,"Justice, 4th Court of Appeals District, Place 2",,REP,Marialyn Barnard,1504,1229,275
+Kerr,312,"Justice, 4th Court of Appeals District, Place 2",,DEM,Beth Watkins,641,497,144
+Kerr,312,"Justice, 4th Court of Appeals District, Place 3",,,Over Votes,0,0,0
+Kerr,312,"Justice, 4th Court of Appeals District, Place 3",,,Under Votes,63,53,10
+Kerr,312,"Justice, 4th Court of Appeals District, Place 3",,REP,Jason Pulliam,1493,1220,273
+Kerr,312,"Justice, 4th Court of Appeals District, Place 3",,DEM,Patricia O'Connell Alvarez,654,507,147
+Kerr,312,"Justice, 4th Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Kerr,312,"Justice, 4th Court of Appeals District, Place 4",,,Under Votes,69,58,11
+Kerr,312,"Justice, 4th Court of Appeals District, Place 4",,REP,Patrick Ballantyne,1511,1234,277
+Kerr,312,"Justice, 4th Court of Appeals District, Place 4",,DEM,Luz Elena Chapa,630,488,142
+Kerr,312,"Justice, 4th Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Kerr,312,"Justice, 4th Court of Appeals District, Place 5",,,Under Votes,70,59,11
+Kerr,312,"Justice, 4th Court of Appeals District, Place 5",,REP,Rebecca Simmons,1512,1234,278
+Kerr,312,"Justice, 4th Court of Appeals District, Place 5",,DEM,Liza Rodriguez,628,487,141
+Kerr,312,"Justice, 4th Court of Appeals District, Place 7",,,Over Votes,1,1,0
+Kerr,312,"Justice, 4th Court of Appeals District, Place 7",,,Under Votes,66,55,11
+Kerr,312,"Justice, 4th Court of Appeals District, Place 7",,REP,Shane Stolarczyk,1500,1227,273
+Kerr,312,"Justice, 4th Court of Appeals District, Place 7",,DEM,Rebeca Martinez,643,497,146
+Kerr,312,"District Judge, 198th Judicial District",,,Over Votes,0,0,0
+Kerr,312,"District Judge, 198th Judicial District",,,Under Votes,513,403,110
+Kerr,312,"District Judge, 198th Judicial District",,REP,Rex Emerson,1697,1377,320
+Kerr,312,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,Over Votes,0,0,0
+Kerr,312,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,Under Votes,1,1,0
+Kerr,312,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,FOR,1097,877,220
+Kerr,312,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,AGAINST,526,431,95
+Kerr,314,Ballots Cast,,,,1722,1288,434
+Kerr,314,Straight Party,,,Over Votes,0,0,0
+Kerr,314,Straight Party,,,Under Votes,336,255,81
+Kerr,314,Straight Party,,REP,Republican Party,414,308,106
+Kerr,314,Straight Party,,DEM,Democratic Party,268,197,71
+Kerr,314,Straight Party,,LIB,Libertarian Party,9,5,4
+Kerr,314,U.S. Senate,,,Over Votes,0,0,0
+Kerr,314,U.S. Senate,,,Under Votes,5,5,0
+Kerr,314,U.S. Senate,,REP,Ted Cruz,575,420,155
+Kerr,314,U.S. Senate,,DEM,Beto O'Rourke,438,333,105
+Kerr,314,U.S. Senate,,LIB,Neal M. Dikeman,9,7,2
+Kerr,314,U.S. House,21,,Over Votes,0,0,0
+Kerr,314,U.S. House,21,,Under Votes,21,18,3
+Kerr,314,U.S. House,21,REP,Chip Roy,554,403,151
+Kerr,314,U.S. House,21,DEM,Joseph Kopser,426,330,96
+Kerr,314,U.S. House,21,LIB,Lee Santos,26,14,12
+Kerr,314,Governor,,,Over Votes,0,0,0
+Kerr,314,Governor,,,Under Votes,7,7,0
+Kerr,314,Governor,,REP,Greg Abbott,609,445,164
+Kerr,314,Governor,,DEM,Lupe Valdez,389,298,91
+Kerr,314,Governor,,LIB,Mark Jay Tippetts,22,15,7
+Kerr,314,Lieutenant Governor,,,Over Votes,0,0,0
+Kerr,314,Lieutenant Governor,,,Under Votes,8,6,2
+Kerr,314,Lieutenant Governor,,REP,Dan Patrick,587,430,157
+Kerr,314,Lieutenant Governor,,DEM,Mike Collier,406,315,91
+Kerr,314,Lieutenant Governor,,LIB,Kerry Douglas McKennon,26,14,12
+Kerr,314,Attorney General,,,Over Votes,0,0,0
+Kerr,314,Attorney General,,,Under Votes,8,5,3
+Kerr,314,Attorney General,,REP,Ken Paxton,568,416,152
+Kerr,314,Attorney General,,DEM,Justin Nelson,419,324,95
+Kerr,314,Attorney General,,LIB,Michael Ray Harris,32,20,12
+Kerr,314,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Kerr,314,Comptroller of Public Accounts,,,Under Votes,20,14,6
+Kerr,314,Comptroller of Public Accounts,,REP,Glenn Hegar,577,431,146
+Kerr,314,Comptroller of Public Accounts,,DEM,Joi Chevalier,384,292,92
+Kerr,314,Comptroller of Public Accounts,,LIB,Ben Sanders,46,28,18
+Kerr,314,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Kerr,314,Commissioner of the General Land Office,,,Under Votes,16,13,3
+Kerr,314,Commissioner of the General Land Office,,REP,George P. Bush,582,436,146
+Kerr,314,Commissioner of the General Land Office,,DEM,Miguel Suazo,394,299,95
+Kerr,314,Commissioner of the General Land Office,,LIB,Matt Piña,35,17,18
+Kerr,314,Commissioner of Agriculture,,,Over Votes,1,1,0
+Kerr,314,Commissioner of Agriculture,,,Under Votes,25,19,6
+Kerr,314,Commissioner of Agriculture,,REP,Sid Miller,563,420,143
+Kerr,314,Commissioner of Agriculture,,DEM,Kim Olson,402,303,99
+Kerr,314,Commissioner of Agriculture,,LIB,Richard Carpenter,36,22,14
+Kerr,314,Railroad Commissioner,,,Over Votes,1,1,0
+Kerr,314,Railroad Commissioner,,,Under Votes,25,21,4
+Kerr,314,Railroad Commissioner,,REP,Christi Craddick,579,428,151
+Kerr,314,Railroad Commissioner,,DEM,Roman McAllen,383,292,91
+Kerr,314,Railroad Commissioner,,LIB,Mike Wright,39,23,16
+Kerr,314,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Kerr,314,"Justice, Supreme Court, Place 2",,,Under Votes,31,23,8
+Kerr,314,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,582,428,154
+Kerr,314,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,414,314,100
+Kerr,314,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Kerr,314,"Justice, Supreme Court, Place 4",,,Under Votes,35,27,8
+Kerr,314,"Justice, Supreme Court, Place 4",,REP,John Devine,586,431,155
+Kerr,314,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,406,307,99
+Kerr,314,"Justice, Supreme Court, Place 6",,,Over Votes,1,1,0
+Kerr,314,"Justice, Supreme Court, Place 6",,,Under Votes,31,24,7
+Kerr,314,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,583,427,156
+Kerr,314,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,412,313,99
+Kerr,314,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Kerr,314,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,23,19,4
+Kerr,314,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,569,421,148
+Kerr,314,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,399,303,96
+Kerr,314,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,36,22,14
+Kerr,314,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Kerr,314,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,32,24,8
+Kerr,314,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,584,429,155
+Kerr,314,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,411,312,99
+Kerr,314,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Kerr,314,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,235,174,61
+Kerr,314,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,606,447,159
+Kerr,314,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,186,144,42
+Kerr,314,State Representative,53,,Over Votes,0,0,0
+Kerr,314,State Representative,53,,Under Votes,35,28,7
+Kerr,314,State Representative,53,REP,Andrew S. Murr,582,427,155
+Kerr,314,State Representative,53,DEM,Stephanie Lochte Ertel,410,310,100
+Kerr,314,"Justice, 4th Court of Appeals District, Place 2",,,Over Votes,0,0,0
+Kerr,314,"Justice, 4th Court of Appeals District, Place 2",,,Under Votes,37,31,6
+Kerr,314,"Justice, 4th Court of Appeals District, Place 2",,REP,Marialyn Barnard,584,427,157
+Kerr,314,"Justice, 4th Court of Appeals District, Place 2",,DEM,Beth Watkins,406,307,99
+Kerr,314,"Justice, 4th Court of Appeals District, Place 3",,,Over Votes,0,0,0
+Kerr,314,"Justice, 4th Court of Appeals District, Place 3",,,Under Votes,34,28,6
+Kerr,314,"Justice, 4th Court of Appeals District, Place 3",,REP,Jason Pulliam,573,424,149
+Kerr,314,"Justice, 4th Court of Appeals District, Place 3",,DEM,Patricia O'Connell Alvarez,420,313,107
+Kerr,314,"Justice, 4th Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Kerr,314,"Justice, 4th Court of Appeals District, Place 4",,,Under Votes,34,28,6
+Kerr,314,"Justice, 4th Court of Appeals District, Place 4",,REP,Patrick Ballantyne,575,426,149
+Kerr,314,"Justice, 4th Court of Appeals District, Place 4",,DEM,Luz Elena Chapa,418,311,107
+Kerr,314,"Justice, 4th Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Kerr,314,"Justice, 4th Court of Appeals District, Place 5",,,Under Votes,33,27,6
+Kerr,314,"Justice, 4th Court of Appeals District, Place 5",,REP,Rebecca Simmons,578,429,149
+Kerr,314,"Justice, 4th Court of Appeals District, Place 5",,DEM,Liza Rodriguez,416,309,107
+Kerr,314,"Justice, 4th Court of Appeals District, Place 7",,,Over Votes,0,0,0
+Kerr,314,"Justice, 4th Court of Appeals District, Place 7",,,Under Votes,33,27,6
+Kerr,314,"Justice, 4th Court of Appeals District, Place 7",,REP,Shane Stolarczyk,577,429,148
+Kerr,314,"Justice, 4th Court of Appeals District, Place 7",,DEM,Rebeca Martinez,417,309,108
+Kerr,314,"District Judge, 198th Judicial District",,,Over Votes,0,0,0
+Kerr,314,"District Judge, 198th Judicial District",,,Under Votes,355,267,88
+Kerr,314,"District Judge, 198th Judicial District",,REP,Rex Emerson,672,498,174
+Kerr,314,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,Over Votes,0,0,0
+Kerr,314,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,Under Votes,1,1,0
+Kerr,314,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,FOR,490,367,123
+Kerr,314,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,AGAINST,204,155,49
+Kerr,404,Ballots Cast,,,,786,568,218
+Kerr,404,Straight Party,,,Over Votes,0,0,0
+Kerr,404,Straight Party,,,Under Votes,213,162,51
+Kerr,404,Straight Party,,REP,Republican Party,390,298,92
+Kerr,404,Straight Party,,DEM,Democratic Party,35,29,6
+Kerr,404,Straight Party,,LIB,Libertarian Party,2,2,0
+Kerr,404,U.S. Senate,,,Over Votes,0,0,0
+Kerr,404,U.S. Senate,,,Under Votes,1,1,0
+Kerr,404,U.S. Senate,,REP,Ted Cruz,557,426,131
+Kerr,404,U.S. Senate,,DEM,Beto O'Rourke,77,60,17
+Kerr,404,U.S. Senate,,LIB,Neal M. Dikeman,5,4,1
+Kerr,404,U.S. House,21,,Over Votes,0,0,0
+Kerr,404,U.S. House,21,,Under Votes,6,4,2
+Kerr,404,U.S. House,21,REP,Chip Roy,552,425,127
+Kerr,404,U.S. House,21,DEM,Joseph Kopser,74,57,17
+Kerr,404,U.S. House,21,LIB,Lee Santos,8,5,3
+Kerr,404,Governor,,,Over Votes,0,0,0
+Kerr,404,Governor,,,Under Votes,2,2,0
+Kerr,404,Governor,,REP,Greg Abbott,570,436,134
+Kerr,404,Governor,,DEM,Lupe Valdez,58,48,10
+Kerr,404,Governor,,LIB,Mark Jay Tippetts,10,5,5
+Kerr,404,Lieutenant Governor,,,Over Votes,0,0,0
+Kerr,404,Lieutenant Governor,,,Under Votes,4,4,0
+Kerr,404,Lieutenant Governor,,REP,Dan Patrick,555,425,130
+Kerr,404,Lieutenant Governor,,DEM,Mike Collier,73,58,15
+Kerr,404,Lieutenant Governor,,LIB,Kerry Douglas McKennon,8,4,4
+Kerr,404,Attorney General,,,Over Votes,0,0,0
+Kerr,404,Attorney General,,,Under Votes,3,3,0
+Kerr,404,Attorney General,,REP,Ken Paxton,553,422,131
+Kerr,404,Attorney General,,DEM,Justin Nelson,70,56,14
+Kerr,404,Attorney General,,LIB,Michael Ray Harris,14,10,4
+Kerr,404,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Kerr,404,Comptroller of Public Accounts,,,Under Votes,13,9,4
+Kerr,404,Comptroller of Public Accounts,,REP,Glenn Hegar,543,419,124
+Kerr,404,Comptroller of Public Accounts,,DEM,Joi Chevalier,62,50,12
+Kerr,404,Comptroller of Public Accounts,,LIB,Ben Sanders,22,13,9
+Kerr,404,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Kerr,404,Commissioner of the General Land Office,,,Under Votes,14,9,5
+Kerr,404,Commissioner of the General Land Office,,REP,George P. Bush,527,402,125
+Kerr,404,Commissioner of the General Land Office,,DEM,Miguel Suazo,62,51,11
+Kerr,404,Commissioner of the General Land Office,,LIB,Matt Piña,37,29,8
+Kerr,404,Commissioner of Agriculture,,,Over Votes,0,0,0
+Kerr,404,Commissioner of Agriculture,,,Under Votes,9,6,3
+Kerr,404,Commissioner of Agriculture,,REP,Sid Miller,544,419,125
+Kerr,404,Commissioner of Agriculture,,DEM,Kim Olson,66,52,14
+Kerr,404,Commissioner of Agriculture,,LIB,Richard Carpenter,21,14,7
+Kerr,404,Railroad Commissioner,,,Over Votes,0,0,0
+Kerr,404,Railroad Commissioner,,,Under Votes,12,7,5
+Kerr,404,Railroad Commissioner,,REP,Christi Craddick,543,421,122
+Kerr,404,Railroad Commissioner,,DEM,Roman McAllen,61,47,14
+Kerr,404,Railroad Commissioner,,LIB,Mike Wright,24,16,8
+Kerr,404,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Kerr,404,"Justice, Supreme Court, Place 2",,,Under Votes,12,9,3
+Kerr,404,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,554,429,125
+Kerr,404,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,74,53,21
+Kerr,404,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Kerr,404,"Justice, Supreme Court, Place 4",,,Under Votes,12,9,3
+Kerr,404,"Justice, Supreme Court, Place 4",,REP,John Devine,558,430,128
+Kerr,404,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,70,52,18
+Kerr,404,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Kerr,404,"Justice, Supreme Court, Place 6",,,Under Votes,11,8,3
+Kerr,404,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,558,429,129
+Kerr,404,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,71,54,17
+Kerr,404,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,1,1,0
+Kerr,404,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,10,7,3
+Kerr,404,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,550,422,128
+Kerr,404,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,59,48,11
+Kerr,404,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,20,13,7
+Kerr,404,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Kerr,404,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,14,9,5
+Kerr,404,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,556,429,127
+Kerr,404,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,70,53,17
+Kerr,404,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Kerr,404,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,48,37,11
+Kerr,404,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,558,427,131
+Kerr,404,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,34,27,7
+Kerr,404,State Representative,53,,Over Votes,1,1,0
+Kerr,404,State Representative,53,,Under Votes,8,3,5
+Kerr,404,State Representative,53,REP,Andrew S. Murr,558,431,127
+Kerr,404,State Representative,53,DEM,Stephanie Lochte Ertel,73,56,17
+Kerr,404,"Justice, 4th Court of Appeals District, Place 2",,,Over Votes,0,0,0
+Kerr,404,"Justice, 4th Court of Appeals District, Place 2",,,Under Votes,15,8,7
+Kerr,404,"Justice, 4th Court of Appeals District, Place 2",,REP,Marialyn Barnard,554,429,125
+Kerr,404,"Justice, 4th Court of Appeals District, Place 2",,DEM,Beth Watkins,71,54,17
+Kerr,404,"Justice, 4th Court of Appeals District, Place 3",,,Over Votes,0,0,0
+Kerr,404,"Justice, 4th Court of Appeals District, Place 3",,,Under Votes,13,8,5
+Kerr,404,"Justice, 4th Court of Appeals District, Place 3",,REP,Jason Pulliam,549,426,123
+Kerr,404,"Justice, 4th Court of Appeals District, Place 3",,DEM,Patricia O'Connell Alvarez,78,57,21
+Kerr,404,"Justice, 4th Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Kerr,404,"Justice, 4th Court of Appeals District, Place 4",,,Under Votes,13,8,5
+Kerr,404,"Justice, 4th Court of Appeals District, Place 4",,REP,Patrick Ballantyne,554,427,127
+Kerr,404,"Justice, 4th Court of Appeals District, Place 4",,DEM,Luz Elena Chapa,73,56,17
+Kerr,404,"Justice, 4th Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Kerr,404,"Justice, 4th Court of Appeals District, Place 5",,,Under Votes,15,8,7
+Kerr,404,"Justice, 4th Court of Appeals District, Place 5",,REP,Rebecca Simmons,559,433,126
+Kerr,404,"Justice, 4th Court of Appeals District, Place 5",,DEM,Liza Rodriguez,66,50,16
+Kerr,404,"Justice, 4th Court of Appeals District, Place 7",,,Over Votes,1,1,0
+Kerr,404,"Justice, 4th Court of Appeals District, Place 7",,,Under Votes,13,8,5
+Kerr,404,"Justice, 4th Court of Appeals District, Place 7",,REP,Shane Stolarczyk,550,424,126
+Kerr,404,"Justice, 4th Court of Appeals District, Place 7",,DEM,Rebeca Martinez,76,58,18
+Kerr,404,"District Judge, 198th Judicial District",,,Over Votes,0,0,0
+Kerr,404,"District Judge, 198th Judicial District",,,Under Votes,74,54,20
+Kerr,404,"District Judge, 198th Judicial District",,REP,Rex Emerson,566,437,129
+Kerr,404,BOARD OF TRUSTEES,,,Over Votes,0,0,0
+Kerr,404,BOARD OF TRUSTEES,,,Under Votes,274,127,147
+Kerr,404,BOARD OF TRUSTEES,,||N,Steve Wade,50,33,17
+Kerr,404,BOARD OF TRUSTEES,,||N,Henry I. Sherman,37,17,20
+Kerr,404,BOARD OF TRUSTEES,,||N,Mary S. Krebs,88,54,34
+Kerr,404,BOARD OF TRUSTEES,,||N,Quentin A. Bierschwale,53,31,22
+Kerr,404,BOARD OF TRUSTEES,,||N,Dan Abbott,82,46,36
+Kerr,405,Registered Voters,,,,1603,,
+Kerr,405,Ballots Cast,,,,1201,920,281
+Kerr,405,Straight Party,,,Over Votes,0,0,0
+Kerr,405,Straight Party,,,Under Votes,407,288,119
+Kerr,405,Straight Party,,REP,Republican Party,641,513,128
+Kerr,405,Straight Party,,DEM,Democratic Party,150,119,31
+Kerr,405,Straight Party,,LIB,Libertarian Party,3,0,3
+Kerr,405,U.S. Senate,,,Over Votes,0,0,0
+Kerr,405,U.S. Senate,,,Under Votes,4,2,2
+Kerr,405,U.S. Senate,,REP,Ted Cruz,896,695,201
+Kerr,405,U.S. Senate,,DEM,Beto O'Rourke,288,219,69
+Kerr,405,U.S. Senate,,LIB,Neal M. Dikeman,13,4,9
+Kerr,405,U.S. House,21,,Over Votes,0,0,0
+Kerr,405,U.S. House,21,,Under Votes,10,6,4
+Kerr,405,U.S. House,21,REP,Chip Roy,884,684,200
+Kerr,405,U.S. House,21,DEM,Joseph Kopser,296,226,70
+Kerr,405,U.S. House,21,LIB,Lee Santos,11,4,7
+Kerr,405,Governor,,,Over Votes,0,0,0
+Kerr,405,Governor,,,Under Votes,6,3,3
+Kerr,405,Governor,,REP,Greg Abbott,931,718,213
+Kerr,405,Governor,,DEM,Lupe Valdez,242,191,51
+Kerr,405,Governor,,LIB,Mark Jay Tippetts,22,8,14
+Kerr,405,Lieutenant Governor,,,Over Votes,0,0,0
+Kerr,405,Lieutenant Governor,,,Under Votes,11,8,3
+Kerr,405,Lieutenant Governor,,REP,Dan Patrick,871,677,194
+Kerr,405,Lieutenant Governor,,DEM,Mike Collier,297,225,72
+Kerr,405,Lieutenant Governor,,LIB,Kerry Douglas McKennon,22,10,12
+Kerr,405,Attorney General,,,Over Votes,0,0,0
+Kerr,405,Attorney General,,,Under Votes,19,12,7
+Kerr,405,Attorney General,,REP,Ken Paxton,868,674,194
+Kerr,405,Attorney General,,DEM,Justin Nelson,296,224,72
+Kerr,405,Attorney General,,LIB,Michael Ray Harris,18,10,8
+Kerr,405,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Kerr,405,Comptroller of Public Accounts,,,Under Votes,28,11,17
+Kerr,405,Comptroller of Public Accounts,,REP,Glenn Hegar,902,701,201
+Kerr,405,Comptroller of Public Accounts,,DEM,Joi Chevalier,243,191,52
+Kerr,405,Comptroller of Public Accounts,,LIB,Ben Sanders,28,17,11
+Kerr,405,Commissioner of the General Land Office,,,Over Votes,1,1,0
+Kerr,405,Commissioner of the General Land Office,,,Under Votes,22,14,8
+Kerr,405,Commissioner of the General Land Office,,REP,George P. Bush,883,683,200
+Kerr,405,Commissioner of the General Land Office,,DEM,Miguel Suazo,255,196,59
+Kerr,405,Commissioner of the General Land Office,,LIB,Matt Piña,40,26,14
+Kerr,405,Commissioner of Agriculture,,,Over Votes,1,0,1
+Kerr,405,Commissioner of Agriculture,,,Under Votes,24,12,12
+Kerr,405,Commissioner of Agriculture,,REP,Sid Miller,863,669,194
+Kerr,405,Commissioner of Agriculture,,DEM,Kim Olson,288,225,63
+Kerr,405,Commissioner of Agriculture,,LIB,Richard Carpenter,25,14,11
+Kerr,405,Railroad Commissioner,,,Over Votes,1,0,1
+Kerr,405,Railroad Commissioner,,,Under Votes,23,13,10
+Kerr,405,Railroad Commissioner,,REP,Christi Craddick,904,697,207
+Kerr,405,Railroad Commissioner,,DEM,Roman McAllen,240,190,50
+Kerr,405,Railroad Commissioner,,LIB,Mike Wright,33,20,13
+Kerr,405,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Kerr,405,"Justice, Supreme Court, Place 2",,,Under Votes,34,19,15
+Kerr,405,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,904,696,208
+Kerr,405,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,263,205,58
+Kerr,405,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Kerr,405,"Justice, Supreme Court, Place 4",,,Under Votes,36,20,16
+Kerr,405,"Justice, Supreme Court, Place 4",,REP,John Devine,910,699,211
+Kerr,405,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,255,201,54
+Kerr,405,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Kerr,405,"Justice, Supreme Court, Place 6",,,Under Votes,29,14,15
+Kerr,405,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,907,699,208
+Kerr,405,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,265,207,58
+Kerr,405,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Kerr,405,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,27,14,13
+Kerr,405,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,893,691,202
+Kerr,405,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,254,199,55
+Kerr,405,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,27,16,11
+Kerr,405,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Kerr,405,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,31,17,14
+Kerr,405,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,920,707,213
+Kerr,405,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,250,196,54
+Kerr,405,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Kerr,405,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,180,143,37
+Kerr,405,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,925,710,215
+Kerr,405,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,96,67,29
+Kerr,405,State Representative,53,,Over Votes,0,0,0
+Kerr,405,State Representative,53,,Under Votes,23,13,10
+Kerr,405,State Representative,53,REP,Andrew S. Murr,919,704,215
+Kerr,405,State Representative,53,DEM,Stephanie Lochte Ertel,259,203,56
+Kerr,405,"Justice, 4th Court of Appeals District, Place 2",,,Over Votes,0,0,0
+Kerr,405,"Justice, 4th Court of Appeals District, Place 2",,,Under Votes,33,19,14
+Kerr,405,"Justice, 4th Court of Appeals District, Place 2",,REP,Marialyn Barnard,912,702,210
+Kerr,405,"Justice, 4th Court of Appeals District, Place 2",,DEM,Beth Watkins,256,199,57
+Kerr,405,"Justice, 4th Court of Appeals District, Place 3",,,Over Votes,0,0,0
+Kerr,405,"Justice, 4th Court of Appeals District, Place 3",,,Under Votes,31,15,16
+Kerr,405,"Justice, 4th Court of Appeals District, Place 3",,REP,Jason Pulliam,898,695,203
+Kerr,405,"Justice, 4th Court of Appeals District, Place 3",,DEM,Patricia O'Connell Alvarez,272,210,62
+Kerr,405,"Justice, 4th Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Kerr,405,"Justice, 4th Court of Appeals District, Place 4",,,Under Votes,31,16,15
+Kerr,405,"Justice, 4th Court of Appeals District, Place 4",,REP,Patrick Ballantyne,901,690,211
+Kerr,405,"Justice, 4th Court of Appeals District, Place 4",,DEM,Luz Elena Chapa,269,214,55
+Kerr,405,"Justice, 4th Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Kerr,405,"Justice, 4th Court of Appeals District, Place 5",,,Under Votes,30,16,14
+Kerr,405,"Justice, 4th Court of Appeals District, Place 5",,REP,Rebecca Simmons,922,707,215
+Kerr,405,"Justice, 4th Court of Appeals District, Place 5",,DEM,Liza Rodriguez,249,197,52
+Kerr,405,"Justice, 4th Court of Appeals District, Place 7",,,Over Votes,1,1,0
+Kerr,405,"Justice, 4th Court of Appeals District, Place 7",,,Under Votes,28,15,13
+Kerr,405,"Justice, 4th Court of Appeals District, Place 7",,REP,Shane Stolarczyk,909,697,212
+Kerr,405,"Justice, 4th Court of Appeals District, Place 7",,DEM,Rebeca Martinez,263,207,56
+Kerr,405,"District Judge, 198th Judicial District",,,Over Votes,0,0,0
+Kerr,405,"District Judge, 198th Judicial District",,,Under Votes,241,185,56
+Kerr,405,"District Judge, 198th Judicial District",,REP,Rex Emerson,960,735,225
+Kerr,406,Ballots Cast,,,,1937,1577,360
+Kerr,406,Straight Party,,,Over Votes,0,0,0
+Kerr,406,Straight Party,,,Under Votes,565,437,128
+Kerr,406,Straight Party,,REP,Republican Party,1159,966,193
+Kerr,406,Straight Party,,DEM,Democratic Party,201,167,34
+Kerr,406,Straight Party,,LIB,Libertarian Party,9,4,5
+Kerr,406,U.S. Senate,,,Over Votes,0,0,0
+Kerr,406,U.S. Senate,,,Under Votes,6,5,1
+Kerr,406,U.S. Senate,,REP,Ted Cruz,1531,1249,282
+Kerr,406,U.S. Senate,,DEM,Beto O'Rourke,378,312,66
+Kerr,406,U.S. Senate,,LIB,Neal M. Dikeman,19,8,11
+Kerr,406,U.S. House,21,,Over Votes,1,1,0
+Kerr,406,U.S. House,21,,Under Votes,17,15,2
+Kerr,406,U.S. House,21,REP,Chip Roy,1505,1228,277
+Kerr,406,U.S. House,21,DEM,Joseph Kopser,388,317,71
+Kerr,406,U.S. House,21,LIB,Lee Santos,23,13,10
+Kerr,406,Governor,,,Over Votes,0,0,0
+Kerr,406,Governor,,,Under Votes,10,9,1
+Kerr,406,Governor,,REP,Greg Abbott,1580,1282,298
+Kerr,406,Governor,,DEM,Lupe Valdez,322,271,51
+Kerr,406,Governor,,LIB,Mark Jay Tippetts,22,12,10
+Kerr,406,Lieutenant Governor,,,Over Votes,2,2,0
+Kerr,406,Lieutenant Governor,,,Under Votes,7,5,2
+Kerr,406,Lieutenant Governor,,REP,Dan Patrick,1522,1239,283
+Kerr,406,Lieutenant Governor,,DEM,Mike Collier,381,317,64
+Kerr,406,Lieutenant Governor,,LIB,Kerry Douglas McKennon,22,11,11
+Kerr,406,Attorney General,,,Over Votes,0,0,0
+Kerr,406,Attorney General,,,Under Votes,11,10,1
+Kerr,406,Attorney General,,REP,Ken Paxton,1501,1231,270
+Kerr,406,Attorney General,,DEM,Justin Nelson,386,313,73
+Kerr,406,Attorney General,,LIB,Michael Ray Harris,36,20,16
+Kerr,406,Comptroller of Public Accounts,,,Over Votes,1,0,1
+Kerr,406,Comptroller of Public Accounts,,,Under Votes,18,12,6
+Kerr,406,Comptroller of Public Accounts,,REP,Glenn Hegar,1521,1248,273
+Kerr,406,Comptroller of Public Accounts,,DEM,Joi Chevalier,337,283,54
+Kerr,406,Comptroller of Public Accounts,,LIB,Ben Sanders,57,31,26
+Kerr,406,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Kerr,406,Commissioner of the General Land Office,,,Under Votes,24,18,6
+Kerr,406,Commissioner of the General Land Office,,REP,George P. Bush,1500,1233,267
+Kerr,406,Commissioner of the General Land Office,,DEM,Miguel Suazo,334,273,61
+Kerr,406,Commissioner of the General Land Office,,LIB,Matt Piña,76,50,26
+Kerr,406,Commissioner of Agriculture,,,Over Votes,0,0,0
+Kerr,406,Commissioner of Agriculture,,,Under Votes,19,13,6
+Kerr,406,Commissioner of Agriculture,,REP,Sid Miller,1498,1229,269
+Kerr,406,Commissioner of Agriculture,,DEM,Kim Olson,371,305,66
+Kerr,406,Commissioner of Agriculture,,LIB,Richard Carpenter,46,27,19
+Kerr,406,Railroad Commissioner,,,Over Votes,0,0,0
+Kerr,406,Railroad Commissioner,,,Under Votes,25,17,8
+Kerr,406,Railroad Commissioner,,REP,Christi Craddick,1531,1256,275
+Kerr,406,Railroad Commissioner,,DEM,Roman McAllen,335,279,56
+Kerr,406,Railroad Commissioner,,LIB,Mike Wright,43,22,21
+Kerr,406,"Justice, Supreme Court, Place 2",,,Over Votes,2,1,1
+Kerr,406,"Justice, Supreme Court, Place 2",,,Under Votes,36,27,9
+Kerr,406,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1538,1249,289
+Kerr,406,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,358,297,61
+Kerr,406,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Kerr,406,"Justice, Supreme Court, Place 4",,,Under Votes,35,26,9
+Kerr,406,"Justice, Supreme Court, Place 4",,REP,John Devine,1549,1259,290
+Kerr,406,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,350,289,61
+Kerr,406,"Justice, Supreme Court, Place 6",,,Over Votes,1,1,0
+Kerr,406,"Justice, Supreme Court, Place 6",,,Under Votes,34,27,7
+Kerr,406,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1546,1257,289
+Kerr,406,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,353,289,64
+Kerr,406,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Kerr,406,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,27,20,7
+Kerr,406,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1522,1245,277
+Kerr,406,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,343,289,54
+Kerr,406,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,42,20,22
+Kerr,406,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Kerr,406,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,30,24,6
+Kerr,406,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1559,1271,288
+Kerr,406,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,345,279,66
+Kerr,406,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,1,1,0
+Kerr,406,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,194,164,30
+Kerr,406,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1572,1283,289
+Kerr,406,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,167,126,41
+Kerr,406,State Representative,53,,Over Votes,0,0,0
+Kerr,406,State Representative,53,,Under Votes,25,19,6
+Kerr,406,State Representative,53,REP,Andrew S. Murr,1551,1257,294
+Kerr,406,State Representative,53,DEM,Stephanie Lochte Ertel,358,298,60
+Kerr,406,"Justice, 4th Court of Appeals District, Place 2",,,Over Votes,0,0,0
+Kerr,406,"Justice, 4th Court of Appeals District, Place 2",,,Under Votes,34,24,10
+Kerr,406,"Justice, 4th Court of Appeals District, Place 2",,REP,Marialyn Barnard,1550,1262,288
+Kerr,406,"Justice, 4th Court of Appeals District, Place 2",,DEM,Beth Watkins,350,288,62
+Kerr,406,"Justice, 4th Court of Appeals District, Place 3",,,Over Votes,0,0,0
+Kerr,406,"Justice, 4th Court of Appeals District, Place 3",,,Under Votes,38,29,9
+Kerr,406,"Justice, 4th Court of Appeals District, Place 3",,REP,Jason Pulliam,1531,1245,286
+Kerr,406,"Justice, 4th Court of Appeals District, Place 3",,DEM,Patricia O'Connell Alvarez,365,300,65
+Kerr,406,"Justice, 4th Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Kerr,406,"Justice, 4th Court of Appeals District, Place 4",,,Under Votes,35,26,9
+Kerr,406,"Justice, 4th Court of Appeals District, Place 4",,REP,Patrick Ballantyne,1541,1253,288
+Kerr,406,"Justice, 4th Court of Appeals District, Place 4",,DEM,Luz Elena Chapa,358,295,63
+Kerr,406,"Justice, 4th Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Kerr,406,"Justice, 4th Court of Appeals District, Place 5",,,Under Votes,36,27,9
+Kerr,406,"Justice, 4th Court of Appeals District, Place 5",,REP,Rebecca Simmons,1557,1265,292
+Kerr,406,"Justice, 4th Court of Appeals District, Place 5",,DEM,Liza Rodriguez,341,282,59
+Kerr,406,"Justice, 4th Court of Appeals District, Place 7",,,Over Votes,0,0,0
+Kerr,406,"Justice, 4th Court of Appeals District, Place 7",,,Under Votes,38,29,9
+Kerr,406,"Justice, 4th Court of Appeals District, Place 7",,REP,Shane Stolarczyk,1534,1245,289
+Kerr,406,"Justice, 4th Court of Appeals District, Place 7",,DEM,Rebeca Martinez,362,300,62
+Kerr,406,"District Judge, 198th Judicial District",,,Over Votes,0,0,0
+Kerr,406,"District Judge, 198th Judicial District",,,Under Votes,298,253,45
+Kerr,406,"District Judge, 198th Judicial District",,REP,Rex Emerson,1636,1321,315
+Kerr,406,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,Over Votes,0,0,0
+Kerr,406,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,Under Votes,0,0,0
+Kerr,406,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,FOR,0,0,0
+Kerr,406,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,AGAINST,3,3,0
+Kerr,410,Ballots Cast,,,,185,135,50
+Kerr,410,Straight Party,,,Over Votes,0,0,0
+Kerr,410,Straight Party,,,Under Votes,58,38,20
+Kerr,410,Straight Party,,REP,Republican Party,121,95,26
+Kerr,410,Straight Party,,DEM,Democratic Party,5,1,4
+Kerr,410,Straight Party,,LIB,Libertarian Party,0,0,0
+Kerr,410,U.S. Senate,,,Over Votes,0,0,0
+Kerr,410,U.S. Senate,,,Under Votes,1,1,0
+Kerr,410,U.S. Senate,,REP,Ted Cruz,166,127,39
+Kerr,410,U.S. Senate,,DEM,Beto O'Rourke,14,5,9
+Kerr,410,U.S. Senate,,LIB,Neal M. Dikeman,3,1,2
+Kerr,410,U.S. House,21,,Over Votes,0,0,0
+Kerr,410,U.S. House,21,,Under Votes,6,5,1
+Kerr,410,U.S. House,21,REP,Chip Roy,164,124,40
+Kerr,410,U.S. House,21,DEM,Joseph Kopser,14,5,9
+Kerr,410,U.S. House,21,LIB,Lee Santos,0,0,0
+Kerr,410,Governor,,,Over Votes,0,0,0
+Kerr,410,Governor,,,Under Votes,2,2,0
+Kerr,410,Governor,,REP,Greg Abbott,169,127,42
+Kerr,410,Governor,,DEM,Lupe Valdez,10,4,6
+Kerr,410,Governor,,LIB,Mark Jay Tippetts,3,1,2
+Kerr,410,Lieutenant Governor,,,Over Votes,0,0,0
+Kerr,410,Lieutenant Governor,,,Under Votes,1,1,0
+Kerr,410,Lieutenant Governor,,REP,Dan Patrick,162,124,38
+Kerr,410,Lieutenant Governor,,DEM,Mike Collier,20,8,12
+Kerr,410,Lieutenant Governor,,LIB,Kerry Douglas McKennon,1,1,0
+Kerr,410,Attorney General,,,Over Votes,0,0,0
+Kerr,410,Attorney General,,,Under Votes,2,2,0
+Kerr,410,Attorney General,,REP,Ken Paxton,164,125,39
+Kerr,410,Attorney General,,DEM,Justin Nelson,15,6,9
+Kerr,410,Attorney General,,LIB,Michael Ray Harris,3,1,2
+Kerr,410,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Kerr,410,Comptroller of Public Accounts,,,Under Votes,2,1,1
+Kerr,410,Comptroller of Public Accounts,,REP,Glenn Hegar,168,128,40
+Kerr,410,Comptroller of Public Accounts,,DEM,Joi Chevalier,13,4,9
+Kerr,410,Comptroller of Public Accounts,,LIB,Ben Sanders,1,1,0
+Kerr,410,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Kerr,410,Commissioner of the General Land Office,,,Under Votes,2,2,0
+Kerr,410,Commissioner of the General Land Office,,REP,George P. Bush,165,124,41
+Kerr,410,Commissioner of the General Land Office,,DEM,Miguel Suazo,12,4,8
+Kerr,410,Commissioner of the General Land Office,,LIB,Matt Piña,5,4,1
+Kerr,410,Commissioner of Agriculture,,,Over Votes,0,0,0
+Kerr,410,Commissioner of Agriculture,,,Under Votes,3,2,1
+Kerr,410,Commissioner of Agriculture,,REP,Sid Miller,166,127,39
+Kerr,410,Commissioner of Agriculture,,DEM,Kim Olson,15,5,10
+Kerr,410,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0
+Kerr,410,Railroad Commissioner,,,Over Votes,0,0,0
+Kerr,410,Railroad Commissioner,,,Under Votes,3,2,1
+Kerr,410,Railroad Commissioner,,REP,Christi Craddick,165,126,39
+Kerr,410,Railroad Commissioner,,DEM,Roman McAllen,13,4,9
+Kerr,410,Railroad Commissioner,,LIB,Mike Wright,3,2,1
+Kerr,410,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Kerr,410,"Justice, Supreme Court, Place 2",,,Under Votes,3,2,1
+Kerr,410,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,167,126,41
+Kerr,410,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,14,6,8
+Kerr,410,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Kerr,410,"Justice, Supreme Court, Place 4",,,Under Votes,3,2,1
+Kerr,410,"Justice, Supreme Court, Place 4",,REP,John Devine,168,127,41
+Kerr,410,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,13,5,8
+Kerr,410,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Kerr,410,"Justice, Supreme Court, Place 6",,,Under Votes,2,1,1
+Kerr,410,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,168,128,40
+Kerr,410,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,14,5,9
+Kerr,410,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Kerr,410,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,4,2,2
+Kerr,410,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,165,125,40
+Kerr,410,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,14,6,8
+Kerr,410,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,1,1,0
+Kerr,410,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Kerr,410,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,4,2,2
+Kerr,410,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,167,128,39
+Kerr,410,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,13,4,9
+Kerr,410,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Kerr,410,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,8,3,5
+Kerr,410,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,169,127,42
+Kerr,410,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,7,4,3
+Kerr,410,State Representative,53,,Over Votes,0,0,0
+Kerr,410,State Representative,53,,Under Votes,4,4,0
+Kerr,410,State Representative,53,REP,Andrew S. Murr,165,125,40
+Kerr,410,State Representative,53,DEM,Stephanie Lochte Ertel,15,5,10
+Kerr,410,"Justice, 4th Court of Appeals District, Place 2",,,Over Votes,0,0,0
+Kerr,410,"Justice, 4th Court of Appeals District, Place 2",,,Under Votes,6,4,2
+Kerr,410,"Justice, 4th Court of Appeals District, Place 2",,REP,Marialyn Barnard,164,125,39
+Kerr,410,"Justice, 4th Court of Appeals District, Place 2",,DEM,Beth Watkins,14,5,9
+Kerr,410,"Justice, 4th Court of Appeals District, Place 3",,,Over Votes,0,0,0
+Kerr,410,"Justice, 4th Court of Appeals District, Place 3",,,Under Votes,6,4,2
+Kerr,410,"Justice, 4th Court of Appeals District, Place 3",,REP,Jason Pulliam,164,125,39
+Kerr,410,"Justice, 4th Court of Appeals District, Place 3",,DEM,Patricia O'Connell Alvarez,14,5,9
+Kerr,410,"Justice, 4th Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Kerr,410,"Justice, 4th Court of Appeals District, Place 4",,,Under Votes,6,4,2
+Kerr,410,"Justice, 4th Court of Appeals District, Place 4",,REP,Patrick Ballantyne,166,126,40
+Kerr,410,"Justice, 4th Court of Appeals District, Place 4",,DEM,Luz Elena Chapa,12,4,8
+Kerr,410,"Justice, 4th Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Kerr,410,"Justice, 4th Court of Appeals District, Place 5",,,Under Votes,6,4,2
+Kerr,410,"Justice, 4th Court of Appeals District, Place 5",,REP,Rebecca Simmons,164,125,39
+Kerr,410,"Justice, 4th Court of Appeals District, Place 5",,DEM,Liza Rodriguez,14,5,9
+Kerr,410,"Justice, 4th Court of Appeals District, Place 7",,,Over Votes,0,0,0
+Kerr,410,"Justice, 4th Court of Appeals District, Place 7",,,Under Votes,6,4,2
+Kerr,410,"Justice, 4th Court of Appeals District, Place 7",,REP,Shane Stolarczyk,165,125,40
+Kerr,410,"Justice, 4th Court of Appeals District, Place 7",,DEM,Rebeca Martinez,13,5,8
+Kerr,410,"District Judge, 198th Judicial District",,,Over Votes,0,0,0
+Kerr,410,"District Judge, 198th Judicial District",,,Under Votes,14,7,7
+Kerr,410,"District Judge, 198th Judicial District",,REP,Rex Emerson,170,127,43
+Kerr,410,BOARD OF TRUSTEES,,,Over Votes,0,0,0
+Kerr,410,BOARD OF TRUSTEES,,,Under Votes,4,4,0
+Kerr,410,BOARD OF TRUSTEES,,||N,Steve Wade,0,0,0
+Kerr,410,BOARD OF TRUSTEES,,||N,Henry I. Sherman,0,0,0
+Kerr,410,BOARD OF TRUSTEES,,||N,Mary S. Krebs,0,0,0
+Kerr,410,BOARD OF TRUSTEES,,||N,Quentin A. Bierschwale,0,0,0
+Kerr,410,BOARD OF TRUSTEES,,||N,Dan Abbott,0,0,0
+Kerr,416,Ballots Cast,,,,1131,893,238
+Kerr,416,Straight Party,,,Over Votes,1,1,0
+Kerr,416,Straight Party,,,Under Votes,308,232,76
+Kerr,416,Straight Party,,REP,Republican Party,661,537,124
+Kerr,416,Straight Party,,DEM,Democratic Party,109,78,31
+Kerr,416,Straight Party,,LIB,Libertarian Party,3,1,2
+Kerr,416,U.S. Senate,,,Over Votes,0,0,0
+Kerr,416,U.S. Senate,,,Under Votes,6,4,2
+Kerr,416,U.S. Senate,,REP,Ted Cruz,858,683,175
+Kerr,416,U.S. Senate,,DEM,Beto O'Rourke,209,158,51
+Kerr,416,U.S. Senate,,LIB,Neal M. Dikeman,9,4,5
+Kerr,416,U.S. House,21,,Over Votes,0,0,0
+Kerr,416,U.S. House,21,,Under Votes,11,7,4
+Kerr,416,U.S. House,21,REP,Chip Roy,844,673,171
+Kerr,416,U.S. House,21,DEM,Joseph Kopser,215,162,53
+Kerr,416,U.S. House,21,LIB,Lee Santos,12,7,5
+Kerr,416,Governor,,,Over Votes,0,0,0
+Kerr,416,Governor,,,Under Votes,6,4,2
+Kerr,416,Governor,,REP,Greg Abbott,897,714,183
+Kerr,416,Governor,,DEM,Lupe Valdez,163,121,42
+Kerr,416,Governor,,LIB,Mark Jay Tippetts,16,10,6
+Kerr,416,Lieutenant Governor,,,Over Votes,0,0,0
+Kerr,416,Lieutenant Governor,,,Under Votes,5,3,2
+Kerr,416,Lieutenant Governor,,REP,Dan Patrick,864,691,173
+Kerr,416,Lieutenant Governor,,DEM,Mike Collier,201,149,52
+Kerr,416,Lieutenant Governor,,LIB,Kerry Douglas McKennon,12,6,6
+Kerr,416,Attorney General,,,Over Votes,0,0,0
+Kerr,416,Attorney General,,,Under Votes,6,4,2
+Kerr,416,Attorney General,,REP,Ken Paxton,856,684,172
+Kerr,416,Attorney General,,DEM,Justin Nelson,205,153,52
+Kerr,416,Attorney General,,LIB,Michael Ray Harris,15,8,7
+Kerr,416,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Kerr,416,Comptroller of Public Accounts,,,Under Votes,15,11,4
+Kerr,416,Comptroller of Public Accounts,,REP,Glenn Hegar,859,684,175
+Kerr,416,Comptroller of Public Accounts,,DEM,Joi Chevalier,182,137,45
+Kerr,416,Comptroller of Public Accounts,,LIB,Ben Sanders,26,17,9
+Kerr,416,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Kerr,416,Commissioner of the General Land Office,,,Under Votes,15,10,5
+Kerr,416,Commissioner of the General Land Office,,REP,George P. Bush,849,677,172
+Kerr,416,Commissioner of the General Land Office,,DEM,Miguel Suazo,183,142,41
+Kerr,416,Commissioner of the General Land Office,,LIB,Matt Piña,35,20,15
+Kerr,416,Commissioner of Agriculture,,,Over Votes,0,0,0
+Kerr,416,Commissioner of Agriculture,,,Under Votes,9,6,3
+Kerr,416,Commissioner of Agriculture,,REP,Sid Miller,855,683,172
+Kerr,416,Commissioner of Agriculture,,DEM,Kim Olson,201,149,52
+Kerr,416,Commissioner of Agriculture,,LIB,Richard Carpenter,17,11,6
+Kerr,416,Railroad Commissioner,,,Over Votes,0,0,0
+Kerr,416,Railroad Commissioner,,,Under Votes,12,8,4
+Kerr,416,Railroad Commissioner,,REP,Christi Craddick,868,693,175
+Kerr,416,Railroad Commissioner,,DEM,Roman McAllen,181,134,47
+Kerr,416,Railroad Commissioner,,LIB,Mike Wright,21,14,7
+Kerr,416,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Kerr,416,"Justice, Supreme Court, Place 2",,,Under Votes,22,15,7
+Kerr,416,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,862,687,175
+Kerr,416,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,198,147,51
+Kerr,416,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Kerr,416,"Justice, Supreme Court, Place 4",,,Under Votes,14,10,4
+Kerr,416,"Justice, Supreme Court, Place 4",,REP,John Devine,875,699,176
+Kerr,416,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,193,140,53
+Kerr,416,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Kerr,416,"Justice, Supreme Court, Place 6",,,Under Votes,17,10,7
+Kerr,416,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,870,695,175
+Kerr,416,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,195,144,51
+Kerr,416,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Kerr,416,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,11,7,4
+Kerr,416,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,863,688,175
+Kerr,416,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,187,141,46
+Kerr,416,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,21,13,8
+Kerr,416,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Kerr,416,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,16,11,5
+Kerr,416,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,872,695,177
+Kerr,416,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,194,143,51
+Kerr,416,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Kerr,416,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,101,78,23
+Kerr,416,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,891,708,183
+Kerr,416,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,90,63,27
+Kerr,416,State Representative,53,,Over Votes,0,0,0
+Kerr,416,State Representative,53,,Under Votes,16,10,6
+Kerr,416,State Representative,53,REP,Andrew S. Murr,863,688,175
+Kerr,416,State Representative,53,DEM,Stephanie Lochte Ertel,203,151,52
+Kerr,416,"Justice, 4th Court of Appeals District, Place 2",,,Over Votes,0,0,0
+Kerr,416,"Justice, 4th Court of Appeals District, Place 2",,,Under Votes,19,14,5
+Kerr,416,"Justice, 4th Court of Appeals District, Place 2",,REP,Marialyn Barnard,864,686,178
+Kerr,416,"Justice, 4th Court of Appeals District, Place 2",,DEM,Beth Watkins,199,149,50
+Kerr,416,"Justice, 4th Court of Appeals District, Place 3",,,Over Votes,0,0,0
+Kerr,416,"Justice, 4th Court of Appeals District, Place 3",,,Under Votes,20,15,5
+Kerr,416,"Justice, 4th Court of Appeals District, Place 3",,REP,Jason Pulliam,859,687,172
+Kerr,416,"Justice, 4th Court of Appeals District, Place 3",,DEM,Patricia O'Connell Alvarez,203,147,56
+Kerr,416,"Justice, 4th Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Kerr,416,"Justice, 4th Court of Appeals District, Place 4",,,Under Votes,22,15,7
+Kerr,416,"Justice, 4th Court of Appeals District, Place 4",,REP,Patrick Ballantyne,862,686,176
+Kerr,416,"Justice, 4th Court of Appeals District, Place 4",,DEM,Luz Elena Chapa,198,148,50
+Kerr,416,"Justice, 4th Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Kerr,416,"Justice, 4th Court of Appeals District, Place 5",,,Under Votes,22,15,7
+Kerr,416,"Justice, 4th Court of Appeals District, Place 5",,REP,Rebecca Simmons,873,696,177
+Kerr,416,"Justice, 4th Court of Appeals District, Place 5",,DEM,Liza Rodriguez,187,138,49
+Kerr,416,"Justice, 4th Court of Appeals District, Place 7",,,Over Votes,0,0,0
+Kerr,416,"Justice, 4th Court of Appeals District, Place 7",,,Under Votes,20,15,5
+Kerr,416,"Justice, 4th Court of Appeals District, Place 7",,REP,Shane Stolarczyk,854,683,171
+Kerr,416,"Justice, 4th Court of Appeals District, Place 7",,DEM,Rebeca Martinez,208,151,57
+Kerr,416,"District Judge, 198th Judicial District",,,Over Votes,0,0,0
+Kerr,416,"District Judge, 198th Judicial District",,,Under Votes,165,121,44
+Kerr,416,"District Judge, 198th Judicial District",,REP,Rex Emerson,917,728,189
+Kerr,416,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,Over Votes,0,0,0
+Kerr,416,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,Under Votes,0,0,0
+Kerr,416,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,FOR,26,24,2
+Kerr,416,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,AGAINST,23,20,3
+Kerr,417,Ballots Cast,,,,1913,1592,321
+Kerr,417,Straight Party,,,Over Votes,0,0,0
+Kerr,417,Straight Party,,,Under Votes,444,351,93
+Kerr,417,Straight Party,,REP,Republican Party,571,485,86
+Kerr,417,Straight Party,,DEM,Democratic Party,103,90,13
+Kerr,417,Straight Party,,LIB,Libertarian Party,3,1,2
+Kerr,417,U.S. Senate,,,Over Votes,0,0,0
+Kerr,417,U.S. Senate,,,Under Votes,3,2,1
+Kerr,417,U.S. Senate,,REP,Ted Cruz,840,701,139
+Kerr,417,U.S. Senate,,DEM,Beto O'Rourke,271,218,53
+Kerr,417,U.S. Senate,,LIB,Neal M. Dikeman,7,6,1
+Kerr,417,U.S. House,21,,Over Votes,1,1,0
+Kerr,417,U.S. House,21,,Under Votes,10,6,4
+Kerr,417,U.S. House,21,REP,Chip Roy,830,686,144
+Kerr,417,U.S. House,21,DEM,Joseph Kopser,269,227,42
+Kerr,417,U.S. House,21,LIB,Lee Santos,11,7,4
+Kerr,417,Governor,,,Over Votes,0,0,0
+Kerr,417,Governor,,,Under Votes,9,5,4
+Kerr,417,Governor,,REP,Greg Abbott,885,734,151
+Kerr,417,Governor,,DEM,Lupe Valdez,208,176,32
+Kerr,417,Governor,,LIB,Mark Jay Tippetts,19,12,7
+Kerr,417,Lieutenant Governor,,,Over Votes,0,0,0
+Kerr,417,Lieutenant Governor,,,Under Votes,7,5,2
+Kerr,417,Lieutenant Governor,,REP,Dan Patrick,830,690,140
+Kerr,417,Lieutenant Governor,,DEM,Mike Collier,264,219,45
+Kerr,417,Lieutenant Governor,,LIB,Kerry Douglas McKennon,20,13,7
+Kerr,417,Attorney General,,,Over Votes,0,0,0
+Kerr,417,Attorney General,,,Under Votes,16,12,4
+Kerr,417,Attorney General,,REP,Ken Paxton,819,680,139
+Kerr,417,Attorney General,,DEM,Justin Nelson,262,218,44
+Kerr,417,Attorney General,,LIB,Michael Ray Harris,24,17,7
+Kerr,417,Comptroller of Public Accounts,,,Over Votes,0,0,0
+Kerr,417,Comptroller of Public Accounts,,,Under Votes,27,19,8
+Kerr,417,Comptroller of Public Accounts,,REP,Glenn Hegar,852,707,145
+Kerr,417,Comptroller of Public Accounts,,DEM,Joi Chevalier,210,178,32
+Kerr,417,Comptroller of Public Accounts,,LIB,Ben Sanders,32,23,9
+Kerr,417,Commissioner of the General Land Office,,,Over Votes,0,0,0
+Kerr,417,Commissioner of the General Land Office,,,Under Votes,25,20,5
+Kerr,417,Commissioner of the General Land Office,,REP,George P. Bush,837,695,142
+Kerr,417,Commissioner of the General Land Office,,DEM,Miguel Suazo,221,184,37
+Kerr,417,Commissioner of the General Land Office,,LIB,Matt Piña,38,28,10
+Kerr,417,Commissioner of Agriculture,,,Over Votes,0,0,0
+Kerr,417,Commissioner of Agriculture,,,Under Votes,21,16,5
+Kerr,417,Commissioner of Agriculture,,REP,Sid Miller,829,689,140
+Kerr,417,Commissioner of Agriculture,,DEM,Kim Olson,248,204,44
+Kerr,417,Commissioner of Agriculture,,LIB,Richard Carpenter,23,18,5
+Kerr,417,Railroad Commissioner,,,Over Votes,0,0,0
+Kerr,417,Railroad Commissioner,,,Under Votes,20,14,6
+Kerr,417,Railroad Commissioner,,REP,Christi Craddick,855,713,142
+Kerr,417,Railroad Commissioner,,DEM,Roman McAllen,213,176,37
+Kerr,417,Railroad Commissioner,,LIB,Mike Wright,33,24,9
+Kerr,417,"Justice, Supreme Court, Place 2",,,Over Votes,0,0,0
+Kerr,417,"Justice, Supreme Court, Place 2",,,Under Votes,33,27,6
+Kerr,417,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,848,704,144
+Kerr,417,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,240,196,44
+Kerr,417,"Justice, Supreme Court, Place 4",,,Over Votes,0,0,0
+Kerr,417,"Justice, Supreme Court, Place 4",,,Under Votes,36,30,6
+Kerr,417,"Justice, Supreme Court, Place 4",,REP,John Devine,848,703,145
+Kerr,417,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,237,194,43
+Kerr,417,"Justice, Supreme Court, Place 6",,,Over Votes,0,0,0
+Kerr,417,"Justice, Supreme Court, Place 6",,,Under Votes,36,31,5
+Kerr,417,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,851,704,147
+Kerr,417,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,234,192,42
+Kerr,417,"Presiding Judge, Court of Criminal Appeals",,,Over Votes,0,0,0
+Kerr,417,"Presiding Judge, Court of Criminal Appeals",,,Under Votes,30,25,5
+Kerr,417,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,845,704,141
+Kerr,417,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,221,184,37
+Kerr,417,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,25,14,11
+Kerr,417,"Judge, Court of Criminal Appeals, Place 7",,,Over Votes,0,0,0
+Kerr,417,"Judge, Court of Criminal Appeals, Place 7",,,Under Votes,31,26,5
+Kerr,417,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,864,717,147
+Kerr,417,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,226,184,42
+Kerr,417,"Judge, Court of Criminal Appeals, Place 8",,,Over Votes,0,0,0
+Kerr,417,"Judge, Court of Criminal Appeals, Place 8",,,Under Votes,124,112,12
+Kerr,417,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,891,735,156
+Kerr,417,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,106,80,26
+Kerr,417,State Representative,53,,Over Votes,0,0,0
+Kerr,417,State Representative,53,,Under Votes,29,22,7
+Kerr,417,State Representative,53,REP,Andrew S. Murr,856,707,149
+Kerr,417,State Representative,53,DEM,Stephanie Lochte Ertel,236,198,38
+Kerr,417,"Justice, 4th Court of Appeals District, Place 2",,,Over Votes,0,0,0
+Kerr,417,"Justice, 4th Court of Appeals District, Place 2",,,Under Votes,36,30,6
+Kerr,417,"Justice, 4th Court of Appeals District, Place 2",,REP,Marialyn Barnard,851,705,146
+Kerr,417,"Justice, 4th Court of Appeals District, Place 2",,DEM,Beth Watkins,234,192,42
+Kerr,417,"Justice, 4th Court of Appeals District, Place 3",,,Over Votes,0,0,0
+Kerr,417,"Justice, 4th Court of Appeals District, Place 3",,,Under Votes,35,29,6
+Kerr,417,"Justice, 4th Court of Appeals District, Place 3",,REP,Jason Pulliam,853,710,143
+Kerr,417,"Justice, 4th Court of Appeals District, Place 3",,DEM,Patricia O'Connell Alvarez,233,188,45
+Kerr,417,"Justice, 4th Court of Appeals District, Place 4",,,Over Votes,0,0,0
+Kerr,417,"Justice, 4th Court of Appeals District, Place 4",,,Under Votes,34,28,6
+Kerr,417,"Justice, 4th Court of Appeals District, Place 4",,REP,Patrick Ballantyne,864,714,150
+Kerr,417,"Justice, 4th Court of Appeals District, Place 4",,DEM,Luz Elena Chapa,223,185,38
+Kerr,417,"Justice, 4th Court of Appeals District, Place 5",,,Over Votes,0,0,0
+Kerr,417,"Justice, 4th Court of Appeals District, Place 5",,,Under Votes,34,28,6
+Kerr,417,"Justice, 4th Court of Appeals District, Place 5",,REP,Rebecca Simmons,870,719,151
+Kerr,417,"Justice, 4th Court of Appeals District, Place 5",,DEM,Liza Rodriguez,217,180,37
+Kerr,417,"Justice, 4th Court of Appeals District, Place 7",,,Over Votes,0,0,0
+Kerr,417,"Justice, 4th Court of Appeals District, Place 7",,,Under Votes,33,27,6
+Kerr,417,"Justice, 4th Court of Appeals District, Place 7",,REP,Shane Stolarczyk,854,710,144
+Kerr,417,"Justice, 4th Court of Appeals District, Place 7",,DEM,Rebeca Martinez,234,190,44
+Kerr,417,"District Judge, 198th Judicial District",,,Over Votes,0,0,0
+Kerr,417,"District Judge, 198th Judicial District",,,Under Votes,205,171,34
+Kerr,417,"District Judge, 198th Judicial District",,REP,Rex Emerson,916,756,160
+Kerr,417,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,Over Votes,0,0,0
+Kerr,417,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,Under Votes,1,1,0
+Kerr,417,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,FOR,568,489,79
+Kerr,417,KERRVILLE INDEPENDENT SCHOOL DISTRICT PROPOSITION A,,,AGAINST,223,175,48


### PR DESCRIPTION
Common spreadsheet format. 
Strangely, only precincts 308 and 405 had numbers for registered voters.