### PR TITLE
Add precinct-level results for the 2018 general election in Brown County

### DIFF
--- a/2018/20181106__tx__general__brown__precinct.csv
+++ b/2018/20181106__tx__general__brown__precinct.csv
@@ -1,0 +1,1104 @@
+county,precinct,office,district,party,candidate,votes,early_voting,election_day
+Brown,101,Straight Party,,REP,,662,503,159
+Brown,101,Straight Party,,DEM,,92,50,42
+Brown,101,Straight Party,,LIB,,0,0,0
+Brown,101,U.S. Senate,,REP,Ted Cruz,1176,912,264
+Brown,101,U.S. Senate,,DEM,Beto O'Rourke,212,129,83
+Brown,101,U.S. Senate,,LIB,Neal M. Dikeman,3,1,2
+Brown,101,U.S. House,11,REP,Mike Conaway,1214,937,277
+Brown,101,U.S. House,11,DEM,Jennie Lou Leeder,175,108,67
+Brown,101,U.S. House,11,LIB,Rhett Rosenquest Smith,9,7,2
+Brown,101,Governor,,REP,Greg Abbott,1213,938,275
+Brown,101,Governor,,DEM,Lupe Valdez,179,112,67
+Brown,101,Governor,,LIB,Mark Jay Tippetts,12,5,7
+Brown,101,Lieutenant Governor,,REP,Dan Patrick,1140,888,252
+Brown,101,Lieutenant Governor,,DEM,Mike Collier,235,149,86
+Brown,101,Lieutenant Governor,,LIB,Kerry Douglas McKennon,22,13,9
+Brown,101,Attorney General,,REP,Ken Paxton,1158,903,255
+Brown,101,Attorney General,,DEM,Justin Nelson,212,131,81
+Brown,101,Attorney General,,LIB,Michael Ray Harris,23,15,8
+Brown,101,Comptroller of Public Accounts,,REP,Glenn Hegar,1189,926,263
+Brown,101,Comptroller of Public Accounts,,DEM,Joi Chevalier,174,105,69
+Brown,101,Comptroller of Public Accounts,,LIB,Ben Sanders,24,12,12
+Brown,101,Commissioner of the General Land Office,,REP,George P. Bush,1180,914,266
+Brown,101,Commissioner of the General Land Office,,DEM,Miguel Suazo,176,106,70
+Brown,101,Commissioner of the General Land Office,,LIB,Matt Piña,38,29,9
+Brown,101,Commissioner of Agriculture,,REP,Sid Miller,1191,922,269
+Brown,101,Commissioner of Agriculture,,DEM,Kim Olson,184,113,71
+Brown,101,Commissioner of Agriculture,,LIB,Richard Carpenter,13,8,5
+Brown,101,Railroad Commissioner,,REP,Christi Craddick,1191,925,266
+Brown,101,Railroad Commissioner,,DEM,Roman McAllen,177,107,70
+Brown,101,Railroad Commissioner,,LIB,Mike Wright,23,14,9
+Brown,101,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1188,919,269
+Brown,101,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,195,122,73
+Brown,101,"Justice, Supreme Court, Place 4",,REP,John Devine,1197,927,270
+Brown,101,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,187,115,72
+Brown,101,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1193,921,272
+Brown,101,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,192,122,70
+Brown,101,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1178,920,258
+Brown,101,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,192,119,73
+Brown,101,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,20,7,13
+Brown,101,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1191,922,269
+Brown,101,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,191,117,74
+Brown,101,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1213,937,276
+Brown,101,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,92,56,36
+Brown,101,State Representative,60,REP,Mike Lang,1258,961,297
+Brown,101,"Chief Justice, 11th Court of Appeals District",,REP,John Bailey,1241,945,296
+Brown,101,County Judge,,REP,Paul Lilly,814,617,197
+Brown,101,County Judge,,,Steve Fryar (W),491,378,113
+Brown,101,Ballots Cast,,,,1417,,
+Brown,105,Straight Party,,REP,,468,344,124
+Brown,105,Straight Party,,DEM,,50,35,15
+Brown,105,Straight Party,,LIB,,3,1,2
+Brown,105,U.S. Senate,,REP,Ted Cruz,829,614,215
+Brown,105,U.S. Senate,,DEM,Beto O'Rourke,130,97,33
+Brown,105,U.S. Senate,,LIB,Neal M. Dikeman,9,3,6
+Brown,105,U.S. House,11,REP,Mike Conaway,859,636,223
+Brown,105,U.S. House,11,DEM,Jennie Lou Leeder,112,83,29
+Brown,105,U.S. House,11,LIB,Rhett Rosenquest Smith,11,5,6
+Brown,105,Governor,,REP,Greg Abbott,854,631,223
+Brown,105,Governor,,DEM,Lupe Valdez,119,90,29
+Brown,105,Governor,,LIB,Mark Jay Tippetts,16,9,7
+Brown,105,Lieutenant Governor,,REP,Dan Patrick,801,593,208
+Brown,105,Lieutenant Governor,,DEM,Mike Collier,158,118,40
+Brown,105,Lieutenant Governor,,LIB,Kerry Douglas McKennon,26,15,11
+Brown,105,Attorney General,,REP,Ken Paxton,821,603,218
+Brown,105,Attorney General,,DEM,Justin Nelson,139,106,33
+Brown,105,Attorney General,,LIB,Michael Ray Harris,22,15,7
+Brown,105,Comptroller of Public Accounts,,REP,Glenn Hegar,848,629,219
+Brown,105,Comptroller of Public Accounts,,DEM,Joi Chevalier,111,85,26
+Brown,105,Comptroller of Public Accounts,,LIB,Ben Sanders,16,6,10
+Brown,105,Commissioner of the General Land Office,,REP,George P. Bush,823,608,215
+Brown,105,Commissioner of the General Land Office,,DEM,Miguel Suazo,119,90,29
+Brown,105,Commissioner of the General Land Office,,LIB,Matt Piña,34,23,11
+Brown,105,Commissioner of Agriculture,,REP,Sid Miller,833,616,217
+Brown,105,Commissioner of Agriculture,,DEM,Kim Olson,131,99,32
+Brown,105,Commissioner of Agriculture,,LIB,Richard Carpenter,16,10,6
+Brown,105,Railroad Commissioner,,REP,Christi Craddick,838,621,217
+Brown,105,Railroad Commissioner,,DEM,Roman McAllen,115,90,25
+Brown,105,Railroad Commissioner,,LIB,Mike Wright,21,11,10
+Brown,105,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,838,619,219
+Brown,105,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,132,99,33
+Brown,105,"Justice, Supreme Court, Place 4",,REP,John Devine,842,622,220
+Brown,105,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,127,96,31
+Brown,105,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,841,622,219
+Brown,105,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,127,95,32
+Brown,105,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,831,618,213
+Brown,105,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,125,96,29
+Brown,105,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,19,8,11
+Brown,105,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,843,624,219
+Brown,105,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,121,91,30
+Brown,105,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,851,632,219
+Brown,105,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,62,49,13
+Brown,105,State Representative,60,REP,Mike Lang,878,652,226
+Brown,105,"Chief Justice, 11th Court of Appeals District",,REP,John Bailey,876,650,226
+Brown,105,County Judge,,REP,Paul Lilly,591,433,158
+Brown,105,County Judge,,,Steve Fryar (W),327,249,78
+Brown,105,Ballots Cast,,,,992,,
+Brown,109,Straight Party,,REP,,101,54,47
+Brown,109,Straight Party,,DEM,,5,2,3
+Brown,109,Straight Party,,LIB,,0,0,0
+Brown,109,U.S. Senate,,REP,Ted Cruz,157,84,73
+Brown,109,U.S. Senate,,DEM,Beto O'Rourke,15,7,8
+Brown,109,U.S. Senate,,LIB,Neal M. Dikeman,1,1,0
+Brown,109,U.S. House,11,REP,Mike Conaway,167,91,76
+Brown,109,U.S. House,11,DEM,Jennie Lou Leeder,9,4,5
+Brown,109,U.S. House,11,LIB,Rhett Rosenquest Smith,1,0,1
+Brown,109,Governor,,REP,Greg Abbott,166,90,76
+Brown,109,Governor,,DEM,Lupe Valdez,12,6,6
+Brown,109,Governor,,LIB,Mark Jay Tippetts,0,0,0
+Brown,109,Lieutenant Governor,,REP,Dan Patrick,155,86,69
+Brown,109,Lieutenant Governor,,DEM,Mike Collier,19,7,12
+Brown,109,Lieutenant Governor,,LIB,Kerry Douglas McKennon,2,1,1
+Brown,109,Attorney General,,REP,Ken Paxton,163,87,76
+Brown,109,Attorney General,,DEM,Justin Nelson,12,8,4
+Brown,109,Attorney General,,LIB,Michael Ray Harris,0,0,0
+Brown,109,Comptroller of Public Accounts,,REP,Glenn Hegar,164,87,77
+Brown,109,Comptroller of Public Accounts,,DEM,Joi Chevalier,11,7,4
+Brown,109,Comptroller of Public Accounts,,LIB,Ben Sanders,2,2,0
+Brown,109,Commissioner of the General Land Office,,REP,George P. Bush,161,86,75
+Brown,109,Commissioner of the General Land Office,,DEM,Miguel Suazo,12,7,5
+Brown,109,Commissioner of the General Land Office,,LIB,Matt Piña,3,1,2
+Brown,109,Commissioner of Agriculture,,REP,Sid Miller,159,86,73
+Brown,109,Commissioner of Agriculture,,DEM,Kim Olson,14,7,7
+Brown,109,Commissioner of Agriculture,,LIB,Richard Carpenter,1,1,0
+Brown,109,Railroad Commissioner,,REP,Christi Craddick,166,90,76
+Brown,109,Railroad Commissioner,,DEM,Roman McAllen,8,4,4
+Brown,109,Railroad Commissioner,,LIB,Mike Wright,2,1,1
+Brown,109,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,163,86,77
+Brown,109,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,12,8,4
+Brown,109,"Justice, Supreme Court, Place 4",,REP,John Devine,165,88,77
+Brown,109,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,10,6,4
+Brown,109,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,165,88,77
+Brown,109,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,10,6,4
+Brown,109,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,164,88,76
+Brown,109,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,11,7,4
+Brown,109,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,1,1,0
+Brown,109,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,166,88,78
+Brown,109,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,11,7,4
+Brown,109,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,166,90,76
+Brown,109,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,4,2,2
+Brown,109,State Representative,60,REP,Mike Lang,165,91,74
+Brown,109,"Chief Justice, 11th Court of Appeals District",,REP,John Bailey,161,88,73
+Brown,109,County Judge,,REP,Paul Lilly,124,65,59
+Brown,109,County Judge,,,Steve Fryar (W),39,24,15
+Brown,109,Ballots Cast,,,,178,96,82
+Brown,113,Straight Party,,REP,,453,326,127
+Brown,113,Straight Party,,DEM,,60,32,28
+Brown,113,Straight Party,,LIB,,2,0,2
+Brown,113,U.S. Senate,,REP,Ted Cruz,890,621,269
+Brown,113,U.S. Senate,,DEM,Beto O'Rourke,143,89,54
+Brown,113,U.S. Senate,,LIB,Neal M. Dikeman,6,1,5
+Brown,113,U.S. House,11,REP,Mike Conaway,904,631,273
+Brown,113,U.S. House,11,DEM,Jennie Lou Leeder,118,70,48
+Brown,113,U.S. House,11,LIB,Rhett Rosenquest Smith,22,13,9
+Brown,113,Governor,,REP,Greg Abbott,911,634,277
+Brown,113,Governor,,DEM,Lupe Valdez,121,73,48
+Brown,113,Governor,,LIB,Mark Jay Tippetts,16,10,6
+Brown,113,Lieutenant Governor,,REP,Dan Patrick,869,604,265
+Brown,113,Lieutenant Governor,,DEM,Mike Collier,153,99,54
+Brown,113,Lieutenant Governor,,LIB,Kerry Douglas McKennon,22,12,10
+Brown,113,Attorney General,,REP,Ken Paxton,882,612,270
+Brown,113,Attorney General,,DEM,Justin Nelson,144,90,54
+Brown,113,Attorney General,,LIB,Michael Ray Harris,21,15,6
+Brown,113,Comptroller of Public Accounts,,REP,Glenn Hegar,896,625,271
+Brown,113,Comptroller of Public Accounts,,DEM,Joi Chevalier,120,72,48
+Brown,113,Comptroller of Public Accounts,,LIB,Ben Sanders,24,15,9
+Brown,113,Commissioner of the General Land Office,,REP,George P. Bush,874,606,268
+Brown,113,Commissioner of the General Land Office,,DEM,Miguel Suazo,125,78,47
+Brown,113,Commissioner of the General Land Office,,LIB,Matt Piña,41,30,11
+Brown,113,Commissioner of Agriculture,,REP,Sid Miller,887,618,269
+Brown,113,Commissioner of Agriculture,,DEM,Kim Olson,137,83,54
+Brown,113,Commissioner of Agriculture,,LIB,Richard Carpenter,13,10,3
+Brown,113,Railroad Commissioner,,REP,Christi Craddick,899,622,277
+Brown,113,Railroad Commissioner,,DEM,Roman McAllen,117,73,44
+Brown,113,Railroad Commissioner,,LIB,Mike Wright,19,13,6
+Brown,113,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,899,622,277
+Brown,113,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,131,82,49
+Brown,113,"Justice, Supreme Court, Place 4",,REP,John Devine,899,622,277
+Brown,113,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,132,83,49
+Brown,113,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,900,625,275
+Brown,113,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,133,80,53
+Brown,113,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,892,618,274
+Brown,113,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,125,76,49
+Brown,113,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,17,11,6
+Brown,113,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,900,623,277
+Brown,113,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,129,81,48
+Brown,113,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,916,634,282
+Brown,113,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,61,41,20
+Brown,113,State Representative,60,REP,Mike Lang,951,657,294
+Brown,113,"Chief Justice, 11th Court of Appeals District",,REP,John Bailey,942,650,292
+Brown,113,County Judge,,REP,Paul Lilly,655,442,213
+Brown,113,County Judge,,,Steve Fryar (W),315,232,83
+Brown,113,Ballots Cast,,,,1053,,
+Brown,202,Straight Party,,REP,,288,216,72
+Brown,202,Straight Party,,DEM,,76,52,24
+Brown,202,Straight Party,,LIB,,2,2,0
+Brown,202,U.S. Senate,,REP,Ted Cruz,427,324,103
+Brown,202,U.S. Senate,,DEM,Beto O'Rourke,116,80,36
+Brown,202,U.S. Senate,,LIB,Neal M. Dikeman,4,3,1
+Brown,202,U.S. House,11,REP,Mike Conaway,425,325,100
+Brown,202,U.S. House,11,DEM,Jennie Lou Leeder,112,78,34
+Brown,202,U.S. House,11,LIB,Rhett Rosenquest Smith,10,6,4
+Brown,202,Governor,,REP,Greg Abbott,438,330,108
+Brown,202,Governor,,DEM,Lupe Valdez,108,77,31
+Brown,202,Governor,,LIB,Mark Jay Tippetts,7,5,2
+Brown,202,Lieutenant Governor,,REP,Dan Patrick,427,327,100
+Brown,202,Lieutenant Governor,,DEM,Mike Collier,116,79,37
+Brown,202,Lieutenant Governor,,LIB,Kerry Douglas McKennon,9,5,4
+Brown,202,Attorney General,,REP,Ken Paxton,432,328,104
+Brown,202,Attorney General,,DEM,Justin Nelson,114,80,34
+Brown,202,Attorney General,,LIB,Michael Ray Harris,5,4,1
+Brown,202,Comptroller of Public Accounts,,REP,Glenn Hegar,434,332,102
+Brown,202,Comptroller of Public Accounts,,DEM,Joi Chevalier,100,69,31
+Brown,202,Comptroller of Public Accounts,,LIB,Ben Sanders,11,6,5
+Brown,202,Commissioner of the General Land Office,,REP,George P. Bush,412,312,100
+Brown,202,Commissioner of the General Land Office,,DEM,Miguel Suazo,112,79,33
+Brown,202,Commissioner of the General Land Office,,LIB,Matt Piña,24,17,7
+Brown,202,Commissioner of Agriculture,,REP,Sid Miller,428,328,100
+Brown,202,Commissioner of Agriculture,,DEM,Kim Olson,109,74,35
+Brown,202,Commissioner of Agriculture,,LIB,Richard Carpenter,11,7,4
+Brown,202,Railroad Commissioner,,REP,Christi Craddick,429,326,103
+Brown,202,Railroad Commissioner,,DEM,Roman McAllen,106,73,33
+Brown,202,Railroad Commissioner,,LIB,Mike Wright,12,9,3
+Brown,202,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,431,328,103
+Brown,202,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,112,75,37
+Brown,202,"Justice, Supreme Court, Place 4",,REP,John Devine,434,331,103
+Brown,202,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,109,73,36
+Brown,202,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,430,327,103
+Brown,202,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,115,78,37
+Brown,202,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,432,327,105
+Brown,202,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,109,76,33
+Brown,202,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,6,4,2
+Brown,202,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,431,327,104
+Brown,202,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,113,77,36
+Brown,202,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,451,340,111
+Brown,202,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,40,24,16
+Brown,202,State Representative,60,REP,Mike Lang,469,350,119
+Brown,202,"Chief Justice, 11th Court of Appeals District",,REP,John Bailey,465,349,116
+Brown,202,County Judge,,REP,Paul Lilly,359,262,97
+Brown,202,County Judge,,,Steve Fryar (W),126,101,25
+Brown,202,Ballots Cast,,,,559,,
+Brown,204,Straight Party,,REP,,205,139,66
+Brown,204,Straight Party,,DEM,,75,38,37
+Brown,204,Straight Party,,LIB,,1,0,1
+Brown,204,U.S. Senate,,REP,Ted Cruz,307,209,98
+Brown,204,U.S. Senate,,DEM,Beto O'Rourke,143,82,61
+Brown,204,U.S. Senate,,LIB,Neal M. Dikeman,3,3,0
+Brown,204,U.S. House,11,REP,Mike Conaway,329,222,107
+Brown,204,U.S. House,11,DEM,Jennie Lou Leeder,113,66,47
+Brown,204,U.S. House,11,LIB,Rhett Rosenquest Smith,10,4,6
+Brown,204,Governor,,REP,Greg Abbott,323,217,106
+Brown,204,Governor,,DEM,Lupe Valdez,130,81,49
+Brown,204,Governor,,LIB,Mark Jay Tippetts,6,2,4
+Brown,204,Lieutenant Governor,,REP,Dan Patrick,313,211,102
+Brown,204,Lieutenant Governor,,DEM,Mike Collier,129,76,53
+Brown,204,Lieutenant Governor,,LIB,Kerry Douglas McKennon,11,6,5
+Brown,204,Attorney General,,REP,Ken Paxton,308,209,99
+Brown,204,Attorney General,,DEM,Justin Nelson,132,80,52
+Brown,204,Attorney General,,LIB,Michael Ray Harris,12,6,6
+Brown,204,Comptroller of Public Accounts,,REP,Glenn Hegar,312,214,98
+Brown,204,Comptroller of Public Accounts,,DEM,Joi Chevalier,125,75,50
+Brown,204,Comptroller of Public Accounts,,LIB,Ben Sanders,14,5,9
+Brown,204,Commissioner of the General Land Office,,REP,George P. Bush,313,209,104
+Brown,204,Commissioner of the General Land Office,,DEM,Miguel Suazo,112,69,43
+Brown,204,Commissioner of the General Land Office,,LIB,Matt Piña,28,18,10
+Brown,204,Commissioner of Agriculture,,REP,Sid Miller,309,210,99
+Brown,204,Commissioner of Agriculture,,DEM,Kim Olson,139,84,55
+Brown,204,Commissioner of Agriculture,,LIB,Richard Carpenter,7,2,5
+Brown,204,Railroad Commissioner,,REP,Christi Craddick,310,211,99
+Brown,204,Railroad Commissioner,,DEM,Roman McAllen,129,76,53
+Brown,204,Railroad Commissioner,,LIB,Mike Wright,13,6,7
+Brown,204,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,316,214,102
+Brown,204,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,139,81,58
+Brown,204,"Justice, Supreme Court, Place 4",,REP,John Devine,315,212,103
+Brown,204,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,139,83,56
+Brown,204,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,313,211,102
+Brown,204,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,141,84,57
+Brown,204,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,307,209,98
+Brown,204,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,136,81,55
+Brown,204,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,11,6,5
+Brown,204,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,312,210,102
+Brown,204,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,139,83,56
+Brown,204,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,323,220,103
+Brown,204,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,77,44,33
+Brown,204,State Representative,60,REP,Mike Lang,363,237,126
+Brown,204,"Chief Justice, 11th Court of Appeals District",,REP,John Bailey,358,233,125
+Brown,204,County Judge,,REP,Paul Lilly,319,213,106
+Brown,204,County Judge,,,Steve Fryar (W),74,45,29
+Brown,204,Ballots Cast,,,,466,,
+Brown,212,Straight Party,,REP,,36,27,9
+Brown,212,Straight Party,,DEM,,2,0,2
+Brown,212,Straight Party,,LIB,,0,0,0
+Brown,212,U.S. Senate,,REP,Ted Cruz,45,31,14
+Brown,212,U.S. Senate,,DEM,Beto O'Rourke,2,0,2
+Brown,212,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0
+Brown,212,U.S. House,11,REP,Mike Conaway,45,31,14
+Brown,212,U.S. House,11,DEM,Jennie Lou Leeder,1,0,1
+Brown,212,U.S. House,11,LIB,Rhett Rosenquest Smith,0,0,0
+Brown,212,Governor,,REP,Greg Abbott,46,32,14
+Brown,212,Governor,,DEM,Lupe Valdez,1,0,1
+Brown,212,Governor,,LIB,Mark Jay Tippetts,0,0,0
+Brown,212,Lieutenant Governor,,REP,Dan Patrick,44,31,13
+Brown,212,Lieutenant Governor,,DEM,Mike Collier,3,1,2
+Brown,212,Lieutenant Governor,,LIB,Kerry Douglas McKennon,0,0,0
+Brown,212,Attorney General,,REP,Ken Paxton,44,31,13
+Brown,212,Attorney General,,DEM,Justin Nelson,3,1,2
+Brown,212,Attorney General,,LIB,Michael Ray Harris,0,0,0
+Brown,212,Comptroller of Public Accounts,,REP,Glenn Hegar,46,32,14
+Brown,212,Comptroller of Public Accounts,,DEM,Joi Chevalier,1,0,1
+Brown,212,Comptroller of Public Accounts,,LIB,Ben Sanders,0,0,0
+Brown,212,Commissioner of the General Land Office,,REP,George P. Bush,45,31,14
+Brown,212,Commissioner of the General Land Office,,DEM,Miguel Suazo,2,0,2
+Brown,212,Commissioner of the General Land Office,,LIB,Matt Piña,1,1,0
+Brown,212,Commissioner of Agriculture,,REP,Sid Miller,45,32,13
+Brown,212,Commissioner of Agriculture,,DEM,Kim Olson,2,0,2
+Brown,212,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0
+Brown,212,Railroad Commissioner,,REP,Christi Craddick,45,32,13
+Brown,212,Railroad Commissioner,,DEM,Roman McAllen,2,0,2
+Brown,212,Railroad Commissioner,,LIB,Mike Wright,0,0,0
+Brown,212,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,45,31,14
+Brown,212,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,2,1,1
+Brown,212,"Justice, Supreme Court, Place 4",,REP,John Devine,46,32,14
+Brown,212,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,1,0,1
+Brown,212,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,46,32,14
+Brown,212,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,1,0,1
+Brown,212,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,45,32,13
+Brown,212,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,2,0,2
+Brown,212,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,1,0,1
+Brown,212,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,46,32,14
+Brown,212,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,1,0,1
+Brown,212,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,44,31,13
+Brown,212,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,3,1,2
+Brown,212,State Representative,60,REP,Mike Lang,47,32,15
+Brown,212,"Chief Justice, 11th Court of Appeals District",,REP,John Bailey,47,32,15
+Brown,212,County Judge,,REP,Paul Lilly,41,29,12
+Brown,212,County Judge,,,Steve Fryar (W),4,1,3
+Brown,212,Ballots Cast,,,,48,32,16
+Brown,212 - ISD,Straight Party,,REP,,229,104,125
+Brown,212 - ISD,Straight Party,,DEM,,18,12,6
+Brown,212 - ISD,Straight Party,,LIB,,1,1,0
+Brown,212 - ISD,U.S. Senate,,REP,Ted Cruz,394,178,216
+Brown,212 - ISD,U.S. Senate,,DEM,Beto O'Rourke,45,21,24
+Brown,212 - ISD,U.S. Senate,,LIB,Neal M. Dikeman,3,2,1
+Brown,212 - ISD,U.S. House,11,REP,Mike Conaway,402,181,221
+Brown,212 - ISD,U.S. House,11,DEM,Jennie Lou Leeder,45,22,23
+Brown,212 - ISD,U.S. House,11,LIB,Rhett Rosenquest Smith,2,0,2
+Brown,212 - ISD,Governor,,REP,Greg Abbott,406,183,223
+Brown,212 - ISD,Governor,,DEM,Lupe Valdez,40,20,20
+Brown,212 - ISD,Governor,,LIB,Mark Jay Tippetts,2,0,2
+Brown,212 - ISD,Lieutenant Governor,,REP,Dan Patrick,385,177,208
+Brown,212 - ISD,Lieutenant Governor,,DEM,Mike Collier,54,23,31
+Brown,212 - ISD,Lieutenant Governor,,LIB,Kerry Douglas McKennon,6,3,3
+Brown,212 - ISD,Attorney General,,REP,Ken Paxton,391,176,215
+Brown,212 - ISD,Attorney General,,DEM,Justin Nelson,51,25,26
+Brown,212 - ISD,Attorney General,,LIB,Michael Ray Harris,2,1,1
+Brown,212 - ISD,Comptroller of Public Accounts,,REP,Glenn Hegar,395,178,217
+Brown,212 - ISD,Comptroller of Public Accounts,,DEM,Joi Chevalier,43,22,21
+Brown,212 - ISD,Comptroller of Public Accounts,,LIB,Ben Sanders,5,1,4
+Brown,212 - ISD,Commissioner of the General Land Office,,REP,George P. Bush,389,175,214
+Brown,212 - ISD,Commissioner of the General Land Office,,DEM,Miguel Suazo,41,21,20
+Brown,212 - ISD,Commissioner of the General Land Office,,LIB,Matt Piña,16,8,8
+Brown,212 - ISD,Commissioner of Agriculture,,REP,Sid Miller,391,178,213
+Brown,212 - ISD,Commissioner of Agriculture,,DEM,Kim Olson,49,23,26
+Brown,212 - ISD,Commissioner of Agriculture,,LIB,Richard Carpenter,6,1,5
+Brown,212 - ISD,Railroad Commissioner,,REP,Christi Craddick,390,176,214
+Brown,212 - ISD,Railroad Commissioner,,DEM,Roman McAllen,47,24,23
+Brown,212 - ISD,Railroad Commissioner,,LIB,Mike Wright,6,0,6
+Brown,212 - ISD,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,389,178,211
+Brown,212 - ISD,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,52,22,30
+Brown,212 - ISD,"Justice, Supreme Court, Place 4",,REP,John Devine,396,179,217
+Brown,212 - ISD,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,43,21,22
+Brown,212 - ISD,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,391,177,214
+Brown,212 - ISD,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,46,22,24
+Brown,212 - ISD,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,392,179,213
+Brown,212 - ISD,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,43,21,22
+Brown,212 - ISD,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,7,1,6
+Brown,212 - ISD,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,393,177,216
+Brown,212 - ISD,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,46,22,24
+Brown,212 - ISD,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,395,177,218
+Brown,212 - ISD,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,20,6,14
+Brown,212 - ISD,State Representative,60,REP,Mike Lang,404,182,222
+Brown,212 - ISD,"Chief Justice, 11th Court of Appeals District",,REP,John Bailey,399,180,219
+Brown,212 - ISD,County Judge,,REP,Paul Lilly,311,136,175
+Brown,212 - ISD,County Judge,,,Steve Fryar (W),107,54,53
+Brown,212 - ISD,Ballots Cast,,,,459,,
+Brown,214,Straight Party,,REP,,13,13,0
+Brown,214,Straight Party,,DEM,,0,0,0
+Brown,214,Straight Party,,LIB,,0,0,0
+Brown,214,U.S. Senate,,REP,Ted Cruz,20,20,0
+Brown,214,U.S. Senate,,DEM,Beto O'Rourke,2,1,1
+Brown,214,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0
+Brown,214,U.S. House,11,REP,Mike Conaway,22,22,0
+Brown,214,U.S. House,11,DEM,Jennie Lou Leeder,1,0,1
+Brown,214,U.S. House,11,LIB,Rhett Rosenquest Smith,0,0,0
+Brown,214,Governor,,REP,Greg Abbott,22,22,0
+Brown,214,Governor,,DEM,Lupe Valdez,1,0,1
+Brown,214,Governor,,LIB,Mark Jay Tippetts,0,0,0
+Brown,214,Lieutenant Governor,,REP,Dan Patrick,22,22,0
+Brown,214,Lieutenant Governor,,DEM,Mike Collier,1,0,1
+Brown,214,Lieutenant Governor,,LIB,Kerry Douglas McKennon,0,0,0
+Brown,214,Attorney General,,REP,Ken Paxton,22,22,0
+Brown,214,Attorney General,,DEM,Justin Nelson,1,0,1
+Brown,214,Attorney General,,LIB,Michael Ray Harris,0,0,0
+Brown,214,Comptroller of Public Accounts,,REP,Glenn Hegar,20,20,0
+Brown,214,Comptroller of Public Accounts,,DEM,Joi Chevalier,3,2,1
+Brown,214,Comptroller of Public Accounts,,LIB,Ben Sanders,0,0,0
+Brown,214,Commissioner of the General Land Office,,REP,George P. Bush,22,21,1
+Brown,214,Commissioner of the General Land Office,,DEM,Miguel Suazo,1,1,0
+Brown,214,Commissioner of the General Land Office,,LIB,Matt Piña,0,0,0
+Brown,214,Commissioner of Agriculture,,REP,Sid Miller,21,21,0
+Brown,214,Commissioner of Agriculture,,DEM,Kim Olson,2,1,1
+Brown,214,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0
+Brown,214,Railroad Commissioner,,REP,Christi Craddick,21,21,0
+Brown,214,Railroad Commissioner,,DEM,Roman McAllen,2,1,1
+Brown,214,Railroad Commissioner,,LIB,Mike Wright,0,0,0
+Brown,214,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,21,21,0
+Brown,214,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,2,1,1
+Brown,214,"Justice, Supreme Court, Place 4",,REP,John Devine,22,22,0
+Brown,214,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,1,0,1
+Brown,214,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,22,22,0
+Brown,214,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,1,0,1
+Brown,214,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,21,21,0
+Brown,214,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,2,1,1
+Brown,214,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,0,0,0
+Brown,214,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,21,21,0
+Brown,214,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,1,1,0
+Brown,214,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,20,20,0
+Brown,214,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,2,2,0
+Brown,214,State Representative,60,REP,Mike Lang,22,22,0
+Brown,214,"Chief Justice, 11th Court of Appeals District",,REP,John Bailey,22,22,0
+Brown,214,County Judge,,REP,Paul Lilly,17,17,0
+Brown,214,County Judge,,,Steve Fryar (W),6,5,1
+Brown,214,Ballots Cast,,,,23,22,1
+Brown,214 - ISD,Straight Party,,REP,,213,165,48
+Brown,214 - ISD,Straight Party,,DEM,,18,14,4
+Brown,214 - ISD,Straight Party,,LIB,,1,1,0
+Brown,214 - ISD,U.S. Senate,,REP,Ted Cruz,327,256,71
+Brown,214 - ISD,U.S. Senate,,DEM,Beto O'Rourke,50,34,16
+Brown,214 - ISD,U.S. Senate,,LIB,Neal M. Dikeman,3,1,2
+Brown,214 - ISD,U.S. House,11,REP,Mike Conaway,341,260,81
+Brown,214 - ISD,U.S. House,11,DEM,Jennie Lou Leeder,47,34,13
+Brown,214 - ISD,U.S. House,11,LIB,Rhett Rosenquest Smith,4,3,1
+Brown,214 - ISD,Governor,,REP,Greg Abbott,346,261,85
+Brown,214 - ISD,Governor,,DEM,Lupe Valdez,39,31,8
+Brown,214 - ISD,Governor,,LIB,Mark Jay Tippetts,4,3,1
+Brown,214 - ISD,Lieutenant Governor,,REP,Dan Patrick,334,257,77
+Brown,214 - ISD,Lieutenant Governor,,DEM,Mike Collier,53,38,15
+Brown,214 - ISD,Lieutenant Governor,,LIB,Kerry Douglas McKennon,4,2,2
+Brown,214 - ISD,Attorney General,,REP,Ken Paxton,323,249,74
+Brown,214 - ISD,Attorney General,,DEM,Justin Nelson,56,39,17
+Brown,214 - ISD,Attorney General,,LIB,Michael Ray Harris,9,8,1
+Brown,214 - ISD,Comptroller of Public Accounts,,REP,Glenn Hegar,329,252,77
+Brown,214 - ISD,Comptroller of Public Accounts,,DEM,Joi Chevalier,47,36,11
+Brown,214 - ISD,Comptroller of Public Accounts,,LIB,Ben Sanders,8,6,2
+Brown,214 - ISD,Commissioner of the General Land Office,,REP,George P. Bush,329,249,80
+Brown,214 - ISD,Commissioner of the General Land Office,,DEM,Miguel Suazo,50,39,11
+Brown,214 - ISD,Commissioner of the General Land Office,,LIB,Matt Piña,7,7,0
+Brown,214 - ISD,Commissioner of Agriculture,,REP,Sid Miller,329,252,77
+Brown,214 - ISD,Commissioner of Agriculture,,DEM,Kim Olson,53,40,13
+Brown,214 - ISD,Commissioner of Agriculture,,LIB,Richard Carpenter,7,5,2
+Brown,214 - ISD,Railroad Commissioner,,REP,Christi Craddick,333,255,78
+Brown,214 - ISD,Railroad Commissioner,,DEM,Roman McAllen,47,34,13
+Brown,214 - ISD,Railroad Commissioner,,LIB,Mike Wright,8,7,1
+Brown,214 - ISD,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,332,257,75
+Brown,214 - ISD,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,53,35,18
+Brown,214 - ISD,"Justice, Supreme Court, Place 4",,REP,John Devine,333,256,77
+Brown,214 - ISD,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,51,36,15
+Brown,214 - ISD,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,334,256,78
+Brown,214 - ISD,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,52,37,15
+Brown,214 - ISD,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,330,252,78
+Brown,214 - ISD,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,49,35,14
+Brown,214 - ISD,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,7,7,0
+Brown,214 - ISD,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,336,256,80
+Brown,214 - ISD,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,50,37,13
+Brown,214 - ISD,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,341,260,81
+Brown,214 - ISD,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,28,20,8
+Brown,214 - ISD,State Representative,60,REP,Mike Lang,353,270,83
+Brown,214 - ISD,"Chief Justice, 11th Court of Appeals District",,REP,John Bailey,346,266,80
+Brown,214 - ISD,County Judge,,REP,Paul Lilly,280,205,75
+Brown,214 - ISD,County Judge,,,Steve Fryar (W),80,70,10
+Brown,214 - ISD,Ballots Cast,,,,393,,
+Brown,215,Straight Party,,REP,,88,60,28
+Brown,215,Straight Party,,DEM,,5,4,1
+Brown,215,Straight Party,,LIB,,0,0,0
+Brown,215,U.S. Senate,,REP,Ted Cruz,153,97,56
+Brown,215,U.S. Senate,,DEM,Beto O'Rourke,8,6,2
+Brown,215,U.S. Senate,,LIB,Neal M. Dikeman,1,0,1
+Brown,215,U.S. House,11,REP,Mike Conaway,156,98,58
+Brown,215,U.S. House,11,DEM,Jennie Lou Leeder,8,6,2
+Brown,215,U.S. House,11,LIB,Rhett Rosenquest Smith,1,1,0
+Brown,215,Governor,,REP,Greg Abbott,156,98,58
+Brown,215,Governor,,DEM,Lupe Valdez,8,6,2
+Brown,215,Governor,,LIB,Mark Jay Tippetts,1,1,0
+Brown,215,Lieutenant Governor,,REP,Dan Patrick,151,97,54
+Brown,215,Lieutenant Governor,,DEM,Mike Collier,12,7,5
+Brown,215,Lieutenant Governor,,LIB,Kerry Douglas McKennon,1,0,1
+Brown,215,Attorney General,,REP,Ken Paxton,155,97,58
+Brown,215,Attorney General,,DEM,Justin Nelson,9,7,2
+Brown,215,Attorney General,,LIB,Michael Ray Harris,1,1,0
+Brown,215,Comptroller of Public Accounts,,REP,Glenn Hegar,155,97,58
+Brown,215,Comptroller of Public Accounts,,DEM,Joi Chevalier,9,7,2
+Brown,215,Comptroller of Public Accounts,,LIB,Ben Sanders,1,1,0
+Brown,215,Commissioner of the General Land Office,,REP,George P. Bush,148,90,58
+Brown,215,Commissioner of the General Land Office,,DEM,Miguel Suazo,10,8,2
+Brown,215,Commissioner of the General Land Office,,LIB,Matt Piña,7,6,1
+Brown,215,Commissioner of Agriculture,,REP,Sid Miller,153,95,58
+Brown,215,Commissioner of Agriculture,,DEM,Kim Olson,10,7,3
+Brown,215,Commissioner of Agriculture,,LIB,Richard Carpenter,2,2,0
+Brown,215,Railroad Commissioner,,REP,Christi Craddick,155,97,58
+Brown,215,Railroad Commissioner,,DEM,Roman McAllen,8,6,2
+Brown,215,Railroad Commissioner,,LIB,Mike Wright,2,2,0
+Brown,215,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,157,98,59
+Brown,215,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,9,7,2
+Brown,215,"Justice, Supreme Court, Place 4",,REP,John Devine,157,98,59
+Brown,215,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,7,6,1
+Brown,215,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,156,98,58
+Brown,215,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,10,7,3
+Brown,215,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,158,99,59
+Brown,215,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,7,6,1
+Brown,215,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,1,0,1
+Brown,215,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,156,97,59
+Brown,215,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,8,6,2
+Brown,215,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,156,96,60
+Brown,215,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,3,3,0
+Brown,215,State Representative,60,REP,Mike Lang,153,94,59
+Brown,215,"Chief Justice, 11th Court of Appeals District",,REP,John Bailey,151,95,56
+Brown,215,County Judge,,REP,Paul Lilly,129,84,45
+Brown,215,County Judge,,,Steve Fryar (W),28,14,14
+Brown,215,Ballots Cast,,,,166,105,61
+Brown,215 - ISD,Straight Party,,REP,,0,0,0
+Brown,215 - ISD,Straight Party,,DEM,,0,0,0
+Brown,215 - ISD,Straight Party,,LIB,,0,0,0
+Brown,215 - ISD,U.S. Senate,,REP,Ted Cruz,0,0,0
+Brown,215 - ISD,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
+Brown,215 - ISD,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0
+Brown,215 - ISD,U.S. House,11,REP,Mike Conaway,0,0,0
+Brown,215 - ISD,U.S. House,11,DEM,Jennie Lou Leeder,0,0,0
+Brown,215 - ISD,U.S. House,11,LIB,Rhett Rosenquest Smith,0,0,0
+Brown,215 - ISD,Governor,,REP,Greg Abbott,0,0,0
+Brown,215 - ISD,Governor,,DEM,Lupe Valdez,0,0,0
+Brown,215 - ISD,Governor,,LIB,Mark Jay Tippetts,0,0,0
+Brown,215 - ISD,Lieutenant Governor,,REP,Dan Patrick,0,0,0
+Brown,215 - ISD,Lieutenant Governor,,DEM,Mike Collier,0,0,0
+Brown,215 - ISD,Lieutenant Governor,,LIB,Kerry Douglas McKennon,0,0,0
+Brown,215 - ISD,Attorney General,,REP,Ken Paxton,0,0,0
+Brown,215 - ISD,Attorney General,,DEM,Justin Nelson,0,0,0
+Brown,215 - ISD,Attorney General,,LIB,Michael Ray Harris,0,0,0
+Brown,215 - ISD,Comptroller of Public Accounts,,REP,Glenn Hegar,0,0,0
+Brown,215 - ISD,Comptroller of Public Accounts,,DEM,Joi Chevalier,0,0,0
+Brown,215 - ISD,Comptroller of Public Accounts,,LIB,Ben Sanders,0,0,0
+Brown,215 - ISD,Commissioner of the General Land Office,,REP,George P. Bush,0,0,0
+Brown,215 - ISD,Commissioner of the General Land Office,,DEM,Miguel Suazo,0,0,0
+Brown,215 - ISD,Commissioner of the General Land Office,,LIB,Matt Piña,0,0,0
+Brown,215 - ISD,Commissioner of Agriculture,,REP,Sid Miller,0,0,0
+Brown,215 - ISD,Commissioner of Agriculture,,DEM,Kim Olson,0,0,0
+Brown,215 - ISD,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0
+Brown,215 - ISD,Railroad Commissioner,,REP,Christi Craddick,0,0,0
+Brown,215 - ISD,Railroad Commissioner,,DEM,Roman McAllen,0,0,0
+Brown,215 - ISD,Railroad Commissioner,,LIB,Mike Wright,0,0,0
+Brown,215 - ISD,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,0,0,0
+Brown,215 - ISD,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,0,0,0
+Brown,215 - ISD,"Justice, Supreme Court, Place 4",,REP,John Devine,0,0,0
+Brown,215 - ISD,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,0,0,0
+Brown,215 - ISD,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,0,0,0
+Brown,215 - ISD,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,0,0,0
+Brown,215 - ISD,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,0,0,0
+Brown,215 - ISD,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,0,0,0
+Brown,215 - ISD,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,0,0,0
+Brown,215 - ISD,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,0,0,0
+Brown,215 - ISD,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0,0
+Brown,215 - ISD,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,0,0,0
+Brown,215 - ISD,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,0,0,0
+Brown,215 - ISD,State Representative,60,REP,Mike Lang,0,0,0
+Brown,215 - ISD,"Chief Justice, 11th Court of Appeals District",,REP,John Bailey,0,0,0
+Brown,215 - ISD,County Judge,,REP,Paul Lilly,0,0,0
+Brown,215 - ISD,County Judge,,,Steve Fryar (W),0,0,0
+Brown,215 - ISD,Ballots Cast,,,,0,0,0
+Brown,303,Straight Party,,REP,,295,219,76
+Brown,303,Straight Party,,DEM,,43,28,15
+Brown,303,Straight Party,,LIB,,2,0,2
+Brown,303,U.S. Senate,,REP,Ted Cruz,494,356,138
+Brown,303,U.S. Senate,,DEM,Beto O'Rourke,112,69,43
+Brown,303,U.S. Senate,,LIB,Neal M. Dikeman,6,3,3
+Brown,303,U.S. House,11,REP,Mike Conaway,503,362,141
+Brown,303,U.S. House,11,DEM,Jennie Lou Leeder,97,61,36
+Brown,303,U.S. House,11,LIB,Rhett Rosenquest Smith,10,6,4
+Brown,303,Governor,,REP,Greg Abbott,507,363,144
+Brown,303,Governor,,DEM,Lupe Valdez,100,64,36
+Brown,303,Governor,,LIB,Mark Jay Tippetts,7,5,2
+Brown,303,Lieutenant Governor,,REP,Dan Patrick,486,349,137
+Brown,303,Lieutenant Governor,,DEM,Mike Collier,110,72,38
+Brown,303,Lieutenant Governor,,LIB,Kerry Douglas McKennon,14,7,7
+Brown,303,Attorney General,,REP,Ken Paxton,486,350,136
+Brown,303,Attorney General,,DEM,Justin Nelson,110,68,42
+Brown,303,Attorney General,,LIB,Michael Ray Harris,12,9,3
+Brown,303,Comptroller of Public Accounts,,REP,Glenn Hegar,496,359,137
+Brown,303,Comptroller of Public Accounts,,DEM,Joi Chevalier,94,59,35
+Brown,303,Comptroller of Public Accounts,,LIB,Ben Sanders,15,9,6
+Brown,303,Commissioner of the General Land Office,,REP,George P. Bush,480,341,139
+Brown,303,Commissioner of the General Land Office,,DEM,Miguel Suazo,94,63,31
+Brown,303,Commissioner of the General Land Office,,LIB,Matt Piña,33,23,10
+Brown,303,Commissioner of Agriculture,,REP,Sid Miller,492,353,139
+Brown,303,Commissioner of Agriculture,,DEM,Kim Olson,102,67,35
+Brown,303,Commissioner of Agriculture,,LIB,Richard Carpenter,15,7,8
+Brown,303,Railroad Commissioner,,REP,Christi Craddick,495,354,141
+Brown,303,Railroad Commissioner,,DEM,Roman McAllen,93,61,32
+Brown,303,Railroad Commissioner,,LIB,Mike Wright,20,12,8
+Brown,303,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,498,359,139
+Brown,303,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,108,67,41
+Brown,303,"Justice, Supreme Court, Place 4",,REP,John Devine,508,365,143
+Brown,303,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,99,62,37
+Brown,303,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,501,362,139
+Brown,303,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,105,64,41
+Brown,303,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,493,358,135
+Brown,303,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,97,61,36
+Brown,303,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,16,7,9
+Brown,303,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,505,364,141
+Brown,303,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,102,62,40
+Brown,303,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,516,371,145
+Brown,303,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,59,33,26
+Brown,303,State Representative,60,REP,Mike Lang,529,370,159
+Brown,303,"Chief Justice, 11th Court of Appeals District",,REP,John Bailey,533,374,159
+Brown,303,County Judge,,REP,Paul Lilly,401,283,118
+Brown,303,County Judge,,,Steve Fryar (W),153,108,45
+Brown,303,Ballots Cast,,,,619,,
+Brown,306,Straight Party,,REP,,562,429,133
+Brown,306,Straight Party,,DEM,,55,44,11
+Brown,306,Straight Party,,LIB,,5,4,1
+Brown,306,U.S. Senate,,REP,Ted Cruz,920,671,249
+Brown,306,U.S. Senate,,DEM,Beto O'Rourke,103,77,26
+Brown,306,U.S. Senate,,LIB,Neal M. Dikeman,5,4,1
+Brown,306,U.S. House,11,REP,Mike Conaway,916,667,249
+Brown,306,U.S. House,11,DEM,Jennie Lou Leeder,97,72,25
+Brown,306,U.S. House,11,LIB,Rhett Rosenquest Smith,14,9,5
+Brown,306,Governor,,REP,Greg Abbott,923,673,250
+Brown,306,Governor,,DEM,Lupe Valdez,95,72,23
+Brown,306,Governor,,LIB,Mark Jay Tippetts,14,9,5
+Brown,306,Lieutenant Governor,,REP,Dan Patrick,854,630,224
+Brown,306,Lieutenant Governor,,DEM,Mike Collier,145,104,41
+Brown,306,Lieutenant Governor,,LIB,Kerry Douglas McKennon,25,15,10
+Brown,306,Attorney General,,REP,Ken Paxton,895,659,236
+Brown,306,Attorney General,,DEM,Justin Nelson,116,85,31
+Brown,306,Attorney General,,LIB,Michael Ray Harris,14,6,8
+Brown,306,Comptroller of Public Accounts,,REP,Glenn Hegar,911,672,239
+Brown,306,Comptroller of Public Accounts,,DEM,Joi Chevalier,92,69,23
+Brown,306,Comptroller of Public Accounts,,LIB,Ben Sanders,21,10,11
+Brown,306,Commissioner of the General Land Office,,REP,George P. Bush,898,660,238
+Brown,306,Commissioner of the General Land Office,,DEM,Miguel Suazo,92,66,26
+Brown,306,Commissioner of the General Land Office,,LIB,Matt Piña,38,27,11
+Brown,306,Commissioner of Agriculture,,REP,Sid Miller,899,658,241
+Brown,306,Commissioner of Agriculture,,DEM,Kim Olson,107,81,26
+Brown,306,Commissioner of Agriculture,,LIB,Richard Carpenter,19,13,6
+Brown,306,Railroad Commissioner,,REP,Christi Craddick,911,672,239
+Brown,306,Railroad Commissioner,,DEM,Roman McAllen,92,65,27
+Brown,306,Railroad Commissioner,,LIB,Mike Wright,20,13,7
+Brown,306,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,919,674,245
+Brown,306,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,101,74,27
+Brown,306,"Justice, Supreme Court, Place 4",,REP,John Devine,922,673,249
+Brown,306,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,95,72,23
+Brown,306,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,920,675,245
+Brown,306,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,98,71,27
+Brown,306,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,913,671,242
+Brown,306,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,89,66,23
+Brown,306,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,17,12,5
+Brown,306,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,922,675,247
+Brown,306,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,92,69,23
+Brown,306,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,923,677,246
+Brown,306,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,47,32,15
+Brown,306,State Representative,60,REP,Mike Lang,941,683,258
+Brown,306,"Chief Justice, 11th Court of Appeals District",,REP,John Bailey,939,681,258
+Brown,306,County Judge,,REP,Paul Lilly,694,504,190
+Brown,306,County Judge,,,Steve Fryar (W),263,196,67
+Brown,306,Ballots Cast,,,,1040,,
+Brown,307,Straight Party,,REP,,193,105,88
+Brown,307,Straight Party,,DEM,,17,8,9
+Brown,307,Straight Party,,LIB,,0,0,0
+Brown,307,U.S. Senate,,REP,Ted Cruz,362,182,180
+Brown,307,U.S. Senate,,DEM,Beto O'Rourke,46,29,17
+Brown,307,U.S. Senate,,LIB,Neal M. Dikeman,1,0,1
+Brown,307,U.S. House,11,REP,Mike Conaway,362,181,181
+Brown,307,U.S. House,11,DEM,Jennie Lou Leeder,40,24,16
+Brown,307,U.S. House,11,LIB,Rhett Rosenquest Smith,8,5,3
+Brown,307,Governor,,REP,Greg Abbott,373,186,187
+Brown,307,Governor,,DEM,Lupe Valdez,34,19,15
+Brown,307,Governor,,LIB,Mark Jay Tippetts,6,5,1
+Brown,307,Lieutenant Governor,,REP,Dan Patrick,348,177,171
+Brown,307,Lieutenant Governor,,DEM,Mike Collier,50,26,24
+Brown,307,Lieutenant Governor,,LIB,Kerry Douglas McKennon,12,6,6
+Brown,307,Attorney General,,REP,Ken Paxton,359,178,181
+Brown,307,Attorney General,,DEM,Justin Nelson,47,27,20
+Brown,307,Attorney General,,LIB,Michael Ray Harris,4,3,1
+Brown,307,Comptroller of Public Accounts,,REP,Glenn Hegar,359,182,177
+Brown,307,Comptroller of Public Accounts,,DEM,Joi Chevalier,37,20,17
+Brown,307,Comptroller of Public Accounts,,LIB,Ben Sanders,10,6,4
+Brown,307,Commissioner of the General Land Office,,REP,George P. Bush,344,173,171
+Brown,307,Commissioner of the General Land Office,,DEM,Miguel Suazo,40,22,18
+Brown,307,Commissioner of the General Land Office,,LIB,Matt Piña,22,12,10
+Brown,307,Commissioner of Agriculture,,REP,Sid Miller,365,184,181
+Brown,307,Commissioner of Agriculture,,DEM,Kim Olson,42,23,19
+Brown,307,Commissioner of Agriculture,,LIB,Richard Carpenter,5,2,3
+Brown,307,Railroad Commissioner,,REP,Christi Craddick,362,178,184
+Brown,307,Railroad Commissioner,,DEM,Roman McAllen,39,23,16
+Brown,307,Railroad Commissioner,,LIB,Mike Wright,9,7,2
+Brown,307,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,369,186,183
+Brown,307,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,41,23,18
+Brown,307,"Justice, Supreme Court, Place 4",,REP,John Devine,369,184,185
+Brown,307,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,40,24,16
+Brown,307,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,368,186,182
+Brown,307,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,41,22,19
+Brown,307,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,365,186,179
+Brown,307,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,38,20,18
+Brown,307,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,8,3,5
+Brown,307,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,370,187,183
+Brown,307,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,36,21,15
+Brown,307,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,369,186,183
+Brown,307,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,25,15,10
+Brown,307,State Representative,60,REP,Mike Lang,381,192,189
+Brown,307,"Chief Justice, 11th Court of Appeals District",,REP,John Bailey,380,193,187
+Brown,307,County Judge,,REP,Paul Lilly,286,149,137
+Brown,307,County Judge,,,Steve Fryar (W),100,48,52
+Brown,307,Ballots Cast,,,,418,,
+Brown,307 - ISD,Straight Party,,REP,,2,1,1
+Brown,307 - ISD,Straight Party,,DEM,,0,0,0
+Brown,307 - ISD,Straight Party,,LIB,,0,0,0
+Brown,307 - ISD,U.S. Senate,,REP,Ted Cruz,3,2,1
+Brown,307 - ISD,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
+Brown,307 - ISD,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0
+Brown,307 - ISD,U.S. House,11,REP,Mike Conaway,3,2,1
+Brown,307 - ISD,U.S. House,11,DEM,Jennie Lou Leeder,0,0,0
+Brown,307 - ISD,U.S. House,11,LIB,Rhett Rosenquest Smith,0,0,0
+Brown,307 - ISD,Governor,,REP,Greg Abbott,3,2,1
+Brown,307 - ISD,Governor,,DEM,Lupe Valdez,0,0,0
+Brown,307 - ISD,Governor,,LIB,Mark Jay Tippetts,0,0,0
+Brown,307 - ISD,Lieutenant Governor,,REP,Dan Patrick,3,2,1
+Brown,307 - ISD,Lieutenant Governor,,DEM,Mike Collier,0,0,0
+Brown,307 - ISD,Lieutenant Governor,,LIB,Kerry Douglas McKennon,0,0,0
+Brown,307 - ISD,Attorney General,,REP,Ken Paxton,3,2,1
+Brown,307 - ISD,Attorney General,,DEM,Justin Nelson,0,0,0
+Brown,307 - ISD,Attorney General,,LIB,Michael Ray Harris,0,0,0
+Brown,307 - ISD,Comptroller of Public Accounts,,REP,Glenn Hegar,3,2,1
+Brown,307 - ISD,Comptroller of Public Accounts,,DEM,Joi Chevalier,0,0,0
+Brown,307 - ISD,Comptroller of Public Accounts,,LIB,Ben Sanders,0,0,0
+Brown,307 - ISD,Commissioner of the General Land Office,,REP,George P. Bush,3,2,1
+Brown,307 - ISD,Commissioner of the General Land Office,,DEM,Miguel Suazo,0,0,0
+Brown,307 - ISD,Commissioner of the General Land Office,,LIB,Matt Piña,0,0,0
+Brown,307 - ISD,Commissioner of Agriculture,,REP,Sid Miller,3,2,1
+Brown,307 - ISD,Commissioner of Agriculture,,DEM,Kim Olson,0,0,0
+Brown,307 - ISD,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0
+Brown,307 - ISD,Railroad Commissioner,,REP,Christi Craddick,3,2,1
+Brown,307 - ISD,Railroad Commissioner,,DEM,Roman McAllen,0,0,0
+Brown,307 - ISD,Railroad Commissioner,,LIB,Mike Wright,0,0,0
+Brown,307 - ISD,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,3,2,1
+Brown,307 - ISD,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,0,0,0
+Brown,307 - ISD,"Justice, Supreme Court, Place 4",,REP,John Devine,3,2,1
+Brown,307 - ISD,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,0,0,0
+Brown,307 - ISD,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,3,2,1
+Brown,307 - ISD,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,0,0,0
+Brown,307 - ISD,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,3,2,1
+Brown,307 - ISD,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,0,0,0
+Brown,307 - ISD,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,0,0,0
+Brown,307 - ISD,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,3,2,1
+Brown,307 - ISD,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0,0
+Brown,307 - ISD,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,3,2,1
+Brown,307 - ISD,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,0,0,0
+Brown,307 - ISD,State Representative,60,REP,Mike Lang,3,2,1
+Brown,307 - ISD,"Chief Justice, 11th Court of Appeals District",,REP,John Bailey,3,2,1
+Brown,307 - ISD,County Judge,,REP,Paul Lilly,2,1,1
+Brown,307 - ISD,County Judge,,,Steve Fryar (W),1,1,0
+Brown,307 - ISD,Ballots Cast,,,,3,2,1
+Brown,308,Straight Party,,REP,,185,95,90
+Brown,308,Straight Party,,DEM,,11,9,2
+Brown,308,Straight Party,,LIB,,2,1,1
+Brown,308,U.S. Senate,,REP,Ted Cruz,311,155,156
+Brown,308,U.S. Senate,,DEM,Beto O'Rourke,22,14,8
+Brown,308,U.S. Senate,,LIB,Neal M. Dikeman,3,2,1
+Brown,308,U.S. House,11,REP,Mike Conaway,313,155,158
+Brown,308,U.S. House,11,DEM,Jennie Lou Leeder,19,12,7
+Brown,308,U.S. House,11,LIB,Rhett Rosenquest Smith,5,3,2
+Brown,308,Governor,,REP,Greg Abbott,318,158,160
+Brown,308,Governor,,DEM,Lupe Valdez,18,12,6
+Brown,308,Governor,,LIB,Mark Jay Tippetts,2,1,1
+Brown,308,Lieutenant Governor,,REP,Dan Patrick,300,153,147
+Brown,308,Lieutenant Governor,,DEM,Mike Collier,33,16,17
+Brown,308,Lieutenant Governor,,LIB,Kerry Douglas McKennon,5,2,3
+Brown,308,Attorney General,,REP,Ken Paxton,310,155,155
+Brown,308,Attorney General,,DEM,Justin Nelson,24,14,10
+Brown,308,Attorney General,,LIB,Michael Ray Harris,3,2,1
+Brown,308,Comptroller of Public Accounts,,REP,Glenn Hegar,308,153,155
+Brown,308,Comptroller of Public Accounts,,DEM,Joi Chevalier,21,13,8
+Brown,308,Comptroller of Public Accounts,,LIB,Ben Sanders,7,4,3
+Brown,308,Commissioner of the General Land Office,,REP,George P. Bush,308,154,154
+Brown,308,Commissioner of the General Land Office,,DEM,Miguel Suazo,22,13,9
+Brown,308,Commissioner of the General Land Office,,LIB,Matt Piña,7,4,3
+Brown,308,Commissioner of Agriculture,,REP,Sid Miller,306,153,153
+Brown,308,Commissioner of Agriculture,,DEM,Kim Olson,23,13,10
+Brown,308,Commissioner of Agriculture,,LIB,Richard Carpenter,7,4,3
+Brown,308,Railroad Commissioner,,REP,Christi Craddick,307,155,152
+Brown,308,Railroad Commissioner,,DEM,Roman McAllen,20,13,7
+Brown,308,Railroad Commissioner,,LIB,Mike Wright,9,3,6
+Brown,308,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,310,156,154
+Brown,308,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,23,13,10
+Brown,308,"Justice, Supreme Court, Place 4",,REP,John Devine,311,155,156
+Brown,308,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,23,14,9
+Brown,308,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,310,156,154
+Brown,308,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,23,13,10
+Brown,308,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,310,153,157
+Brown,308,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,20,13,7
+Brown,308,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,4,2,2
+Brown,308,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,311,155,156
+Brown,308,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,18,12,6
+Brown,308,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,306,151,155
+Brown,308,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,12,7,5
+Brown,308,State Representative,60,REP,Mike Lang,314,154,160
+Brown,308,"Chief Justice, 11th Court of Appeals District",,REP,John Bailey,311,151,160
+Brown,308,County Judge,,REP,Paul Lilly,200,100,100
+Brown,308,County Judge,,,Steve Fryar (W),113,53,60
+Brown,308,Ballots Cast,,,,341,,
+Brown,316,Straight Party,,REP,,57,42,15
+Brown,316,Straight Party,,DEM,,3,2,1
+Brown,316,Straight Party,,LIB,,0,0,0
+Brown,316,U.S. Senate,,REP,Ted Cruz,86,66,20
+Brown,316,U.S. Senate,,DEM,Beto O'Rourke,4,3,1
+Brown,316,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0
+Brown,316,U.S. House,11,REP,Mike Conaway,85,65,20
+Brown,316,U.S. House,11,DEM,Jennie Lou Leeder,4,3,1
+Brown,316,U.S. House,11,LIB,Rhett Rosenquest Smith,1,1,0
+Brown,316,Governor,,REP,Greg Abbott,87,67,20
+Brown,316,Governor,,DEM,Lupe Valdez,4,3,1
+Brown,316,Governor,,LIB,Mark Jay Tippetts,0,0,0
+Brown,316,Lieutenant Governor,,REP,Dan Patrick,85,65,20
+Brown,316,Lieutenant Governor,,DEM,Mike Collier,5,4,1
+Brown,316,Lieutenant Governor,,LIB,Kerry Douglas McKennon,1,1,0
+Brown,316,Attorney General,,REP,Ken Paxton,86,66,20
+Brown,316,Attorney General,,DEM,Justin Nelson,5,4,1
+Brown,316,Attorney General,,LIB,Michael Ray Harris,0,0,0
+Brown,316,Comptroller of Public Accounts,,REP,Glenn Hegar,86,66,20
+Brown,316,Comptroller of Public Accounts,,DEM,Joi Chevalier,4,3,1
+Brown,316,Comptroller of Public Accounts,,LIB,Ben Sanders,0,0,0
+Brown,316,Commissioner of the General Land Office,,REP,George P. Bush,79,60,19
+Brown,316,Commissioner of the General Land Office,,DEM,Miguel Suazo,5,4,1
+Brown,316,Commissioner of the General Land Office,,LIB,Matt Piña,6,5,1
+Brown,316,Commissioner of Agriculture,,REP,Sid Miller,85,65,20
+Brown,316,Commissioner of Agriculture,,DEM,Kim Olson,5,4,1
+Brown,316,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0
+Brown,316,Railroad Commissioner,,REP,Christi Craddick,86,66,20
+Brown,316,Railroad Commissioner,,DEM,Roman McAllen,4,3,1
+Brown,316,Railroad Commissioner,,LIB,Mike Wright,1,1,0
+Brown,316,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,87,67,20
+Brown,316,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,4,3,1
+Brown,316,"Justice, Supreme Court, Place 4",,REP,John Devine,87,67,20
+Brown,316,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,4,3,1
+Brown,316,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,87,67,20
+Brown,316,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,4,3,1
+Brown,316,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,87,67,20
+Brown,316,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,4,3,1
+Brown,316,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,0,0,0
+Brown,316,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,87,67,20
+Brown,316,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,4,3,1
+Brown,316,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,88,67,21
+Brown,316,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,1,1,0
+Brown,316,State Representative,60,REP,Mike Lang,87,66,21
+Brown,316,"Chief Justice, 11th Court of Appeals District",,REP,John Bailey,86,65,21
+Brown,316,County Judge,,REP,Paul Lilly,66,46,20
+Brown,316,County Judge,,,Steve Fryar (W),20,19,1
+Brown,316,Ballots Cast,,,,91,70,21
+Brown,316 - ISD,Straight Party,,REP,,34,18,16
+Brown,316 - ISD,Straight Party,,DEM,,0,0,0
+Brown,316 - ISD,Straight Party,,LIB,,0,0,0
+Brown,316 - ISD,U.S. Senate,,REP,Ted Cruz,53,27,26
+Brown,316 - ISD,U.S. Senate,,DEM,Beto O'Rourke,7,5,2
+Brown,316 - ISD,U.S. Senate,,LIB,Neal M. Dikeman,0,0,0
+Brown,316 - ISD,U.S. House,11,REP,Mike Conaway,54,27,27
+Brown,316 - ISD,U.S. House,11,DEM,Jennie Lou Leeder,5,4,1
+Brown,316 - ISD,U.S. House,11,LIB,Rhett Rosenquest Smith,1,1,0
+Brown,316 - ISD,Governor,,REP,Greg Abbott,54,27,27
+Brown,316 - ISD,Governor,,DEM,Lupe Valdez,5,5,0
+Brown,316 - ISD,Governor,,LIB,Mark Jay Tippetts,1,0,1
+Brown,316 - ISD,Lieutenant Governor,,REP,Dan Patrick,52,26,26
+Brown,316 - ISD,Lieutenant Governor,,DEM,Mike Collier,7,6,1
+Brown,316 - ISD,Lieutenant Governor,,LIB,Kerry Douglas McKennon,0,0,0
+Brown,316 - ISD,Attorney General,,REP,Ken Paxton,52,26,26
+Brown,316 - ISD,Attorney General,,DEM,Justin Nelson,8,6,2
+Brown,316 - ISD,Attorney General,,LIB,Michael Ray Harris,0,0,0
+Brown,316 - ISD,Comptroller of Public Accounts,,REP,Glenn Hegar,51,27,24
+Brown,316 - ISD,Comptroller of Public Accounts,,DEM,Joi Chevalier,7,5,2
+Brown,316 - ISD,Comptroller of Public Accounts,,LIB,Ben Sanders,1,0,1
+Brown,316 - ISD,Commissioner of the General Land Office,,REP,George P. Bush,49,25,24
+Brown,316 - ISD,Commissioner of the General Land Office,,DEM,Miguel Suazo,8,7,1
+Brown,316 - ISD,Commissioner of the General Land Office,,LIB,Matt Piña,2,0,2
+Brown,316 - ISD,Commissioner of Agriculture,,REP,Sid Miller,53,25,28
+Brown,316 - ISD,Commissioner of Agriculture,,DEM,Kim Olson,7,7,0
+Brown,316 - ISD,Commissioner of Agriculture,,LIB,Richard Carpenter,0,0,0
+Brown,316 - ISD,Railroad Commissioner,,REP,Christi Craddick,52,27,25
+Brown,316 - ISD,Railroad Commissioner,,DEM,Roman McAllen,6,5,1
+Brown,316 - ISD,Railroad Commissioner,,LIB,Mike Wright,1,0,1
+Brown,316 - ISD,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,52,27,25
+Brown,316 - ISD,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,6,5,1
+Brown,316 - ISD,"Justice, Supreme Court, Place 4",,REP,John Devine,53,27,26
+Brown,316 - ISD,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,5,5,0
+Brown,316 - ISD,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,52,27,25
+Brown,316 - ISD,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,6,5,1
+Brown,316 - ISD,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,50,27,23
+Brown,316 - ISD,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,7,5,2
+Brown,316 - ISD,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,1,0,1
+Brown,316 - ISD,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,53,27,26
+Brown,316 - ISD,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,5,5,0
+Brown,316 - ISD,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,55,29,26
+Brown,316 - ISD,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,3,3,0
+Brown,316 - ISD,State Representative,60,REP,Mike Lang,56,29,27
+Brown,316 - ISD,"Chief Justice, 11th Court of Appeals District",,REP,John Bailey,55,30,25
+Brown,316 - ISD,County Judge,,REP,Paul Lilly,43,24,19
+Brown,316 - ISD,County Judge,,,Steve Fryar (W),10,4,6
+Brown,316 - ISD,Ballots Cast,,,,60,32,28
+Brown,318,Straight Party,,REP,,501,366,135
+Brown,318,Straight Party,,DEM,,47,42,5
+Brown,318,Straight Party,,LIB,,1,1,0
+Brown,318,U.S. Senate,,REP,Ted Cruz,831,609,222
+Brown,318,U.S. Senate,,DEM,Beto O'Rourke,118,93,25
+Brown,318,U.S. Senate,,LIB,Neal M. Dikeman,7,4,3
+Brown,318,U.S. House,11,REP,Mike Conaway,834,607,227
+Brown,318,U.S. House,11,DEM,Jennie Lou Leeder,94,79,15
+Brown,318,U.S. House,11,LIB,Rhett Rosenquest Smith,19,14,5
+Brown,318,Governor,,REP,Greg Abbott,841,618,223
+Brown,318,Governor,,DEM,Lupe Valdez,95,76,19
+Brown,318,Governor,,LIB,Mark Jay Tippetts,14,9,5
+Brown,318,Lieutenant Governor,,REP,Dan Patrick,769,567,202
+Brown,318,Lieutenant Governor,,DEM,Mike Collier,154,123,31
+Brown,318,Lieutenant Governor,,LIB,Kerry Douglas McKennon,27,13,14
+Brown,318,Attorney General,,REP,Ken Paxton,814,593,221
+Brown,318,Attorney General,,DEM,Justin Nelson,116,93,23
+Brown,318,Attorney General,,LIB,Michael Ray Harris,23,16,7
+Brown,318,Comptroller of Public Accounts,,REP,Glenn Hegar,823,601,222
+Brown,318,Comptroller of Public Accounts,,DEM,Joi Chevalier,95,78,17
+Brown,318,Comptroller of Public Accounts,,LIB,Ben Sanders,23,16,7
+Brown,318,Commissioner of the General Land Office,,REP,George P. Bush,813,594,219
+Brown,318,Commissioner of the General Land Office,,DEM,Miguel Suazo,106,86,20
+Brown,318,Commissioner of the General Land Office,,LIB,Matt Piña,29,18,11
+Brown,318,Commissioner of Agriculture,,REP,Sid Miller,817,592,225
+Brown,318,Commissioner of Agriculture,,DEM,Kim Olson,107,89,18
+Brown,318,Commissioner of Agriculture,,LIB,Richard Carpenter,19,13,6
+Brown,318,Railroad Commissioner,,REP,Christi Craddick,827,601,226
+Brown,318,Railroad Commissioner,,DEM,Roman McAllen,94,76,18
+Brown,318,Railroad Commissioner,,LIB,Mike Wright,19,14,5
+Brown,318,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,836,607,229
+Brown,318,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,105,87,18
+Brown,318,"Justice, Supreme Court, Place 4",,REP,John Devine,838,612,226
+Brown,318,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,103,82,21
+Brown,318,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,831,601,230
+Brown,318,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,106,89,17
+Brown,318,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,821,598,223
+Brown,318,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,99,81,18
+Brown,318,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,21,16,5
+Brown,318,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,833,604,229
+Brown,318,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,98,80,18
+Brown,318,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,839,615,224
+Brown,318,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,57,38,19
+Brown,318,State Representative,60,REP,Mike Lang,854,617,237
+Brown,318,"Chief Justice, 11th Court of Appeals District",,REP,John Bailey,860,625,235
+Brown,318,County Judge,,REP,Paul Lilly,661,485,176
+Brown,318,County Judge,,,Steve Fryar (W),239,180,59
+Brown,318,Ballots Cast,,,,966,,
+Brown,410,Straight Party,,REP,,753,480,273
+Brown,410,Straight Party,,DEM,,77,45,32
+Brown,410,Straight Party,,LIB,,7,4,3
+Brown,410,U.S. Senate,,REP,Ted Cruz,1196,753,443
+Brown,410,U.S. Senate,,DEM,Beto O'Rourke,131,76,55
+Brown,410,U.S. Senate,,LIB,Neal M. Dikeman,3,1,2
+Brown,410,U.S. House,11,REP,Mike Conaway,1204,754,450
+Brown,410,U.S. House,11,DEM,Jennie Lou Leeder,122,69,53
+Brown,410,U.S. House,11,LIB,Rhett Rosenquest Smith,15,9,6
+Brown,410,Governor,,REP,Greg Abbott,1215,758,457
+Brown,410,Governor,,DEM,Lupe Valdez,118,69,49
+Brown,410,Governor,,LIB,Mark Jay Tippetts,11,7,4
+Brown,410,Lieutenant Governor,,REP,Dan Patrick,1158,724,434
+Brown,410,Lieutenant Governor,,DEM,Mike Collier,168,103,65
+Brown,410,Lieutenant Governor,,LIB,Kerry Douglas McKennon,18,9,9
+Brown,410,Attorney General,,REP,Ken Paxton,1183,741,442
+Brown,410,Attorney General,,DEM,Justin Nelson,143,84,59
+Brown,410,Attorney General,,LIB,Michael Ray Harris,19,11,8
+Brown,410,Comptroller of Public Accounts,,REP,Glenn Hegar,1194,754,440
+Brown,410,Comptroller of Public Accounts,,DEM,Joi Chevalier,112,61,51
+Brown,410,Comptroller of Public Accounts,,LIB,Ben Sanders,33,19,14
+Brown,410,Commissioner of the General Land Office,,REP,George P. Bush,1148,711,437
+Brown,410,Commissioner of the General Land Office,,DEM,Miguel Suazo,141,88,53
+Brown,410,Commissioner of the General Land Office,,LIB,Matt Piña,53,35,18
+Brown,410,Commissioner of Agriculture,,REP,Sid Miller,1194,748,446
+Brown,410,Commissioner of Agriculture,,DEM,Kim Olson,126,73,53
+Brown,410,Commissioner of Agriculture,,LIB,Richard Carpenter,23,13,10
+Brown,410,Railroad Commissioner,,REP,Christi Craddick,1181,749,432
+Brown,410,Railroad Commissioner,,DEM,Roman McAllen,128,70,58
+Brown,410,Railroad Commissioner,,LIB,Mike Wright,30,15,15
+Brown,410,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1197,753,444
+Brown,410,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,138,77,61
+Brown,410,"Justice, Supreme Court, Place 4",,REP,John Devine,1199,753,446
+Brown,410,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,135,76,59
+Brown,410,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1202,758,444
+Brown,410,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,132,72,60
+Brown,410,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1188,752,436
+Brown,410,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,127,69,58
+Brown,410,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,24,11,13
+Brown,410,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1207,760,447
+Brown,410,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,125,70,55
+Brown,410,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1206,759,447
+Brown,410,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,65,35,30
+Brown,410,State Representative,60,REP,Mike Lang,1230,766,464
+Brown,410,"Chief Justice, 11th Court of Appeals District",,REP,John Bailey,1228,764,464
+Brown,410,County Judge,,REP,Paul Lilly,1030,633,397
+Brown,410,County Judge,,,Steve Fryar (W),206,139,67
+Brown,410,Ballots Cast,,,,1359,,
+Brown,411,Straight Party,,REP,,260,171,89
+Brown,411,Straight Party,,DEM,,68,31,37
+Brown,411,Straight Party,,LIB,,3,1,2
+Brown,411,U.S. Senate,,REP,Ted Cruz,411,268,143
+Brown,411,U.S. Senate,,DEM,Beto O'Rourke,146,70,76
+Brown,411,U.S. Senate,,LIB,Neal M. Dikeman,6,3,3
+Brown,411,U.S. House,11,REP,Mike Conaway,416,265,151
+Brown,411,U.S. House,11,DEM,Jennie Lou Leeder,121,61,60
+Brown,411,U.S. House,11,LIB,Rhett Rosenquest Smith,14,3,11
+Brown,411,Governor,,REP,Greg Abbott,425,275,150
+Brown,411,Governor,,DEM,Lupe Valdez,123,59,64
+Brown,411,Governor,,LIB,Mark Jay Tippetts,15,6,9
+Brown,411,Lieutenant Governor,,REP,Dan Patrick,395,257,138
+Brown,411,Lieutenant Governor,,DEM,Mike Collier,138,67,71
+Brown,411,Lieutenant Governor,,LIB,Kerry Douglas McKennon,19,7,12
+Brown,411,Attorney General,,REP,Ken Paxton,406,262,144
+Brown,411,Attorney General,,DEM,Justin Nelson,129,63,66
+Brown,411,Attorney General,,LIB,Michael Ray Harris,19,8,11
+Brown,411,Comptroller of Public Accounts,,REP,Glenn Hegar,412,262,150
+Brown,411,Comptroller of Public Accounts,,DEM,Joi Chevalier,119,61,58
+Brown,411,Comptroller of Public Accounts,,LIB,Ben Sanders,20,8,12
+Brown,411,Commissioner of the General Land Office,,REP,George P. Bush,401,260,141
+Brown,411,Commissioner of the General Land Office,,DEM,Miguel Suazo,118,60,58
+Brown,411,Commissioner of the General Land Office,,LIB,Matt Piña,35,12,23
+Brown,411,Commissioner of Agriculture,,REP,Sid Miller,410,264,146
+Brown,411,Commissioner of Agriculture,,DEM,Kim Olson,122,60,62
+Brown,411,Commissioner of Agriculture,,LIB,Richard Carpenter,20,8,12
+Brown,411,Railroad Commissioner,,REP,Christi Craddick,416,263,153
+Brown,411,Railroad Commissioner,,DEM,Roman McAllen,117,58,59
+Brown,411,Railroad Commissioner,,LIB,Mike Wright,16,7,9
+Brown,411,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,416,266,150
+Brown,411,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,132,63,69
+Brown,411,"Justice, Supreme Court, Place 4",,REP,John Devine,417,267,150
+Brown,411,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,131,63,68
+Brown,411,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,418,267,151
+Brown,411,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,133,65,68
+Brown,411,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,406,261,145
+Brown,411,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,128,63,65
+Brown,411,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,17,7,10
+Brown,411,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,424,270,154
+Brown,411,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,125,61,64
+Brown,411,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,429,275,154
+Brown,411,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,70,33,37
+Brown,411,State Representative,60,REP,Mike Lang,469,295,174
+Brown,411,"Chief Justice, 11th Court of Appeals District",,REP,John Bailey,463,292,171
+Brown,411,County Judge,,REP,Paul Lilly,381,232,149
+Brown,411,County Judge,,,Steve Fryar (W),117,79,38
+Brown,411,Ballots Cast,,,,570,,
+Brown,417,Straight Party,,REP,,668,442,226
+Brown,417,Straight Party,,DEM,,72,58,14
+Brown,417,Straight Party,,LIB,,2,1,1
+Brown,417,U.S. Senate,,REP,Ted Cruz,999,664,335
+Brown,417,U.S. Senate,,DEM,Beto O'Rourke,115,86,29
+Brown,417,U.S. Senate,,LIB,Neal M. Dikeman,7,2,5
+Brown,417,U.S. House,11,REP,Mike Conaway,1001,664,337
+Brown,417,U.S. House,11,DEM,Jennie Lou Leeder,108,81,27
+Brown,417,U.S. House,11,LIB,Rhett Rosenquest Smith,14,9,5
+Brown,417,Governor,,REP,Greg Abbott,1013,669,344
+Brown,417,Governor,,DEM,Lupe Valdez,108,85,23
+Brown,417,Governor,,LIB,Mark Jay Tippetts,8,4,4
+Brown,417,Lieutenant Governor,,REP,Dan Patrick,975,642,333
+Brown,417,Lieutenant Governor,,DEM,Mike Collier,131,103,28
+Brown,417,Lieutenant Governor,,LIB,Kerry Douglas McKennon,15,10,5
+Brown,417,Attorney General,,REP,Ken Paxton,983,649,334
+Brown,417,Attorney General,,DEM,Justin Nelson,124,97,27
+Brown,417,Attorney General,,LIB,Michael Ray Harris,16,8,8
+Brown,417,Comptroller of Public Accounts,,REP,Glenn Hegar,991,659,332
+Brown,417,Comptroller of Public Accounts,,DEM,Joi Chevalier,111,86,25
+Brown,417,Comptroller of Public Accounts,,LIB,Ben Sanders,19,8,11
+Brown,417,Commissioner of the General Land Office,,REP,George P. Bush,961,638,323
+Brown,417,Commissioner of the General Land Office,,DEM,Miguel Suazo,115,85,30
+Brown,417,Commissioner of the General Land Office,,LIB,Matt Piña,40,26,14
+Brown,417,Commissioner of Agriculture,,REP,Sid Miller,990,657,333
+Brown,417,Commissioner of Agriculture,,DEM,Kim Olson,115,90,25
+Brown,417,Commissioner of Agriculture,,LIB,Richard Carpenter,18,9,9
+Brown,417,Railroad Commissioner,,REP,Christi Craddick,994,661,333
+Brown,417,Railroad Commissioner,,DEM,Roman McAllen,113,84,29
+Brown,417,Railroad Commissioner,,LIB,Mike Wright,16,9,7
+Brown,417,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1001,663,338
+Brown,417,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,118,89,29
+Brown,417,"Justice, Supreme Court, Place 4",,REP,John Devine,1004,666,338
+Brown,417,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,114,86,28
+Brown,417,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,995,659,336
+Brown,417,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,124,93,31
+Brown,417,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,986,657,329
+Brown,417,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,109,80,29
+Brown,417,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,23,13,10
+Brown,417,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1004,669,335
+Brown,417,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,113,83,30
+Brown,417,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1008,666,342
+Brown,417,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,54,40,14
+Brown,417,State Representative,60,REP,Mike Lang,1020,674,346
+Brown,417,"Chief Justice, 11th Court of Appeals District",,REP,John Bailey,1022,678,344
+Brown,417,County Judge,,REP,Paul Lilly,851,553,298
+Brown,417,County Judge,,,Steve Fryar (W),197,146,51


### PR DESCRIPTION
Brown County, though it uses Hart HVS, does not include statistics on over/undervotes.
As such, I can't get accurate numbers on ballots cast by type per precinct.