### PR TITLE
Add precinct-level results for the 2018 general election in Edwards County

### DIFF
--- a/2018/20181106__tx__general__edwards__precinct.csv
+++ b/2018/20181106__tx__general__edwards__precinct.csv
@@ -1,0 +1,488 @@
+county,precinct,office,district,party,candidate,votes,early_voting,election_day
+Edwards,1,REGISTERED VOTERS - TOTAL,,,REGISTERED VOTERS - TOTAL,281,,
+Edwards,2,REGISTERED VOTERS - TOTAL,,,REGISTERED VOTERS - TOTAL,436,,
+Edwards,3,REGISTERED VOTERS - TOTAL,,,REGISTERED VOTERS - TOTAL,391,,
+Edwards,4,REGISTERED VOTERS - TOTAL,,,REGISTERED VOTERS - TOTAL,348,,
+Edwards,1,BALLOTS CAST - TOTAL,,,BALLOTS CAST - TOTAL,101,71,30
+Edwards,2,BALLOTS CAST - TOTAL,,,BALLOTS CAST - TOTAL,274,135,139
+Edwards,3,BALLOTS CAST - TOTAL,,,BALLOTS CAST - TOTAL,228,173,55
+Edwards,4,BALLOTS CAST - TOTAL,,,BALLOTS CAST - TOTAL,166,116,50
+Edwards,1,Straight Party,,REP,Republican Party,35,28,7
+Edwards,2,Straight Party,,REP,Republican Party,124,62,62
+Edwards,3,Straight Party,,REP,Republican Party,99,80,19
+Edwards,4,Straight Party,,REP,Republican Party,65,48,17
+Edwards,1,Straight Party,,DEM,Democratic Party,15,7,8
+Edwards,2,Straight Party,,DEM,Democratic Party,14,4,10
+Edwards,3,Straight Party,,DEM,Democratic Party,17,7,10
+Edwards,4,Straight Party,,DEM,Democratic Party,19,11,8
+Edwards,1,Straight Party,,LIB,Libertarian Party,1,0,1
+Edwards,2,Straight Party,,LIB,Libertarian Party,2,1,1
+Edwards,3,Straight Party,,LIB,Libertarian Party,1,1,0
+Edwards,4,Straight Party,,LIB,Libertarian Party,1,1,0
+Edwards,1,Straight Party,,,OVER VOTES,0,0,0
+Edwards,2,Straight Party,,,OVER VOTES,0,0,0
+Edwards,3,Straight Party,,,OVER VOTES,0,0,0
+Edwards,4,Straight Party,,,OVER VOTES,0,0,0
+Edwards,1,Straight Party,,,UNDER VOTES,50,36,14
+Edwards,2,Straight Party,,,UNDER VOTES,132,67,65
+Edwards,3,Straight Party,,,UNDER VOTES,111,85,26
+Edwards,4,Straight Party,,,UNDER VOTES,81,56,25
+Edwards,1,U.S. Senate,,REP,Ted Cruz,67,55,12
+Edwards,2,U.S. Senate,,REP,Ted Cruz,240,124,116
+Edwards,3,U.S. Senate,,REP,Ted Cruz,187,148,39
+Edwards,4,U.S. Senate,,REP,Ted Cruz,110,87,23
+Edwards,1,U.S. Senate,,DEM,Beto O'Rourke,30,13,17
+Edwards,2,U.S. Senate,,DEM,Beto O'Rourke,29,9,20
+Edwards,3,U.S. Senate,,DEM,Beto O'Rourke,35,20,15
+Edwards,4,U.S. Senate,,DEM,Beto O'Rourke,51,25,26
+Edwards,1,U.S. Senate,,LIB,Neal M. Dikeman,1,1,0
+Edwards,2,U.S. Senate,,LIB,Neal M. Dikeman,3,1,2
+Edwards,3,U.S. Senate,,LIB,Neal M. Dikeman,3,2,1
+Edwards,4,U.S. Senate,,LIB,Neal M. Dikeman,1,1,0
+Edwards,1,U.S. Senate,,,OVER VOTES,1,1,0
+Edwards,2,U.S. Senate,,,OVER VOTES,0,0,0
+Edwards,3,U.S. Senate,,,OVER VOTES,0,0,0
+Edwards,4,U.S. Senate,,,OVER VOTES,0,0,0
+Edwards,1,U.S. Senate,,,UNDER VOTES,2,1,1
+Edwards,2,U.S. Senate,,,UNDER VOTES,2,1,1
+Edwards,3,U.S. Senate,,,UNDER VOTES,3,3,0
+Edwards,4,U.S. Senate,,,UNDER VOTES,4,3,1
+Edwards,1,U.S. House,23,REP,Will Hurd,67,54,13
+Edwards,2,U.S. House,23,REP,Will Hurd,238,125,113
+Edwards,3,U.S. House,23,REP,Will Hurd,187,148,39
+Edwards,4,U.S. House,23,REP,Will Hurd,109,84,25
+Edwards,1,U.S. House,23,DEM,Gina Ortiz Jones,32,17,15
+Edwards,2,U.S. House,23,DEM,Gina Ortiz Jones,30,9,21
+Edwards,3,U.S. House,23,DEM,Gina Ortiz Jones,34,20,14
+Edwards,4,U.S. House,23,DEM,Gina Ortiz Jones,48,25,23
+Edwards,1,U.S. House,23,LIB,Ruben Corvalan,0,0,0
+Edwards,2,U.S. House,23,LIB,Ruben Corvalan,4,0,4
+Edwards,3,U.S. House,23,LIB,Ruben Corvalan,4,3,1
+Edwards,4,U.S. House,23,LIB,Ruben Corvalan,3,3,0
+Edwards,1,U.S. House,23,,OVER VOTES,0,0,0
+Edwards,2,U.S. House,23,,OVER VOTES,0,0,0
+Edwards,3,U.S. House,23,,OVER VOTES,0,0,0
+Edwards,4,U.S. House,23,,OVER VOTES,0,0,0
+Edwards,1,U.S. House,23,,UNDER VOTES,2,0,2
+Edwards,2,U.S. House,23,,UNDER VOTES,2,1,1
+Edwards,3,U.S. House,23,,UNDER VOTES,3,2,1
+Edwards,4,U.S. House,23,,UNDER VOTES,6,4,2
+Edwards,1,Governor,,REP,Greg Abbott,74,60,14
+Edwards,2,Governor,,REP,Greg Abbott,245,125,120
+Edwards,3,Governor,,REP,Greg Abbott,199,157,42
+Edwards,4,Governor,,REP,Greg Abbott,117,89,28
+Edwards,1,Governor,,DEM,Lupe Valdez,21,10,11
+Edwards,2,Governor,,DEM,Lupe Valdez,21,5,16
+Edwards,3,Governor,,DEM,Lupe Valdez,23,13,10
+Edwards,4,Governor,,DEM,Lupe Valdez,35,21,14
+Edwards,1,Governor,,LIB,Mark Jay Tippetts,0,0,0
+Edwards,2,Governor,,LIB,Mark Jay Tippetts,4,1,3
+Edwards,3,Governor,,LIB,Mark Jay Tippetts,2,1,1
+Edwards,4,Governor,,LIB,Mark Jay Tippetts,1,1,0
+Edwards,1,Governor,,,OVER VOTES,0,0,0
+Edwards,2,Governor,,,OVER VOTES,0,0,0
+Edwards,3,Governor,,,OVER VOTES,0,0,0
+Edwards,4,Governor,,,OVER VOTES,0,0,0
+Edwards,1,Governor,,,UNDER VOTES,6,1,5
+Edwards,2,Governor,,,UNDER VOTES,4,4,0
+Edwards,3,Governor,,,UNDER VOTES,4,2,2
+Edwards,4,Governor,,,UNDER VOTES,13,5,8
+Edwards,1,Lieutenant Governor,,REP,Dan Patrick,68,58,10
+Edwards,2,Lieutenant Governor,,REP,Dan Patrick,235,121,114
+Edwards,3,Lieutenant Governor,,REP,Dan Patrick,182,144,38
+Edwards,4,Lieutenant Governor,,REP,Dan Patrick,111,85,26
+Edwards,1,Lieutenant Governor,,DEM,Mike Collier,25,10,15
+Edwards,2,Lieutenant Governor,,DEM,Mike Collier,28,9,19
+Edwards,3,Lieutenant Governor,,DEM,Mike Collier,30,18,12
+Edwards,4,Lieutenant Governor,,DEM,Mike Collier,33,20,13
+Edwards,1,Lieutenant Governor,,LIB,Kerry Douglas McKennon,1,0,1
+Edwards,2,Lieutenant Governor,,LIB,Kerry Douglas McKennon,6,1,5
+Edwards,3,Lieutenant Governor,,LIB,Kerry Douglas McKennon,5,4,1
+Edwards,4,Lieutenant Governor,,LIB,Kerry Douglas McKennon,2,2,0
+Edwards,1,Lieutenant Governor,,,OVER VOTES,0,0,0
+Edwards,2,Lieutenant Governor,,,OVER VOTES,0,0,0
+Edwards,3,Lieutenant Governor,,,OVER VOTES,0,0,0
+Edwards,4,Lieutenant Governor,,,OVER VOTES,0,0,0
+Edwards,1,Lieutenant Governor,,,UNDER VOTES,7,3,4
+Edwards,2,Lieutenant Governor,,,UNDER VOTES,5,4,1
+Edwards,3,Lieutenant Governor,,,UNDER VOTES,11,7,4
+Edwards,4,Lieutenant Governor,,,UNDER VOTES,20,9,11
+Edwards,1,Attorney General,,REP,Ken Paxton,66,55,11
+Edwards,2,Attorney General,,REP,Ken Paxton,236,119,117
+Edwards,3,Attorney General,,REP,Ken Paxton,178,143,35
+Edwards,4,Attorney General,,REP,Ken Paxton,108,84,24
+Edwards,1,Attorney General,,DEM,Justin Nelson,24,12,12
+Edwards,2,Attorney General,,DEM,Justin Nelson,27,10,17
+Edwards,3,Attorney General,,DEM,Justin Nelson,33,20,13
+Edwards,4,Attorney General,,DEM,Justin Nelson,37,22,15
+Edwards,1,Attorney General,,LIB,Michael Ray Harris,2,1,1
+Edwards,2,Attorney General,,LIB,Michael Ray Harris,5,1,4
+Edwards,3,Attorney General,,LIB,Michael Ray Harris,9,6,3
+Edwards,4,Attorney General,,LIB,Michael Ray Harris,1,1,0
+Edwards,1,Attorney General,,,OVER VOTES,0,0,0
+Edwards,2,Attorney General,,,OVER VOTES,0,0,0
+Edwards,3,Attorney General,,,OVER VOTES,0,0,0
+Edwards,4,Attorney General,,,OVER VOTES,0,0,0
+Edwards,1,Attorney General,,,UNDER VOTES,9,3,6
+Edwards,2,Attorney General,,,UNDER VOTES,6,5,1
+Edwards,3,Attorney General,,,UNDER VOTES,8,4,4
+Edwards,4,Attorney General,,,UNDER VOTES,20,9,11
+Edwards,1,Comptroller of Public Accounts,,REP,Glenn Hegar,69,57,12
+Edwards,2,Comptroller of Public Accounts,,REP,Glenn Hegar,240,124,116
+Edwards,3,Comptroller of Public Accounts,,REP,Glenn Hegar,179,145,34
+Edwards,4,Comptroller of Public Accounts,,REP,Glenn Hegar,104,82,22
+Edwards,1,Comptroller of Public Accounts,,DEM,Joi Chevalier,20,8,12
+Edwards,2,Comptroller of Public Accounts,,DEM,Joi Chevalier,23,6,17
+Edwards,3,Comptroller of Public Accounts,,DEM,Joi Chevalier,27,15,12
+Edwards,4,Comptroller of Public Accounts,,DEM,Joi Chevalier,34,21,13
+Edwards,1,Comptroller of Public Accounts,,LIB,Ben Sanders,3,2,1
+Edwards,2,Comptroller of Public Accounts,,LIB,Ben Sanders,5,1,4
+Edwards,3,Comptroller of Public Accounts,,LIB,Ben Sanders,9,5,4
+Edwards,4,Comptroller of Public Accounts,,LIB,Ben Sanders,7,5,2
+Edwards,1,Comptroller of Public Accounts,,,OVER VOTES,0,0,0
+Edwards,2,Comptroller of Public Accounts,,,OVER VOTES,0,0,0
+Edwards,3,Comptroller of Public Accounts,,,OVER VOTES,0,0,0
+Edwards,4,Comptroller of Public Accounts,,,OVER VOTES,0,0,0
+Edwards,1,Comptroller of Public Accounts,,,UNDER VOTES,9,4,5
+Edwards,2,Comptroller of Public Accounts,,,UNDER VOTES,6,4,2
+Edwards,3,Comptroller of Public Accounts,,,UNDER VOTES,13,8,5
+Edwards,4,Comptroller of Public Accounts,,,UNDER VOTES,21,8,13
+Edwards,1,Commissioner of the General Land Office,,REP,George P. Bush,63,50,13
+Edwards,2,Commissioner of the General Land Office,,REP,George P. Bush,225,117,108
+Edwards,3,Commissioner of the General Land Office,,REP,George P. Bush,172,136,36
+Edwards,4,Commissioner of the General Land Office,,REP,George P. Bush,104,80,24
+Edwards,1,Commissioner of the General Land Office,,DEM,Miguel Suazo,26,13,13
+Edwards,2,Commissioner of the General Land Office,,DEM,Miguel Suazo,23,5,18
+Edwards,3,Commissioner of the General Land Office,,DEM,Miguel Suazo,27,15,12
+Edwards,4,Commissioner of the General Land Office,,DEM,Miguel Suazo,34,22,12
+Edwards,1,Commissioner of the General Land Office,,LIB,Matt Pina,5,4,1
+Edwards,2,Commissioner of the General Land Office,,LIB,Matt Pina,19,9,10
+Edwards,3,Commissioner of the General Land Office,,LIB,Matt Pina,15,12,3
+Edwards,4,Commissioner of the General Land Office,,LIB,Matt Pina,7,5,2
+Edwards,1,Commissioner of the General Land Office,,,OVER VOTES,0,0,0
+Edwards,2,Commissioner of the General Land Office,,,OVER VOTES,0,0,0
+Edwards,3,Commissioner of the General Land Office,,,OVER VOTES,0,0,0
+Edwards,4,Commissioner of the General Land Office,,,OVER VOTES,0,0,0
+Edwards,1,Commissioner of the General Land Office,,,UNDER VOTES,7,4,3
+Edwards,2,Commissioner of the General Land Office,,,UNDER VOTES,7,4,3
+Edwards,3,Commissioner of the General Land Office,,,UNDER VOTES,14,10,4
+Edwards,4,Commissioner of the General Land Office,,,UNDER VOTES,21,9,12
+Edwards,1,Commissioner of Agriculture,,REP,Sid Miller,67,56,11
+Edwards,2,Commissioner of Agriculture,,REP,Sid Miller,236,124,112
+Edwards,3,Commissioner of Agriculture,,REP,Sid Miller,182,147,35
+Edwards,4,Commissioner of Agriculture,,REP,Sid Miller,102,81,21
+Edwards,1,Commissioner of Agriculture,,DEM,Kim Olson,22,10,12
+Edwards,2,Commissioner of Agriculture,,DEM,Kim Olson,27,7,20
+Edwards,3,Commissioner of Agriculture,,DEM,Kim Olson,25,13,12
+Edwards,4,Commissioner of Agriculture,,DEM,Kim Olson,36,23,13
+Edwards,1,Commissioner of Agriculture,,LIB,Richard Carpenter,3,1,2
+Edwards,2,Commissioner of Agriculture,,LIB,Richard Carpenter,3,0,3
+Edwards,3,Commissioner of Agriculture,,LIB,Richard Carpenter,7,5,2
+Edwards,4,Commissioner of Agriculture,,LIB,Richard Carpenter,5,4,1
+Edwards,1,Commissioner of Agriculture,,,OVER VOTES,0,0,0
+Edwards,2,Commissioner of Agriculture,,,OVER VOTES,0,0,0
+Edwards,3,Commissioner of Agriculture,,,OVER VOTES,0,0,0
+Edwards,4,Commissioner of Agriculture,,,OVER VOTES,0,0,0
+Edwards,1,Commissioner of Agriculture,,,UNDER VOTES,9,4,5
+Edwards,2,Commissioner of Agriculture,,,UNDER VOTES,8,4,4
+Edwards,3,Commissioner of Agriculture,,,UNDER VOTES,14,8,6
+Edwards,4,Commissioner of Agriculture,,,UNDER VOTES,23,8,15
+Edwards,1,Railroad Commissioner,,REP,Christi Craddick,69,57,12
+Edwards,2,Railroad Commissioner,,REP,Christi Craddick,235,125,110
+Edwards,3,Railroad Commissioner,,REP,Christi Craddick,181,144,37
+Edwards,4,Railroad Commissioner,,REP,Christi Craddick,105,83,22
+Edwards,1,Railroad Commissioner,,DEM,Roman McAllen,21,10,11
+Edwards,2,Railroad Commissioner,,DEM,Roman McAllen,23,5,18
+Edwards,3,Railroad Commissioner,,DEM,Roman McAllen,29,17,12
+Edwards,4,Railroad Commissioner,,DEM,Roman McAllen,36,22,14
+Edwards,1,Railroad Commissioner,,LIB,Mike Wright,1,0,1
+Edwards,2,Railroad Commissioner,,LIB,Mike Wright,8,1,7
+Edwards,3,Railroad Commissioner,,LIB,Mike Wright,8,7,1
+Edwards,4,Railroad Commissioner,,LIB,Mike Wright,3,3,0
+Edwards,1,Railroad Commissioner,,,OVER VOTES,0,0,0
+Edwards,2,Railroad Commissioner,,,OVER VOTES,0,0,0
+Edwards,3,Railroad Commissioner,,,OVER VOTES,0,0,0
+Edwards,4,Railroad Commissioner,,,OVER VOTES,0,0,0
+Edwards,1,Railroad Commissioner,,,UNDER VOTES,10,4,6
+Edwards,2,Railroad Commissioner,,,UNDER VOTES,8,4,4
+Edwards,3,Railroad Commissioner,,,UNDER VOTES,10,5,5
+Edwards,4,Railroad Commissioner,,,UNDER VOTES,22,8,14
+Edwards,1,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,66,56,10
+Edwards,2,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,238,123,115
+Edwards,3,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,182,147,35
+Edwards,4,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,108,86,22
+Edwards,1,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,24,11,13
+Edwards,2,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,27,6,21
+Edwards,3,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,31,16,15
+Edwards,4,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,36,23,13
+Edwards,1,"Justice, Supreme Court, Place 2",,,OVER VOTES,0,0,0
+Edwards,2,"Justice, Supreme Court, Place 2",,,OVER VOTES,0,0,0
+Edwards,3,"Justice, Supreme Court, Place 2",,,OVER VOTES,0,0,0
+Edwards,4,"Justice, Supreme Court, Place 2",,,OVER VOTES,0,0,0
+Edwards,1,"Justice, Supreme Court, Place 2",,,UNDER VOTES,11,4,7
+Edwards,2,"Justice, Supreme Court, Place 2",,,UNDER VOTES,9,6,3
+Edwards,3,"Justice, Supreme Court, Place 2",,,UNDER VOTES,15,10,5
+Edwards,4,"Justice, Supreme Court, Place 2",,,UNDER VOTES,22,7,15
+Edwards,1,"Justice, Supreme Court, Place 4",,REP,John Devine,66,56,10
+Edwards,2,"Justice, Supreme Court, Place 4",,REP,John Devine,236,122,114
+Edwards,3,"Justice, Supreme Court, Place 4",,REP,John Devine,184,147,37
+Edwards,4,"Justice, Supreme Court, Place 4",,REP,John Devine,108,86,22
+Edwards,1,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,24,11,13
+Edwards,2,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,27,6,21
+Edwards,3,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,27,14,13
+Edwards,4,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,33,21,12
+Edwards,1,"Justice, Supreme Court, Place 4",,,OVER VOTES,0,0,0
+Edwards,2,"Justice, Supreme Court, Place 4",,,OVER VOTES,0,0,0
+Edwards,3,"Justice, Supreme Court, Place 4",,,OVER VOTES,0,0,0
+Edwards,4,"Justice, Supreme Court, Place 4",,,OVER VOTES,0,0,0
+Edwards,1,"Justice, Supreme Court, Place 4",,,UNDER VOTES,11,4,7
+Edwards,2,"Justice, Supreme Court, Place 4",,,UNDER VOTES,11,7,4
+Edwards,3,"Justice, Supreme Court, Place 4",,,UNDER VOTES,17,12,5
+Edwards,4,"Justice, Supreme Court, Place 4",,,UNDER VOTES,25,9,16
+Edwards,1,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,67,57,10
+Edwards,2,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,236,123,113
+Edwards,3,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,186,148,38
+Edwards,4,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,106,84,22
+Edwards,1,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,23,10,13
+Edwards,2,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,26,5,21
+Edwards,3,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,27,15,12
+Edwards,4,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,38,25,13
+Edwards,1,"Justice, Supreme Court, Place 6",,,OVER VOTES,0,0,0
+Edwards,2,"Justice, Supreme Court, Place 6",,,OVER VOTES,0,0,0
+Edwards,3,"Justice, Supreme Court, Place 6",,,OVER VOTES,0,0,0
+Edwards,4,"Justice, Supreme Court, Place 6",,,OVER VOTES,0,0,0
+Edwards,1,"Justice, Supreme Court, Place 6",,,UNDER VOTES,11,4,7
+Edwards,2,"Justice, Supreme Court, Place 6",,,UNDER VOTES,12,7,5
+Edwards,3,"Justice, Supreme Court, Place 6",,,UNDER VOTES,15,10,5
+Edwards,4,"Justice, Supreme Court, Place 6",,,UNDER VOTES,22,7,15
+Edwards,1,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,65,55,10
+Edwards,2,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,235,122,113
+Edwards,3,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,177,141,36
+Edwards,4,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,107,83,24
+Edwards,1,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,24,12,12
+Edwards,2,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,26,6,20
+Edwards,3,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,31,18,13
+Edwards,4,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,34,23,11
+Edwards,1,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,1,0,1
+Edwards,2,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,5,1,4
+Edwards,3,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,6,5,1
+Edwards,4,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,3,3,0
+Edwards,1,"Presiding Judge, Court of Criminal Appeals",,,OVER VOTES,0,0,0
+Edwards,2,"Presiding Judge, Court of Criminal Appeals",,,OVER VOTES,0,0,0
+Edwards,3,"Presiding Judge, Court of Criminal Appeals",,,OVER VOTES,0,0,0
+Edwards,4,"Presiding Judge, Court of Criminal Appeals",,,OVER VOTES,0,0,0
+Edwards,1,"Presiding Judge, Court of Criminal Appeals",,,UNDER VOTES,11,4,7
+Edwards,2,"Presiding Judge, Court of Criminal Appeals",,,UNDER VOTES,8,6,2
+Edwards,3,"Presiding Judge, Court of Criminal Appeals",,,UNDER VOTES,14,9,5
+Edwards,4,"Presiding Judge, Court of Criminal Appeals",,,UNDER VOTES,22,7,15
+Edwards,1,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,66,56,10
+Edwards,2,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,239,124,115
+Edwards,3,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,182,146,36
+Edwards,4,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,110,87,23
+Edwards,1,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,24,11,13
+Edwards,2,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,26,5,21
+Edwards,3,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,30,16,14
+Edwards,4,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,33,21,12
+Edwards,1,"Judge, Court of Criminal Appeals, Place 7",,,OVER VOTES,0,0,0
+Edwards,2,"Judge, Court of Criminal Appeals, Place 7",,,OVER VOTES,0,0,0
+Edwards,3,"Judge, Court of Criminal Appeals, Place 7",,,OVER VOTES,0,0,0
+Edwards,4,"Judge, Court of Criminal Appeals, Place 7",,,OVER VOTES,0,0,0
+Edwards,1,"Judge, Court of Criminal Appeals, Place 7",,,UNDER VOTES,11,4,7
+Edwards,2,"Judge, Court of Criminal Appeals, Place 7",,,UNDER VOTES,9,6,3
+Edwards,3,"Judge, Court of Criminal Appeals, Place 7",,,UNDER VOTES,16,11,5
+Edwards,4,"Judge, Court of Criminal Appeals, Place 7",,,UNDER VOTES,23,8,15
+Edwards,1,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,71,58,13
+Edwards,2,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,243,123,120
+Edwards,3,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,184,145,39
+Edwards,4,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,115,91,24
+Edwards,1,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,7,4,3
+Edwards,2,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,16,4,12
+Edwards,3,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,21,14,7
+Edwards,4,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,9,5,4
+Edwards,1,"Judge, Court of Criminal Appeals, Place 8",,,OVER VOTES,0,0,0
+Edwards,2,"Judge, Court of Criminal Appeals, Place 8",,,OVER VOTES,0,0,0
+Edwards,3,"Judge, Court of Criminal Appeals, Place 8",,,OVER VOTES,0,0,0
+Edwards,4,"Judge, Court of Criminal Appeals, Place 8",,,OVER VOTES,0,0,0
+Edwards,1,"Judge, Court of Criminal Appeals, Place 8",,,UNDER VOTES,23,9,14
+Edwards,2,"Judge, Court of Criminal Appeals, Place 8",,,UNDER VOTES,15,8,7
+Edwards,3,"Judge, Court of Criminal Appeals, Place 8",,,UNDER VOTES,23,14,9
+Edwards,4,"Judge, Court of Criminal Appeals, Place 8",,,UNDER VOTES,42,20,22
+Edwards,1,State Representative,53,REP,Andrew S. Murr,70,56,14
+Edwards,2,State Representative,53,REP,Andrew S. Murr,241,124,117
+Edwards,3,State Representative,53,REP,Andrew S. Murr,190,150,40
+Edwards,4,State Representative,53,REP,Andrew S. Murr,111,87,24
+Edwards,1,State Representative,53,DEM,Stephanie Lochte Ertel,22,11,11
+Edwards,2,State Representative,53,DEM,Stephanie Lochte Ertel,25,6,19
+Edwards,3,State Representative,53,DEM,Stephanie Lochte Ertel,28,17,11
+Edwards,4,State Representative,53,DEM,Stephanie Lochte Ertel,36,23,13
+Edwards,1,State Representative,53,,OVER VOTES,0,0,0
+Edwards,2,State Representative,53,,OVER VOTES,0,0,0
+Edwards,3,State Representative,53,,OVER VOTES,0,0,0
+Edwards,4,State Representative,53,,OVER VOTES,0,0,0
+Edwards,1,State Representative,53,,UNDER VOTES,9,4,5
+Edwards,2,State Representative,53,,UNDER VOTES,7,4,3
+Edwards,3,State Representative,53,,UNDER VOTES,10,6,4
+Edwards,4,State Representative,53,,UNDER VOTES,19,6,13
+Edwards,1,"Justice, 4th Court of Appeals District, Place 2",,REP,Marialyn Barnard,66,55,11
+Edwards,2,"Justice, 4th Court of Appeals District, Place 2",,REP,Marialyn Barnard,240,125,115
+Edwards,3,"Justice, 4th Court of Appeals District, Place 2",,REP,Marialyn Barnard,184,147,37
+Edwards,4,"Justice, 4th Court of Appeals District, Place 2",,REP,Marialyn Barnard,107,85,22
+Edwards,1,"Justice, 4th Court of Appeals District, Place 2",,DEM,Beth Watkins,23,11,12
+Edwards,2,"Justice, 4th Court of Appeals District, Place 2",,DEM,Beth Watkins,27,5,22
+Edwards,3,"Justice, 4th Court of Appeals District, Place 2",,DEM,Beth Watkins,34,20,14
+Edwards,4,"Justice, 4th Court of Appeals District, Place 2",,DEM,Beth Watkins,37,22,15
+Edwards,1,"Justice, 4th Court of Appeals District, Place 2",,,OVER VOTES,0,0,0
+Edwards,2,"Justice, 4th Court of Appeals District, Place 2",,,OVER VOTES,1,0,1
+Edwards,3,"Justice, 4th Court of Appeals District, Place 2",,,OVER VOTES,0,0,0
+Edwards,4,"Justice, 4th Court of Appeals District, Place 2",,,OVER VOTES,0,0,0
+Edwards,1,"Justice, 4th Court of Appeals District, Place 2",,,UNDER VOTES,12,5,7
+Edwards,2,"Justice, 4th Court of Appeals District, Place 2",,,UNDER VOTES,6,5,1
+Edwards,3,"Justice, 4th Court of Appeals District, Place 2",,,UNDER VOTES,10,6,4
+Edwards,4,"Justice, 4th Court of Appeals District, Place 2",,,UNDER VOTES,22,9,13
+Edwards,1,"Justice, 4th Court of Appeals District, Place 3",,REP,Jason Pulliam,67,55,12
+Edwards,2,"Justice, 4th Court of Appeals District, Place 3",,REP,Jason Pulliam,239,123,116
+Edwards,3,"Justice, 4th Court of Appeals District, Place 3",,REP,Jason Pulliam,187,149,38
+Edwards,4,"Justice, 4th Court of Appeals District, Place 3",,REP,Jason Pulliam,106,83,23
+Edwards,1,"Justice, 4th Court of Appeals District, Place 3",,DEM,Patricia O'Connell Alvarez,22,11,11
+Edwards,2,"Justice, 4th Court of Appeals District, Place 3",,DEM,Patricia O'Connell Alvarez,27,6,21
+Edwards,3,"Justice, 4th Court of Appeals District, Place 3",,DEM,Patricia O'Connell Alvarez,31,18,13
+Edwards,4,"Justice, 4th Court of Appeals District, Place 3",,DEM,Patricia O'Connell Alvarez,37,24,13
+Edwards,1,"Justice, 4th Court of Appeals District, Place 3",,,OVER VOTES,0,0,0
+Edwards,2,"Justice, 4th Court of Appeals District, Place 3",,,OVER VOTES,0,0,0
+Edwards,3,"Justice, 4th Court of Appeals District, Place 3",,,OVER VOTES,0,0,0
+Edwards,4,"Justice, 4th Court of Appeals District, Place 3",,,OVER VOTES,0,0,0
+Edwards,1,"Justice, 4th Court of Appeals District, Place 3",,,UNDER VOTES,12,5,7
+Edwards,2,"Justice, 4th Court of Appeals District, Place 3",,,UNDER VOTES,8,6,2
+Edwards,3,"Justice, 4th Court of Appeals District, Place 3",,,UNDER VOTES,10,6,4
+Edwards,4,"Justice, 4th Court of Appeals District, Place 3",,,UNDER VOTES,23,9,14
+Edwards,1,"Justice, 4th Court of Appeals District, Place 4",,REP,Patrick Ballantyne,66,55,11
+Edwards,2,"Justice, 4th Court of Appeals District, Place 4",,REP,Patrick Ballantyne,240,122,118
+Edwards,3,"Justice, 4th Court of Appeals District, Place 4",,REP,Patrick Ballantyne,185,148,37
+Edwards,4,"Justice, 4th Court of Appeals District, Place 4",,REP,Patrick Ballantyne,108,85,23
+Edwards,1,"Justice, 4th Court of Appeals District, Place 4",,DEM,Luz Elena Chapa,25,13,12
+Edwards,2,"Justice, 4th Court of Appeals District, Place 4",,DEM,Luz Elena Chapa,27,7,20
+Edwards,3,"Justice, 4th Court of Appeals District, Place 4",,DEM,Luz Elena Chapa,31,17,14
+Edwards,4,"Justice, 4th Court of Appeals District, Place 4",,DEM,Luz Elena Chapa,37,24,13
+Edwards,1,"Justice, 4th Court of Appeals District, Place 4",,,OVER VOTES,0,0,0
+Edwards,2,"Justice, 4th Court of Appeals District, Place 4",,,OVER VOTES,0,0,0
+Edwards,3,"Justice, 4th Court of Appeals District, Place 4",,,OVER VOTES,0,0,0
+Edwards,4,"Justice, 4th Court of Appeals District, Place 4",,,OVER VOTES,0,0,0
+Edwards,1,"Justice, 4th Court of Appeals District, Place 4",,,UNDER VOTES,10,3,7
+Edwards,2,"Justice, 4th Court of Appeals District, Place 4",,,UNDER VOTES,7,6,1
+Edwards,3,"Justice, 4th Court of Appeals District, Place 4",,,UNDER VOTES,12,8,4
+Edwards,4,"Justice, 4th Court of Appeals District, Place 4",,,UNDER VOTES,21,7,14
+Edwards,1,"Justice, 4th Court of Appeals District, Place 5",,REP,Rebecca Simmons,66,55,11
+Edwards,2,"Justice, 4th Court of Appeals District, Place 5",,REP,Rebecca Simmons,241,124,117
+Edwards,3,"Justice, 4th Court of Appeals District, Place 5",,REP,Rebecca Simmons,187,150,37
+Edwards,4,"Justice, 4th Court of Appeals District, Place 5",,REP,Rebecca Simmons,107,84,23
+Edwards,1,"Justice, 4th Court of Appeals District, Place 5",,DEM,Liza Rodriguez,25,13,12
+Edwards,2,"Justice, 4th Court of Appeals District, Place 5",,DEM,Liza Rodriguez,25,6,19
+Edwards,3,"Justice, 4th Court of Appeals District, Place 5",,DEM,Liza Rodriguez,30,16,14
+Edwards,4,"Justice, 4th Court of Appeals District, Place 5",,DEM,Liza Rodriguez,38,24,14
+Edwards,1,"Justice, 4th Court of Appeals District, Place 5",,,OVER VOTES,0,0,0
+Edwards,2,"Justice, 4th Court of Appeals District, Place 5",,,OVER VOTES,0,0,0
+Edwards,3,"Justice, 4th Court of Appeals District, Place 5",,,OVER VOTES,0,0,0
+Edwards,4,"Justice, 4th Court of Appeals District, Place 5",,,OVER VOTES,0,0,0
+Edwards,1,"Justice, 4th Court of Appeals District, Place 5",,,UNDER VOTES,10,3,7
+Edwards,2,"Justice, 4th Court of Appeals District, Place 5",,,UNDER VOTES,8,5,3
+Edwards,3,"Justice, 4th Court of Appeals District, Place 5",,,UNDER VOTES,11,7,4
+Edwards,4,"Justice, 4th Court of Appeals District, Place 5",,,UNDER VOTES,21,8,13
+Edwards,1,"Justice, 4th Court of Appeals District, Place 7",,REP,Shane Stolarczyk,67,56,11
+Edwards,2,"Justice, 4th Court of Appeals District, Place 7",,REP,Shane Stolarczyk,241,124,117
+Edwards,3,"Justice, 4th Court of Appeals District, Place 7",,REP,Shane Stolarczyk,187,150,37
+Edwards,4,"Justice, 4th Court of Appeals District, Place 7",,REP,Shane Stolarczyk,105,83,22
+Edwards,1,"Justice, 4th Court of Appeals District, Place 7",,DEM,Rebeca Martinez,23,11,12
+Edwards,2,"Justice, 4th Court of Appeals District, Place 7",,DEM,Rebeca Martinez,26,6,20
+Edwards,3,"Justice, 4th Court of Appeals District, Place 7",,DEM,Rebeca Martinez,30,17,13
+Edwards,4,"Justice, 4th Court of Appeals District, Place 7",,DEM,Rebeca Martinez,39,25,14
+Edwards,1,"Justice, 4th Court of Appeals District, Place 7",,,OVER VOTES,0,0,0
+Edwards,2,"Justice, 4th Court of Appeals District, Place 7",,,OVER VOTES,0,0,0
+Edwards,3,"Justice, 4th Court of Appeals District, Place 7",,,OVER VOTES,0,0,0
+Edwards,4,"Justice, 4th Court of Appeals District, Place 7",,,OVER VOTES,0,0,0
+Edwards,1,"Justice, 4th Court of Appeals District, Place 7",,,UNDER VOTES,11,4,7
+Edwards,2,"Justice, 4th Court of Appeals District, Place 7",,,UNDER VOTES,7,5,2
+Edwards,3,"Justice, 4th Court of Appeals District, Place 7",,,UNDER VOTES,11,6,5
+Edwards,4,"Justice, 4th Court of Appeals District, Place 7",,,UNDER VOTES,22,8,14
+Edwards,1,"District Judge, 452nd Judicial District",,REP,"Robert R. ""Rob"" Hofmann",63,51,12
+Edwards,2,"District Judge, 452nd Judicial District",,REP,"Robert R. ""Rob"" Hofmann",240,119,121
+Edwards,3,"District Judge, 452nd Judicial District",,REP,"Robert R. ""Rob"" Hofmann",190,151,39
+Edwards,4,"District Judge, 452nd Judicial District",,REP,"Robert R. ""Rob"" Hofmann",118,92,26
+Edwards,1,"District Judge, 452nd Judicial District",,,OVER VOTES,0,0,0
+Edwards,2,"District Judge, 452nd Judicial District",,,OVER VOTES,0,0,0
+Edwards,3,"District Judge, 452nd Judicial District",,,OVER VOTES,0,0,0
+Edwards,4,"District Judge, 452nd Judicial District",,,OVER VOTES,0,0,0
+Edwards,1,"District Judge, 452nd Judicial District",,,UNDER VOTES,38,20,18
+Edwards,2,"District Judge, 452nd Judicial District",,,UNDER VOTES,33,15,18
+Edwards,3,"District Judge, 452nd Judicial District",,,UNDER VOTES,38,22,16
+Edwards,4,"District Judge, 452nd Judicial District",,,UNDER VOTES,48,24,24
+Edwards,1,"District Attorney, 452nd Judicial District",,REP,Tonya Spaeth Ahlschwede,62,50,12
+Edwards,2,"District Attorney, 452nd Judicial District",,REP,Tonya Spaeth Ahlschwede,237,119,118
+Edwards,3,"District Attorney, 452nd Judicial District",,REP,Tonya Spaeth Ahlschwede,181,143,38
+Edwards,4,"District Attorney, 452nd Judicial District",,REP,Tonya Spaeth Ahlschwede,108,85,23
+Edwards,1,"District Attorney, 452nd Judicial District",,,OVER VOTES,0,0,0
+Edwards,2,"District Attorney, 452nd Judicial District",,,OVER VOTES,0,0,0
+Edwards,3,"District Attorney, 452nd Judicial District",,,OVER VOTES,0,0,0
+Edwards,4,"District Attorney, 452nd Judicial District",,,OVER VOTES,0,0,0
+Edwards,1,"District Attorney, 452nd Judicial District",,,UNDER VOTES,39,21,18
+Edwards,2,"District Attorney, 452nd Judicial District",,,UNDER VOTES,36,15,21
+Edwards,3,"District Attorney, 452nd Judicial District",,,UNDER VOTES,47,30,17
+Edwards,4,"District Attorney, 452nd Judicial District",,,UNDER VOTES,58,31,27
+Edwards,1,County Judge,,REP,Souli Asa Shanklin,71,56,15
+Edwards,2,County Judge,,REP,Souli Asa Shanklin,237,114,123
+Edwards,3,County Judge,,REP,Souli Asa Shanklin,198,152,46
+Edwards,4,County Judge,,REP,Souli Asa Shanklin,117,87,30
+Edwards,1,County Judge,,,OVER VOTES,0,0,0
+Edwards,2,County Judge,,,OVER VOTES,0,0,0
+Edwards,3,County Judge,,,OVER VOTES,0,0,0
+Edwards,4,County Judge,,,OVER VOTES,0,0,0
+Edwards,1,County Judge,,,UNDER VOTES,30,15,15
+Edwards,2,County Judge,,,UNDER VOTES,36,20,16
+Edwards,3,County Judge,,,UNDER VOTES,30,21,9
+Edwards,4,County Judge,,,UNDER VOTES,49,29,20
+Edwards,1,District and County Clerk,,REP,Olga Lydia Reyes,82,63,19
+Edwards,2,District and County Clerk,,REP,Olga Lydia Reyes,245,123,122
+Edwards,3,District and County Clerk,,REP,Olga Lydia Reyes,203,158,45
+Edwards,4,District and County Clerk,,REP,Olga Lydia Reyes,131,97,34
+Edwards,1,District and County Clerk,,,OVER VOTES,0,0,0
+Edwards,2,District and County Clerk,,,OVER VOTES,0,0,0
+Edwards,3,District and County Clerk,,,OVER VOTES,0,0,0
+Edwards,4,District and County Clerk,,,OVER VOTES,0,0,0
+Edwards,1,District and County Clerk,,,UNDER VOTES,19,8,11
+Edwards,2,District and County Clerk,,,UNDER VOTES,28,11,17
+Edwards,3,District and County Clerk,,,UNDER VOTES,25,15,10
+Edwards,4,District and County Clerk,,,UNDER VOTES,35,19,16
+Edwards,1,County Treasurer,,REP,Lupe S. Enriquez,81,63,18
+Edwards,2,County Treasurer,,REP,Lupe S. Enriquez,248,124,124
+Edwards,3,County Treasurer,,REP,Lupe S. Enriquez,208,157,51
+Edwards,4,County Treasurer,,REP,Lupe S. Enriquez,125,94,31
+Edwards,1,County Treasurer,,,OVER VOTES,0,0,0
+Edwards,2,County Treasurer,,,OVER VOTES,0,0,0
+Edwards,3,County Treasurer,,,OVER VOTES,0,0,0
+Edwards,4,County Treasurer,,,OVER VOTES,0,0,0
+Edwards,1,County Treasurer,,,UNDER VOTES,20,8,12
+Edwards,2,County Treasurer,,,UNDER VOTES,25,10,15
+Edwards,3,County Treasurer,,,UNDER VOTES,20,16,4
+Edwards,4,County Treasurer,,,UNDER VOTES,41,22,19
+Edwards,2,"County Commissioner, Precinct 2",,REP,Lee Sweeten,221,106,115
+Edwards,2,"County Commissioner, Precinct 2",,,OVER VOTES,0,0,0
+Edwards,2,"County Commissioner, Precinct 2",,,UNDER VOTES,52,28,24
+Edwards,4,"County Commissioner, Precinct 4",,REP,Kenneth Reed,107,80,27
+Edwards,4,"County Commissioner, Precinct 4",,DEM,W. Andrew Barnebey,46,27,19
+Edwards,4,"County Commissioner, Precinct 4",,,OVER VOTES,0,0,0
+Edwards,4,"County Commissioner, Precinct 4",,,UNDER VOTES,13,9,4
+Edwards,1,Justice of the Peace,,REP,Tommy M. Walker,73,56,17
+Edwards,2,Justice of the Peace,,REP,Tommy M. Walker,231,120,111
+Edwards,3,Justice of the Peace,,REP,Tommy M. Walker,190,153,37
+Edwards,4,Justice of the Peace,,REP,Tommy M. Walker,110,81,29
+Edwards,1,Justice of the Peace,,DEM,Pauline V. Gonzales,25,12,13
+Edwards,2,Justice of the Peace,,DEM,Pauline V. Gonzales,28,4,24
+Edwards,3,Justice of the Peace,,DEM,Pauline V. Gonzales,32,16,16
+Edwards,4,Justice of the Peace,,DEM,Pauline V. Gonzales,49,30,19
+Edwards,1,Justice of the Peace,,,OVER VOTES,0,0,0
+Edwards,2,Justice of the Peace,,,OVER VOTES,0,0,0
+Edwards,3,Justice of the Peace,,,OVER VOTES,0,0,0
+Edwards,4,Justice of the Peace,,,OVER VOTES,0,0,0
+Edwards,1,Justice of the Peace,,,UNDER VOTES,3,3,0
+Edwards,2,Justice of the Peace,,,UNDER VOTES,14,10,4
+Edwards,3,Justice of the Peace,,,UNDER VOTES,6,4,2
+Edwards,4,Justice of the Peace,,,UNDER VOTES,7,5,2


### PR DESCRIPTION
How frustrating.
The ASC file provided gave only race ID, candidate ID, precinct ID, and vote groups. I was able to deduce the correct races and orders using the SoS's results page and knowledge of other counties' orderings (read: the order in which ES&S sorts races and candidates).

Kendall County is in the 4th Court of Appeals District, along with Edwards County, so I took non-legislative and non-local races from that file. Legislative races were found on the SoS's page, and local races were found by inspecting the sample ballots on the Edwards County web site.