### PR TITLE
Add precinct-level results for the 2018 general election in Waller County

### DIFF
--- a/2018/20181106__tx__general__waller__precinct.csv
+++ b/2018/20181106__tx__general__waller__precinct.csv
@@ -1,0 +1,1778 @@
+county,precinct,office,district,party,candidate,votes,early_voting,election_day
+Waller,101,Registered Voters,,,,1903,,
+Waller,101,Attorney General,,REP,Ken Paxton,683,519,164
+Waller,101,Attorney General,,DEM,Justin Nelson,277,178,99
+Waller,101,Attorney General,,LIB,Michael Ray Harris,19,7,12
+Waller,101,Commissioner of Agriculture,,REP,Sid Miller,679,514,165
+Waller,101,Commissioner of Agriculture,,DEM,Kim Olson,285,186,99
+Waller,101,Commissioner of Agriculture,,LIB,Richard Carpenter,14,4,10
+Waller,101,Commissioner of the GeneralLand Office,,REP,George P. Bush,700,527,173
+Waller,101,Commissioner of the GeneralLand Office,,DEM,Miguel Suazo,252,163,89
+Waller,101,Commissioner of the GeneralLand Office,,LIB,Matt Piña,23,11,12
+Waller,101,Comptroller of Public Accounts,,REP,Glenn Hegar,712,534,178
+Waller,101,Comptroller of Public Accounts,,DEM,Joi Chevalier,247,160,87
+Waller,101,Comptroller of Public Accounts,,LIB,Ben Sanders,19,10,9
+Waller,101,County Clerk,,REP,Debbie Hollan,726,545,181
+Waller,101,County Clerk,,DEM,Shari Griswold,249,156,93
+Waller,101,County Judge,,REP,Trey Duhon,708,530,178
+Waller,101,County Judge,,DEM,Denise Mattox,256,162,94
+Waller,101,County Treasurer,,REP,Joan Sargent,720,541,179
+Waller,101,County Treasurer,,DEM,Tammie Lilly,255,161,94
+Waller,101,Criminal District Attorney Waller County,,REP,"Elton Raymond Mathis, Jr.",755,561,194
+Waller,101,District Clerk,,REP,Liz Pirkle,768,569,199
+Waller,101,Governor,,REP,Greg Abbott,720,540,180
+Waller,101,Governor,,DEM,Lupe Valdez,251,162,89
+Waller,101,Governor,,LIB,Mark Jay Tippetts,7,1,6
+Waller,101,"Judge, County Court-at-Law",,REP,Carol Chaney,777,580,197
+Waller,101,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,696,523,173
+Waller,101,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,269,171,98
+Waller,101,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,729,547,182
+Waller,101,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,111,66,45
+Waller,101,"Justice of the Peace, Precinct 1",,REP,Charles J. Karisch,771,570,201
+Waller,101,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,697,520,177
+Waller,101,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,262,168,94
+Waller,101,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,697,519,178
+Waller,101,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,263,171,92
+Waller,101,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,697,519,178
+Waller,101,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,260,168,92
+Waller,101,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,687,517,170
+Waller,101,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,270,172,98
+Waller,101,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,693,519,174
+Waller,101,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",270,172,98
+Waller,101,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,700,521,179
+Waller,101,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,262,170,92
+Waller,101,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,693,522,171
+Waller,101,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,273,172,101
+Waller,101,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,696,522,174
+Waller,101,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,269,171,98
+Waller,101,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,677,505,172
+Waller,101,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,286,185,101
+Waller,101,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,700,524,176
+Waller,101,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,262,166,96
+Waller,101,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,701,524,177
+Waller,101,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,270,175,95
+Waller,101,"Justice, Supreme Court, Place 4",,REP,John Devine,695,520,175
+Waller,101,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,269,172,97
+Waller,101,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,694,522,172
+Waller,101,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,273,173,100
+Waller,101,Lieutenant Governor,,REP,Dan Patrick,673,509,164
+Waller,101,Lieutenant Governor,,DEM,Mike Collier,291,190,101
+Waller,101,Lieutenant Governor,,LIB,Kerry Douglas McKennon,12,3,9
+Waller,101,"Presiding Judge, Court ofCriminal Appeals",,REP,Sharon Keller,693,522,171
+Waller,101,"Presiding Judge, Court ofCriminal Appeals",,DEM,Maria T. (Terri) Jackson,262,170,92
+Waller,101,"Presiding Judge, Court ofCriminal Appeals",,LIB,William Bryan Strange III,13,4,9
+Waller,101,Railroad Commissioner,,REP,Christi Craddick,704,527,177
+Waller,101,Railroad Commissioner,,DEM,Roman McAllen,252,164,88
+Waller,101,Railroad Commissioner,,LIB,Mike Wright,18,10,8
+Waller,101,State Representative,3,REP,Cecil Bell Jr,705,531,174
+Waller,101,State Representative,3,DEM,Lisa Seger,266,168,98
+Waller,101,Straight Party,,REP,Republican Party,526,405,121
+Waller,101,Straight Party,,DEM,Democratic Party,199,130,69
+Waller,101,Straight Party,,LIB,Libertarian Party,7,1,6
+Waller,101,U.S. House,10,REP,Michael T. McCaul,701,528,173
+Waller,101,U.S. House,10,DEM,Mike Siegel,264,170,94
+Waller,101,U.S. House,10,LIB,Mike Ryan,12,4,8
+Waller,101,U.S. Senate,,REP,Ted Cruz,697,526,171
+Waller,101,U.S. Senate,,DEM,Beto O'Rourke,273,174,99
+Waller,101,U.S. Senate,,LIB,Neal M. Dikeman,6,1,5
+Waller,102,Registered Voters,,,,1773,,
+Waller,102,Attorney General,,REP,Ken Paxton,422,354,68
+Waller,102,Attorney General,,DEM,Justin Nelson,370,255,115
+Waller,102,Attorney General,,LIB,Michael Ray Harris,13,7,6
+Waller,102,Commissioner of Agriculture,,REP,Sid Miller,425,355,70
+Waller,102,Commissioner of Agriculture,,DEM,Kim Olson,371,258,113
+Waller,102,Commissioner of Agriculture,,LIB,Richard Carpenter,11,6,5
+Waller,102,Commissioner of the GeneralLand Office,,REP,George P. Bush,425,353,72
+Waller,102,Commissioner of the GeneralLand Office,,DEM,Miguel Suazo,361,247,114
+Waller,102,Commissioner of the GeneralLand Office,,LIB,Matt Piña,17,14,3
+Waller,102,Comptroller of Public Accounts,,REP,Glenn Hegar,438,365,73
+Waller,102,Comptroller of Public Accounts,,DEM,Joi Chevalier,352,241,111
+Waller,102,Comptroller of Public Accounts,,LIB,Ben Sanders,13,9,4
+Waller,102,County Clerk,,REP,Debbie Hollan,450,373,77
+Waller,102,County Clerk,,DEM,Shari Griswold,359,246,113
+Waller,102,County Judge,,REP,Trey Duhon,452,372,80
+Waller,102,County Judge,,DEM,Denise Mattox,357,247,110
+Waller,102,County Treasurer,,REP,Joan Sargent,450,378,72
+Waller,102,County Treasurer,,DEM,Tammie Lilly,355,239,116
+Waller,102,Criminal District Attorney Waller County,,REP,"Elton Raymond Mathis, Jr.",518,421,97
+Waller,102,District Clerk,,REP,Liz Pirkle,526,433,93
+Waller,102,Governor,,REP,Greg Abbott,446,372,74
+Waller,102,Governor,,DEM,Lupe Valdez,355,243,112
+Waller,102,Governor,,LIB,Mark Jay Tippetts,6,3,3
+Waller,102,"Judge, County Court-at-Law",,REP,Carol Chaney,523,429,94
+Waller,102,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,431,360,71
+Waller,102,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,369,253,116
+Waller,102,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,454,376,78
+Waller,102,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,143,108,35
+Waller,102,"Justice of the Peace, Precinct 1",,REP,Charles J. Karisch,538,437,101
+Waller,102,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,430,359,71
+Waller,102,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,368,252,116
+Waller,102,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,435,362,73
+Waller,102,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,363,249,114
+Waller,102,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,434,361,73
+Waller,102,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,364,250,114
+Waller,102,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,434,363,71
+Waller,102,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,366,250,116
+Waller,102,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,430,358,72
+Waller,102,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",367,253,114
+Waller,102,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,432,361,71
+Waller,102,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,368,252,116
+Waller,102,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,432,360,72
+Waller,102,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,367,252,115
+Waller,102,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,429,357,72
+Waller,102,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,368,253,115
+Waller,102,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,426,356,70
+Waller,102,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,375,257,118
+Waller,102,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,429,359,70
+Waller,102,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,369,252,117
+Waller,102,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,428,357,71
+Waller,102,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,371,255,116
+Waller,102,"Justice, Supreme Court, Place 4",,REP,John Devine,432,360,72
+Waller,102,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,371,256,115
+Waller,102,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,432,361,71
+Waller,102,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,370,254,116
+Waller,102,Lieutenant Governor,,REP,Dan Patrick,429,358,71
+Waller,102,Lieutenant Governor,,DEM,Mike Collier,373,258,115
+Waller,102,Lieutenant Governor,,LIB,Kerry Douglas McKennon,6,3,3
+Waller,102,"Presiding Judge, Court ofCriminal Appeals",,REP,Sharon Keller,426,355,71
+Waller,102,"Presiding Judge, Court ofCriminal Appeals",,DEM,Maria T. (Terri) Jackson,367,254,113
+Waller,102,"Presiding Judge, Court ofCriminal Appeals",,LIB,William Bryan Strange III,8,4,4
+Waller,102,Railroad Commissioner,,REP,Christi Craddick,431,360,71
+Waller,102,Railroad Commissioner,,DEM,Roman McAllen,360,249,111
+Waller,102,Railroad Commissioner,,LIB,Mike Wright,10,5,5
+Waller,102,State Representative,3,REP,Cecil Bell Jr,437,365,72
+Waller,102,State Representative,3,DEM,Lisa Seger,367,251,116
+Waller,102,Straight Party,,REP,Republican Party,339,276,63
+Waller,102,Straight Party,,DEM,Democratic Party,296,192,104
+Waller,102,Straight Party,,LIB,Libertarian Party,4,2,2
+Waller,102,U.S. House,10,REP,Michael T. McCaul,435,362,73
+Waller,102,U.S. House,10,DEM,Mike Siegel,370,256,114
+Waller,102,U.S. House,10,LIB,Mike Ryan,5,2,3
+Waller,102,U.S. Senate,,REP,Ted Cruz,431,358,73
+Waller,102,U.S. Senate,,DEM,Beto O'Rourke,371,257,114
+Waller,102,U.S. Senate,,LIB,Neal M. Dikeman,6,3,3
+Waller,103,Registered Voters,,,,1377,,
+Waller,103,Attorney General,,REP,Ken Paxton,335,268,67
+Waller,103,Attorney General,,DEM,Justin Nelson,284,187,97
+Waller,103,Attorney General,,LIB,Michael Ray Harris,13,8,5
+Waller,103,Commissioner of Agriculture,,REP,Sid Miller,344,271,73
+Waller,103,Commissioner of Agriculture,,DEM,Kim Olson,277,184,93
+Waller,103,Commissioner of Agriculture,,LIB,Richard Carpenter,8,5,3
+Waller,103,Commissioner of the GeneralLand Office,,REP,George P. Bush,352,275,77
+Waller,103,Commissioner of the GeneralLand Office,,DEM,Miguel Suazo,263,175,88
+Waller,103,Commissioner of the GeneralLand Office,,LIB,Matt Piña,18,13,5
+Waller,103,Comptroller of Public Accounts,,REP,Glenn Hegar,361,284,77
+Waller,103,Comptroller of Public Accounts,,DEM,Joi Chevalier,260,175,85
+Waller,103,Comptroller of Public Accounts,,LIB,Ben Sanders,12,5,7
+Waller,103,County Clerk,,REP,Debbie Hollan,378,291,87
+Waller,103,County Clerk,,DEM,Shari Griswold,251,169,82
+Waller,103,County Judge,,REP,Trey Duhon,365,283,82
+Waller,103,County Judge,,DEM,Denise Mattox,258,170,88
+Waller,103,County Treasurer,,REP,Joan Sargent,368,286,82
+Waller,103,County Treasurer,,DEM,Tammie Lilly,261,174,87
+Waller,103,Criminal District Attorney Waller County,,REP,"Elton Raymond Mathis, Jr.",423,312,111
+Waller,103,District Clerk,,REP,Liz Pirkle,432,324,108
+Waller,103,Governor,,REP,Greg Abbott,369,289,80
+Waller,103,Governor,,DEM,Lupe Valdez,263,177,86
+Waller,103,Governor,,LIB,Mark Jay Tippetts,4,2,2
+Waller,103,"Judge, County Court-at-Law",,REP,Carol Chaney,421,315,106
+Waller,103,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,348,272,76
+Waller,103,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,280,188,92
+Waller,103,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,387,296,91
+Waller,103,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,112,75,37
+Waller,103,"Justice of the Peace, Precinct 1",,REP,Charles J. Karisch,430,319,111
+Waller,103,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,356,281,75
+Waller,103,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,270,177,93
+Waller,103,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,356,280,76
+Waller,103,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,270,178,92
+Waller,103,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,350,274,76
+Waller,103,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,273,181,92
+Waller,103,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,348,273,75
+Waller,103,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,277,184,93
+Waller,103,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,350,274,76
+Waller,103,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",275,183,92
+Waller,103,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,353,278,75
+Waller,103,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,273,180,93
+Waller,103,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,353,276,77
+Waller,103,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,272,181,91
+Waller,103,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,353,277,76
+Waller,103,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,273,181,92
+Waller,103,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,344,272,72
+Waller,103,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,282,186,96
+Waller,103,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,351,274,77
+Waller,103,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,275,184,91
+Waller,103,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,348,275,73
+Waller,103,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,280,184,96
+Waller,103,"Justice, Supreme Court, Place 4",,REP,John Devine,353,280,73
+Waller,103,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,275,180,95
+Waller,103,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,352,277,75
+Waller,103,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,277,184,93
+Waller,103,Lieutenant Governor,,REP,Dan Patrick,341,271,70
+Waller,103,Lieutenant Governor,,DEM,Mike Collier,285,190,95
+Waller,103,Lieutenant Governor,,LIB,Kerry Douglas McKennon,9,5,4
+Waller,103,"Presiding Judge, Court ofCriminal Appeals",,REP,Sharon Keller,346,274,72
+Waller,103,"Presiding Judge, Court ofCriminal Appeals",,DEM,Maria T. (Terri) Jackson,279,183,96
+Waller,103,"Presiding Judge, Court ofCriminal Appeals",,LIB,William Bryan Strange III,5,4,1
+Waller,103,Railroad Commissioner,,REP,Christi Craddick,351,275,76
+Waller,103,Railroad Commissioner,,DEM,Roman McAllen,263,174,89
+Waller,103,Railroad Commissioner,,LIB,Mike Wright,12,9,3
+Waller,103,State Representative,3,REP,Cecil Bell Jr,356,278,78
+Waller,103,State Representative,3,DEM,Lisa Seger,271,181,90
+Waller,103,Straight Party,,REP,Republican Party,251,196,55
+Waller,103,Straight Party,,DEM,Democratic Party,214,141,73
+Waller,103,Straight Party,,LIB,Libertarian Party,1,0,1
+Waller,103,U.S. House,10,REP,Michael T. McCaul,353,278,75
+Waller,103,U.S. House,10,DEM,Mike Siegel,276,183,93
+Waller,103,U.S. House,10,LIB,Mike Ryan,6,5,1
+Waller,103,U.S. Senate,,REP,Ted Cruz,342,272,70
+Waller,103,U.S. Senate,,DEM,Beto O'Rourke,289,192,97
+Waller,103,U.S. Senate,,LIB,Neal M. Dikeman,4,2,2
+Waller,104,Registered Voters,,,,802,,
+Waller,104,Attorney General,,REP,Ken Paxton,222,149,73
+Waller,104,Attorney General,,DEM,Justin Nelson,118,83,35
+Waller,104,Attorney General,,LIB,Michael Ray Harris,9,3,6
+Waller,104,Commissioner of Agriculture,,REP,Sid Miller,222,149,73
+Waller,104,Commissioner of Agriculture,,DEM,Kim Olson,118,82,36
+Waller,104,Commissioner of Agriculture,,LIB,Richard Carpenter,7,4,3
+Waller,104,Commissioner of the GeneralLand Office,,REP,George P. Bush,228,149,79
+Waller,104,Commissioner of the GeneralLand Office,,DEM,Miguel Suazo,111,80,31
+Waller,104,Commissioner of the GeneralLand Office,,LIB,Matt Piña,10,7,3
+Waller,104,Comptroller of Public Accounts,,REP,Glenn Hegar,236,158,78
+Waller,104,Comptroller of Public Accounts,,DEM,Joi Chevalier,105,74,31
+Waller,104,Comptroller of Public Accounts,,LIB,Ben Sanders,7,4,3
+Waller,104,County Clerk,,REP,Debbie Hollan,236,152,84
+Waller,104,County Clerk,,DEM,Shari Griswold,112,81,31
+Waller,104,County Judge,,REP,Trey Duhon,243,162,81
+Waller,104,County Judge,,DEM,Denise Mattox,105,72,33
+Waller,104,County Treasurer,,REP,Joan Sargent,232,152,80
+Waller,104,County Treasurer,,DEM,Tammie Lilly,116,81,35
+Waller,104,Criminal District Attorney Waller County,,REP,"Elton Raymond Mathis, Jr.",254,164,90
+Waller,104,District Clerk,,REP,Liz Pirkle,258,169,89
+Waller,104,Governor,,REP,Greg Abbott,238,156,82
+Waller,104,Governor,,DEM,Lupe Valdez,108,80,28
+Waller,104,Governor,,LIB,Mark Jay Tippetts,7,2,5
+Waller,104,"Judge, County Court-at-Law",,REP,Carol Chaney,265,174,91
+Waller,104,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,234,154,80
+Waller,104,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,117,82,35
+Waller,104,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,244,162,82
+Waller,104,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,58,40,18
+Waller,104,"Justice of the Peace, Precinct 1",,REP,Charles J. Karisch,263,174,89
+Waller,104,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,229,151,78
+Waller,104,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,118,83,35
+Waller,104,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,229,151,78
+Waller,104,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,118,83,35
+Waller,104,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,233,153,80
+Waller,104,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,113,80,33
+Waller,104,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,226,150,76
+Waller,104,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,121,84,37
+Waller,104,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,228,150,78
+Waller,104,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",119,84,35
+Waller,104,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,230,153,77
+Waller,104,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,117,80,37
+Waller,104,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,230,150,80
+Waller,104,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,117,84,33
+Waller,104,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,230,150,80
+Waller,104,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,117,84,33
+Waller,104,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,227,151,76
+Waller,104,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,119,82,37
+Waller,104,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,232,153,79
+Waller,104,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,115,81,34
+Waller,104,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,228,151,77
+Waller,104,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,120,82,38
+Waller,104,"Justice, Supreme Court, Place 4",,REP,John Devine,230,152,78
+Waller,104,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,118,81,37
+Waller,104,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,230,152,78
+Waller,104,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,120,83,37
+Waller,104,Lieutenant Governor,,REP,Dan Patrick,224,149,75
+Waller,104,Lieutenant Governor,,DEM,Mike Collier,124,87,37
+Waller,104,Lieutenant Governor,,LIB,Kerry Douglas McKennon,4,2,2
+Waller,104,"Presiding Judge, Court ofCriminal Appeals",,REP,Sharon Keller,231,151,80
+Waller,104,"Presiding Judge, Court ofCriminal Appeals",,DEM,Maria T. (Terri) Jackson,114,81,33
+Waller,104,"Presiding Judge, Court ofCriminal Appeals",,LIB,William Bryan Strange III,4,2,2
+Waller,104,Railroad Commissioner,,REP,Christi Craddick,230,151,79
+Waller,104,Railroad Commissioner,,DEM,Roman McAllen,109,79,30
+Waller,104,Railroad Commissioner,,LIB,Mike Wright,7,3,4
+Waller,104,State Representative,3,REP,Cecil Bell Jr,233,152,81
+Waller,104,State Representative,3,DEM,Lisa Seger,114,81,33
+Waller,104,Straight Party,,REP,Republican Party,171,113,58
+Waller,104,Straight Party,,DEM,Democratic Party,90,62,28
+Waller,104,Straight Party,,LIB,Libertarian Party,3,2,1
+Waller,104,U.S. House,10,REP,Michael T. McCaul,230,153,77
+Waller,104,U.S. House,10,DEM,Mike Siegel,114,80,34
+Waller,104,U.S. House,10,LIB,Mike Ryan,6,3,3
+Waller,104,U.S. Senate,,REP,Ted Cruz,227,148,79
+Waller,104,U.S. Senate,,DEM,Beto O'Rourke,120,85,35
+Waller,104,U.S. Senate,,LIB,Neal M. Dikeman,5,4,1
+Waller,105,Registered Voters,,,,796,,
+Waller,105,Attorney General,,REP,Ken Paxton,388,248,140
+Waller,105,Attorney General,,DEM,Justin Nelson,79,45,34
+Waller,105,Attorney General,,LIB,Michael Ray Harris,8,7,1
+Waller,105,Commissioner of Agriculture,,REP,Sid Miller,387,244,143
+Waller,105,Commissioner of Agriculture,,DEM,Kim Olson,80,49,31
+Waller,105,Commissioner of Agriculture,,LIB,Richard Carpenter,6,6,0
+Waller,105,Commissioner of the GeneralLand Office,,REP,George P. Bush,386,242,144
+Waller,105,Commissioner of the GeneralLand Office,,DEM,Miguel Suazo,71,43,28
+Waller,105,Commissioner of the GeneralLand Office,,LIB,Matt Piña,17,14,3
+Waller,105,Comptroller of Public Accounts,,REP,Glenn Hegar,403,254,149
+Waller,105,Comptroller of Public Accounts,,DEM,Joi Chevalier,67,41,26
+Waller,105,Comptroller of Public Accounts,,LIB,Ben Sanders,4,4,0
+Waller,105,County Clerk,,REP,Debbie Hollan,398,256,142
+Waller,105,County Clerk,,DEM,Shari Griswold,73,40,33
+Waller,105,County Judge,,REP,Trey Duhon,397,250,147
+Waller,105,County Judge,,DEM,Denise Mattox,70,42,28
+Waller,105,County Treasurer,,REP,Joan Sargent,398,255,143
+Waller,105,County Treasurer,,DEM,Tammie Lilly,73,41,32
+Waller,105,Criminal District Attorney Waller County,,REP,"Elton Raymond Mathis, Jr.",420,262,158
+Waller,105,District Clerk,,REP,Liz Pirkle,424,264,160
+Waller,105,Governor,,REP,Greg Abbott,398,250,148
+Waller,105,Governor,,DEM,Lupe Valdez,69,44,25
+Waller,105,Governor,,LIB,Mark Jay Tippetts,7,6,1
+Waller,105,"Judge, County Court-at-Law",,REP,Carol Chaney,423,264,159
+Waller,105,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,397,250,147
+Waller,105,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,74,47,27
+Waller,105,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,404,253,151
+Waller,105,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,38,23,15
+Waller,105,"Justice of the Peace, Precinct 1",,REP,Charles J. Karisch,417,260,157
+Waller,105,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,395,248,147
+Waller,105,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,76,48,28
+Waller,105,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,397,249,148
+Waller,105,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,73,46,27
+Waller,105,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,398,249,149
+Waller,105,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,72,46,26
+Waller,105,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,390,246,144
+Waller,105,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,80,49,31
+Waller,105,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,389,247,142
+Waller,105,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",80,49,31
+Waller,105,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,398,248,150
+Waller,105,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,73,48,25
+Waller,105,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,391,245,146
+Waller,105,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,80,51,29
+Waller,105,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,395,250,145
+Waller,105,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,78,48,30
+Waller,105,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,388,245,143
+Waller,105,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,82,51,31
+Waller,105,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,399,250,149
+Waller,105,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,71,45,26
+Waller,105,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,394,249,145
+Waller,105,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,78,49,29
+Waller,105,"Justice, Supreme Court, Place 4",,REP,John Devine,393,249,144
+Waller,105,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,79,49,30
+Waller,105,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,394,248,146
+Waller,105,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,78,48,30
+Waller,105,Lieutenant Governor,,REP,Dan Patrick,392,247,145
+Waller,105,Lieutenant Governor,,DEM,Mike Collier,75,49,26
+Waller,105,Lieutenant Governor,,LIB,Kerry Douglas McKennon,8,4,4
+Waller,105,"Presiding Judge, Court ofCriminal Appeals",,REP,Sharon Keller,392,247,145
+Waller,105,"Presiding Judge, Court ofCriminal Appeals",,DEM,Maria T. (Terri) Jackson,74,45,29
+Waller,105,"Presiding Judge, Court ofCriminal Appeals",,LIB,William Bryan Strange III,7,5,2
+Waller,105,Railroad Commissioner,,REP,Christi Craddick,393,248,145
+Waller,105,Railroad Commissioner,,DEM,Roman McAllen,70,42,28
+Waller,105,Railroad Commissioner,,LIB,Mike Wright,10,9,1
+Waller,105,State Representative,3,REP,Cecil Bell Jr,390,246,144
+Waller,105,State Representative,3,DEM,Lisa Seger,81,50,31
+Waller,105,Straight Party,,REP,Republican Party,303,189,114
+Waller,105,Straight Party,,DEM,Democratic Party,52,32,20
+Waller,105,Straight Party,,LIB,Libertarian Party,2,1,1
+Waller,105,U.S. House,10,REP,Michael T. McCaul,394,249,145
+Waller,105,U.S. House,10,DEM,Mike Siegel,74,46,28
+Waller,105,U.S. House,10,LIB,Mike Ryan,7,4,3
+Waller,105,U.S. Senate,,REP,Ted Cruz,385,245,140
+Waller,105,U.S. Senate,,DEM,Beto O'Rourke,86,49,37
+Waller,105,U.S. Senate,,LIB,Neal M. Dikeman,2,2,0
+Waller,206,Registered Voters,,,,2736,,
+Waller,206,Attorney General,,REP,Ken Paxton,1282,852,430
+Waller,206,Attorney General,,DEM,Justin Nelson,255,181,74
+Waller,206,Attorney General,,LIB,Michael Ray Harris,28,18,10
+Waller,206,Commissioner of Agriculture,,REP,Sid Miller,1299,867,432
+Waller,206,Commissioner of Agriculture,,DEM,Kim Olson,238,167,71
+Waller,206,Commissioner of Agriculture,,LIB,Richard Carpenter,24,13,11
+Waller,206,Commissioner of the GeneralLand Office,,REP,George P. Bush,1292,865,427
+Waller,206,Commissioner of the GeneralLand Office,,DEM,Miguel Suazo,224,157,67
+Waller,206,Commissioner of the GeneralLand Office,,LIB,Matt Piña,42,24,18
+Waller,206,Comptroller of Public Accounts,,REP,Glenn Hegar,1331,884,447
+Waller,206,Comptroller of Public Accounts,,DEM,Joi Chevalier,206,148,58
+Waller,206,Comptroller of Public Accounts,,LIB,Ben Sanders,25,16,9
+Waller,206,County Clerk,,REP,Debbie Hollan,1318,880,438
+Waller,206,County Clerk,,DEM,Shari Griswold,233,160,73
+Waller,206,"County Commissioner,Precinct 2",,REP,Walter Smith,1382,912,470
+Waller,206,County Judge,,REP,Trey Duhon,1322,884,438
+Waller,206,County Judge,,DEM,Denise Mattox,230,156,74
+Waller,206,County Treasurer,,REP,Joan Sargent,1319,877,442
+Waller,206,County Treasurer,,DEM,Tammie Lilly,226,158,68
+Waller,206,Criminal District Attorney Waller County,,REP,"Elton Raymond Mathis, Jr.",1388,913,475
+Waller,206,District Clerk,,REP,Liz Pirkle,1378,906,472
+Waller,206,Governor,,REP,Greg Abbott,1331,887,444
+Waller,206,Governor,,DEM,Lupe Valdez,219,152,67
+Waller,206,Governor,,LIB,Mark Jay Tippetts,14,11,3
+Waller,206,"Judge, County Court-at-Law",,REP,Carol Chaney,1390,916,474
+Waller,206,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1324,878,446
+Waller,206,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,234,167,67
+Waller,206,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1334,882,452
+Waller,206,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,124,85,39
+Waller,206,"Justice of the Peace, Precinct 2",,REP,J.R. Woolley,1381,910,471
+Waller,206,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,1315,872,443
+Waller,206,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,231,164,67
+Waller,206,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,1310,871,439
+Waller,206,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,232,161,71
+Waller,206,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,1318,874,444
+Waller,206,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,226,159,67
+Waller,206,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,1312,871,441
+Waller,206,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,235,164,71
+Waller,206,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,1312,871,441
+Waller,206,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",232,163,69
+Waller,206,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,1314,875,439
+Waller,206,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,233,163,70
+Waller,206,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,1310,868,442
+Waller,206,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,237,168,69
+Waller,206,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,1311,873,438
+Waller,206,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,236,164,72
+Waller,206,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,1302,864,438
+Waller,206,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,244,172,72
+Waller,206,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,1312,869,443
+Waller,206,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,231,164,67
+Waller,206,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1311,871,440
+Waller,206,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,244,172,72
+Waller,206,"Justice, Supreme Court, Place 4",,REP,John Devine,1314,872,442
+Waller,206,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,242,172,70
+Waller,206,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1319,875,444
+Waller,206,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,235,167,68
+Waller,206,Lieutenant Governor,,REP,Dan Patrick,1299,866,433
+Waller,206,Lieutenant Governor,,DEM,Mike Collier,244,175,69
+Waller,206,Lieutenant Governor,,LIB,Kerry Douglas McKennon,23,11,12
+Waller,206,"Presiding Judge, Court ofCriminal Appeals",,REP,Sharon Keller,1307,871,436
+Waller,206,"Presiding Judge, Court ofCriminal Appeals",,DEM,Maria T. (Terri) Jackson,227,162,65
+Waller,206,"Presiding Judge, Court ofCriminal Appeals",,LIB,William Bryan Strange III,24,12,12
+Waller,206,Railroad Commissioner,,REP,Christi Craddick,1314,875,439
+Waller,206,Railroad Commissioner,,DEM,Roman McAllen,215,153,62
+Waller,206,Railroad Commissioner,,LIB,Mike Wright,29,18,11
+Waller,206,State Representative,3,REP,Cecil Bell Jr,1314,874,440
+Waller,206,State Representative,3,DEM,Lisa Seger,239,166,73
+Waller,206,Straight Party,,REP,Republican Party,1037,687,350
+Waller,206,Straight Party,,DEM,Democratic Party,142,97,45
+Waller,206,Straight Party,,LIB,Libertarian Party,7,5,2
+Waller,206,U.S. House,10,REP,Michael T. McCaul,1306,871,435
+Waller,206,U.S. House,10,DEM,Mike Siegel,235,162,73
+Waller,206,U.S. House,10,LIB,Mike Ryan,22,16,6
+Waller,206,U.S. Senate,,REP,Ted Cruz,1309,868,441
+Waller,206,U.S. Senate,,DEM,Beto O'Rourke,245,173,72
+Waller,206,U.S. Senate,,LIB,Neal M. Dikeman,5,3,2
+Waller,207,Registered Voters,,,,3476,,
+Waller,207,Attorney General,,REP,Ken Paxton,1557,1137,420
+Waller,207,Attorney General,,DEM,Justin Nelson,247,175,72
+Waller,207,Attorney General,,LIB,Michael Ray Harris,31,21,10
+Waller,207,Commissioner of Agriculture,,REP,Sid Miller,1551,1129,422
+Waller,207,Commissioner of Agriculture,,DEM,Kim Olson,240,172,68
+Waller,207,Commissioner of Agriculture,,LIB,Richard Carpenter,32,24,8
+Waller,207,Commissioner of the GeneralLand Office,,REP,George P. Bush,1530,1107,423
+Waller,207,Commissioner of the GeneralLand Office,,DEM,Miguel Suazo,226,166,60
+Waller,207,Commissioner of the GeneralLand Office,,LIB,Matt Piña,66,50,16
+Waller,207,Comptroller of Public Accounts,,REP,Glenn Hegar,1597,1161,436
+Waller,207,Comptroller of Public Accounts,,DEM,Joi Chevalier,197,147,50
+Waller,207,Comptroller of Public Accounts,,LIB,Ben Sanders,37,22,15
+Waller,207,County Clerk,,REP,Debbie Hollan,1585,1154,431
+Waller,207,County Clerk,,DEM,Shari Griswold,224,160,64
+Waller,207,"County Commissioner,Precinct 2",,REP,Walter Smith,1654,1191,463
+Waller,207,County Judge,,REP,Trey Duhon,1594,1149,445
+Waller,207,County Judge,,DEM,Denise Mattox,222,166,56
+Waller,207,County Treasurer,,REP,Joan Sargent,1584,1153,431
+Waller,207,County Treasurer,,DEM,Tammie Lilly,222,158,64
+Waller,207,Criminal District Attorney Waller County,,REP,"Elton Raymond Mathis, Jr.",1650,1182,468
+Waller,207,District Clerk,,REP,Liz Pirkle,1647,1186,461
+Waller,207,Governor,,REP,Greg Abbott,1605,1170,435
+Waller,207,Governor,,DEM,Lupe Valdez,209,152,57
+Waller,207,Governor,,LIB,Mark Jay Tippetts,19,11,8
+Waller,207,"Judge, County Court-at-Law",,REP,Carol Chaney,1652,1189,463
+Waller,207,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1593,1162,431
+Waller,207,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,226,160,66
+Waller,207,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1603,1168,435
+Waller,207,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,146,100,46
+Waller,207,"Justice of the Peace, Precinct 2",,REP,J.R. Woolley,1647,1184,463
+Waller,207,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,1584,1158,426
+Waller,207,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,234,163,71
+Waller,207,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,1595,1163,432
+Waller,207,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,224,158,66
+Waller,207,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,1595,1164,431
+Waller,207,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,221,155,66
+Waller,207,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,1580,1153,427
+Waller,207,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,236,167,69
+Waller,207,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,1581,1153,428
+Waller,207,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",235,167,68
+Waller,207,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,1584,1156,428
+Waller,207,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,234,163,71
+Waller,207,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,1584,1152,432
+Waller,207,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,234,167,67
+Waller,207,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,1584,1154,430
+Waller,207,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,235,167,68
+Waller,207,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,1580,1155,425
+Waller,207,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,236,165,71
+Waller,207,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,1598,1163,435
+Waller,207,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,220,158,62
+Waller,207,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1583,1158,425
+Waller,207,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,239,167,72
+Waller,207,"Justice, Supreme Court, Place 4",,REP,John Devine,1586,1157,429
+Waller,207,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,233,165,68
+Waller,207,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1583,1155,428
+Waller,207,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,242,171,71
+Waller,207,Lieutenant Governor,,REP,Dan Patrick,1565,1141,424
+Waller,207,Lieutenant Governor,,DEM,Mike Collier,247,175,72
+Waller,207,Lieutenant Governor,,LIB,Kerry Douglas McKennon,23,15,8
+Waller,207,"Presiding Judge, Court ofCriminal Appeals",,REP,Sharon Keller,1558,1137,421
+Waller,207,"Presiding Judge, Court ofCriminal Appeals",,DEM,Maria T. (Terri) Jackson,225,163,62
+Waller,207,"Presiding Judge, Court ofCriminal Appeals",,LIB,William Bryan Strange III,37,22,15
+Waller,207,Railroad Commissioner,,REP,Christi Craddick,1574,1148,426
+Waller,207,Railroad Commissioner,,DEM,Roman McAllen,210,151,59
+Waller,207,Railroad Commissioner,,LIB,Mike Wright,42,29,13
+Waller,207,State Representative,3,REP,Cecil Bell Jr,1589,1151,438
+Waller,207,State Representative,3,DEM,Lisa Seger,229,166,63
+Waller,207,Straight Party,,REP,Republican Party,1272,927,345
+Waller,207,Straight Party,,DEM,Democratic Party,142,100,42
+Waller,207,Straight Party,,LIB,Libertarian Party,10,7,3
+Waller,207,U.S. House,10,REP,Michael T. McCaul,1573,1146,427
+Waller,207,U.S. House,10,DEM,Mike Siegel,227,166,61
+Waller,207,U.S. House,10,LIB,Mike Ryan,37,22,15
+Waller,207,U.S. Senate,,REP,Ted Cruz,1581,1153,428
+Waller,207,U.S. Senate,,DEM,Beto O'Rourke,246,172,74
+Waller,207,U.S. Senate,,LIB,Neal M. Dikeman,13,9,4
+Waller,208,Registered Voters,,,,1649,,
+Waller,208,Attorney General,,REP,Ken Paxton,511,380,131
+Waller,208,Attorney General,,DEM,Justin Nelson,229,159,70
+Waller,208,Attorney General,,LIB,Michael Ray Harris,18,14,4
+Waller,208,Commissioner of Agriculture,,REP,Sid Miller,518,385,133
+Waller,208,Commissioner of Agriculture,,DEM,Kim Olson,227,159,68
+Waller,208,Commissioner of Agriculture,,LIB,Richard Carpenter,12,9,3
+Waller,208,Commissioner of the GeneralLand Office,,REP,George P. Bush,521,390,131
+Waller,208,Commissioner of the GeneralLand Office,,DEM,Miguel Suazo,219,150,69
+Waller,208,Commissioner of the GeneralLand Office,,LIB,Matt Piña,14,11,3
+Waller,208,Comptroller of Public Accounts,,REP,Glenn Hegar,546,410,136
+Waller,208,Comptroller of Public Accounts,,DEM,Joi Chevalier,201,136,65
+Waller,208,Comptroller of Public Accounts,,LIB,Ben Sanders,12,8,4
+Waller,208,County Clerk,,REP,Debbie Hollan,528,397,131
+Waller,208,County Clerk,,DEM,Shari Griswold,223,149,74
+Waller,208,"County Commissioner,Precinct 2",,REP,Walter Smith,581,429,152
+Waller,208,County Judge,,REP,Trey Duhon,531,398,133
+Waller,208,County Judge,,DEM,Denise Mattox,218,148,70
+Waller,208,County Treasurer,,REP,Joan Sargent,536,402,134
+Waller,208,County Treasurer,,DEM,Tammie Lilly,213,143,70
+Waller,208,Criminal District Attorney Waller County,,REP,"Elton Raymond Mathis, Jr.",589,434,155
+Waller,208,District Clerk,,REP,Liz Pirkle,587,432,155
+Waller,208,Governor,,REP,Greg Abbott,540,401,139
+Waller,208,Governor,,DEM,Lupe Valdez,213,149,64
+Waller,208,Governor,,LIB,Mark Jay Tippetts,6,5,1
+Waller,208,"Judge, County Court-at-Law",,REP,Carol Chaney,590,435,155
+Waller,208,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,532,400,132
+Waller,208,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,221,150,71
+Waller,208,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,551,414,137
+Waller,208,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,101,59,42
+Waller,208,"Justice of the Peace, Precinct 2",,REP,J.R. Woolley,587,435,152
+Waller,208,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,532,399,133
+Waller,208,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,219,148,71
+Waller,208,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,529,398,131
+Waller,208,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,221,149,72
+Waller,208,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,532,397,135
+Waller,208,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,219,150,69
+Waller,208,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,527,396,131
+Waller,208,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,224,151,73
+Waller,208,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,525,396,129
+Waller,208,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",225,150,75
+Waller,208,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,531,397,134
+Waller,208,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,218,149,69
+Waller,208,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,525,393,132
+Waller,208,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,226,155,71
+Waller,208,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,524,391,133
+Waller,208,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,226,155,71
+Waller,208,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,526,392,134
+Waller,208,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,227,157,70
+Waller,208,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,527,394,133
+Waller,208,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,223,152,71
+Waller,208,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,523,392,131
+Waller,208,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,231,159,72
+Waller,208,"Justice, Supreme Court, Place 4",,REP,John Devine,526,393,133
+Waller,208,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,228,158,70
+Waller,208,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,531,397,134
+Waller,208,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,222,151,71
+Waller,208,Lieutenant Governor,,REP,Dan Patrick,520,389,131
+Waller,208,Lieutenant Governor,,DEM,Mike Collier,224,155,69
+Waller,208,Lieutenant Governor,,LIB,Kerry Douglas McKennon,12,8,4
+Waller,208,"Presiding Judge, Court ofCriminal Appeals",,REP,Sharon Keller,517,390,127
+Waller,208,"Presiding Judge, Court ofCriminal Appeals",,DEM,Maria T. (Terri) Jackson,221,153,68
+Waller,208,"Presiding Judge, Court ofCriminal Appeals",,LIB,William Bryan Strange III,15,7,8
+Waller,208,Railroad Commissioner,,REP,Christi Craddick,532,401,131
+Waller,208,Railroad Commissioner,,DEM,Roman McAllen,211,143,68
+Waller,208,Railroad Commissioner,,LIB,Mike Wright,12,6,6
+Waller,208,State Representative,3,REP,Cecil Bell Jr,523,392,131
+Waller,208,State Representative,3,DEM,Lisa Seger,222,150,72
+Waller,208,Straight Party,,REP,Republican Party,402,297,105
+Waller,208,Straight Party,,DEM,Democratic Party,165,109,56
+Waller,208,Straight Party,,LIB,Libertarian Party,3,3,0
+Waller,208,U.S. House,10,REP,Michael T. McCaul,524,393,131
+Waller,208,U.S. House,10,DEM,Mike Siegel,223,152,71
+Waller,208,U.S. House,10,LIB,Mike Ryan,12,8,4
+Waller,208,U.S. Senate,,REP,Ted Cruz,522,392,130
+Waller,208,U.S. Senate,,DEM,Beto O'Rourke,230,158,72
+Waller,208,U.S. Senate,,LIB,Neal M. Dikeman,4,1,3
+Waller,309,Registered Voters,,,,4834,,
+Waller,309,Attorney General,,REP,Ken Paxton,38,33,5
+Waller,309,Attorney General,,DEM,Justin Nelson,1645,1399,246
+Waller,309,Attorney General,,LIB,Michael Ray Harris,24,21,3
+Waller,309,Commissioner of Agriculture,,REP,Sid Miller,36,30,6
+Waller,309,Commissioner of Agriculture,,DEM,Kim Olson,1652,1410,242
+Waller,309,Commissioner of Agriculture,,LIB,Richard Carpenter,16,11,5
+Waller,309,Commissioner of the GeneralLand Office,,REP,George P. Bush,46,40,6
+Waller,309,Commissioner of the GeneralLand Office,,DEM,Miguel Suazo,1650,1406,244
+Waller,309,Commissioner of the GeneralLand Office,,LIB,Matt Piña,10,6,4
+Waller,309,Comptroller of Public Accounts,,REP,Glenn Hegar,32,28,4
+Waller,309,Comptroller of Public Accounts,,DEM,Joi Chevalier,1623,1387,236
+Waller,309,Comptroller of Public Accounts,,LIB,Ben Sanders,51,37,14
+Waller,309,County Clerk,,REP,Debbie Hollan,34,29,5
+Waller,309,County Clerk,,DEM,Shari Griswold,1599,1354,245
+Waller,309,County Judge,,REP,Trey Duhon,35,30,5
+Waller,309,County Judge,,DEM,Denise Mattox,1605,1358,247
+Waller,309,County Treasurer,,REP,Joan Sargent,34,27,7
+Waller,309,County Treasurer,,DEM,Tammie Lilly,1603,1357,246
+Waller,309,Criminal District Attorney Waller County,,REP,"Elton Raymond Mathis, Jr.",511,439,72
+Waller,309,District Clerk,,REP,Liz Pirkle,486,416,70
+Waller,309,Governor,,REP,Greg Abbott,77,64,13
+Waller,309,Governor,,DEM,Lupe Valdez,1626,1386,240
+Waller,309,Governor,,LIB,Mark Jay Tippetts,8,5,3
+Waller,309,"Judge, County Court-at-Law",,REP,Carol Chaney,486,414,72
+Waller,309,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,38,33,5
+Waller,309,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,1660,1412,248
+Waller,309,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,210,186,24
+Waller,309,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,871,738,133
+Waller,309,"Justice of the Peace, Precinct 3",,REP,Brian Davis,29,20,9
+Waller,309,"Justice of the Peace, Precinct 3",,DEM,Marian Elaine Jackson,1619,1373,246
+Waller,309,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,44,37,7
+Waller,309,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,1613,1368,245
+Waller,309,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,38,32,6
+Waller,309,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,1621,1375,246
+Waller,309,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,36,30,6
+Waller,309,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,1623,1377,246
+Waller,309,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,31,25,6
+Waller,309,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,1632,1385,247
+Waller,309,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,31,24,7
+Waller,309,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",1630,1384,246
+Waller,309,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,39,32,7
+Waller,309,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,1623,1377,246
+Waller,309,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,39,32,7
+Waller,309,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,1621,1375,246
+Waller,309,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,41,35,6
+Waller,309,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,1617,1371,246
+Waller,309,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,27,21,6
+Waller,309,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,1635,1388,247
+Waller,309,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,41,33,8
+Waller,309,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,1620,1375,245
+Waller,309,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,29,24,5
+Waller,309,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,1673,1425,248
+Waller,309,"Justice, Supreme Court, Place 4",,REP,John Devine,39,32,7
+Waller,309,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,1661,1416,245
+Waller,309,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,37,30,7
+Waller,309,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,1661,1416,245
+Waller,309,Lieutenant Governor,,REP,Dan Patrick,40,34,6
+Waller,309,Lieutenant Governor,,DEM,Mike Collier,1644,1400,244
+Waller,309,Lieutenant Governor,,LIB,Kerry Douglas McKennon,24,20,4
+Waller,309,"Presiding Judge, Court ofCriminal Appeals",,REP,Sharon Keller,25,21,4
+Waller,309,"Presiding Judge, Court ofCriminal Appeals",,DEM,Maria T. (Terri) Jackson,1671,1424,247
+Waller,309,"Presiding Judge, Court ofCriminal Appeals",,LIB,William Bryan Strange III,14,11,3
+Waller,309,Railroad Commissioner,,REP,Christi Craddick,41,34,7
+Waller,309,Railroad Commissioner,,DEM,Roman McAllen,1636,1395,241
+Waller,309,Railroad Commissioner,,LIB,Mike Wright,23,19,4
+Waller,309,State Representative,3,REP,Cecil Bell Jr,37,31,6
+Waller,309,State Representative,3,DEM,Lisa Seger,1605,1357,248
+Waller,309,Straight Party,,REP,Republican Party,27,22,5
+Waller,309,Straight Party,,DEM,Democratic Party,1437,1215,222
+Waller,309,Straight Party,,LIB,Libertarian Party,5,4,1
+Waller,309,U.S. House,10,REP,Michael T. McCaul,27,22,5
+Waller,309,U.S. House,10,DEM,Mike Siegel,1631,1384,247
+Waller,309,U.S. House,10,LIB,Mike Ryan,12,9,3
+Waller,309,U.S. Senate,,REP,Ted Cruz,20,17,3
+Waller,309,U.S. Senate,,DEM,Beto O'Rourke,1700,1446,254
+Waller,309,U.S. Senate,,LIB,Neal M. Dikeman,1,1,0
+Waller,310,Registered Voters,,,,2003,,
+Waller,310,Attorney General,,REP,Ken Paxton,145,118,27
+Waller,310,Attorney General,,DEM,Justin Nelson,737,573,164
+Waller,310,Attorney General,,LIB,Michael Ray Harris,22,18,4
+Waller,310,Commissioner of Agriculture,,REP,Sid Miller,142,116,26
+Waller,310,Commissioner of Agriculture,,DEM,Kim Olson,752,585,167
+Waller,310,Commissioner of Agriculture,,LIB,Richard Carpenter,14,11,3
+Waller,310,Commissioner of the GeneralLand Office,,REP,George P. Bush,163,132,31
+Waller,310,Commissioner of the GeneralLand Office,,DEM,Miguel Suazo,717,559,158
+Waller,310,Commissioner of the GeneralLand Office,,LIB,Matt Piña,25,21,4
+Waller,310,Comptroller of Public Accounts,,REP,Glenn Hegar,168,136,32
+Waller,310,Comptroller of Public Accounts,,DEM,Joi Chevalier,706,549,157
+Waller,310,Comptroller of Public Accounts,,LIB,Ben Sanders,31,26,5
+Waller,310,County Clerk,,REP,Debbie Hollan,153,124,29
+Waller,310,County Clerk,,DEM,Shari Griswold,731,567,164
+Waller,310,County Judge,,REP,Trey Duhon,160,127,33
+Waller,310,County Judge,,DEM,Denise Mattox,721,560,161
+Waller,310,County Treasurer,,REP,Joan Sargent,160,131,29
+Waller,310,County Treasurer,,DEM,Tammie Lilly,721,556,165
+Waller,310,Criminal District Attorney Waller County,,REP,"Elton Raymond Mathis, Jr.",344,274,70
+Waller,310,District Clerk,,REP,Liz Pirkle,333,267,66
+Waller,310,Governor,,REP,Greg Abbott,192,151,41
+Waller,310,Governor,,DEM,Lupe Valdez,701,553,148
+Waller,310,Governor,,LIB,Mark Jay Tippetts,13,8,5
+Waller,310,"Judge, County Court-at-Law",,REP,Carol Chaney,337,270,67
+Waller,310,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,147,117,30
+Waller,310,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,755,591,164
+Waller,310,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,216,170,46
+Waller,310,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,358,285,73
+Waller,310,"Justice of the Peace, Precinct 3",,REP,Brian Davis,157,126,31
+Waller,310,"Justice of the Peace, Precinct 3",,DEM,Marian Elaine Jackson,734,570,164
+Waller,310,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,152,123,29
+Waller,310,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,731,569,162
+Waller,310,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,152,123,29
+Waller,310,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,732,569,163
+Waller,310,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,161,131,30
+Waller,310,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,724,562,162
+Waller,310,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,149,120,29
+Waller,310,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,738,575,163
+Waller,310,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,146,120,26
+Waller,310,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",742,576,166
+Waller,310,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,149,122,27
+Waller,310,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,737,573,164
+Waller,310,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,152,121,31
+Waller,310,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,736,576,160
+Waller,310,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,149,120,29
+Waller,310,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,737,574,163
+Waller,310,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,142,114,28
+Waller,310,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,743,579,164
+Waller,310,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,156,126,30
+Waller,310,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,728,566,162
+Waller,310,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,145,116,29
+Waller,310,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,759,595,164
+Waller,310,"Justice, Supreme Court, Place 4",,REP,John Devine,149,120,29
+Waller,310,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,750,586,164
+Waller,310,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,153,121,32
+Waller,310,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,750,589,161
+Waller,310,Lieutenant Governor,,REP,Dan Patrick,153,123,30
+Waller,310,Lieutenant Governor,,DEM,Mike Collier,736,572,164
+Waller,310,Lieutenant Governor,,LIB,Kerry Douglas McKennon,19,17,2
+Waller,310,"Presiding Judge, Court ofCriminal Appeals",,REP,Sharon Keller,136,110,26
+Waller,310,"Presiding Judge, Court ofCriminal Appeals",,DEM,Maria T. (Terri) Jackson,756,592,164
+Waller,310,"Presiding Judge, Court ofCriminal Appeals",,LIB,William Bryan Strange III,16,11,5
+Waller,310,Railroad Commissioner,,REP,Christi Craddick,151,120,31
+Waller,310,Railroad Commissioner,,DEM,Roman McAllen,729,569,160
+Waller,310,Railroad Commissioner,,LIB,Mike Wright,21,18,3
+Waller,310,State Representative,3,REP,Cecil Bell Jr,167,135,32
+Waller,310,State Representative,3,DEM,Lisa Seger,714,553,161
+Waller,310,Straight Party,,REP,Republican Party,104,84,20
+Waller,310,Straight Party,,DEM,Democratic Party,580,449,131
+Waller,310,Straight Party,,LIB,Libertarian Party,3,3,0
+Waller,310,U.S. House,10,REP,Michael T. McCaul,151,123,28
+Waller,310,U.S. House,10,DEM,Mike Siegel,727,564,163
+Waller,310,U.S. House,10,LIB,Mike Ryan,14,11,3
+Waller,310,U.S. Senate,,REP,Ted Cruz,140,111,29
+Waller,310,U.S. Senate,,DEM,Beto O'Rourke,767,601,166
+Waller,310,U.S. Senate,,LIB,Neal M. Dikeman,4,3,1
+Waller,311,Registered Voters,,,,663,,
+Waller,311,Attorney General,,REP,Ken Paxton,256,177,79
+Waller,311,Attorney General,,DEM,Justin Nelson,121,78,43
+Waller,311,Attorney General,,LIB,Michael Ray Harris,11,5,6
+Waller,311,Commissioner of Agriculture,,REP,Sid Miller,261,177,84
+Waller,311,Commissioner of Agriculture,,DEM,Kim Olson,122,78,44
+Waller,311,Commissioner of Agriculture,,LIB,Richard Carpenter,5,3,2
+Waller,311,Commissioner of the GeneralLand Office,,REP,George P. Bush,263,179,84
+Waller,311,Commissioner of the GeneralLand Office,,DEM,Miguel Suazo,111,73,38
+Waller,311,Commissioner of the GeneralLand Office,,LIB,Matt Piña,11,5,6
+Waller,311,Comptroller of Public Accounts,,REP,Glenn Hegar,273,184,89
+Waller,311,Comptroller of Public Accounts,,DEM,Joi Chevalier,107,70,37
+Waller,311,Comptroller of Public Accounts,,LIB,Ben Sanders,7,4,3
+Waller,311,County Clerk,,REP,Debbie Hollan,272,184,88
+Waller,311,County Clerk,,DEM,Shari Griswold,115,74,41
+Waller,311,County Judge,,REP,Trey Duhon,262,177,85
+Waller,311,County Judge,,DEM,Denise Mattox,119,78,41
+Waller,311,County Treasurer,,REP,Joan Sargent,275,187,88
+Waller,311,County Treasurer,,DEM,Tammie Lilly,110,70,40
+Waller,311,Criminal District Attorney Waller County,,REP,"Elton Raymond Mathis, Jr.",284,186,98
+Waller,311,District Clerk,,REP,Liz Pirkle,294,191,103
+Waller,311,Governor,,REP,Greg Abbott,277,187,90
+Waller,311,Governor,,DEM,Lupe Valdez,106,70,36
+Waller,311,Governor,,LIB,Mark Jay Tippetts,7,3,4
+Waller,311,"Judge, County Court-at-Law",,REP,Carol Chaney,301,197,104
+Waller,311,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,269,184,85
+Waller,311,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,116,75,41
+Waller,311,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,279,187,92
+Waller,311,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,59,40,19
+Waller,311,"Justice of the Peace, Precinct 3",,REP,Brian Davis,279,187,92
+Waller,311,"Justice of the Peace, Precinct 3",,DEM,Marian Elaine Jackson,108,71,37
+Waller,311,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,268,183,85
+Waller,311,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,115,75,40
+Waller,311,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,265,183,82
+Waller,311,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,118,75,43
+Waller,311,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,266,183,83
+Waller,311,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,118,75,43
+Waller,311,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,270,183,87
+Waller,311,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,115,75,40
+Waller,311,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,270,183,87
+Waller,311,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",115,75,40
+Waller,311,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,267,184,83
+Waller,311,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,118,75,43
+Waller,311,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,263,181,82
+Waller,311,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,121,78,43
+Waller,311,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,267,184,83
+Waller,311,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,119,75,44
+Waller,311,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,267,183,84
+Waller,311,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,119,76,43
+Waller,311,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,266,182,84
+Waller,311,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,119,77,42
+Waller,311,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,262,181,81
+Waller,311,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,126,79,47
+Waller,311,"Justice, Supreme Court, Place 4",,REP,John Devine,265,183,82
+Waller,311,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,120,76,44
+Waller,311,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,271,184,87
+Waller,311,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,115,75,40
+Waller,311,Lieutenant Governor,,REP,Dan Patrick,258,176,82
+Waller,311,Lieutenant Governor,,DEM,Mike Collier,126,81,45
+Waller,311,Lieutenant Governor,,LIB,Kerry Douglas McKennon,4,2,2
+Waller,311,"Presiding Judge, Court ofCriminal Appeals",,REP,Sharon Keller,267,181,86
+Waller,311,"Presiding Judge, Court ofCriminal Appeals",,DEM,Maria T. (Terri) Jackson,116,74,42
+Waller,311,"Presiding Judge, Court ofCriminal Appeals",,LIB,William Bryan Strange III,4,4,0
+Waller,311,Railroad Commissioner,,REP,Christi Craddick,258,178,80
+Waller,311,Railroad Commissioner,,DEM,Roman McAllen,117,73,44
+Waller,311,Railroad Commissioner,,LIB,Mike Wright,11,8,3
+Waller,311,State Representative,3,REP,Cecil Bell Jr,265,181,84
+Waller,311,State Representative,3,DEM,Lisa Seger,116,75,41
+Waller,311,Straight Party,,REP,Republican Party,197,132,65
+Waller,311,Straight Party,,DEM,Democratic Party,82,57,25
+Waller,311,Straight Party,,LIB,Libertarian Party,0,0,0
+Waller,311,U.S. House,10,REP,Michael T. McCaul,267,181,86
+Waller,311,U.S. House,10,DEM,Mike Siegel,116,74,42
+Waller,311,U.S. House,10,LIB,Mike Ryan,5,4,1
+Waller,311,U.S. Senate,,REP,Ted Cruz,269,183,86
+Waller,311,U.S. Senate,,DEM,Beto O'Rourke,118,75,43
+Waller,311,U.S. Senate,,LIB,Neal M. Dikeman,2,1,1
+Waller,312,Registered Voters,,,,1642,,
+Waller,312,Attorney General,,REP,Ken Paxton,806,624,182
+Waller,312,Attorney General,,DEM,Justin Nelson,164,112,52
+Waller,312,Attorney General,,LIB,Michael Ray Harris,12,12,0
+Waller,312,Commissioner of Agriculture,,REP,Sid Miller,807,628,179
+Waller,312,Commissioner of Agriculture,,DEM,Kim Olson,159,108,51
+Waller,312,Commissioner of Agriculture,,LIB,Richard Carpenter,11,9,2
+Waller,312,Commissioner of the GeneralLand Office,,REP,George P. Bush,812,628,184
+Waller,312,Commissioner of the GeneralLand Office,,DEM,Miguel Suazo,141,95,46
+Waller,312,Commissioner of the GeneralLand Office,,LIB,Matt Piña,24,23,1
+Waller,312,Comptroller of Public Accounts,,REP,Glenn Hegar,841,654,187
+Waller,312,Comptroller of Public Accounts,,DEM,Joi Chevalier,127,87,40
+Waller,312,Comptroller of Public Accounts,,LIB,Ben Sanders,14,8,6
+Waller,312,County Clerk,,REP,Debbie Hollan,820,639,181
+Waller,312,County Clerk,,DEM,Shari Griswold,148,98,50
+Waller,312,County Judge,,REP,Trey Duhon,832,647,185
+Waller,312,County Judge,,DEM,Denise Mattox,138,91,47
+Waller,312,County Treasurer,,REP,Joan Sargent,825,640,185
+Waller,312,County Treasurer,,DEM,Tammie Lilly,144,98,46
+Waller,312,Criminal District Attorney Waller County,,REP,"Elton Raymond Mathis, Jr.",880,679,201
+Waller,312,District Clerk,,REP,Liz Pirkle,879,673,206
+Waller,312,Governor,,REP,Greg Abbott,836,647,189
+Waller,312,Governor,,DEM,Lupe Valdez,140,97,43
+Waller,312,Governor,,LIB,Mark Jay Tippetts,7,5,2
+Waller,312,"Judge, County Court-at-Law",,REP,Carol Chaney,883,676,207
+Waller,312,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,823,637,186
+Waller,312,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,149,103,46
+Waller,312,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,857,659,198
+Waller,312,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,69,49,20
+Waller,312,"Justice of the Peace, Precinct 3",,REP,Brian Davis,825,639,186
+Waller,312,"Justice of the Peace, Precinct 3",,DEM,Marian Elaine Jackson,146,99,47
+Waller,312,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,820,637,183
+Waller,312,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,148,101,47
+Waller,312,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,824,638,186
+Waller,312,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,146,101,45
+Waller,312,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,824,639,185
+Waller,312,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,146,100,46
+Waller,312,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,811,628,183
+Waller,312,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,157,109,48
+Waller,312,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,818,637,181
+Waller,312,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",150,100,50
+Waller,312,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,821,638,183
+Waller,312,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,147,100,47
+Waller,312,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,822,636,186
+Waller,312,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,149,103,46
+Waller,312,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,816,632,184
+Waller,312,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,154,107,47
+Waller,312,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,806,627,179
+Waller,312,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,164,113,51
+Waller,312,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,819,635,184
+Waller,312,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,151,104,47
+Waller,312,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,816,633,183
+Waller,312,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,161,111,50
+Waller,312,"Justice, Supreme Court, Place 4",,REP,John Devine,815,631,184
+Waller,312,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,157,109,48
+Waller,312,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,820,638,182
+Waller,312,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,153,103,50
+Waller,312,Lieutenant Governor,,REP,Dan Patrick,794,614,180
+Waller,312,Lieutenant Governor,,DEM,Mike Collier,175,125,50
+Waller,312,Lieutenant Governor,,LIB,Kerry Douglas McKennon,14,11,3
+Waller,312,"Presiding Judge, Court ofCriminal Appeals",,REP,Sharon Keller,812,631,181
+Waller,312,"Presiding Judge, Court ofCriminal Appeals",,DEM,Maria T. (Terri) Jackson,152,104,48
+Waller,312,"Presiding Judge, Court ofCriminal Appeals",,LIB,William Bryan Strange III,9,7,2
+Waller,312,Railroad Commissioner,,REP,Christi Craddick,822,639,183
+Waller,312,Railroad Commissioner,,DEM,Roman McAllen,140,98,42
+Waller,312,Railroad Commissioner,,LIB,Mike Wright,17,10,7
+Waller,312,State Representative,3,REP,Cecil Bell Jr,818,634,184
+Waller,312,State Representative,3,DEM,Lisa Seger,154,107,47
+Waller,312,Straight Party,,REP,Republican Party,636,482,154
+Waller,312,Straight Party,,DEM,Democratic Party,97,63,34
+Waller,312,Straight Party,,LIB,Libertarian Party,1,1,0
+Waller,312,U.S. House,10,REP,Michael T. McCaul,812,629,183
+Waller,312,U.S. House,10,DEM,Mike Siegel,160,110,50
+Waller,312,U.S. House,10,LIB,Mike Ryan,11,10,1
+Waller,312,U.S. Senate,,REP,Ted Cruz,813,632,181
+Waller,312,U.S. Senate,,DEM,Beto O'Rourke,163,112,51
+Waller,312,U.S. Senate,,LIB,Neal M. Dikeman,5,3,2
+Waller,418,Registered Voters,,,,2383,,
+Waller,418,Attorney General,,REP,Ken Paxton,1172,867,305
+Waller,418,Attorney General,,DEM,Justin Nelson,339,252,87
+Waller,418,Attorney General,,LIB,Michael Ray Harris,33,21,12
+Waller,418,Commissioner of Agriculture,,REP,Sid Miller,1188,874,314
+Waller,418,Commissioner of Agriculture,,DEM,Kim Olson,322,245,77
+Waller,418,Commissioner of Agriculture,,LIB,Richard Carpenter,27,17,10
+Waller,418,Commissioner of the GeneralLand Office,,REP,George P. Bush,1217,885,332
+Waller,418,Commissioner of the GeneralLand Office,,DEM,Miguel Suazo,285,227,58
+Waller,418,Commissioner of the GeneralLand Office,,LIB,Matt Piña,36,24,12
+Waller,418,Comptroller of Public Accounts,,REP,Glenn Hegar,1237,905,332
+Waller,418,Comptroller of Public Accounts,,DEM,Joi Chevalier,274,216,58
+Waller,418,Comptroller of Public Accounts,,LIB,Ben Sanders,29,18,11
+Waller,418,County Clerk,,REP,Debbie Hollan,1225,896,329
+Waller,418,County Clerk,,DEM,Shari Griswold,300,231,69
+Waller,418,"County Commissioner,Precinct 4",,REP,Justin Beckendorff,1337,980,357
+Waller,418,"County Commissioner,Precinct 4",,,Ethel Wilmore,23,20,3
+Waller,418,"County Commissioner,Precinct 4",,,Rejected write-ins,7,5,2
+Waller,418,"County Commissioner,Precinct 4",,,Unassigned write-ins,1,0,1
+Waller,418,County Judge,,REP,Trey Duhon,1272,932,340
+Waller,418,County Judge,,DEM,Denise Mattox,267,203,64
+Waller,418,County Treasurer,,REP,Joan Sargent,1233,899,334
+Waller,418,County Treasurer,,DEM,Tammie Lilly,290,227,63
+Waller,418,Criminal District Attorney Waller County,,REP,"Elton Raymond Mathis, Jr.",1337,977,360
+Waller,418,District Clerk,,REP,Liz Pirkle,1336,976,360
+Waller,418,Governor,,REP,Greg Abbott,1260,923,337
+Waller,418,Governor,,DEM,Lupe Valdez,276,216,60
+Waller,418,Governor,,LIB,Mark Jay Tippetts,13,6,7
+Waller,418,"Judge, County Court-at-Law",,REP,Carol Chaney,1344,983,361
+Waller,418,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1235,899,336
+Waller,418,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,297,235,62
+Waller,418,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1271,932,339
+Waller,418,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,178,136,42
+Waller,418,"Justice of the Peace, Precinct 4",,REP,Ted Krenek,1230,899,331
+Waller,418,"Justice of the Peace, Precinct 4",,DEM,Jennifer Sheedy,298,231,67
+Waller,418,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,1234,898,336
+Waller,418,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,294,233,61
+Waller,418,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,1230,896,334
+Waller,418,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,294,234,60
+Waller,418,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,1234,900,334
+Waller,418,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,293,230,63
+Waller,418,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,1217,893,324
+Waller,418,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,306,237,69
+Waller,418,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,1219,890,329
+Waller,418,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",308,241,67
+Waller,418,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,1241,905,336
+Waller,418,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,289,227,62
+Waller,418,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,1215,885,330
+Waller,418,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,314,247,67
+Waller,418,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,1219,889,330
+Waller,418,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,312,243,69
+Waller,418,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,1219,889,330
+Waller,418,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,310,243,67
+Waller,418,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,1231,897,334
+Waller,418,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,296,232,64
+Waller,418,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1223,894,329
+Waller,418,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,308,241,67
+Waller,418,"Justice, Supreme Court, Place 4",,REP,John Devine,1223,886,337
+Waller,418,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,308,248,60
+Waller,418,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1230,896,334
+Waller,418,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,302,239,63
+Waller,418,Lieutenant Governor,,REP,Dan Patrick,1189,872,317
+Waller,418,Lieutenant Governor,,DEM,Mike Collier,328,256,72
+Waller,418,Lieutenant Governor,,LIB,Kerry Douglas McKennon,27,15,12
+Waller,418,"Presiding Judge, Court ofCriminal Appeals",,REP,Sharon Keller,1214,889,325
+Waller,418,"Presiding Judge, Court ofCriminal Appeals",,DEM,Maria T. (Terri) Jackson,301,238,63
+Waller,418,"Presiding Judge, Court ofCriminal Appeals",,LIB,William Bryan Strange III,19,8,11
+Waller,418,Railroad Commissioner,,REP,Christi Craddick,1224,897,327
+Waller,418,Railroad Commissioner,,DEM,Roman McAllen,280,219,61
+Waller,418,Railroad Commissioner,,LIB,Mike Wright,33,18,15
+Waller,418,State Representative,3,REP,Cecil Bell Jr,1219,892,327
+Waller,418,State Representative,3,DEM,Lisa Seger,316,242,74
+Waller,418,Straight Party,,REP,Republican Party,960,705,255
+Waller,418,Straight Party,,DEM,Democratic Party,199,157,42
+Waller,418,Straight Party,,LIB,Libertarian Party,4,1,3
+Waller,418,U.S. House,10,REP,Michael T. McCaul,1205,885,320
+Waller,418,U.S. House,10,DEM,Mike Siegel,308,240,68
+Waller,418,U.S. House,10,LIB,Mike Ryan,29,16,13
+Waller,418,U.S. Senate,,REP,Ted Cruz,1202,887,315
+Waller,418,U.S. Senate,,DEM,Beto O'Rourke,338,255,83
+Waller,418,U.S. Senate,,LIB,Neal M. Dikeman,7,2,5
+Waller,419,Registered Voters,,,,202,,
+Waller,419,Attorney General,,REP,Ken Paxton,114,79,35
+Waller,419,Attorney General,,DEM,Justin Nelson,33,26,7
+Waller,419,Attorney General,,LIB,Michael Ray Harris,11,8,3
+Waller,419,Commissioner of Agriculture,,REP,Sid Miller,114,81,33
+Waller,419,Commissioner of Agriculture,,DEM,Kim Olson,34,26,8
+Waller,419,Commissioner of Agriculture,,LIB,Richard Carpenter,7,4,3
+Waller,419,Commissioner of the GeneralLand Office,,REP,George P. Bush,126,86,40
+Waller,419,Commissioner of the GeneralLand Office,,DEM,Miguel Suazo,26,22,4
+Waller,419,Commissioner of the GeneralLand Office,,LIB,Matt Piña,6,5,1
+Waller,419,Comptroller of Public Accounts,,REP,Glenn Hegar,126,88,38
+Waller,419,Comptroller of Public Accounts,,DEM,Joi Chevalier,27,22,5
+Waller,419,Comptroller of Public Accounts,,LIB,Ben Sanders,4,2,2
+Waller,419,County Clerk,,REP,Debbie Hollan,117,81,36
+Waller,419,County Clerk,,DEM,Shari Griswold,31,25,6
+Waller,419,"County Commissioner,Precinct 4",,REP,Justin Beckendorff,130,90,40
+Waller,419,"County Commissioner,Precinct 4",,,Ethel Wilmore,2,2,0
+Waller,419,"County Commissioner,Precinct 4",,,Rejected write-ins,1,1,0
+Waller,419,"County Commissioner,Precinct 4",,,Unassigned write-ins,0,0,0
+Waller,419,County Judge,,REP,Trey Duhon,121,80,41
+Waller,419,County Judge,,DEM,Denise Mattox,29,26,3
+Waller,419,County Treasurer,,REP,Joan Sargent,123,84,39
+Waller,419,County Treasurer,,DEM,Tammie Lilly,25,22,3
+Waller,419,Criminal District Attorney Waller County,,REP,"Elton Raymond Mathis, Jr.",133,92,41
+Waller,419,District Clerk,,REP,Liz Pirkle,135,94,41
+Waller,419,Governor,,REP,Greg Abbott,130,91,39
+Waller,419,Governor,,DEM,Lupe Valdez,27,23,4
+Waller,419,Governor,,LIB,Mark Jay Tippetts,3,1,2
+Waller,419,"Judge, County Court-at-Law",,REP,Carol Chaney,133,92,41
+Waller,419,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,125,86,39
+Waller,419,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,29,24,5
+Waller,419,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,122,84,38
+Waller,419,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,22,17,5
+Waller,419,"Justice of the Peace, Precinct 4",,REP,Ted Krenek,118,79,39
+Waller,419,"Justice of the Peace, Precinct 4",,DEM,Jennifer Sheedy,31,27,4
+Waller,419,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,123,84,39
+Waller,419,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,27,22,5
+Waller,419,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,125,84,41
+Waller,419,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,27,23,4
+Waller,419,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,122,84,38
+Waller,419,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,28,22,6
+Waller,419,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,125,84,41
+Waller,419,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,25,22,3
+Waller,419,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,120,83,37
+Waller,419,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",29,23,6
+Waller,419,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,122,84,38
+Waller,419,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,27,22,5
+Waller,419,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,121,84,37
+Waller,419,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,29,23,6
+Waller,419,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,125,85,40
+Waller,419,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,25,22,3
+Waller,419,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,120,81,39
+Waller,419,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,31,26,5
+Waller,419,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,125,86,39
+Waller,419,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,25,21,4
+Waller,419,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,124,86,38
+Waller,419,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,30,25,5
+Waller,419,"Justice, Supreme Court, Place 4",,REP,John Devine,123,85,38
+Waller,419,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,29,25,4
+Waller,419,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,124,86,38
+Waller,419,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,28,24,4
+Waller,419,Lieutenant Governor,,REP,Dan Patrick,119,82,37
+Waller,419,Lieutenant Governor,,DEM,Mike Collier,35,29,6
+Waller,419,Lieutenant Governor,,LIB,Kerry Douglas McKennon,4,2,2
+Waller,419,"Presiding Judge, Court ofCriminal Appeals",,REP,Sharon Keller,117,80,37
+Waller,419,"Presiding Judge, Court ofCriminal Appeals",,DEM,Maria T. (Terri) Jackson,29,24,5
+Waller,419,"Presiding Judge, Court ofCriminal Appeals",,LIB,William Bryan Strange III,7,5,2
+Waller,419,Railroad Commissioner,,REP,Christi Craddick,121,84,37
+Waller,419,Railroad Commissioner,,DEM,Roman McAllen,27,23,4
+Waller,419,Railroad Commissioner,,LIB,Mike Wright,6,4,2
+Waller,419,State Representative,3,REP,Cecil Bell Jr,118,80,38
+Waller,419,State Representative,3,DEM,Lisa Seger,35,29,6
+Waller,419,Straight Party,,REP,Republican Party,83,60,23
+Waller,419,Straight Party,,DEM,Democratic Party,16,16,0
+Waller,419,Straight Party,,LIB,Libertarian Party,2,1,1
+Waller,419,U.S. House,10,REP,Michael T. McCaul,116,80,36
+Waller,419,U.S. House,10,DEM,Mike Siegel,34,28,6
+Waller,419,U.S. House,10,LIB,Mike Ryan,5,2,3
+Waller,419,U.S. Senate,,REP,Ted Cruz,120,82,38
+Waller,419,U.S. Senate,,DEM,Beto O'Rourke,38,32,6
+Waller,419,U.S. Senate,,LIB,Neal M. Dikeman,2,1,1
+Waller,420,Registered Voters,,,,1330,,
+Waller,420,Attorney General,,REP,Ken Paxton,651,482,169
+Waller,420,Attorney General,,DEM,Justin Nelson,218,157,61
+Waller,420,Attorney General,,LIB,Michael Ray Harris,17,7,10
+Waller,420,Commissioner of Agriculture,,REP,Sid Miller,664,484,180
+Waller,420,Commissioner of Agriculture,,DEM,Kim Olson,205,152,53
+Waller,420,Commissioner of Agriculture,,LIB,Richard Carpenter,14,7,7
+Waller,420,Commissioner of the GeneralLand Office,,REP,George P. Bush,690,500,190
+Waller,420,Commissioner of the GeneralLand Office,,DEM,Miguel Suazo,182,136,46
+Waller,420,Commissioner of the GeneralLand Office,,LIB,Matt Piña,13,9,4
+Waller,420,Comptroller of Public Accounts,,REP,Glenn Hegar,701,514,187
+Waller,420,Comptroller of Public Accounts,,DEM,Joi Chevalier,170,125,45
+Waller,420,Comptroller of Public Accounts,,LIB,Ben Sanders,13,6,7
+Waller,420,County Clerk,,REP,Debbie Hollan,675,496,179
+Waller,420,County Clerk,,DEM,Shari Griswold,198,141,57
+Waller,420,"County Commissioner,Precinct 4",,REP,Justin Beckendorff,745,538,207
+Waller,420,"County Commissioner,Precinct 4",,,Ethel Wilmore,13,10,3
+Waller,420,"County Commissioner,Precinct 4",,,Rejected write-ins,4,2,2
+Waller,420,"County Commissioner,Precinct 4",,,Unassigned write-ins,0,0,0
+Waller,420,County Judge,,REP,Trey Duhon,685,496,189
+Waller,420,County Judge,,DEM,Denise Mattox,196,146,50
+Waller,420,County Treasurer,,REP,Joan Sargent,687,499,188
+Waller,420,County Treasurer,,DEM,Tammie Lilly,184,138,46
+Waller,420,Criminal District Attorney Waller County,,REP,"Elton Raymond Mathis, Jr.",747,537,210
+Waller,420,District Clerk,,REP,Liz Pirkle,744,538,206
+Waller,420,Governor,,REP,Greg Abbott,699,510,189
+Waller,420,Governor,,DEM,Lupe Valdez,178,131,47
+Waller,420,Governor,,LIB,Mark Jay Tippetts,11,6,5
+Waller,420,"Judge, County Court-at-Law",,REP,Carol Chaney,742,535,207
+Waller,420,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,687,500,187
+Waller,420,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,190,141,49
+Waller,420,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,717,519,198
+Waller,420,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,97,74,23
+Waller,420,"Justice of the Peace, Precinct 4",,REP,Ted Krenek,689,502,187
+Waller,420,"Justice of the Peace, Precinct 4",,DEM,Jennifer Sheedy,184,136,48
+Waller,420,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,687,499,188
+Waller,420,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,182,138,44
+Waller,420,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,689,502,187
+Waller,420,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,181,135,46
+Waller,420,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,689,501,188
+Waller,420,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,179,136,43
+Waller,420,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,686,502,184
+Waller,420,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,184,135,49
+Waller,420,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,679,497,182
+Waller,420,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",192,140,52
+Waller,420,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,684,496,188
+Waller,420,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,190,141,49
+Waller,420,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,682,499,183
+Waller,420,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,192,140,52
+Waller,420,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,679,498,181
+Waller,420,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,194,141,53
+Waller,420,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,668,489,179
+Waller,420,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,203,147,56
+Waller,420,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,682,495,187
+Waller,420,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,189,141,48
+Waller,420,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,678,494,184
+Waller,420,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,200,146,54
+Waller,420,"Justice, Supreme Court, Place 4",,REP,John Devine,681,498,183
+Waller,420,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,196,142,54
+Waller,420,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,689,502,187
+Waller,420,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,189,139,50
+Waller,420,Lieutenant Governor,,REP,Dan Patrick,656,479,177
+Waller,420,Lieutenant Governor,,DEM,Mike Collier,217,159,58
+Waller,420,Lieutenant Governor,,LIB,Kerry Douglas McKennon,15,9,6
+Waller,420,"Presiding Judge, Court ofCriminal Appeals",,REP,Sharon Keller,672,490,182
+Waller,420,"Presiding Judge, Court ofCriminal Appeals",,DEM,Maria T. (Terri) Jackson,194,146,48
+Waller,420,"Presiding Judge, Court ofCriminal Appeals",,LIB,William Bryan Strange III,12,6,6
+Waller,420,Railroad Commissioner,,REP,Christi Craddick,688,504,184
+Waller,420,Railroad Commissioner,,DEM,Roman McAllen,172,128,44
+Waller,420,Railroad Commissioner,,LIB,Mike Wright,16,8,8
+Waller,420,State Representative,3,REP,Cecil Bell Jr,681,494,187
+Waller,420,State Representative,3,DEM,Lisa Seger,197,145,52
+Waller,420,Straight Party,,REP,Republican Party,535,393,142
+Waller,420,Straight Party,,DEM,Democratic Party,122,92,30
+Waller,420,Straight Party,,LIB,Libertarian Party,1,1,0
+Waller,420,U.S. House,10,REP,Michael T. McCaul,683,500,183
+Waller,420,U.S. House,10,DEM,Mike Siegel,194,141,53
+Waller,420,U.S. House,10,LIB,Mike Ryan,8,4,4
+Waller,420,U.S. Senate,,REP,Ted Cruz,665,489,176
+Waller,420,U.S. Senate,,DEM,Beto O'Rourke,212,152,60
+Waller,420,U.S. Senate,,LIB,Neal M. Dikeman,9,5,4
+Waller,311 - R,Registered Voters,,,,125,,
+Waller,311 - R,Attorney General,,REP,Ken Paxton,43,29,14
+Waller,311 - R,Attorney General,,DEM,Justin Nelson,11,10,1
+Waller,311 - R,Attorney General,,LIB,Michael Ray Harris,3,1,2
+Waller,311 - R,Commissioner of Agriculture,,REP,Sid Miller,43,29,14
+Waller,311 - R,Commissioner of Agriculture,,DEM,Kim Olson,12,10,2
+Waller,311 - R,Commissioner of Agriculture,,LIB,Richard Carpenter,1,1,0
+Waller,311 - R,Commissioner of the GeneralLand Office,,REP,George P. Bush,43,29,14
+Waller,311 - R,Commissioner of the GeneralLand Office,,DEM,Miguel Suazo,10,9,1
+Waller,311 - R,Commissioner of the GeneralLand Office,,LIB,Matt Piña,4,2,2
+Waller,311 - R,Comptroller of Public Accounts,,REP,Glenn Hegar,46,30,16
+Waller,311 - R,Comptroller of Public Accounts,,DEM,Joi Chevalier,11,10,1
+Waller,311 - R,Comptroller of Public Accounts,,LIB,Ben Sanders,1,0,1
+Waller,311 - R,County Clerk,,REP,Debbie Hollan,46,31,15
+Waller,311 - R,County Clerk,,DEM,Shari Griswold,11,9,2
+Waller,311 - R,County Judge,,REP,Trey Duhon,46,32,14
+Waller,311 - R,County Judge,,DEM,Denise Mattox,9,7,2
+Waller,311 - R,County Treasurer,,REP,Joan Sargent,46,31,15
+Waller,311 - R,County Treasurer,,DEM,Tammie Lilly,10,9,1
+Waller,311 - R,Criminal District Attorney Waller County,,REP,"Elton Raymond Mathis, Jr.",47,32,15
+Waller,311 - R,District Clerk,,REP,Liz Pirkle,50,33,17
+Waller,311 - R,Governor,,REP,Greg Abbott,48,31,17
+Waller,311 - R,Governor,,DEM,Lupe Valdez,9,8,1
+Waller,311 - R,Governor,,LIB,Mark Jay Tippetts,1,1,0
+Waller,311 - R,"Judge, County Court-at-Law",,REP,Carol Chaney,49,33,16
+Waller,311 - R,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,45,30,15
+Waller,311 - R,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,11,10,1
+Waller,311 - R,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,45,30,15
+Waller,311 - R,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,8,7,1
+Waller,311 - R,"Justice of the Peace, Precinct 3",,REP,Brian Davis,49,33,16
+Waller,311 - R,"Justice of the Peace, Precinct 3",,DEM,Marian Elaine Jackson,8,7,1
+Waller,311 - R,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,44,29,15
+Waller,311 - R,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,12,11,1
+Waller,311 - R,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,47,32,15
+Waller,311 - R,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,9,8,1
+Waller,311 - R,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,46,31,15
+Waller,311 - R,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,10,9,1
+Waller,311 - R,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,45,30,15
+Waller,311 - R,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,11,10,1
+Waller,311 - R,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,44,29,15
+Waller,311 - R,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",11,10,1
+Waller,311 - R,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,45,30,15
+Waller,311 - R,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,11,10,1
+Waller,311 - R,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,44,29,15
+Waller,311 - R,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,12,11,1
+Waller,311 - R,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,44,30,14
+Waller,311 - R,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,12,10,2
+Waller,311 - R,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,45,30,15
+Waller,311 - R,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,11,10,1
+Waller,311 - R,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,45,30,15
+Waller,311 - R,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,11,10,1
+Waller,311 - R,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,44,29,15
+Waller,311 - R,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,13,11,2
+Waller,311 - R,"Justice, Supreme Court, Place 4",,REP,John Devine,46,30,16
+Waller,311 - R,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,11,10,1
+Waller,311 - R,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,44,29,15
+Waller,311 - R,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,12,11,1
+Waller,311 - R,Lieutenant Governor,,REP,Dan Patrick,45,29,16
+Waller,311 - R,Lieutenant Governor,,DEM,Mike Collier,11,10,1
+Waller,311 - R,Lieutenant Governor,,LIB,Kerry Douglas McKennon,2,1,1
+Waller,311 - R,"Presiding Judge, Court ofCriminal Appeals",,REP,Sharon Keller,45,30,15
+Waller,311 - R,"Presiding Judge, Court ofCriminal Appeals",,DEM,Maria T. (Terri) Jackson,10,9,1
+Waller,311 - R,"Presiding Judge, Court ofCriminal Appeals",,LIB,William Bryan Strange III,1,1,0
+Waller,311 - R,Railroad Commissioner,,REP,Christi Craddick,45,30,15
+Waller,311 - R,Railroad Commissioner,,DEM,Roman McAllen,10,9,1
+Waller,311 - R,Railroad Commissioner,,LIB,Mike Wright,2,1,1
+Waller,311 - R,State Representative,3,REP,Cecil Bell Jr,45,30,15
+Waller,311 - R,State Representative,3,DEM,Lisa Seger,13,10,3
+Waller,311 - R,Straight Party,,REP,Republican Party,30,19,11
+Waller,311 - R,Straight Party,,DEM,Democratic Party,9,8,1
+Waller,311 - R,Straight Party,,LIB,Libertarian Party,1,0,1
+Waller,311 - R,"Trustee, Position 1",,,Darrell Fountain,23,15,8
+Waller,311 - R,"Trustee, Position 1",,,Joseph Campos,19,13,6
+Waller,311 - R,"Trustee, Position 2",,,Adrian Rocha,19,13,6
+Waller,311 - R,"Trustee, Position 2",,,Cheri Fontenot,21,16,5
+Waller,311 - R,"Trustee, Position 3",,,Mike Glover,18,11,7
+Waller,311 - R,"Trustee, Position 3",,,Scott Hartman,26,20,6
+Waller,311 - R,"Trustee, Position 4",,,"Nathaniel Richardson, Jr.",22,18,4
+Waller,311 - R,"Trustee, Position 4",,,Angie Ibarra,19,11,8
+Waller,311 - R,U.S. House,10,REP,Michael T. McCaul,45,30,15
+Waller,311 - R,U.S. House,10,DEM,Mike Siegel,10,9,1
+Waller,311 - R,U.S. House,10,LIB,Mike Ryan,3,1,2
+Waller,311 - R,U.S. Senate,,REP,Ted Cruz,44,29,15
+Waller,311 - R,U.S. Senate,,DEM,Beto O'Rourke,11,10,1
+Waller,311 - R,U.S. Senate,,LIB,Neal M. Dikeman,3,1,2
+Waller,313 R,Registered Voters,,,,628,,
+Waller,313 R,Attorney General,,REP,Ken Paxton,189,124,65
+Waller,313 R,Attorney General,,DEM,Justin Nelson,95,63,32
+Waller,313 R,Attorney General,,LIB,Michael Ray Harris,7,1,6
+Waller,313 R,Commissioner of Agriculture,,REP,Sid Miller,185,121,64
+Waller,313 R,Commissioner of Agriculture,,DEM,Kim Olson,95,63,32
+Waller,313 R,Commissioner of Agriculture,,LIB,Richard Carpenter,8,2,6
+Waller,313 R,Commissioner of the GeneralLand Office,,REP,George P. Bush,186,121,65
+Waller,313 R,Commissioner of the GeneralLand Office,,DEM,Miguel Suazo,91,61,30
+Waller,313 R,Commissioner of the GeneralLand Office,,LIB,Matt Piña,11,4,7
+Waller,313 R,Comptroller of Public Accounts,,REP,Glenn Hegar,187,124,63
+Waller,313 R,Comptroller of Public Accounts,,DEM,Joi Chevalier,89,58,31
+Waller,313 R,Comptroller of Public Accounts,,LIB,Ben Sanders,12,4,8
+Waller,313 R,County Clerk,,REP,Debbie Hollan,195,127,68
+Waller,313 R,County Clerk,,DEM,Shari Griswold,93,59,34
+Waller,313 R,County Judge,,REP,Trey Duhon,197,128,69
+Waller,313 R,County Judge,,DEM,Denise Mattox,91,58,33
+Waller,313 R,County Treasurer,,REP,Joan Sargent,196,127,69
+Waller,313 R,County Treasurer,,DEM,Tammie Lilly,91,59,32
+Waller,313 R,Criminal District Attorney Waller County,,REP,"Elton Raymond Mathis, Jr.",219,139,80
+Waller,313 R,District Clerk,,REP,Liz Pirkle,217,139,78
+Waller,313 R,Governor,,REP,Greg Abbott,194,126,68
+Waller,313 R,Governor,,DEM,Lupe Valdez,94,61,33
+Waller,313 R,Governor,,LIB,Mark Jay Tippetts,4,1,3
+Waller,313 R,"Judge, County Court-at-Law",,REP,Carol Chaney,219,139,80
+Waller,313 R,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,194,126,68
+Waller,313 R,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,94,60,34
+Waller,313 R,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,200,133,67
+Waller,313 R,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,53,31,22
+Waller,313 R,"Justice of the Peace, Precinct 3",,REP,Brian Davis,200,129,71
+Waller,313 R,"Justice of the Peace, Precinct 3",,DEM,Marian Elaine Jackson,88,57,31
+Waller,313 R,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,196,127,69
+Waller,313 R,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,91,58,33
+Waller,313 R,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,196,127,69
+Waller,313 R,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,91,58,33
+Waller,313 R,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,197,127,70
+Waller,313 R,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,91,59,32
+Waller,313 R,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,195,126,69
+Waller,313 R,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,93,60,33
+Waller,313 R,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,195,126,69
+Waller,313 R,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",93,60,33
+Waller,313 R,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,196,126,70
+Waller,313 R,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,92,60,32
+Waller,313 R,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,195,125,70
+Waller,313 R,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,93,61,32
+Waller,313 R,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,193,124,69
+Waller,313 R,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,95,62,33
+Waller,313 R,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,194,125,69
+Waller,313 R,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,93,60,33
+Waller,313 R,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,197,127,70
+Waller,313 R,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,91,59,32
+Waller,313 R,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,195,126,69
+Waller,313 R,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,93,60,33
+Waller,313 R,"Justice, Supreme Court, Place 4",,REP,John Devine,196,127,69
+Waller,313 R,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,92,59,33
+Waller,313 R,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,192,124,68
+Waller,313 R,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,95,62,33
+Waller,313 R,Lieutenant Governor,,REP,Dan Patrick,194,127,67
+Waller,313 R,Lieutenant Governor,,DEM,Mike Collier,92,60,32
+Waller,313 R,Lieutenant Governor,,LIB,Kerry Douglas McKennon,6,1,5
+Waller,313 R,"Presiding Judge, Court ofCriminal Appeals",,REP,Sharon Keller,189,127,62
+Waller,313 R,"Presiding Judge, Court ofCriminal Appeals",,DEM,Maria T. (Terri) Jackson,91,58,33
+Waller,313 R,"Presiding Judge, Court ofCriminal Appeals",,LIB,William Bryan Strange III,8,1,7
+Waller,313 R,Railroad Commissioner,,REP,Christi Craddick,192,129,63
+Waller,313 R,Railroad Commissioner,,DEM,Roman McAllen,90,57,33
+Waller,313 R,Railroad Commissioner,,LIB,Mike Wright,8,1,7
+Waller,313 R,State Representative,3,REP,Cecil Bell Jr,195,127,68
+Waller,313 R,State Representative,3,DEM,Lisa Seger,94,59,35
+Waller,313 R,Straight Party,,REP,Republican Party,151,98,53
+Waller,313 R,Straight Party,,DEM,Democratic Party,71,47,24
+Waller,313 R,Straight Party,,LIB,Libertarian Party,2,0,2
+Waller,313 R,"Trustee, Position 1",,,Darrell Fountain,100,59,41
+Waller,313 R,"Trustee, Position 1",,,Joseph Campos,99,60,39
+Waller,313 R,"Trustee, Position 2",,,Adrian Rocha,96,56,40
+Waller,313 R,"Trustee, Position 2",,,Cheri Fontenot,113,71,42
+Waller,313 R,"Trustee, Position 3",,,Mike Glover,104,64,40
+Waller,313 R,"Trustee, Position 3",,,Scott Hartman,99,57,42
+Waller,313 R,"Trustee, Position 4",,,"Nathaniel Richardson, Jr.",120,73,47
+Waller,313 R,"Trustee, Position 4",,,Angie Ibarra,87,50,37
+Waller,313 R,U.S. House,10,REP,Michael T. McCaul,189,125,64
+Waller,313 R,U.S. House,10,DEM,Mike Siegel,92,61,31
+Waller,313 R,U.S. House,10,LIB,Mike Ryan,8,1,7
+Waller,313 R,U.S. Senate,,REP,Ted Cruz,193,125,68
+Waller,313 R,U.S. Senate,,DEM,Beto O'Rourke,94,61,33
+Waller,313 R,U.S. Senate,,LIB,Neal M. Dikeman,3,1,2
+Waller,414 R,Registered Voters,,,,358,,
+Waller,414 R,Attorney General,,REP,Ken Paxton,89,57,32
+Waller,414 R,Attorney General,,DEM,Justin Nelson,113,56,57
+Waller,414 R,Attorney General,,LIB,Michael Ray Harris,1,0,1
+Waller,414 R,Commissioner of Agriculture,,REP,Sid Miller,90,58,32
+Waller,414 R,Commissioner of Agriculture,,DEM,Kim Olson,113,56,57
+Waller,414 R,Commissioner of Agriculture,,LIB,Richard Carpenter,2,1,1
+Waller,414 R,Commissioner of the GeneralLand Office,,REP,George P. Bush,86,52,34
+Waller,414 R,Commissioner of the GeneralLand Office,,DEM,Miguel Suazo,110,56,54
+Waller,414 R,Commissioner of the GeneralLand Office,,LIB,Matt Piña,4,2,2
+Waller,414 R,Comptroller of Public Accounts,,REP,Glenn Hegar,94,58,36
+Waller,414 R,Comptroller of Public Accounts,,DEM,Joi Chevalier,107,54,53
+Waller,414 R,Comptroller of Public Accounts,,LIB,Ben Sanders,2,1,1
+Waller,414 R,County Clerk,,REP,Debbie Hollan,92,56,36
+Waller,414 R,County Clerk,,DEM,Shari Griswold,109,56,53
+Waller,414 R,"County Commissioner,Precinct 4",,REP,Justin Beckendorff,104,65,39
+Waller,414 R,"County Commissioner,Precinct 4",,,Ethel Wilmore,20,9,11
+Waller,414 R,"County Commissioner,Precinct 4",,,Rejected write-ins,0,0,0
+Waller,414 R,"County Commissioner,Precinct 4",,,Unassigned write-ins,0,0,0
+Waller,414 R,County Judge,,REP,Trey Duhon,89,55,34
+Waller,414 R,County Judge,,DEM,Denise Mattox,114,58,56
+Waller,414 R,County Treasurer,,REP,Joan Sargent,91,57,34
+Waller,414 R,County Treasurer,,DEM,Tammie Lilly,111,55,56
+Waller,414 R,Criminal District Attorney Waller County,,REP,"Elton Raymond Mathis, Jr.",104,65,39
+Waller,414 R,District Clerk,,REP,Liz Pirkle,106,66,40
+Waller,414 R,Governor,,REP,Greg Abbott,99,59,40
+Waller,414 R,Governor,,DEM,Lupe Valdez,105,55,50
+Waller,414 R,Governor,,LIB,Mark Jay Tippetts,0,0,0
+Waller,414 R,"Judge, County Court-at-Law",,REP,Carol Chaney,106,66,40
+Waller,414 R,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,91,58,33
+Waller,414 R,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,110,54,56
+Waller,414 R,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,100,62,38
+Waller,414 R,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,45,26,19
+Waller,414 R,"Justice of the Peace, Precinct 4",,REP,Ted Krenek,102,61,41
+Waller,414 R,"Justice of the Peace, Precinct 4",,DEM,Jennifer Sheedy,101,53,48
+Waller,414 R,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,93,57,36
+Waller,414 R,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,108,55,53
+Waller,414 R,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,93,56,37
+Waller,414 R,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,107,55,52
+Waller,414 R,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,91,55,36
+Waller,414 R,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,108,55,53
+Waller,414 R,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,91,55,36
+Waller,414 R,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,108,55,53
+Waller,414 R,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,91,56,35
+Waller,414 R,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",109,55,54
+Waller,414 R,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,94,58,36
+Waller,414 R,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,106,53,53
+Waller,414 R,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,93,57,36
+Waller,414 R,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,108,55,53
+Waller,414 R,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,91,56,35
+Waller,414 R,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,110,56,54
+Waller,414 R,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,88,55,33
+Waller,414 R,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,113,57,56
+Waller,414 R,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,94,57,37
+Waller,414 R,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,107,55,52
+Waller,414 R,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,90,56,34
+Waller,414 R,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,112,56,56
+Waller,414 R,"Justice, Supreme Court, Place 4",,REP,John Devine,92,56,36
+Waller,414 R,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,110,56,54
+Waller,414 R,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,92,57,35
+Waller,414 R,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,110,55,55
+Waller,414 R,Lieutenant Governor,,REP,Dan Patrick,91,58,33
+Waller,414 R,Lieutenant Governor,,DEM,Mike Collier,112,55,57
+Waller,414 R,Lieutenant Governor,,LIB,Kerry Douglas McKennon,2,2,0
+Waller,414 R,"Presiding Judge, Court ofCriminal Appeals",,REP,Sharon Keller,91,57,34
+Waller,414 R,"Presiding Judge, Court ofCriminal Appeals",,DEM,Maria T. (Terri) Jackson,110,55,55
+Waller,414 R,"Presiding Judge, Court ofCriminal Appeals",,LIB,William Bryan Strange III,2,1,1
+Waller,414 R,Railroad Commissioner,,REP,Christi Craddick,93,59,34
+Waller,414 R,Railroad Commissioner,,DEM,Roman McAllen,108,54,54
+Waller,414 R,Railroad Commissioner,,LIB,Mike Wright,2,0,2
+Waller,414 R,State Representative,3,REP,Cecil Bell Jr,92,57,35
+Waller,414 R,State Representative,3,DEM,Lisa Seger,109,56,53
+Waller,414 R,Straight Party,,REP,Republican Party,65,40,25
+Waller,414 R,Straight Party,,DEM,Democratic Party,92,44,48
+Waller,414 R,Straight Party,,LIB,Libertarian Party,1,0,1
+Waller,414 R,"Trustee, Position 1",,,Darrell Fountain,68,25,43
+Waller,414 R,"Trustee, Position 1",,,Joseph Campos,87,61,26
+Waller,414 R,"Trustee, Position 2",,,Adrian Rocha,78,38,40
+Waller,414 R,"Trustee, Position 2",,,Cheri Fontenot,75,47,28
+Waller,414 R,"Trustee, Position 3",,,Mike Glover,91,40,51
+Waller,414 R,"Trustee, Position 3",,,Scott Hartman,81,53,28
+Waller,414 R,"Trustee, Position 4",,,"Nathaniel Richardson, Jr.",105,50,55
+Waller,414 R,"Trustee, Position 4",,,Angie Ibarra,66,42,24
+Waller,414 R,U.S. House,10,REP,Michael T. McCaul,89,56,33
+Waller,414 R,U.S. House,10,DEM,Mike Siegel,112,56,56
+Waller,414 R,U.S. House,10,LIB,Mike Ryan,3,2,1
+Waller,414 R,U.S. Senate,,REP,Ted Cruz,94,58,36
+Waller,414 R,U.S. Senate,,DEM,Beto O'Rourke,112,58,54
+Waller,414 R,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0
+Waller,415 R,Registered Voters,,,,1353,,
+Waller,415 R,Attorney General,,REP,Ken Paxton,597,424,173
+Waller,415 R,Attorney General,,DEM,Justin Nelson,216,156,60
+Waller,415 R,Attorney General,,LIB,Michael Ray Harris,28,15,13
+Waller,415 R,Commissioner of Agriculture,,REP,Sid Miller,609,442,167
+Waller,415 R,Commissioner of Agriculture,,DEM,Kim Olson,205,139,66
+Waller,415 R,Commissioner of Agriculture,,LIB,Richard Carpenter,23,12,11
+Waller,415 R,Commissioner of the GeneralLand Office,,REP,George P. Bush,594,423,171
+Waller,415 R,Commissioner of the GeneralLand Office,,DEM,Miguel Suazo,196,140,56
+Waller,415 R,Commissioner of the GeneralLand Office,,LIB,Matt Piña,49,30,19
+Waller,415 R,Comptroller of Public Accounts,,REP,Glenn Hegar,628,452,176
+Waller,415 R,Comptroller of Public Accounts,,DEM,Joi Chevalier,186,132,54
+Waller,415 R,Comptroller of Public Accounts,,LIB,Ben Sanders,27,12,15
+Waller,415 R,County Clerk,,REP,Debbie Hollan,633,453,180
+Waller,415 R,County Clerk,,DEM,Shari Griswold,201,136,65
+Waller,415 R,"County Commissioner,Precinct 4",,REP,Justin Beckendorff,674,469,205
+Waller,415 R,"County Commissioner,Precinct 4",,,Ethel Wilmore,31,29,2
+Waller,415 R,"County Commissioner,Precinct 4",,,Rejected write-ins,5,4,1
+Waller,415 R,"County Commissioner,Precinct 4",,,Unassigned write-ins,0,0,0
+Waller,415 R,County Judge,,REP,Trey Duhon,599,429,170
+Waller,415 R,County Judge,,DEM,Denise Mattox,222,152,70
+Waller,415 R,County Treasurer,,REP,Joan Sargent,633,457,176
+Waller,415 R,County Treasurer,,DEM,Tammie Lilly,196,132,64
+Waller,415 R,Criminal District Attorney Waller County,,REP,"Elton Raymond Mathis, Jr.",674,472,202
+Waller,415 R,District Clerk,,REP,Liz Pirkle,680,476,204
+Waller,415 R,Governor,,REP,Greg Abbott,646,463,183
+Waller,415 R,Governor,,DEM,Lupe Valdez,187,128,59
+Waller,415 R,Governor,,LIB,Mark Jay Tippetts,16,8,8
+Waller,415 R,"Judge, County Court-at-Law",,REP,Carol Chaney,681,474,207
+Waller,415 R,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,634,452,182
+Waller,415 R,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,198,137,61
+Waller,415 R,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,648,464,184
+Waller,415 R,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,108,72,36
+Waller,415 R,"Justice of the Peace, Precinct 4",,REP,Ted Krenek,666,478,188
+Waller,415 R,"Justice of the Peace, Precinct 4",,DEM,Jennifer Sheedy,171,116,55
+Waller,415 R,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,625,447,178
+Waller,415 R,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,202,139,63
+Waller,415 R,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,629,449,180
+Waller,415 R,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,196,136,60
+Waller,415 R,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,621,445,176
+Waller,415 R,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,205,141,64
+Waller,415 R,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,618,442,176
+Waller,415 R,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,207,142,65
+Waller,415 R,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,622,446,176
+Waller,415 R,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",206,141,65
+Waller,415 R,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,625,447,178
+Waller,415 R,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,202,139,63
+Waller,415 R,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,624,446,178
+Waller,415 R,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,205,142,63
+Waller,415 R,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,623,447,176
+Waller,415 R,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,205,140,65
+Waller,415 R,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,624,444,180
+Waller,415 R,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,204,142,62
+Waller,415 R,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,625,446,179
+Waller,415 R,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,202,139,63
+Waller,415 R,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,626,443,183
+Waller,415 R,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,204,143,61
+Waller,415 R,"Justice, Supreme Court, Place 4",,REP,John Devine,624,446,178
+Waller,415 R,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,202,139,63
+Waller,415 R,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,628,448,180
+Waller,415 R,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,203,140,63
+Waller,415 R,Lieutenant Governor,,REP,Dan Patrick,599,428,171
+Waller,415 R,Lieutenant Governor,,DEM,Mike Collier,218,154,64
+Waller,415 R,Lieutenant Governor,,LIB,Kerry Douglas McKennon,27,14,13
+Waller,415 R,"Presiding Judge, Court ofCriminal Appeals",,REP,Sharon Keller,609,439,170
+Waller,415 R,"Presiding Judge, Court ofCriminal Appeals",,DEM,Maria T. (Terri) Jackson,198,138,60
+Waller,415 R,"Presiding Judge, Court ofCriminal Appeals",,LIB,William Bryan Strange III,26,12,14
+Waller,415 R,Railroad Commissioner,,REP,Christi Craddick,618,445,173
+Waller,415 R,Railroad Commissioner,,DEM,Roman McAllen,190,135,55
+Waller,415 R,Railroad Commissioner,,LIB,Mike Wright,26,11,15
+Waller,415 R,State Representative,3,REP,Cecil Bell Jr,620,443,177
+Waller,415 R,State Representative,3,DEM,Lisa Seger,212,146,66
+Waller,415 R,Straight Party,,REP,Republican Party,410,295,115
+Waller,415 R,Straight Party,,DEM,Democratic Party,138,93,45
+Waller,415 R,Straight Party,,LIB,Libertarian Party,6,2,4
+Waller,415 R,"Trustee, Position 1",,,Darrell Fountain,248,180,68
+Waller,415 R,"Trustee, Position 1",,,Joseph Campos,385,263,122
+Waller,415 R,"Trustee, Position 2",,,Adrian Rocha,239,166,73
+Waller,415 R,"Trustee, Position 2",,,Cheri Fontenot,394,280,114
+Waller,415 R,"Trustee, Position 3",,,Mike Glover,226,153,73
+Waller,415 R,"Trustee, Position 3",,,Scott Hartman,420,301,119
+Waller,415 R,"Trustee, Position 4",,,"Nathaniel Richardson, Jr.",272,194,78
+Waller,415 R,"Trustee, Position 4",,,Angie Ibarra,386,267,119
+Waller,415 R,U.S. House,10,REP,Michael T. McCaul,619,445,174
+Waller,415 R,U.S. House,10,DEM,Mike Siegel,200,140,60
+Waller,415 R,U.S. House,10,LIB,Mike Ryan,21,11,10
+Waller,415 R,U.S. Senate,,REP,Ted Cruz,623,451,172
+Waller,415 R,U.S. Senate,,DEM,Beto O'Rourke,212,144,68
+Waller,415 R,U.S. Senate,,LIB,Neal M. Dikeman,9,3,6
+Waller,416 R,Registered Voters,,,,1541,,
+Waller,416 R,Attorney General,,REP,Ken Paxton,297,230,67
+Waller,416 R,Attorney General,,DEM,Justin Nelson,310,206,104
+Waller,416 R,Attorney General,,LIB,Michael Ray Harris,18,10,8
+Waller,416 R,Commissioner of Agriculture,,REP,Sid Miller,286,219,67
+Waller,416 R,Commissioner of Agriculture,,DEM,Kim Olson,320,218,102
+Waller,416 R,Commissioner of Agriculture,,LIB,Richard Carpenter,18,9,9
+Waller,416 R,Commissioner of the GeneralLand Office,,REP,George P. Bush,302,230,72
+Waller,416 R,Commissioner of the GeneralLand Office,,DEM,Miguel Suazo,301,202,99
+Waller,416 R,Commissioner of the GeneralLand Office,,LIB,Matt Piña,21,13,8
+Waller,416 R,Comptroller of Public Accounts,,REP,Glenn Hegar,309,239,70
+Waller,416 R,Comptroller of Public Accounts,,DEM,Joi Chevalier,294,195,99
+Waller,416 R,Comptroller of Public Accounts,,LIB,Ben Sanders,21,12,9
+Waller,416 R,County Clerk,,REP,Debbie Hollan,313,240,73
+Waller,416 R,County Clerk,,DEM,Shari Griswold,310,207,103
+Waller,416 R,"County Commissioner,Precinct 4",,REP,Justin Beckendorff,373,279,94
+Waller,416 R,"County Commissioner,Precinct 4",,,Ethel Wilmore,45,34,11
+Waller,416 R,"County Commissioner,Precinct 4",,,Rejected write-ins,2,2,0
+Waller,416 R,"County Commissioner,Precinct 4",,,Unassigned write-ins,0,0,0
+Waller,416 R,County Judge,,REP,Trey Duhon,308,236,72
+Waller,416 R,County Judge,,DEM,Denise Mattox,314,210,104
+Waller,416 R,County Treasurer,,REP,Joan Sargent,312,238,74
+Waller,416 R,County Treasurer,,DEM,Tammie Lilly,311,209,102
+Waller,416 R,Criminal District Attorney Waller County,,REP,"Elton Raymond Mathis, Jr.",373,271,102
+Waller,416 R,District Clerk,,REP,Liz Pirkle,372,273,99
+Waller,416 R,Governor,,REP,Greg Abbott,315,241,74
+Waller,416 R,Governor,,DEM,Lupe Valdez,303,203,100
+Waller,416 R,Governor,,LIB,Mark Jay Tippetts,12,6,6
+Waller,416 R,"Judge, County Court-at-Law",,REP,Carol Chaney,378,275,103
+Waller,416 R,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,307,235,72
+Waller,416 R,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,313,210,103
+Waller,416 R,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,335,251,84
+Waller,416 R,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,161,107,54
+Waller,416 R,"Justice of the Peace, Precinct 4",,REP,Ted Krenek,334,256,78
+Waller,416 R,"Justice of the Peace, Precinct 4",,DEM,Jennifer Sheedy,291,194,97
+Waller,416 R,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,309,236,73
+Waller,416 R,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,311,209,102
+Waller,416 R,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,311,238,73
+Waller,416 R,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,309,207,102
+Waller,416 R,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,311,237,74
+Waller,416 R,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,308,206,102
+Waller,416 R,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,305,234,71
+Waller,416 R,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,315,210,105
+Waller,416 R,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,309,238,71
+Waller,416 R,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",312,207,105
+Waller,416 R,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,311,236,75
+Waller,416 R,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,309,209,100
+Waller,416 R,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,311,238,73
+Waller,416 R,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,310,207,103
+Waller,416 R,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,307,237,70
+Waller,416 R,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,314,208,106
+Waller,416 R,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,305,232,73
+Waller,416 R,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,316,213,103
+Waller,416 R,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,307,234,73
+Waller,416 R,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,311,209,102
+Waller,416 R,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,309,237,72
+Waller,416 R,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,315,210,105
+Waller,416 R,"Justice, Supreme Court, Place 4",,REP,John Devine,313,238,75
+Waller,416 R,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,311,209,102
+Waller,416 R,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,316,242,74
+Waller,416 R,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,306,204,102
+Waller,416 R,Lieutenant Governor,,REP,Dan Patrick,303,236,67
+Waller,416 R,Lieutenant Governor,,DEM,Mike Collier,310,205,105
+Waller,416 R,Lieutenant Governor,,LIB,Kerry Douglas McKennon,14,7,7
+Waller,416 R,"Presiding Judge, Court ofCriminal Appeals",,REP,Sharon Keller,299,229,70
+Waller,416 R,"Presiding Judge, Court ofCriminal Appeals",,DEM,Maria T. (Terri) Jackson,308,207,101
+Waller,416 R,"Presiding Judge, Court ofCriminal Appeals",,LIB,William Bryan Strange III,16,9,7
+Waller,416 R,Railroad Commissioner,,REP,Christi Craddick,304,234,70
+Waller,416 R,Railroad Commissioner,,DEM,Roman McAllen,302,202,100
+Waller,416 R,Railroad Commissioner,,LIB,Mike Wright,17,9,8
+Waller,416 R,State Representative,3,REP,Cecil Bell Jr,306,233,73
+Waller,416 R,State Representative,3,DEM,Lisa Seger,315,211,104
+Waller,416 R,Straight Party,,REP,Republican Party,222,175,47
+Waller,416 R,Straight Party,,DEM,Democratic Party,236,155,81
+Waller,416 R,Straight Party,,LIB,Libertarian Party,4,1,3
+Waller,416 R,"Trustee, Position 1",,,Darrell Fountain,199,147,52
+Waller,416 R,"Trustee, Position 1",,,Joseph Campos,271,177,94
+Waller,416 R,"Trustee, Position 2",,,Adrian Rocha,253,174,79
+Waller,416 R,"Trustee, Position 2",,,Cheri Fontenot,222,155,67
+Waller,416 R,"Trustee, Position 3",,,Mike Glover,284,190,94
+Waller,416 R,"Trustee, Position 3",,,Scott Hartman,194,142,52
+Waller,416 R,"Trustee, Position 4",,,"Nathaniel Richardson, Jr.",259,190,69
+Waller,416 R,"Trustee, Position 4",,,Angie Ibarra,238,158,80
+Waller,416 R,U.S. House,10,REP,Michael T. McCaul,304,235,69
+Waller,416 R,U.S. House,10,DEM,Mike Siegel,309,204,105
+Waller,416 R,U.S. House,10,LIB,Mike Ryan,12,6,6
+Waller,416 R,U.S. Senate,,REP,Ted Cruz,293,228,65
+Waller,416 R,U.S. Senate,,DEM,Beto O'Rourke,326,215,111
+Waller,416 R,U.S. Senate,,LIB,Neal M. Dikeman,10,5,5
+Waller,417 R,Registered Voters,,,,1308,,
+Waller,417 R,Attorney General,,REP,Ken Paxton,176,128,48
+Waller,417 R,Attorney General,,DEM,Justin Nelson,353,225,128
+Waller,417 R,Attorney General,,LIB,Michael Ray Harris,7,4,3
+Waller,417 R,Commissioner of Agriculture,,REP,Sid Miller,174,130,44
+Waller,417 R,Commissioner of Agriculture,,DEM,Kim Olson,359,230,129
+Waller,417 R,Commissioner of Agriculture,,LIB,Richard Carpenter,4,0,4
+Waller,417 R,Commissioner of the GeneralLand Office,,REP,George P. Bush,183,133,50
+Waller,417 R,Commissioner of the GeneralLand Office,,DEM,Miguel Suazo,347,222,125
+Waller,417 R,Commissioner of the GeneralLand Office,,LIB,Matt Piña,6,3,3
+Waller,417 R,Comptroller of Public Accounts,,REP,Glenn Hegar,191,140,51
+Waller,417 R,Comptroller of Public Accounts,,DEM,Joi Chevalier,333,208,125
+Waller,417 R,Comptroller of Public Accounts,,LIB,Ben Sanders,11,9,2
+Waller,417 R,County Clerk,,REP,Debbie Hollan,174,127,47
+Waller,417 R,County Clerk,,DEM,Shari Griswold,360,230,130
+Waller,417 R,"County Commissioner,Precinct 4",,REP,Justin Beckendorff,245,176,69
+Waller,417 R,"County Commissioner,Precinct 4",,,Ethel Wilmore,55,41,14
+Waller,417 R,"County Commissioner,Precinct 4",,,Rejected write-ins,2,0,2
+Waller,417 R,"County Commissioner,Precinct 4",,,Unassigned write-ins,0,0,0
+Waller,417 R,County Judge,,REP,Trey Duhon,186,140,46
+Waller,417 R,County Judge,,DEM,Denise Mattox,350,220,130
+Waller,417 R,County Treasurer,,REP,Joan Sargent,176,131,45
+Waller,417 R,County Treasurer,,DEM,Tammie Lilly,356,224,132
+Waller,417 R,Criminal District Attorney Waller County,,REP,"Elton Raymond Mathis, Jr.",251,178,73
+Waller,417 R,District Clerk,,REP,Liz Pirkle,244,172,72
+Waller,417 R,Governor,,REP,Greg Abbott,200,146,54
+Waller,417 R,Governor,,DEM,Lupe Valdez,337,216,121
+Waller,417 R,Governor,,LIB,Mark Jay Tippetts,5,1,4
+Waller,417 R,"Judge, County Court-at-Law",,REP,Carol Chaney,249,173,76
+Waller,417 R,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,179,131,48
+Waller,417 R,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,353,224,129
+Waller,417 R,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,219,162,57
+Waller,417 R,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,162,97,65
+Waller,417 R,"Justice of the Peace, Precinct 4",,REP,Ted Krenek,208,155,53
+Waller,417 R,"Justice of the Peace, Precinct 4",,DEM,Jennifer Sheedy,331,207,124
+Waller,417 R,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,181,131,50
+Waller,417 R,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,352,224,128
+Waller,417 R,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,181,131,50
+Waller,417 R,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,353,225,128
+Waller,417 R,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,182,131,51
+Waller,417 R,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,351,224,127
+Waller,417 R,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,176,128,48
+Waller,417 R,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,356,226,130
+Waller,417 R,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,177,128,49
+Waller,417 R,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",356,227,129
+Waller,417 R,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,174,127,47
+Waller,417 R,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,360,229,131
+Waller,417 R,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,179,132,47
+Waller,417 R,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,352,223,129
+Waller,417 R,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,178,130,48
+Waller,417 R,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,355,226,129
+Waller,417 R,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,176,129,47
+Waller,417 R,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,356,226,130
+Waller,417 R,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,178,128,50
+Waller,417 R,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,356,228,128
+Waller,417 R,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,175,129,46
+Waller,417 R,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,357,226,131
+Waller,417 R,"Justice, Supreme Court, Place 4",,REP,John Devine,179,130,49
+Waller,417 R,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,352,225,127
+Waller,417 R,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,178,130,48
+Waller,417 R,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,354,226,128
+Waller,417 R,Lieutenant Governor,,REP,Dan Patrick,182,130,52
+Waller,417 R,Lieutenant Governor,,DEM,Mike Collier,351,227,124
+Waller,417 R,Lieutenant Governor,,LIB,Kerry Douglas McKennon,3,1,2
+Waller,417 R,"Presiding Judge, Court ofCriminal Appeals",,REP,Sharon Keller,171,124,47
+Waller,417 R,"Presiding Judge, Court ofCriminal Appeals",,DEM,Maria T. (Terri) Jackson,359,231,128
+Waller,417 R,"Presiding Judge, Court ofCriminal Appeals",,LIB,William Bryan Strange III,5,3,2
+Waller,417 R,Railroad Commissioner,,REP,Christi Craddick,178,131,47
+Waller,417 R,Railroad Commissioner,,DEM,Roman McAllen,352,225,127
+Waller,417 R,Railroad Commissioner,,LIB,Mike Wright,4,0,4
+Waller,417 R,State Representative,3,REP,Cecil Bell Jr,181,133,48
+Waller,417 R,State Representative,3,DEM,Lisa Seger,352,223,129
+Waller,417 R,Straight Party,,REP,Republican Party,124,90,34
+Waller,417 R,Straight Party,,DEM,Democratic Party,278,168,110
+Waller,417 R,Straight Party,,LIB,Libertarian Party,3,2,1
+Waller,417 R,"Trustee, Position 1",,,Darrell Fountain,201,129,72
+Waller,417 R,"Trustee, Position 1",,,Joseph Campos,258,173,85
+Waller,417 R,"Trustee, Position 2",,,Adrian Rocha,239,149,90
+Waller,417 R,"Trustee, Position 2",,,Cheri Fontenot,195,136,59
+Waller,417 R,"Trustee, Position 3",,,Mike Glover,317,205,112
+Waller,417 R,"Trustee, Position 3",,,Scott Hartman,145,100,45
+Waller,417 R,"Trustee, Position 4",,,"Nathaniel Richardson, Jr.",327,211,116
+Waller,417 R,"Trustee, Position 4",,,Angie Ibarra,146,103,43
+Waller,417 R,U.S. House,10,REP,Michael T. McCaul,176,126,50
+Waller,417 R,U.S. House,10,DEM,Mike Siegel,358,231,127
+Waller,417 R,U.S. House,10,LIB,Mike Ryan,3,2,1
+Waller,417 R,U.S. Senate,,REP,Ted Cruz,178,130,48
+Waller,417 R,U.S. Senate,,DEM,Beto O'Rourke,368,238,130
+Waller,417 R,U.S. Senate,,LIB,Neal M. Dikeman,1,0,1
+Waller,418 - R,Registered Voters,,,,131,,
+Waller,418 - R,Attorney General,,REP,Ken Paxton,18,11,7
+Waller,418 - R,Attorney General,,DEM,Justin Nelson,16,8,8
+Waller,418 - R,Attorney General,,LIB,Michael Ray Harris,0,0,0
+Waller,418 - R,Commissioner of Agriculture,,REP,Sid Miller,17,11,6
+Waller,418 - R,Commissioner of Agriculture,,DEM,Kim Olson,17,8,9
+Waller,418 - R,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0
+Waller,418 - R,Commissioner of the GeneralLand Office,,REP,George P. Bush,19,11,8
+Waller,418 - R,Commissioner of the GeneralLand Office,,DEM,Miguel Suazo,15,8,7
+Waller,418 - R,Commissioner of the GeneralLand Office,,LIB,Matt Piña,0,0,0
+Waller,418 - R,Comptroller of Public Accounts,,REP,Glenn Hegar,20,11,9
+Waller,418 - R,Comptroller of Public Accounts,,DEM,Joi Chevalier,14,8,6
+Waller,418 - R,Comptroller of Public Accounts,,LIB,Ben Sanders,0,0,0
+Waller,418 - R,County Clerk,,REP,Debbie Hollan,19,11,8
+Waller,418 - R,County Clerk,,DEM,Shari Griswold,15,8,7
+Waller,418 - R,"County Commissioner,Precinct 4",,REP,Justin Beckendorff,24,13,11
+Waller,418 - R,"County Commissioner,Precinct 4",,,Ethel Wilmore,0,0,0
+Waller,418 - R,"County Commissioner,Precinct 4",,,Rejected write-ins,0,0,0
+Waller,418 - R,"County Commissioner,Precinct 4",,,Unassigned write-ins,0,0,0
+Waller,418 - R,County Judge,,REP,Trey Duhon,17,11,6
+Waller,418 - R,County Judge,,DEM,Denise Mattox,17,8,9
+Waller,418 - R,County Treasurer,,REP,Joan Sargent,21,12,9
+Waller,418 - R,County Treasurer,,DEM,Tammie Lilly,13,7,6
+Waller,418 - R,Criminal District Attorney Waller County,,REP,"Elton Raymond Mathis, Jr.",22,11,11
+Waller,418 - R,District Clerk,,REP,Liz Pirkle,21,11,10
+Waller,418 - R,Governor,,REP,Greg Abbott,19,11,8
+Waller,418 - R,Governor,,DEM,Lupe Valdez,15,8,7
+Waller,418 - R,Governor,,LIB,Mark Jay Tippetts,0,0,0
+Waller,418 - R,"Judge, County Court-at-Law",,REP,Carol Chaney,22,12,10
+Waller,418 - R,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,21,12,9
+Waller,418 - R,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,13,7,6
+Waller,418 - R,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,21,11,10
+Waller,418 - R,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,7,5,2
+Waller,418 - R,"Justice of the Peace, Precinct 4",,REP,Ted Krenek,21,11,10
+Waller,418 - R,"Justice of the Peace, Precinct 4",,DEM,Jennifer Sheedy,12,7,5
+Waller,418 - R,"Justice, 14th Court of Appeals District, Place 3",,REP,Brett Busby,21,12,9
+Waller,418 - R,"Justice, 14th Court of Appeals District, Place 3",,DEM,Jerry Zimmerer,13,7,6
+Waller,418 - R,"Justice, 14th Court of Appeals District, Place 4",,REP,Marc Brown,21,12,9
+Waller,418 - R,"Justice, 14th Court of Appeals District, Place 4",,DEM,Charles Spain,13,7,6
+Waller,418 - R,"Justice, 14th Court of Appeals District, Place 5",,REP,Martha Hill Jamison,19,11,8
+Waller,418 - R,"Justice, 14th Court of Appeals District, Place 5",,DEM,Frances Bourliot,15,8,7
+Waller,418 - R,"Justice, 14th Court of Appeals District, Place 6",,REP,Bill Boyce,20,11,9
+Waller,418 - R,"Justice, 14th Court of Appeals District, Place 6",,DEM,Meagan Hassan,14,8,6
+Waller,418 - R,"Justice, 14th Court of Appeals District, Place 8",,REP,John Donovan,21,12,9
+Waller,418 - R,"Justice, 14th Court of Appeals District, Place 8",,DEM,"Margaret ""Meg"" Poissant",13,7,6
+Waller,418 - R,"Justice, 1st Court of Appeals District, Place 2",,REP,Jane Bland,20,12,8
+Waller,418 - R,"Justice, 1st Court of Appeals District, Place 2",,DEM,Gordon Goodman,14,7,7
+Waller,418 - R,"Justice, 1st Court of Appeals District, Place 6",,REP,Harvey Brown,20,11,9
+Waller,418 - R,"Justice, 1st Court of Appeals District, Place 6",,DEM,Sarah Beth Landau,14,8,6
+Waller,418 - R,"Justice, 1st Court of Appeals District, Place 7",,REP,Terry Yates,18,11,7
+Waller,418 - R,"Justice, 1st Court of Appeals District, Place 7",,DEM,Julie Countiss,16,8,8
+Waller,418 - R,"Justice, 1st Court of Appeals District, Place 8",,REP,Michael Massengale,19,11,8
+Waller,418 - R,"Justice, 1st Court of Appeals District, Place 8",,DEM,Richard Hightower,15,8,7
+Waller,418 - R,"Justice, 1st Court of Appeals District, Place 9",,REP,Jennifer Caughey,20,11,9
+Waller,418 - R,"Justice, 1st Court of Appeals District, Place 9",,DEM,Peter Kelly,14,8,6
+Waller,418 - R,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,20,11,9
+Waller,418 - R,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,14,8,6
+Waller,418 - R,"Justice, Supreme Court, Place 4",,REP,John Devine,19,11,8
+Waller,418 - R,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,15,8,7
+Waller,418 - R,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,20,12,8
+Waller,418 - R,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,14,7,7
+Waller,418 - R,Lieutenant Governor,,REP,Dan Patrick,19,11,8
+Waller,418 - R,Lieutenant Governor,,DEM,Mike Collier,15,8,7
+Waller,418 - R,Lieutenant Governor,,LIB,Kerry Douglas McKennon,0,0,0
+Waller,418 - R,"Presiding Judge, Court ofCriminal Appeals",,REP,Sharon Keller,20,11,9
+Waller,418 - R,"Presiding Judge, Court ofCriminal Appeals",,DEM,Maria T. (Terri) Jackson,14,8,6
+Waller,418 - R,"Presiding Judge, Court ofCriminal Appeals",,LIB,William Bryan Strange III,0,0,0
+Waller,418 - R,Railroad Commissioner,,REP,Christi Craddick,20,11,9
+Waller,418 - R,Railroad Commissioner,,DEM,Roman McAllen,14,8,6
+Waller,418 - R,Railroad Commissioner,,LIB,Mike Wright,0,0,0
+Waller,418 - R,State Representative,3,REP,Cecil Bell Jr,19,11,8
+Waller,418 - R,State Representative,3,DEM,Lisa Seger,15,8,7
+Waller,418 - R,Straight Party,,REP,Republican Party,13,10,3
+Waller,418 - R,Straight Party,,DEM,Democratic Party,11,6,5
+Waller,418 - R,Straight Party,,LIB,Libertarian Party,0,0,0
+Waller,418 - R,"Trustee, Position 1",,,Darrell Fountain,11,5,6
+Waller,418 - R,"Trustee, Position 1",,,Joseph Campos,13,6,7
+Waller,418 - R,"Trustee, Position 2",,,Adrian Rocha,16,9,7
+Waller,418 - R,"Trustee, Position 2",,,Cheri Fontenot,9,3,6
+Waller,418 - R,"Trustee, Position 3",,,Mike Glover,16,7,9
+Waller,418 - R,"Trustee, Position 3",,,Scott Hartman,6,3,3
+Waller,418 - R,"Trustee, Position 4",,,"Nathaniel Richardson, Jr.",9,5,4
+Waller,418 - R,"Trustee, Position 4",,,Angie Ibarra,14,5,9
+Waller,418 - R,U.S. House,10,REP,Michael T. McCaul,20,11,9
+Waller,418 - R,U.S. House,10,DEM,Mike Siegel,14,8,6
+Waller,418 - R,U.S. House,10,LIB,Mike Ryan,0,0,0
+Waller,418 - R,U.S. Senate,,REP,Ted Cruz,19,11,8
+Waller,418 - R,U.S. Senate,,DEM,Beto O'Rourke,16,9,7
+Waller,418 - R,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0


### PR DESCRIPTION
I would have preferred for the county to have the Verity precinct-level PDF available than what they gave, which is a spreadsheet reminiscent of Randall County's.