### PR TITLE
Update precinct-level results for the 2018 general election in Comal County

### DIFF
--- a/2018/20181106__tx__general__comal__precinct.csv
+++ b/2018/20181106__tx__general__comal__precinct.csv
@@ -1,1879 +1,1935 @@
-county,precinct,office,district,party,candidate,votes
-Comal,101,Straight Party,,REP,Republican Party,1085
-Comal,102,Straight Party,,REP,Republican Party,1449
-Comal,103,Straight Party,,REP,Republican Party,1294
-Comal,104,Straight Party,,REP,Republican Party,752
-Comal,105,Straight Party,,REP,Republican Party,1782
-Comal,106,Straight Party,,REP,Republican Party,1890
-Comal,107,Straight Party,,REP,Republican Party,775
-Comal,201,Straight Party,,REP,Republican Party,1182
-Comal,202,Straight Party,,REP,Republican Party,337
-Comal,203,Straight Party,,REP,Republican Party,1507
-Comal,204,Straight Party,,REP,Republican Party,1247
-Comal,205,Straight Party,,REP,Republican Party,1887
-Comal,206,Straight Party,,REP,Republican Party,1822
-Comal,207,Straight Party,,REP,Republican Party,725
-Comal,208,Straight Party,,REP,Republican Party,746
-Comal,301,Straight Party,,REP,Republican Party,597
-Comal,302,Straight Party,,REP,Republican Party,1165
-Comal,303,Straight Party,,REP,Republican Party,144
-Comal,304,Straight Party,,REP,Republican Party,855
-Comal,305,Straight Party,,REP,Republican Party,551
-Comal,306,Straight Party,,REP,Republican Party,342
-Comal,401,Straight Party,,REP,Republican Party,638
-Comal,402,Straight Party,,REP,Republican Party,1498
-Comal,403,Straight Party,,REP,Republican Party,1868
-Comal,404,Straight Party,,REP,Republican Party,1196
-Comal,405,Straight Party,,REP,Republican Party,1358
-Comal,406,Straight Party,,REP,Republican Party,1561
-Comal,407,Straight Party,,REP,Republican Party,1029
-Comal,101,Straight Party,,DEM,Democratic Party,385
-Comal,102,Straight Party,,DEM,Democratic Party,225
-Comal,103,Straight Party,,DEM,Democratic Party,231
-Comal,104,Straight Party,,DEM,Democratic Party,175
-Comal,105,Straight Party,,DEM,Democratic Party,415
-Comal,106,Straight Party,,DEM,Democratic Party,302
-Comal,107,Straight Party,,DEM,Democratic Party,154
-Comal,201,Straight Party,,DEM,Democratic Party,471
-Comal,202,Straight Party,,DEM,Democratic Party,127
-Comal,203,Straight Party,,DEM,Democratic Party,338
-Comal,204,Straight Party,,DEM,Democratic Party,252
-Comal,205,Straight Party,,DEM,Democratic Party,470
-Comal,206,Straight Party,,DEM,Democratic Party,340
-Comal,207,Straight Party,,DEM,Democratic Party,128
-Comal,208,Straight Party,,DEM,Democratic Party,139
-Comal,301,Straight Party,,DEM,Democratic Party,599
-Comal,302,Straight Party,,DEM,Democratic Party,553
-Comal,303,Straight Party,,DEM,Democratic Party,156
-Comal,304,Straight Party,,DEM,Democratic Party,473
-Comal,305,Straight Party,,DEM,Democratic Party,206
-Comal,306,Straight Party,,DEM,Democratic Party,178
-Comal,401,Straight Party,,DEM,Democratic Party,203
-Comal,402,Straight Party,,DEM,Democratic Party,401
-Comal,403,Straight Party,,DEM,Democratic Party,403
-Comal,404,Straight Party,,DEM,Democratic Party,262
-Comal,405,Straight Party,,DEM,Democratic Party,268
-Comal,406,Straight Party,,DEM,Democratic Party,476
-Comal,407,Straight Party,,DEM,Democratic Party,184
-Comal,101,Straight Party,,LIB,Libertarian Party,11
-Comal,102,Straight Party,,LIB,Libertarian Party,11
-Comal,103,Straight Party,,LIB,Libertarian Party,6
-Comal,104,Straight Party,,LIB,Libertarian Party,8
-Comal,105,Straight Party,,LIB,Libertarian Party,12
-Comal,106,Straight Party,,LIB,Libertarian Party,9
-Comal,107,Straight Party,,LIB,Libertarian Party,5
-Comal,201,Straight Party,,LIB,Libertarian Party,8
-Comal,202,Straight Party,,LIB,Libertarian Party,2
-Comal,203,Straight Party,,LIB,Libertarian Party,9
-Comal,204,Straight Party,,LIB,Libertarian Party,11
-Comal,205,Straight Party,,LIB,Libertarian Party,10
-Comal,206,Straight Party,,LIB,Libertarian Party,9
-Comal,207,Straight Party,,LIB,Libertarian Party,1
-Comal,208,Straight Party,,LIB,Libertarian Party,2
-Comal,301,Straight Party,,LIB,Libertarian Party,11
-Comal,302,Straight Party,,LIB,Libertarian Party,11
-Comal,303,Straight Party,,LIB,Libertarian Party,2
-Comal,304,Straight Party,,LIB,Libertarian Party,5
-Comal,305,Straight Party,,LIB,Libertarian Party,4
-Comal,306,Straight Party,,LIB,Libertarian Party,7
-Comal,401,Straight Party,,LIB,Libertarian Party,5
-Comal,402,Straight Party,,LIB,Libertarian Party,12
-Comal,403,Straight Party,,LIB,Libertarian Party,7
-Comal,404,Straight Party,,LIB,Libertarian Party,7
-Comal,405,Straight Party,,LIB,Libertarian Party,9
-Comal,406,Straight Party,,LIB,Libertarian Party,7
-Comal,407,Straight Party,,LIB,Libertarian Party,6
-Comal,101,United States Senator,,REP,Ted Cruz,1606
-Comal,102,United States Senator,,REP,Ted Cruz,1951
-Comal,103,United States Senator,,REP,Ted Cruz,1871
-Comal,104,United States Senator,,REP,Ted Cruz,1036
-Comal,105,United States Senator,,REP,Ted Cruz,2390
-Comal,106,United States Senator,,REP,Ted Cruz,2539
-Comal,107,United States Senator,,REP,Ted Cruz,1088
-Comal,201,United States Senator,,REP,Ted Cruz,1725
-Comal,202,United States Senator,,REP,Ted Cruz,469
-Comal,203,United States Senator,,REP,Ted Cruz,2128
-Comal,204,United States Senator,,REP,Ted Cruz,1748
-Comal,205,United States Senator,,REP,Ted Cruz,2651
-Comal,206,United States Senator,,REP,Ted Cruz,2625
-Comal,207,United States Senator,,REP,Ted Cruz,1088
-Comal,208,United States Senator,,REP,Ted Cruz,1020
-Comal,301,United States Senator,,REP,Ted Cruz,849
-Comal,302,United States Senator,,REP,Ted Cruz,1660
-Comal,303,United States Senator,,REP,Ted Cruz,212
-Comal,304,United States Senator,,REP,Ted Cruz,1204
-Comal,305,United States Senator,,REP,Ted Cruz,832
-Comal,306,United States Senator,,REP,Ted Cruz,509
-Comal,401,United States Senator,,REP,Ted Cruz,924
-Comal,402,United States Senator,,REP,Ted Cruz,2106
-Comal,403,United States Senator,,REP,Ted Cruz,2607
-Comal,404,United States Senator,,REP,Ted Cruz,1720
-Comal,405,United States Senator,,REP,Ted Cruz,1827
-Comal,406,United States Senator,,REP,Ted Cruz,2194
-Comal,407,United States Senator,,REP,Ted Cruz,1500
-Comal,101,United States Senator,,DEM,Beto O'Rourke,858
-Comal,102,United States Senator,,DEM,Beto O'Rourke,461
-Comal,103,United States Senator,,DEM,Beto O'Rourke,527
-Comal,104,United States Senator,,DEM,Beto O'Rourke,325
-Comal,105,United States Senator,,DEM,Beto O'Rourke,772
-Comal,106,United States Senator,,DEM,Beto O'Rourke,613
-Comal,107,United States Senator,,DEM,Beto O'Rourke,341
-Comal,201,United States Senator,,DEM,Beto O'Rourke,889
-Comal,202,United States Senator,,DEM,Beto O'Rourke,201
-Comal,203,United States Senator,,DEM,Beto O'Rourke,703
-Comal,204,United States Senator,,DEM,Beto O'Rourke,518
-Comal,205,United States Senator,,DEM,Beto O'Rourke,998
-Comal,206,United States Senator,,DEM,Beto O'Rourke,723
-Comal,207,United States Senator,,DEM,Beto O'Rourke,308
-Comal,208,United States Senator,,DEM,Beto O'Rourke,289
-Comal,301,United States Senator,,DEM,Beto O'Rourke,935
-Comal,302,United States Senator,,DEM,Beto O'Rourke,1065
-Comal,303,United States Senator,,DEM,Beto O'Rourke,266
-Comal,304,United States Senator,,DEM,Beto O'Rourke,854
-Comal,305,United States Senator,,DEM,Beto O'Rourke,441
-Comal,306,United States Senator,,DEM,Beto O'Rourke,316
-Comal,401,United States Senator,,DEM,Beto O'Rourke,424
-Comal,402,United States Senator,,DEM,Beto O'Rourke,781
-Comal,403,United States Senator,,DEM,Beto O'Rourke,768
-Comal,404,United States Senator,,DEM,Beto O'Rourke,545
-Comal,405,United States Senator,,DEM,Beto O'Rourke,508
-Comal,406,United States Senator,,DEM,Beto O'Rourke,942
-Comal,407,United States Senator,,DEM,Beto O'Rourke,459
-Comal,101,United States Senator,,LIB,Neal M. Dikeman,26
-Comal,102,United States Senator,,LIB,Neal M. Dikeman,18
-Comal,103,United States Senator,,LIB,Neal M. Dikeman,22
-Comal,104,United States Senator,,LIB,Neal M. Dikeman,21
-Comal,105,United States Senator,,LIB,Neal M. Dikeman,34
-Comal,106,United States Senator,,LIB,Neal M. Dikeman,24
-Comal,107,United States Senator,,LIB,Neal M. Dikeman,12
-Comal,201,United States Senator,,LIB,Neal M. Dikeman,34
-Comal,202,United States Senator,,LIB,Neal M. Dikeman,4
-Comal,203,United States Senator,,LIB,Neal M. Dikeman,20
-Comal,204,United States Senator,,LIB,Neal M. Dikeman,23
-Comal,205,United States Senator,,LIB,Neal M. Dikeman,32
-Comal,206,United States Senator,,LIB,Neal M. Dikeman,36
-Comal,207,United States Senator,,LIB,Neal M. Dikeman,5
-Comal,208,United States Senator,,LIB,Neal M. Dikeman,3
-Comal,301,United States Senator,,LIB,Neal M. Dikeman,21
-Comal,302,United States Senator,,LIB,Neal M. Dikeman,42
-Comal,303,United States Senator,,LIB,Neal M. Dikeman,2
-Comal,304,United States Senator,,LIB,Neal M. Dikeman,18
-Comal,305,United States Senator,,LIB,Neal M. Dikeman,12
-Comal,306,United States Senator,,LIB,Neal M. Dikeman,13
-Comal,401,United States Senator,,LIB,Neal M. Dikeman,15
-Comal,402,United States Senator,,LIB,Neal M. Dikeman,39
-Comal,403,United States Senator,,LIB,Neal M. Dikeman,23
-Comal,404,United States Senator,,LIB,Neal M. Dikeman,17
-Comal,405,United States Senator,,LIB,Neal M. Dikeman,23
-Comal,406,United States Senator,,LIB,Neal M. Dikeman,21
-Comal,407,United States Senator,,LIB,Neal M. Dikeman,26
-Comal,101,United States Representative,21,REP,Chip Roy,1602
-Comal,102,United States Representative,21,REP,Chip Roy,1966
-Comal,103,United States Representative,21,REP,Chip Roy,1876
-Comal,104,United States Representative,21,REP,Chip Roy,1036
-Comal,105,United States Representative,21,REP,Chip Roy,2405
-Comal,106,United States Representative,21,REP,Chip Roy,2549
-Comal,107,United States Representative,21,REP,Chip Roy,1091
-Comal,203,United States Representative,21,REP,Chip Roy,2151
-Comal,204,United States Representative,21,REP,Chip Roy,1748
-Comal,205,United States Representative,21,REP,Chip Roy,2658
-Comal,206,United States Representative,21,REP,Chip Roy,2624
-Comal,207,United States Representative,21,REP,Chip Roy,1104
-Comal,208,United States Representative,21,REP,Chip Roy,1023
-Comal,305,United States Representative,21,REP,Chip Roy,828
-Comal,401,United States Representative,21,REP,Chip Roy,925
-Comal,402,United States Representative,21,REP,Chip Roy,2090
-Comal,403,United States Representative,21,REP,Chip Roy,2612
-Comal,404,United States Representative,21,REP,Chip Roy,1715
-Comal,405,United States Representative,21,REP,Chip Roy,1808
-Comal,406,United States Representative,21,REP,Chip Roy,2201
-Comal,407,United States Representative,21,REP,Chip Roy,1502
-Comal,101,United States Representative,21,DEM,Joseph Kopser,812
-Comal,102,United States Representative,21,DEM,Joseph Kopser,440
-Comal,103,United States Representative,21,DEM,Joseph Kopser,500
-Comal,104,United States Representative,21,DEM,Joseph Kopser,312
-Comal,105,United States Representative,21,DEM,Joseph Kopser,744
-Comal,106,United States Representative,21,DEM,Joseph Kopser,587
-Comal,107,United States Representative,21,DEM,Joseph Kopser,329
-Comal,203,United States Representative,21,DEM,Joseph Kopser,669
-Comal,204,United States Representative,21,DEM,Joseph Kopser,515
-Comal,205,United States Representative,21,DEM,Joseph Kopser,965
-Comal,206,United States Representative,21,DEM,Joseph Kopser,713
-Comal,207,United States Representative,21,DEM,Joseph Kopser,284
-Comal,208,United States Representative,21,DEM,Joseph Kopser,273
-Comal,305,United States Representative,21,DEM,Joseph Kopser,414
-Comal,401,United States Representative,21,DEM,Joseph Kopser,417
-Comal,402,United States Representative,21,DEM,Joseph Kopser,769
-Comal,403,United States Representative,21,DEM,Joseph Kopser,741
-Comal,404,United States Representative,21,DEM,Joseph Kopser,515
-Comal,405,United States Representative,21,DEM,Joseph Kopser,505
-Comal,406,United States Representative,21,DEM,Joseph Kopser,909
-Comal,407,United States Representative,21,DEM,Joseph Kopser,442
-Comal,101,United States Representative,21,LIB,Lee Santos,69
-Comal,102,United States Representative,21,LIB,Lee Santos,41
-Comal,103,United States Representative,21,LIB,Lee Santos,31
-Comal,104,United States Representative,21,LIB,Lee Santos,27
-Comal,105,United States Representative,21,LIB,Lee Santos,53
-Comal,106,United States Representative,21,LIB,Lee Santos,42
-Comal,107,United States Representative,21,LIB,Lee Santos,22
-Comal,203,United States Representative,21,LIB,Lee Santos,26
-Comal,204,United States Representative,21,LIB,Lee Santos,33
-Comal,205,United States Representative,21,LIB,Lee Santos,55
-Comal,206,United States Representative,21,LIB,Lee Santos,56
-Comal,207,United States Representative,21,LIB,Lee Santos,11
-Comal,208,United States Representative,21,LIB,Lee Santos,14
-Comal,305,United States Representative,21,LIB,Lee Santos,34
-Comal,401,United States Representative,21,LIB,Lee Santos,27
-Comal,402,United States Representative,21,LIB,Lee Santos,57
-Comal,403,United States Representative,21,LIB,Lee Santos,43
-Comal,404,United States Representative,21,LIB,Lee Santos,39
-Comal,405,United States Representative,21,LIB,Lee Santos,44
-Comal,406,United States Representative,21,LIB,Lee Santos,49
-Comal,407,United States Representative,21,LIB,Lee Santos,34
-Comal,201,United States Representative,35,REP,David Smalling,1674
-Comal,202,United States Representative,35,REP,David Smalling,453
-Comal,301,United States Representative,35,REP,David Smalling,812
-Comal,302,United States Representative,35,REP,David Smalling,1606
-Comal,303,United States Representative,35,REP,David Smalling,199
-Comal,304,United States Representative,35,REP,David Smalling,1171
-Comal,306,United States Representative,35,REP,David Smalling,486
-Comal,201,United States Representative,35,DEM,Lloyd Doggett,888
-Comal,202,United States Representative,35,DEM,Lloyd Doggett,206
-Comal,301,United States Representative,35,DEM,Lloyd Doggett,919
-Comal,302,United States Representative,35,DEM,Lloyd Doggett,1048
-Comal,303,United States Representative,35,DEM,Lloyd Doggett,270
-Comal,304,United States Representative,35,DEM,Lloyd Doggett,820
-Comal,306,United States Representative,35,DEM,Lloyd Doggett,320
-Comal,201,United States Representative,35,LIB,Clark Patterson,61
-Comal,202,United States Representative,35,LIB,Clark Patterson,9
-Comal,301,United States Representative,35,LIB,Clark Patterson,49
-Comal,302,United States Representative,35,LIB,Clark Patterson,88
-Comal,303,United States Representative,35,LIB,Clark Patterson,13
-Comal,304,United States Representative,35,LIB,Clark Patterson,52
-Comal,306,United States Representative,35,LIB,Clark Patterson,23
-Comal,101,Governor,,REP,Greg Abbott,1743
-Comal,102,Governor,,REP,Greg Abbott,2034
-Comal,103,Governor,,REP,Greg Abbott,1962
-Comal,104,Governor,,REP,Greg Abbott,1088
-Comal,105,Governor,,REP,Greg Abbott,2539
-Comal,106,Governor,,REP,Greg Abbott,2657
-Comal,107,Governor,,REP,Greg Abbott,1144
-Comal,201,Governor,,REP,Greg Abbott,1845
-Comal,202,Governor,,REP,Greg Abbott,486
-Comal,203,Governor,,REP,Greg Abbott,2261
-Comal,204,Governor,,REP,Greg Abbott,1830
-Comal,205,Governor,,REP,Greg Abbott,2835
-Comal,206,Governor,,REP,Greg Abbott,2772
-Comal,207,Governor,,REP,Greg Abbott,1155
-Comal,208,Governor,,REP,Greg Abbott,1077
-Comal,301,Governor,,REP,Greg Abbott,945
-Comal,302,Governor,,REP,Greg Abbott,1789
-Comal,303,Governor,,REP,Greg Abbott,233
-Comal,304,Governor,,REP,Greg Abbott,1281
-Comal,305,Governor,,REP,Greg Abbott,894
-Comal,306,Governor,,REP,Greg Abbott,549
-Comal,401,Governor,,REP,Greg Abbott,977
-Comal,402,Governor,,REP,Greg Abbott,2200
-Comal,403,Governor,,REP,Greg Abbott,2711
-Comal,404,Governor,,REP,Greg Abbott,1809
-Comal,405,Governor,,REP,Greg Abbott,1892
-Comal,406,Governor,,REP,Greg Abbott,2341
-Comal,407,Governor,,REP,Greg Abbott,1586
-Comal,101,Governor,,DEM,Lupe Valdez,690
-Comal,102,Governor,,DEM,Lupe Valdez,391
-Comal,103,Governor,,DEM,Lupe Valdez,438
-Comal,104,Governor,,DEM,Lupe Valdez,273
-Comal,105,Governor,,DEM,Lupe Valdez,634
-Comal,106,Governor,,DEM,Lupe Valdez,491
-Comal,107,Governor,,DEM,Lupe Valdez,282
-Comal,201,Governor,,DEM,Lupe Valdez,771
-Comal,202,Governor,,DEM,Lupe Valdez,183
-Comal,203,Governor,,DEM,Lupe Valdez,582
-Comal,204,Governor,,DEM,Lupe Valdez,446
-Comal,205,Governor,,DEM,Lupe Valdez,803
-Comal,206,Governor,,DEM,Lupe Valdez,598
-Comal,207,Governor,,DEM,Lupe Valdez,231
-Comal,208,Governor,,DEM,Lupe Valdez,234
-Comal,301,Governor,,DEM,Lupe Valdez,831
-Comal,302,Governor,,DEM,Lupe Valdez,922
-Comal,303,Governor,,DEM,Lupe Valdez,243
-Comal,304,Governor,,DEM,Lupe Valdez,756
-Comal,305,Governor,,DEM,Lupe Valdez,357
-Comal,306,Governor,,DEM,Lupe Valdez,277
-Comal,401,Governor,,DEM,Lupe Valdez,354
-Comal,402,Governor,,DEM,Lupe Valdez,671
-Comal,403,Governor,,DEM,Lupe Valdez,664
-Comal,404,Governor,,DEM,Lupe Valdez,440
-Comal,405,Governor,,DEM,Lupe Valdez,444
-Comal,406,Governor,,DEM,Lupe Valdez,774
-Comal,407,Governor,,DEM,Lupe Valdez,365
-Comal,101,Governor,,LIB,Mark Jay Tippetts,65
-Comal,102,Governor,,LIB,Mark Jay Tippetts,31
-Comal,103,Governor,,LIB,Mark Jay Tippetts,29
-Comal,104,Governor,,LIB,Mark Jay Tippetts,28
-Comal,105,Governor,,LIB,Mark Jay Tippetts,49
-Comal,106,Governor,,LIB,Mark Jay Tippetts,45
-Comal,107,Governor,,LIB,Mark Jay Tippetts,24
-Comal,201,Governor,,LIB,Mark Jay Tippetts,47
-Comal,202,Governor,,LIB,Mark Jay Tippetts,8
-Comal,203,Governor,,LIB,Mark Jay Tippetts,34
-Comal,204,Governor,,LIB,Mark Jay Tippetts,27
-Comal,205,Governor,,LIB,Mark Jay Tippetts,58
-Comal,206,Governor,,LIB,Mark Jay Tippetts,42
-Comal,207,Governor,,LIB,Mark Jay Tippetts,14
-Comal,208,Governor,,LIB,Mark Jay Tippetts,12
-Comal,301,Governor,,LIB,Mark Jay Tippetts,30
-Comal,302,Governor,,LIB,Mark Jay Tippetts,69
-Comal,303,Governor,,LIB,Mark Jay Tippetts,8
-Comal,304,Governor,,LIB,Mark Jay Tippetts,37
-Comal,305,Governor,,LIB,Mark Jay Tippetts,35
-Comal,306,Governor,,LIB,Mark Jay Tippetts,15
-Comal,401,Governor,,LIB,Mark Jay Tippetts,35
-Comal,402,Governor,,LIB,Mark Jay Tippetts,60
-Comal,403,Governor,,LIB,Mark Jay Tippetts,39
-Comal,404,Governor,,LIB,Mark Jay Tippetts,41
-Comal,405,Governor,,LIB,Mark Jay Tippetts,32
-Comal,406,Governor,,LIB,Mark Jay Tippetts,64
-Comal,407,Governor,,LIB,Mark Jay Tippetts,37
-Comal,101,Lieutenant Governor,,REP,Dan Patrick,1604
-Comal,102,Lieutenant Governor,,REP,Dan Patrick,1963
-Comal,103,Lieutenant Governor,,REP,Dan Patrick,1860
-Comal,104,Lieutenant Governor,,REP,Dan Patrick,1047
-Comal,105,Lieutenant Governor,,REP,Dan Patrick,2447
-Comal,106,Lieutenant Governor,,REP,Dan Patrick,2555
-Comal,107,Lieutenant Governor,,REP,Dan Patrick,1094
-Comal,201,Lieutenant Governor,,REP,Dan Patrick,1751
-Comal,202,Lieutenant Governor,,REP,Dan Patrick,468
-Comal,203,Lieutenant Governor,,REP,Dan Patrick,2148
-Comal,204,Lieutenant Governor,,REP,Dan Patrick,1757
-Comal,205,Lieutenant Governor,,REP,Dan Patrick,2683
-Comal,206,Lieutenant Governor,,REP,Dan Patrick,2648
-Comal,207,Lieutenant Governor,,REP,Dan Patrick,1105
-Comal,208,Lieutenant Governor,,REP,Dan Patrick,1039
-Comal,301,Lieutenant Governor,,REP,Dan Patrick,878
-Comal,302,Lieutenant Governor,,REP,Dan Patrick,1676
-Comal,303,Lieutenant Governor,,REP,Dan Patrick,216
-Comal,304,Lieutenant Governor,,REP,Dan Patrick,1218
-Comal,305,Lieutenant Governor,,REP,Dan Patrick,841
-Comal,306,Lieutenant Governor,,REP,Dan Patrick,514
-Comal,401,Lieutenant Governor,,REP,Dan Patrick,906
-Comal,402,Lieutenant Governor,,REP,Dan Patrick,2109
-Comal,403,Lieutenant Governor,,REP,Dan Patrick,2628
-Comal,404,Lieutenant Governor,,REP,Dan Patrick,1715
-Comal,405,Lieutenant Governor,,REP,Dan Patrick,1832
-Comal,406,Lieutenant Governor,,REP,Dan Patrick,2214
-Comal,407,Lieutenant Governor,,REP,Dan Patrick,1481
-Comal,101,Lieutenant Governor,,DEM,Mike Collier,795
-Comal,102,Lieutenant Governor,,DEM,Mike Collier,432
-Comal,103,Lieutenant Governor,,DEM,Mike Collier,511
-Comal,104,Lieutenant Governor,,DEM,Mike Collier,304
-Comal,105,Lieutenant Governor,,DEM,Mike Collier,706
-Comal,106,Lieutenant Governor,,DEM,Mike Collier,577
-Comal,107,Lieutenant Governor,,DEM,Mike Collier,322
-Comal,201,Lieutenant Governor,,DEM,Mike Collier,829
-Comal,202,Lieutenant Governor,,DEM,Mike Collier,199
-Comal,203,Lieutenant Governor,,DEM,Mike Collier,671
-Comal,204,Lieutenant Governor,,DEM,Mike Collier,494
-Comal,205,Lieutenant Governor,,DEM,Mike Collier,951
-Comal,206,Lieutenant Governor,,DEM,Mike Collier,683
-Comal,207,Lieutenant Governor,,DEM,Mike Collier,276
-Comal,208,Lieutenant Governor,,DEM,Mike Collier,263
-Comal,301,Lieutenant Governor,,DEM,Mike Collier,869
-Comal,302,Lieutenant Governor,,DEM,Mike Collier,1008
-Comal,303,Lieutenant Governor,,DEM,Mike Collier,248
-Comal,304,Lieutenant Governor,,DEM,Mike Collier,797
-Comal,305,Lieutenant Governor,,DEM,Mike Collier,409
-Comal,306,Lieutenant Governor,,DEM,Mike Collier,306
-Comal,401,Lieutenant Governor,,DEM,Mike Collier,420
-Comal,402,Lieutenant Governor,,DEM,Mike Collier,747
-Comal,403,Lieutenant Governor,,DEM,Mike Collier,736
-Comal,404,Lieutenant Governor,,DEM,Mike Collier,523
-Comal,405,Lieutenant Governor,,DEM,Mike Collier,480
-Comal,406,Lieutenant Governor,,DEM,Mike Collier,893
-Comal,407,Lieutenant Governor,,DEM,Mike Collier,447
-Comal,101,Lieutenant Governor,,LIB,Kerry Douglas McKennon,90
-Comal,102,Lieutenant Governor,,LIB,Kerry Douglas McKennon,58
-Comal,103,Lieutenant Governor,,LIB,Kerry Douglas McKennon,50
-Comal,104,Lieutenant Governor,,LIB,Kerry Douglas McKennon,37
-Comal,105,Lieutenant Governor,,LIB,Kerry Douglas McKennon,69
-Comal,106,Lieutenant Governor,,LIB,Kerry Douglas McKennon,55
-Comal,107,Lieutenant Governor,,LIB,Kerry Douglas McKennon,28
-Comal,201,Lieutenant Governor,,LIB,Kerry Douglas McKennon,70
-Comal,202,Lieutenant Governor,,LIB,Kerry Douglas McKennon,8
-Comal,203,Lieutenant Governor,,LIB,Kerry Douglas McKennon,57
-Comal,204,Lieutenant Governor,,LIB,Kerry Douglas McKennon,49
-Comal,205,Lieutenant Governor,,LIB,Kerry Douglas McKennon,66
-Comal,206,Lieutenant Governor,,LIB,Kerry Douglas McKennon,78
-Comal,207,Lieutenant Governor,,LIB,Kerry Douglas McKennon,19
-Comal,208,Lieutenant Governor,,LIB,Kerry Douglas McKennon,18
-Comal,301,Lieutenant Governor,,LIB,Kerry Douglas McKennon,53
-Comal,302,Lieutenant Governor,,LIB,Kerry Douglas McKennon,88
-Comal,303,Lieutenant Governor,,LIB,Kerry Douglas McKennon,21
-Comal,304,Lieutenant Governor,,LIB,Kerry Douglas McKennon,57
-Comal,305,Lieutenant Governor,,LIB,Kerry Douglas McKennon,32
-Comal,306,Lieutenant Governor,,LIB,Kerry Douglas McKennon,21
-Comal,401,Lieutenant Governor,,LIB,Kerry Douglas McKennon,42
-Comal,402,Lieutenant Governor,,LIB,Kerry Douglas McKennon,75
-Comal,403,Lieutenant Governor,,LIB,Kerry Douglas McKennon,54
-Comal,404,Lieutenant Governor,,LIB,Kerry Douglas McKennon,46
-Comal,405,Lieutenant Governor,,LIB,Kerry Douglas McKennon,49
-Comal,406,Lieutenant Governor,,LIB,Kerry Douglas McKennon,65
-Comal,407,Lieutenant Governor,,LIB,Kerry Douglas McKennon,55
-Comal,101,Attorney General,,REP,Ken Paxton,1588
-Comal,102,Attorney General,,REP,Ken Paxton,1949
-Comal,103,Attorney General,,REP,Ken Paxton,1831
-Comal,104,Attorney General,,REP,Ken Paxton,1016
-Comal,105,Attorney General,,REP,Ken Paxton,2391
-Comal,106,Attorney General,,REP,Ken Paxton,2524
-Comal,107,Attorney General,,REP,Ken Paxton,1098
-Comal,201,Attorney General,,REP,Ken Paxton,1705
-Comal,202,Attorney General,,REP,Ken Paxton,462
-Comal,203,Attorney General,,REP,Ken Paxton,2128
-Comal,204,Attorney General,,REP,Ken Paxton,1730
-Comal,205,Attorney General,,REP,Ken Paxton,2627
-Comal,206,Attorney General,,REP,Ken Paxton,2604
-Comal,207,Attorney General,,REP,Ken Paxton,1082
-Comal,208,Attorney General,,REP,Ken Paxton,1011
-Comal,301,Attorney General,,REP,Ken Paxton,859
-Comal,302,Attorney General,,REP,Ken Paxton,1637
-Comal,303,Attorney General,,REP,Ken Paxton,213
-Comal,304,Attorney General,,REP,Ken Paxton,1211
-Comal,305,Attorney General,,REP,Ken Paxton,832
-Comal,306,Attorney General,,REP,Ken Paxton,511
-Comal,401,Attorney General,,REP,Ken Paxton,894
-Comal,402,Attorney General,,REP,Ken Paxton,2079
-Comal,403,Attorney General,,REP,Ken Paxton,2580
-Comal,404,Attorney General,,REP,Ken Paxton,1688
-Comal,405,Attorney General,,REP,Ken Paxton,1780
-Comal,406,Attorney General,,REP,Ken Paxton,2184
-Comal,407,Attorney General,,REP,Ken Paxton,1468
-Comal,101,Attorney General,,DEM,Justin Nelson,813
-Comal,102,Attorney General,,DEM,Justin Nelson,448
-Comal,103,Attorney General,,DEM,Justin Nelson,523
-Comal,104,Attorney General,,DEM,Justin Nelson,319
-Comal,105,Attorney General,,DEM,Justin Nelson,758
-Comal,106,Attorney General,,DEM,Justin Nelson,604
-Comal,107,Attorney General,,DEM,Justin Nelson,320
-Comal,201,Attorney General,,DEM,Justin Nelson,856
-Comal,202,Attorney General,,DEM,Justin Nelson,201
-Comal,203,Attorney General,,DEM,Justin Nelson,689
-Comal,204,Attorney General,,DEM,Justin Nelson,515
-Comal,205,Attorney General,,DEM,Justin Nelson,991
-Comal,206,Attorney General,,DEM,Justin Nelson,719
-Comal,207,Attorney General,,DEM,Justin Nelson,292
-Comal,208,Attorney General,,DEM,Justin Nelson,285
-Comal,301,Attorney General,,DEM,Justin Nelson,889
-Comal,302,Attorney General,,DEM,Justin Nelson,1042
-Comal,303,Attorney General,,DEM,Justin Nelson,253
-Comal,304,Attorney General,,DEM,Justin Nelson,795
-Comal,305,Attorney General,,DEM,Justin Nelson,412
-Comal,306,Attorney General,,DEM,Justin Nelson,306
-Comal,401,Attorney General,,DEM,Justin Nelson,420
-Comal,402,Attorney General,,DEM,Justin Nelson,762
-Comal,403,Attorney General,,DEM,Justin Nelson,753
-Comal,404,Attorney General,,DEM,Justin Nelson,528
-Comal,405,Attorney General,,DEM,Justin Nelson,508
-Comal,406,Attorney General,,DEM,Justin Nelson,912
-Comal,407,Attorney General,,DEM,Justin Nelson,459
-Comal,101,Attorney General,,LIB,Michael Ray Harris,82
-Comal,102,Attorney General,,LIB,Michael Ray Harris,49
-Comal,103,Attorney General,,LIB,Michael Ray Harris,55
-Comal,104,Attorney General,,LIB,Michael Ray Harris,47
-Comal,105,Attorney General,,LIB,Michael Ray Harris,74
-Comal,106,Attorney General,,LIB,Michael Ray Harris,58
-Comal,107,Attorney General,,LIB,Michael Ray Harris,24
-Comal,201,Attorney General,,LIB,Michael Ray Harris,81
-Comal,202,Attorney General,,LIB,Michael Ray Harris,11
-Comal,203,Attorney General,,LIB,Michael Ray Harris,51
-Comal,204,Attorney General,,LIB,Michael Ray Harris,52
-Comal,205,Attorney General,,LIB,Michael Ray Harris,76
-Comal,206,Attorney General,,LIB,Michael Ray Harris,74
-Comal,207,Attorney General,,LIB,Michael Ray Harris,24
-Comal,208,Attorney General,,LIB,Michael Ray Harris,19
-Comal,301,Attorney General,,LIB,Michael Ray Harris,47
-Comal,302,Attorney General,,LIB,Michael Ray Harris,90
-Comal,303,Attorney General,,LIB,Michael Ray Harris,18
-Comal,304,Attorney General,,LIB,Michael Ray Harris,60
-Comal,305,Attorney General,,LIB,Michael Ray Harris,36
-Comal,306,Attorney General,,LIB,Michael Ray Harris,21
-Comal,401,Attorney General,,LIB,Michael Ray Harris,50
-Comal,402,Attorney General,,LIB,Michael Ray Harris,88
-Comal,403,Attorney General,,LIB,Michael Ray Harris,70
-Comal,404,Attorney General,,LIB,Michael Ray Harris,65
-Comal,405,Attorney General,,LIB,Michael Ray Harris,69
-Comal,406,Attorney General,,LIB,Michael Ray Harris,64
-Comal,407,Attorney General,,LIB,Michael Ray Harris,50
-Comal,101,Comptroller of Public Accounts,,REP,Glenn Hegar,1676
-Comal,102,Comptroller of Public Accounts,,REP,Glenn Hegar,1970
-Comal,103,Comptroller of Public Accounts,,REP,Glenn Hegar,1891
-Comal,104,Comptroller of Public Accounts,,REP,Glenn Hegar,1063
-Comal,105,Comptroller of Public Accounts,,REP,Glenn Hegar,2448
-Comal,106,Comptroller of Public Accounts,,REP,Glenn Hegar,2576
-Comal,107,Comptroller of Public Accounts,,REP,Glenn Hegar,1120
-Comal,201,Comptroller of Public Accounts,,REP,Glenn Hegar,1749
-Comal,202,Comptroller of Public Accounts,,REP,Glenn Hegar,472
-Comal,203,Comptroller of Public Accounts,,REP,Glenn Hegar,2193
-Comal,204,Comptroller of Public Accounts,,REP,Glenn Hegar,1771
-Comal,205,Comptroller of Public Accounts,,REP,Glenn Hegar,2749
-Comal,206,Comptroller of Public Accounts,,REP,Glenn Hegar,2687
-Comal,207,Comptroller of Public Accounts,,REP,Glenn Hegar,1116
-Comal,208,Comptroller of Public Accounts,,REP,Glenn Hegar,1044
-Comal,301,Comptroller of Public Accounts,,REP,Glenn Hegar,856
-Comal,302,Comptroller of Public Accounts,,REP,Glenn Hegar,1693
-Comal,303,Comptroller of Public Accounts,,REP,Glenn Hegar,217
-Comal,304,Comptroller of Public Accounts,,REP,Glenn Hegar,1236
-Comal,305,Comptroller of Public Accounts,,REP,Glenn Hegar,845
-Comal,306,Comptroller of Public Accounts,,REP,Glenn Hegar,516
-Comal,401,Comptroller of Public Accounts,,REP,Glenn Hegar,957
-Comal,402,Comptroller of Public Accounts,,REP,Glenn Hegar,2149
-Comal,403,Comptroller of Public Accounts,,REP,Glenn Hegar,2649
-Comal,404,Comptroller of Public Accounts,,REP,Glenn Hegar,1766
-Comal,405,Comptroller of Public Accounts,,REP,Glenn Hegar,1813
-Comal,406,Comptroller of Public Accounts,,REP,Glenn Hegar,2259
-Comal,407,Comptroller of Public Accounts,,REP,Glenn Hegar,1530
-Comal,101,Comptroller of Public Accounts,,DEM,Joi Chevalier,685
-Comal,102,Comptroller of Public Accounts,,DEM,Joi Chevalier,406
-Comal,103,Comptroller of Public Accounts,,DEM,Joi Chevalier,434
-Comal,104,Comptroller of Public Accounts,,DEM,Joi Chevalier,274
-Comal,105,Comptroller of Public Accounts,,DEM,Joi Chevalier,651
-Comal,106,Comptroller of Public Accounts,,DEM,Joi Chevalier,517
-Comal,107,Comptroller of Public Accounts,,DEM,Joi Chevalier,283
-Comal,201,Comptroller of Public Accounts,,DEM,Joi Chevalier,791
-Comal,202,Comptroller of Public Accounts,,DEM,Joi Chevalier,184
-Comal,203,Comptroller of Public Accounts,,DEM,Joi Chevalier,595
-Comal,204,Comptroller of Public Accounts,,DEM,Joi Chevalier,440
-Comal,205,Comptroller of Public Accounts,,DEM,Joi Chevalier,821
-Comal,206,Comptroller of Public Accounts,,DEM,Joi Chevalier,612
-Comal,207,Comptroller of Public Accounts,,DEM,Joi Chevalier,236
-Comal,208,Comptroller of Public Accounts,,DEM,Joi Chevalier,244
-Comal,301,Comptroller of Public Accounts,,DEM,Joi Chevalier,863
-Comal,302,Comptroller of Public Accounts,,DEM,Joi Chevalier,914
-Comal,303,Comptroller of Public Accounts,,DEM,Joi Chevalier,244
-Comal,304,Comptroller of Public Accounts,,DEM,Joi Chevalier,736
-Comal,305,Comptroller of Public Accounts,,DEM,Joi Chevalier,381
-Comal,306,Comptroller of Public Accounts,,DEM,Joi Chevalier,275
-Comal,401,Comptroller of Public Accounts,,DEM,Joi Chevalier,341
-Comal,402,Comptroller of Public Accounts,,DEM,Joi Chevalier,678
-Comal,403,Comptroller of Public Accounts,,DEM,Joi Chevalier,654
-Comal,404,Comptroller of Public Accounts,,DEM,Joi Chevalier,431
-Comal,405,Comptroller of Public Accounts,,DEM,Joi Chevalier,450
-Comal,406,Comptroller of Public Accounts,,DEM,Joi Chevalier,794
-Comal,407,Comptroller of Public Accounts,,DEM,Joi Chevalier,370
-Comal,101,Comptroller of Public Accounts,,LIB,Ben Sanders,98
-Comal,102,Comptroller of Public Accounts,,LIB,Ben Sanders,62
-Comal,103,Comptroller of Public Accounts,,LIB,Ben Sanders,70
-Comal,104,Comptroller of Public Accounts,,LIB,Ben Sanders,47
-Comal,105,Comptroller of Public Accounts,,LIB,Ben Sanders,103
-Comal,106,Comptroller of Public Accounts,,LIB,Ben Sanders,79
-Comal,107,Comptroller of Public Accounts,,LIB,Ben Sanders,41
-Comal,201,Comptroller of Public Accounts,,LIB,Ben Sanders,93
-Comal,202,Comptroller of Public Accounts,,LIB,Ben Sanders,17
-Comal,203,Comptroller of Public Accounts,,LIB,Ben Sanders,64
-Comal,204,Comptroller of Public Accounts,,LIB,Ben Sanders,74
-Comal,205,Comptroller of Public Accounts,,LIB,Ben Sanders,109
-Comal,206,Comptroller of Public Accounts,,LIB,Ben Sanders,89
-Comal,207,Comptroller of Public Accounts,,LIB,Ben Sanders,35
-Comal,208,Comptroller of Public Accounts,,LIB,Ben Sanders,23
-Comal,301,Comptroller of Public Accounts,,LIB,Ben Sanders,73
-Comal,302,Comptroller of Public Accounts,,LIB,Ben Sanders,136
-Comal,303,Comptroller of Public Accounts,,LIB,Ben Sanders,23
-Comal,304,Comptroller of Public Accounts,,LIB,Ben Sanders,83
-Comal,305,Comptroller of Public Accounts,,LIB,Ben Sanders,47
-Comal,306,Comptroller of Public Accounts,,LIB,Ben Sanders,36
-Comal,401,Comptroller of Public Accounts,,LIB,Ben Sanders,57
-Comal,402,Comptroller of Public Accounts,,LIB,Ben Sanders,88
-Comal,403,Comptroller of Public Accounts,,LIB,Ben Sanders,79
-Comal,404,Comptroller of Public Accounts,,LIB,Ben Sanders,72
-Comal,405,Comptroller of Public Accounts,,LIB,Ben Sanders,84
-Comal,406,Comptroller of Public Accounts,,LIB,Ben Sanders,98
-Comal,407,Comptroller of Public Accounts,,LIB,Ben Sanders,66
-Comal,101,Commissioner of the General Land Office,,REP,George P. Bush,1713
-Comal,102,Commissioner of the General Land Office,,REP,George P. Bush,1953
-Comal,103,Commissioner of the General Land Office,,REP,George P. Bush,1899
-Comal,104,Commissioner of the General Land Office,,REP,George P. Bush,1053
-Comal,105,Commissioner of the General Land Office,,REP,George P. Bush,2390
-Comal,106,Commissioner of the General Land Office,,REP,George P. Bush,2549
-Comal,107,Commissioner of the General Land Office,,REP,George P. Bush,1109
-Comal,201,Commissioner of the General Land Office,,REP,George P. Bush,1765
-Comal,202,Commissioner of the General Land Office,,REP,George P. Bush,466
-Comal,203,Commissioner of the General Land Office,,REP,George P. Bush,2190
-Comal,204,Commissioner of the General Land Office,,REP,George P. Bush,1733
-Comal,205,Commissioner of the General Land Office,,REP,George P. Bush,2784
-Comal,206,Commissioner of the General Land Office,,REP,George P. Bush,2648
-Comal,207,Commissioner of the General Land Office,,REP,George P. Bush,1132
-Comal,208,Commissioner of the General Land Office,,REP,George P. Bush,1042
-Comal,301,Commissioner of the General Land Office,,REP,George P. Bush,876
-Comal,302,Commissioner of the General Land Office,,REP,George P. Bush,1730
-Comal,303,Commissioner of the General Land Office,,REP,George P. Bush,227
-Comal,304,Commissioner of the General Land Office,,REP,George P. Bush,1225
-Comal,305,Commissioner of the General Land Office,,REP,George P. Bush,849
-Comal,306,Commissioner of the General Land Office,,REP,George P. Bush,529
-Comal,401,Commissioner of the General Land Office,,REP,George P. Bush,973
-Comal,402,Commissioner of the General Land Office,,REP,George P. Bush,2140
-Comal,403,Commissioner of the General Land Office,,REP,George P. Bush,2604
-Comal,404,Commissioner of the General Land Office,,REP,George P. Bush,1772
-Comal,405,Commissioner of the General Land Office,,REP,George P. Bush,1797
-Comal,406,Commissioner of the General Land Office,,REP,George P. Bush,2259
-Comal,407,Commissioner of the General Land Office,,REP,George P. Bush,1548
-Comal,101,Commissioner of the General Land Office,,DEM,Miguel Suazo,663
-Comal,102,Commissioner of the General Land Office,,DEM,Miguel Suazo,382
-Comal,103,Commissioner of the General Land Office,,DEM,Miguel Suazo,431
-Comal,104,Commissioner of the General Land Office,,DEM,Miguel Suazo,267
-Comal,105,Commissioner of the General Land Office,,DEM,Miguel Suazo,665
-Comal,106,Commissioner of the General Land Office,,DEM,Miguel Suazo,508
-Comal,107,Commissioner of the General Land Office,,DEM,Miguel Suazo,287
-Comal,201,Commissioner of the General Land Office,,DEM,Miguel Suazo,760
-Comal,202,Commissioner of the General Land Office,,DEM,Miguel Suazo,187
-Comal,203,Commissioner of the General Land Office,,DEM,Miguel Suazo,578
-Comal,204,Commissioner of the General Land Office,,DEM,Miguel Suazo,458
-Comal,205,Commissioner of the General Land Office,,DEM,Miguel Suazo,801
-Comal,206,Commissioner of the General Land Office,,DEM,Miguel Suazo,608
-Comal,207,Commissioner of the General Land Office,,DEM,Miguel Suazo,226
-Comal,208,Commissioner of the General Land Office,,DEM,Miguel Suazo,239
-Comal,301,Commissioner of the General Land Office,,DEM,Miguel Suazo,847
-Comal,302,Commissioner of the General Land Office,,DEM,Miguel Suazo,915
-Comal,303,Commissioner of the General Land Office,,DEM,Miguel Suazo,236
-Comal,304,Commissioner of the General Land Office,,DEM,Miguel Suazo,746
-Comal,305,Commissioner of the General Land Office,,DEM,Miguel Suazo,364
-Comal,306,Commissioner of the General Land Office,,DEM,Miguel Suazo,274
-Comal,401,Commissioner of the General Land Office,,DEM,Miguel Suazo,351
-Comal,402,Commissioner of the General Land Office,,DEM,Miguel Suazo,653
-Comal,403,Commissioner of the General Land Office,,DEM,Miguel Suazo,665
-Comal,404,Commissioner of the General Land Office,,DEM,Miguel Suazo,423
-Comal,405,Commissioner of the General Land Office,,DEM,Miguel Suazo,443
-Comal,406,Commissioner of the General Land Office,,DEM,Miguel Suazo,778
-Comal,407,Commissioner of the General Land Office,,DEM,Miguel Suazo,355
-Comal,101,Commissioner of the General Land Office,,LIB,Matt Piña,100
-Comal,102,Commissioner of the General Land Office,,LIB,Matt Piña,115
-Comal,103,Commissioner of the General Land Office,,LIB,Matt Piña,81
-Comal,104,Commissioner of the General Land Office,,LIB,Matt Piña,66
-Comal,105,Commissioner of the General Land Office,,LIB,Matt Piña,147
-Comal,106,Commissioner of the General Land Office,,LIB,Matt Piña,117
-Comal,107,Commissioner of the General Land Office,,LIB,Matt Piña,49
-Comal,201,Commissioner of the General Land Office,,LIB,Matt Piña,115
-Comal,202,Commissioner of the General Land Office,,LIB,Matt Piña,19
-Comal,203,Commissioner of the General Land Office,,LIB,Matt Piña,91
-Comal,204,Commissioner of the General Land Office,,LIB,Matt Piña,101
-Comal,205,Commissioner of the General Land Office,,LIB,Matt Piña,108
-Comal,206,Commissioner of the General Land Office,,LIB,Matt Piña,134
-Comal,207,Commissioner of the General Land Office,,LIB,Matt Piña,38
-Comal,208,Commissioner of the General Land Office,,LIB,Matt Piña,33
-Comal,301,Commissioner of the General Land Office,,LIB,Matt Piña,83
-Comal,302,Commissioner of the General Land Office,,LIB,Matt Piña,119
-Comal,303,Commissioner of the General Land Office,,LIB,Matt Piña,22
-Comal,304,Commissioner of the General Land Office,,LIB,Matt Piña,93
-Comal,305,Commissioner of the General Land Office,,LIB,Matt Piña,69
-Comal,306,Commissioner of the General Land Office,,LIB,Matt Piña,34
-Comal,401,Commissioner of the General Land Office,,LIB,Matt Piña,44
-Comal,402,Commissioner of the General Land Office,,LIB,Matt Piña,137
-Comal,403,Commissioner of the General Land Office,,LIB,Matt Piña,137
-Comal,404,Commissioner of the General Land Office,,LIB,Matt Piña,86
-Comal,405,Commissioner of the General Land Office,,LIB,Matt Piña,108
-Comal,406,Commissioner of the General Land Office,,LIB,Matt Piña,111
-Comal,407,Commissioner of the General Land Office,,LIB,Matt Piña,72
-Comal,101,Commissioner of Agriculture,,REP,Sid Miller,1599
-Comal,102,Commissioner of Agriculture,,REP,Sid Miller,1945
-Comal,103,Commissioner of Agriculture,,REP,Sid Miller,1857
-Comal,104,Commissioner of Agriculture,,REP,Sid Miller,1032
-Comal,105,Commissioner of Agriculture,,REP,Sid Miller,2405
-Comal,106,Commissioner of Agriculture,,REP,Sid Miller,2540
-Comal,107,Commissioner of Agriculture,,REP,Sid Miller,1095
-Comal,201,Commissioner of Agriculture,,REP,Sid Miller,1707
-Comal,202,Commissioner of Agriculture,,REP,Sid Miller,464
-Comal,203,Commissioner of Agriculture,,REP,Sid Miller,2155
-Comal,204,Commissioner of Agriculture,,REP,Sid Miller,1752
-Comal,205,Commissioner of Agriculture,,REP,Sid Miller,2634
-Comal,206,Commissioner of Agriculture,,REP,Sid Miller,2611
-Comal,207,Commissioner of Agriculture,,REP,Sid Miller,1096
-Comal,208,Commissioner of Agriculture,,REP,Sid Miller,1025
-Comal,301,Commissioner of Agriculture,,REP,Sid Miller,852
-Comal,302,Commissioner of Agriculture,,REP,Sid Miller,1657
-Comal,303,Commissioner of Agriculture,,REP,Sid Miller,207
-Comal,304,Commissioner of Agriculture,,REP,Sid Miller,1214
-Comal,305,Commissioner of Agriculture,,REP,Sid Miller,838
-Comal,306,Commissioner of Agriculture,,REP,Sid Miller,509
-Comal,401,Commissioner of Agriculture,,REP,Sid Miller,918
-Comal,402,Commissioner of Agriculture,,REP,Sid Miller,2098
-Comal,403,Commissioner of Agriculture,,REP,Sid Miller,2595
-Comal,404,Commissioner of Agriculture,,REP,Sid Miller,1725
-Comal,405,Commissioner of Agriculture,,REP,Sid Miller,1804
-Comal,406,Commissioner of Agriculture,,REP,Sid Miller,2165
-Comal,407,Commissioner of Agriculture,,REP,Sid Miller,1495
-Comal,101,Commissioner of Agriculture,,DEM,Kim Olson,778
-Comal,102,Commissioner of Agriculture,,DEM,Kim Olson,446
-Comal,103,Commissioner of Agriculture,,DEM,Kim Olson,482
-Comal,104,Commissioner of Agriculture,,DEM,Kim Olson,305
-Comal,105,Commissioner of Agriculture,,DEM,Kim Olson,727
-Comal,106,Commissioner of Agriculture,,DEM,Kim Olson,574
-Comal,107,Commissioner of Agriculture,,DEM,Kim Olson,316
-Comal,201,Commissioner of Agriculture,,DEM,Kim Olson,847
-Comal,202,Commissioner of Agriculture,,DEM,Kim Olson,196
-Comal,203,Commissioner of Agriculture,,DEM,Kim Olson,645
-Comal,204,Commissioner of Agriculture,,DEM,Kim Olson,483
-Comal,205,Commissioner of Agriculture,,DEM,Kim Olson,964
-Comal,206,Commissioner of Agriculture,,DEM,Kim Olson,688
-Comal,207,Commissioner of Agriculture,,DEM,Kim Olson,274
-Comal,208,Commissioner of Agriculture,,DEM,Kim Olson,275
-Comal,301,Commissioner of Agriculture,,DEM,Kim Olson,886
-Comal,302,Commissioner of Agriculture,,DEM,Kim Olson,1013
-Comal,303,Commissioner of Agriculture,,DEM,Kim Olson,257
-Comal,304,Commissioner of Agriculture,,DEM,Kim Olson,794
-Comal,305,Commissioner of Agriculture,,DEM,Kim Olson,404
-Comal,306,Commissioner of Agriculture,,DEM,Kim Olson,303
-Comal,401,Commissioner of Agriculture,,DEM,Kim Olson,402
-Comal,402,Commissioner of Agriculture,,DEM,Kim Olson,741
-Comal,403,Commissioner of Agriculture,,DEM,Kim Olson,728
-Comal,404,Commissioner of Agriculture,,DEM,Kim Olson,500
-Comal,405,Commissioner of Agriculture,,DEM,Kim Olson,486
-Comal,406,Commissioner of Agriculture,,DEM,Kim Olson,907
-Comal,407,Commissioner of Agriculture,,DEM,Kim Olson,423
-Comal,101,Commissioner of Agriculture,,LIB,Richard Carpenter,77
-Comal,102,Commissioner of Agriculture,,LIB,Richard Carpenter,53
-Comal,103,Commissioner of Agriculture,,LIB,Richard Carpenter,52
-Comal,104,Commissioner of Agriculture,,LIB,Richard Carpenter,37
-Comal,105,Commissioner of Agriculture,,LIB,Richard Carpenter,71
-Comal,106,Commissioner of Agriculture,,LIB,Richard Carpenter,58
-Comal,107,Commissioner of Agriculture,,LIB,Richard Carpenter,32
-Comal,201,Commissioner of Agriculture,,LIB,Richard Carpenter,70
-Comal,202,Commissioner of Agriculture,,LIB,Richard Carpenter,14
-Comal,203,Commissioner of Agriculture,,LIB,Richard Carpenter,52
-Comal,204,Commissioner of Agriculture,,LIB,Richard Carpenter,55
-Comal,205,Commissioner of Agriculture,,LIB,Richard Carpenter,81
-Comal,206,Commissioner of Agriculture,,LIB,Richard Carpenter,80
-Comal,207,Commissioner of Agriculture,,LIB,Richard Carpenter,18
-Comal,208,Commissioner of Agriculture,,LIB,Richard Carpenter,13
-Comal,301,Commissioner of Agriculture,,LIB,Richard Carpenter,55
-Comal,302,Commissioner of Agriculture,,LIB,Richard Carpenter,83
-Comal,303,Commissioner of Agriculture,,LIB,Richard Carpenter,16
-Comal,304,Commissioner of Agriculture,,LIB,Richard Carpenter,51
-Comal,305,Commissioner of Agriculture,,LIB,Richard Carpenter,34
-Comal,306,Commissioner of Agriculture,,LIB,Richard Carpenter,21
-Comal,401,Commissioner of Agriculture,,LIB,Richard Carpenter,39
-Comal,402,Commissioner of Agriculture,,LIB,Richard Carpenter,85
-Comal,403,Commissioner of Agriculture,,LIB,Richard Carpenter,64
-Comal,404,Commissioner of Agriculture,,LIB,Richard Carpenter,45
-Comal,405,Commissioner of Agriculture,,LIB,Richard Carpenter,53
-Comal,406,Commissioner of Agriculture,,LIB,Richard Carpenter,73
-Comal,407,Commissioner of Agriculture,,LIB,Richard Carpenter,43
-Comal,101,Railroad Commissioner,,REP,Christi Craddick,1668
-Comal,102,Railroad Commissioner,,REP,Christi Craddick,1976
-Comal,103,Railroad Commissioner,,REP,Christi Craddick,1895
-Comal,104,Railroad Commissioner,,REP,Christi Craddick,1067
-Comal,105,Railroad Commissioner,,REP,Christi Craddick,2435
-Comal,106,Railroad Commissioner,,REP,Christi Craddick,2577
-Comal,107,Railroad Commissioner,,REP,Christi Craddick,1122
-Comal,201,Railroad Commissioner,,REP,Christi Craddick,1753
-Comal,202,Railroad Commissioner,,REP,Christi Craddick,474
-Comal,203,Railroad Commissioner,,REP,Christi Craddick,2191
-Comal,204,Railroad Commissioner,,REP,Christi Craddick,1783
-Comal,205,Railroad Commissioner,,REP,Christi Craddick,2748
-Comal,206,Railroad Commissioner,,REP,Christi Craddick,2683
-Comal,207,Railroad Commissioner,,REP,Christi Craddick,1122
-Comal,208,Railroad Commissioner,,REP,Christi Craddick,1051
-Comal,301,Railroad Commissioner,,REP,Christi Craddick,860
-Comal,302,Railroad Commissioner,,REP,Christi Craddick,1714
-Comal,303,Railroad Commissioner,,REP,Christi Craddick,217
-Comal,304,Railroad Commissioner,,REP,Christi Craddick,1239
-Comal,305,Railroad Commissioner,,REP,Christi Craddick,852
-Comal,306,Railroad Commissioner,,REP,Christi Craddick,520
-Comal,401,Railroad Commissioner,,REP,Christi Craddick,944
-Comal,402,Railroad Commissioner,,REP,Christi Craddick,2156
-Comal,403,Railroad Commissioner,,REP,Christi Craddick,2649
-Comal,404,Railroad Commissioner,,REP,Christi Craddick,1775
-Comal,405,Railroad Commissioner,,REP,Christi Craddick,1841
-Comal,406,Railroad Commissioner,,REP,Christi Craddick,2253
-Comal,407,Railroad Commissioner,,REP,Christi Craddick,1535
-Comal,101,Railroad Commissioner,,DEM,Roman McAllen,694
-Comal,102,Railroad Commissioner,,DEM,Roman McAllen,400
-Comal,103,Railroad Commissioner,,DEM,Roman McAllen,434
-Comal,104,Railroad Commissioner,,DEM,Roman McAllen,268
-Comal,105,Railroad Commissioner,,DEM,Roman McAllen,658
-Comal,106,Railroad Commissioner,,DEM,Roman McAllen,517
-Comal,107,Railroad Commissioner,,DEM,Roman McAllen,290
-Comal,201,Railroad Commissioner,,DEM,Roman McAllen,782
-Comal,202,Railroad Commissioner,,DEM,Roman McAllen,183
-Comal,203,Railroad Commissioner,,DEM,Roman McAllen,597
-Comal,204,Railroad Commissioner,,DEM,Roman McAllen,437
-Comal,205,Railroad Commissioner,,DEM,Roman McAllen,824
-Comal,206,Railroad Commissioner,,DEM,Roman McAllen,621
-Comal,207,Railroad Commissioner,,DEM,Roman McAllen,239
-Comal,208,Railroad Commissioner,,DEM,Roman McAllen,234
-Comal,301,Railroad Commissioner,,DEM,Roman McAllen,855
-Comal,302,Railroad Commissioner,,DEM,Roman McAllen,920
-Comal,303,Railroad Commissioner,,DEM,Roman McAllen,242
-Comal,304,Railroad Commissioner,,DEM,Roman McAllen,748
-Comal,305,Railroad Commissioner,,DEM,Roman McAllen,369
-Comal,306,Railroad Commissioner,,DEM,Roman McAllen,281
-Comal,401,Railroad Commissioner,,DEM,Roman McAllen,360
-Comal,402,Railroad Commissioner,,DEM,Roman McAllen,682
-Comal,403,Railroad Commissioner,,DEM,Roman McAllen,656
-Comal,404,Railroad Commissioner,,DEM,Roman McAllen,438
-Comal,405,Railroad Commissioner,,DEM,Roman McAllen,439
-Comal,406,Railroad Commissioner,,DEM,Roman McAllen,801
-Comal,407,Railroad Commissioner,,DEM,Roman McAllen,377
-Comal,101,Railroad Commissioner,,LIB,Mike Wright,86
-Comal,102,Railroad Commissioner,,LIB,Mike Wright,63
-Comal,103,Railroad Commissioner,,LIB,Mike Wright,63
-Comal,104,Railroad Commissioner,,LIB,Mike Wright,46
-Comal,105,Railroad Commissioner,,LIB,Mike Wright,102
-Comal,106,Railroad Commissioner,,LIB,Mike Wright,75
-Comal,107,Railroad Commissioner,,LIB,Mike Wright,31
-Comal,201,Railroad Commissioner,,LIB,Mike Wright,92
-Comal,202,Railroad Commissioner,,LIB,Mike Wright,15
-Comal,203,Railroad Commissioner,,LIB,Mike Wright,62
-Comal,204,Railroad Commissioner,,LIB,Mike Wright,65
-Comal,205,Railroad Commissioner,,LIB,Mike Wright,107
-Comal,206,Railroad Commissioner,,LIB,Mike Wright,76
-Comal,207,Railroad Commissioner,,LIB,Mike Wright,26
-Comal,208,Railroad Commissioner,,LIB,Mike Wright,25
-Comal,301,Railroad Commissioner,,LIB,Mike Wright,73
-Comal,302,Railroad Commissioner,,LIB,Mike Wright,104
-Comal,303,Railroad Commissioner,,LIB,Mike Wright,20
-Comal,304,Railroad Commissioner,,LIB,Mike Wright,70
-Comal,305,Railroad Commissioner,,LIB,Mike Wright,52
-Comal,306,Railroad Commissioner,,LIB,Mike Wright,31
-Comal,401,Railroad Commissioner,,LIB,Mike Wright,45
-Comal,402,Railroad Commissioner,,LIB,Mike Wright,90
-Comal,403,Railroad Commissioner,,LIB,Mike Wright,80
-Comal,404,Railroad Commissioner,,LIB,Mike Wright,61
-Comal,405,Railroad Commissioner,,LIB,Mike Wright,63
-Comal,406,Railroad Commissioner,,LIB,Mike Wright,88
-Comal,407,Railroad Commissioner,,LIB,Mike Wright,52
-Comal,101,Justice, Supreme Court,REP,Jimmy Blacklock,1669
-Comal,102,Justice, Supreme Court,REP,Jimmy Blacklock,1986
-Comal,103,Justice, Supreme Court,REP,Jimmy Blacklock,1895
-Comal,104,Justice, Supreme Court,REP,Jimmy Blacklock,1059
-Comal,105,Justice, Supreme Court,REP,Jimmy Blacklock,2444
-Comal,106,Justice, Supreme Court,REP,Jimmy Blacklock,2595
-Comal,107,Justice, Supreme Court,REP,Jimmy Blacklock,1118
-Comal,201,Justice, Supreme Court,REP,Jimmy Blacklock,1762
-Comal,202,Justice, Supreme Court,REP,Jimmy Blacklock,468
-Comal,203,Justice, Supreme Court,REP,Jimmy Blacklock,2182
-Comal,204,Justice, Supreme Court,REP,Jimmy Blacklock,1789
-Comal,205,Justice, Supreme Court,REP,Jimmy Blacklock,2720
-Comal,206,Justice, Supreme Court,REP,Jimmy Blacklock,2671
-Comal,207,Justice, Supreme Court,REP,Jimmy Blacklock,1105
-Comal,208,Justice, Supreme Court,REP,Jimmy Blacklock,1044
-Comal,301,Justice, Supreme Court,REP,Jimmy Blacklock,870
-Comal,302,Justice, Supreme Court,REP,Jimmy Blacklock,1695
-Comal,303,Justice, Supreme Court,REP,Jimmy Blacklock,212
-Comal,304,Justice, Supreme Court,REP,Jimmy Blacklock,1227
-Comal,305,Justice, Supreme Court,REP,Jimmy Blacklock,869
-Comal,306,Justice, Supreme Court,REP,Jimmy Blacklock,511
-Comal,401,Justice, Supreme Court,REP,Jimmy Blacklock,950
-Comal,402,Justice, Supreme Court,REP,Jimmy Blacklock,2149
-Comal,403,Justice, Supreme Court,REP,Jimmy Blacklock,2660
-Comal,404,Justice, Supreme Court,REP,Jimmy Blacklock,1764
-Comal,405,Justice, Supreme Court,REP,Jimmy Blacklock,1837
-Comal,406,Justice, Supreme Court,REP,Jimmy Blacklock,2241
-Comal,407,Justice, Supreme Court,REP,Jimmy Blacklock,1533
-Comal,101,Justice, Supreme Court,DEM,Steven Kirkland,760
-Comal,102,Justice, Supreme Court,DEM,Steven Kirkland,443
-Comal,103,Justice, Supreme Court,DEM,Steven Kirkland,482
-Comal,104,Justice, Supreme Court,DEM,Steven Kirkland,310
-Comal,105,Justice, Supreme Court,DEM,Steven Kirkland,726
-Comal,106,Justice, Supreme Court,DEM,Steven Kirkland,551
-Comal,107,Justice, Supreme Court,DEM,Steven Kirkland,318
-Comal,201,Justice, Supreme Court,DEM,Steven Kirkland,837
-Comal,202,Justice, Supreme Court,DEM,Steven Kirkland,194
-Comal,203,Justice, Supreme Court,DEM,Steven Kirkland,656
-Comal,204,Justice, Supreme Court,DEM,Steven Kirkland,489
-Comal,205,Justice, Supreme Court,DEM,Steven Kirkland,942
-Comal,206,Justice, Supreme Court,DEM,Steven Kirkland,687
-Comal,207,Justice, Supreme Court,DEM,Steven Kirkland,268
-Comal,208,Justice, Supreme Court,DEM,Steven Kirkland,259
-Comal,301,Justice, Supreme Court,DEM,Steven Kirkland,909
-Comal,302,Justice, Supreme Court,DEM,Steven Kirkland,1021
-Comal,303,Justice, Supreme Court,DEM,Steven Kirkland,262
-Comal,304,Justice, Supreme Court,DEM,Steven Kirkland,808
-Comal,305,Justice, Supreme Court,DEM,Steven Kirkland,392
-Comal,306,Justice, Supreme Court,DEM,Steven Kirkland,310
-Comal,401,Justice, Supreme Court,DEM,Steven Kirkland,389
-Comal,402,Justice, Supreme Court,DEM,Steven Kirkland,749
-Comal,403,Justice, Supreme Court,DEM,Steven Kirkland,705
-Comal,404,Justice, Supreme Court,DEM,Steven Kirkland,493
-Comal,405,Justice, Supreme Court,DEM,Steven Kirkland,486
-Comal,406,Justice, Supreme Court,DEM,Steven Kirkland,878
-Comal,407,Justice, Supreme Court,DEM,Steven Kirkland,416
-Comal,101,Justice, Supreme Court,REP,John Devine,1691
-Comal,102,Justice, Supreme Court,REP,John Devine,1989
-Comal,103,Justice, Supreme Court,REP,John Devine,1899
-Comal,104,Justice, Supreme Court,REP,John Devine,1071
-Comal,105,Justice, Supreme Court,REP,John Devine,2471
-Comal,106,Justice, Supreme Court,REP,John Devine,2599
-Comal,107,Justice, Supreme Court,REP,John Devine,1126
-Comal,201,Justice, Supreme Court,REP,John Devine,1773
-Comal,202,Justice, Supreme Court,REP,John Devine,472
-Comal,203,Justice, Supreme Court,REP,John Devine,2203
-Comal,204,Justice, Supreme Court,REP,John Devine,1800
-Comal,205,Justice, Supreme Court,REP,John Devine,2760
-Comal,206,Justice, Supreme Court,REP,John Devine,2693
-Comal,207,Justice, Supreme Court,REP,John Devine,1111
-Comal,208,Justice, Supreme Court,REP,John Devine,1039
-Comal,301,Justice, Supreme Court,REP,John Devine,880
-Comal,302,Justice, Supreme Court,REP,John Devine,1713
-Comal,303,Justice, Supreme Court,REP,John Devine,220
-Comal,304,Justice, Supreme Court,REP,John Devine,1234
-Comal,305,Justice, Supreme Court,REP,John Devine,865
-Comal,306,Justice, Supreme Court,REP,John Devine,518
-Comal,401,Justice, Supreme Court,REP,John Devine,951
-Comal,402,Justice, Supreme Court,REP,John Devine,2163
-Comal,403,Justice, Supreme Court,REP,John Devine,2648
-Comal,404,Justice, Supreme Court,REP,John Devine,1766
-Comal,405,Justice, Supreme Court,REP,John Devine,1847
-Comal,406,Justice, Supreme Court,REP,John Devine,2263
-Comal,407,Justice, Supreme Court,REP,John Devine,1544
-Comal,101,Justice, Supreme Court,DEM,R.K. Sandill,731
-Comal,102,Justice, Supreme Court,DEM,R.K. Sandill,438
-Comal,103,Justice, Supreme Court,DEM,R.K. Sandill,472
-Comal,104,Justice, Supreme Court,DEM,R.K. Sandill,296
-Comal,105,Justice, Supreme Court,DEM,R.K. Sandill,701
-Comal,106,Justice, Supreme Court,DEM,R.K. Sandill,546
-Comal,107,Justice, Supreme Court,DEM,R.K. Sandill,310
-Comal,201,Justice, Supreme Court,DEM,R.K. Sandill,825
-Comal,202,Justice, Supreme Court,DEM,R.K. Sandill,190
-Comal,203,Justice, Supreme Court,DEM,R.K. Sandill,632
-Comal,204,Justice, Supreme Court,DEM,R.K. Sandill,481
-Comal,205,Justice, Supreme Court,DEM,R.K. Sandill,898
-Comal,206,Justice, Supreme Court,DEM,R.K. Sandill,658
-Comal,207,Justice, Supreme Court,DEM,R.K. Sandill,260
-Comal,208,Justice, Supreme Court,DEM,R.K. Sandill,262
-Comal,301,Justice, Supreme Court,DEM,R.K. Sandill,897
-Comal,302,Justice, Supreme Court,DEM,R.K. Sandill,995
-Comal,303,Justice, Supreme Court,DEM,R.K. Sandill,251
-Comal,304,Justice, Supreme Court,DEM,R.K. Sandill,798
-Comal,305,Justice, Supreme Court,DEM,R.K. Sandill,392
-Comal,306,Justice, Supreme Court,DEM,R.K. Sandill,301
-Comal,401,Justice, Supreme Court,DEM,R.K. Sandill,383
-Comal,402,Justice, Supreme Court,DEM,R.K. Sandill,734
-Comal,403,Justice, Supreme Court,DEM,R.K. Sandill,706
-Comal,404,Justice, Supreme Court,DEM,R.K. Sandill,486
-Comal,405,Justice, Supreme Court,DEM,R.K. Sandill,476
-Comal,406,Justice, Supreme Court,DEM,R.K. Sandill,846
-Comal,407,Justice, Supreme Court,DEM,R.K. Sandill,406
-Comal,101,Justice, Supreme Court,REP,Jeff Brown,1684
-Comal,102,Justice, Supreme Court,REP,Jeff Brown,1986
-Comal,103,Justice, Supreme Court,REP,Jeff Brown,1899
-Comal,104,Justice, Supreme Court,REP,Jeff Brown,1074
-Comal,105,Justice, Supreme Court,REP,Jeff Brown,2457
-Comal,106,Justice, Supreme Court,REP,Jeff Brown,2607
-Comal,107,Justice, Supreme Court,REP,Jeff Brown,1122
-Comal,201,Justice, Supreme Court,REP,Jeff Brown,1765
-Comal,202,Justice, Supreme Court,REP,Jeff Brown,470
-Comal,203,Justice, Supreme Court,REP,Jeff Brown,2194
-Comal,204,Justice, Supreme Court,REP,Jeff Brown,1795
-Comal,205,Justice, Supreme Court,REP,Jeff Brown,2739
-Comal,206,Justice, Supreme Court,REP,Jeff Brown,2684
-Comal,207,Justice, Supreme Court,REP,Jeff Brown,1106
-Comal,208,Justice, Supreme Court,REP,Jeff Brown,1039
-Comal,301,Justice, Supreme Court,REP,Jeff Brown,876
-Comal,302,Justice, Supreme Court,REP,Jeff Brown,1717
-Comal,303,Justice, Supreme Court,REP,Jeff Brown,216
-Comal,304,Justice, Supreme Court,REP,Jeff Brown,1229
-Comal,305,Justice, Supreme Court,REP,Jeff Brown,869
-Comal,306,Justice, Supreme Court,REP,Jeff Brown,508
-Comal,401,Justice, Supreme Court,REP,Jeff Brown,954
-Comal,402,Justice, Supreme Court,REP,Jeff Brown,2154
-Comal,403,Justice, Supreme Court,REP,Jeff Brown,2651
-Comal,404,Justice, Supreme Court,REP,Jeff Brown,1767
-Comal,405,Justice, Supreme Court,REP,Jeff Brown,1840
-Comal,406,Justice, Supreme Court,REP,Jeff Brown,2259
-Comal,407,Justice, Supreme Court,REP,Jeff Brown,1535
-Comal,101,Justice, Supreme Court,DEM,Kathy Cheng,737
-Comal,102,Justice, Supreme Court,DEM,Kathy Cheng,442
-Comal,103,Justice, Supreme Court,DEM,Kathy Cheng,476
-Comal,104,Justice, Supreme Court,DEM,Kathy Cheng,295
-Comal,105,Justice, Supreme Court,DEM,Kathy Cheng,715
-Comal,106,Justice, Supreme Court,DEM,Kathy Cheng,542
-Comal,107,Justice, Supreme Court,DEM,Kathy Cheng,314
-Comal,201,Justice, Supreme Court,DEM,Kathy Cheng,829
-Comal,202,Justice, Supreme Court,DEM,Kathy Cheng,193
-Comal,203,Justice, Supreme Court,DEM,Kathy Cheng,643
-Comal,204,Justice, Supreme Court,DEM,Kathy Cheng,488
-Comal,205,Justice, Supreme Court,DEM,Kathy Cheng,920
-Comal,206,Justice, Supreme Court,DEM,Kathy Cheng,674
-Comal,207,Justice, Supreme Court,DEM,Kathy Cheng,264
-Comal,208,Justice, Supreme Court,DEM,Kathy Cheng,260
-Comal,301,Justice, Supreme Court,DEM,Kathy Cheng,905
-Comal,302,Justice, Supreme Court,DEM,Kathy Cheng,1000
-Comal,303,Justice, Supreme Court,DEM,Kathy Cheng,255
-Comal,304,Justice, Supreme Court,DEM,Kathy Cheng,808
-Comal,305,Justice, Supreme Court,DEM,Kathy Cheng,392
-Comal,306,Justice, Supreme Court,DEM,Kathy Cheng,312
-Comal,401,Justice, Supreme Court,DEM,Kathy Cheng,381
-Comal,402,Justice, Supreme Court,DEM,Kathy Cheng,744
-Comal,403,Justice, Supreme Court,DEM,Kathy Cheng,710
-Comal,404,Justice, Supreme Court,DEM,Kathy Cheng,487
-Comal,405,Justice, Supreme Court,DEM,Kathy Cheng,486
-Comal,406,Justice, Supreme Court,DEM,Kathy Cheng,854
-Comal,407,Justice, Supreme Court,DEM,Kathy Cheng,414
-Comal,101,Presiding Judge, Court of Criminal Appeals,REP,Sharon Keller,1637
-Comal,102,Presiding Judge, Court of Criminal Appeals,REP,Sharon Keller,1952
-Comal,103,Presiding Judge, Court of Criminal Appeals,REP,Sharon Keller,1875
-Comal,104,Presiding Judge, Court of Criminal Appeals,REP,Sharon Keller,1041
-Comal,105,Presiding Judge, Court of Criminal Appeals,REP,Sharon Keller,2405
-Comal,106,Presiding Judge, Court of Criminal Appeals,REP,Sharon Keller,2559
-Comal,107,Presiding Judge, Court of Criminal Appeals,REP,Sharon Keller,1100
-Comal,201,Presiding Judge, Court of Criminal Appeals,REP,Sharon Keller,1732
-Comal,202,Presiding Judge, Court of Criminal Appeals,REP,Sharon Keller,463
-Comal,203,Presiding Judge, Court of Criminal Appeals,REP,Sharon Keller,2165
-Comal,204,Presiding Judge, Court of Criminal Appeals,REP,Sharon Keller,1768
-Comal,205,Presiding Judge, Court of Criminal Appeals,REP,Sharon Keller,2688
-Comal,206,Presiding Judge, Court of Criminal Appeals,REP,Sharon Keller,2635
-Comal,207,Presiding Judge, Court of Criminal Appeals,REP,Sharon Keller,1105
-Comal,208,Presiding Judge, Court of Criminal Appeals,REP,Sharon Keller,1035
-Comal,301,Presiding Judge, Court of Criminal Appeals,REP,Sharon Keller,852
-Comal,302,Presiding Judge, Court of Criminal Appeals,REP,Sharon Keller,1677
-Comal,303,Presiding Judge, Court of Criminal Appeals,REP,Sharon Keller,216
-Comal,304,Presiding Judge, Court of Criminal Appeals,REP,Sharon Keller,1203
-Comal,305,Presiding Judge, Court of Criminal Appeals,REP,Sharon Keller,842
-Comal,306,Presiding Judge, Court of Criminal Appeals,REP,Sharon Keller,506
-Comal,401,Presiding Judge, Court of Criminal Appeals,REP,Sharon Keller,940
-Comal,402,Presiding Judge, Court of Criminal Appeals,REP,Sharon Keller,2113
-Comal,403,Presiding Judge, Court of Criminal Appeals,REP,Sharon Keller,2611
-Comal,404,Presiding Judge, Court of Criminal Appeals,REP,Sharon Keller,1744
-Comal,405,Presiding Judge, Court of Criminal Appeals,REP,Sharon Keller,1798
-Comal,406,Presiding Judge, Court of Criminal Appeals,REP,Sharon Keller,2222
-Comal,407,Presiding Judge, Court of Criminal Appeals,REP,Sharon Keller,1515
-Comal,101,Presiding Judge, Court of Criminal Appeals,DEM,Maria T. (Terri) Jackson,725
-Comal,102,Presiding Judge, Court of Criminal Appeals,DEM,Maria T. (Terri) Jackson,428
-Comal,103,Presiding Judge, Court of Criminal Appeals,DEM,Maria T. (Terri) Jackson,459
-Comal,104,Presiding Judge, Court of Criminal Appeals,DEM,Maria T. (Terri) Jackson,292
-Comal,105,Presiding Judge, Court of Criminal Appeals,DEM,Maria T. (Terri) Jackson,706
-Comal,106,Presiding Judge, Court of Criminal Appeals,DEM,Maria T. (Terri) Jackson,530
-Comal,107,Presiding Judge, Court of Criminal Appeals,DEM,Maria T. (Terri) Jackson,308
-Comal,201,Presiding Judge, Court of Criminal Appeals,DEM,Maria T. (Terri) Jackson,800
-Comal,202,Presiding Judge, Court of Criminal Appeals,DEM,Maria T. (Terri) Jackson,185
-Comal,203,Presiding Judge, Court of Criminal Appeals,DEM,Maria T. (Terri) Jackson,624
-Comal,204,Presiding Judge, Court of Criminal Appeals,DEM,Maria T. (Terri) Jackson,471
-Comal,205,Presiding Judge, Court of Criminal Appeals,DEM,Maria T. (Terri) Jackson,895
-Comal,206,Presiding Judge, Court of Criminal Appeals,DEM,Maria T. (Terri) Jackson,651
-Comal,207,Presiding Judge, Court of Criminal Appeals,DEM,Maria T. (Terri) Jackson,252
-Comal,208,Presiding Judge, Court of Criminal Appeals,DEM,Maria T. (Terri) Jackson,254
-Comal,301,Presiding Judge, Court of Criminal Appeals,DEM,Maria T. (Terri) Jackson,881
-Comal,302,Presiding Judge, Court of Criminal Appeals,DEM,Maria T. (Terri) Jackson,970
-Comal,303,Presiding Judge, Court of Criminal Appeals,DEM,Maria T. (Terri) Jackson,243
-Comal,304,Presiding Judge, Court of Criminal Appeals,DEM,Maria T. (Terri) Jackson,785
-Comal,305,Presiding Judge, Court of Criminal Appeals,DEM,Maria T. (Terri) Jackson,381
-Comal,306,Presiding Judge, Court of Criminal Appeals,DEM,Maria T. (Terri) Jackson,288
-Comal,401,Presiding Judge, Court of Criminal Appeals,DEM,Maria T. (Terri) Jackson,376
-Comal,402,Presiding Judge, Court of Criminal Appeals,DEM,Maria T. (Terri) Jackson,711
-Comal,403,Presiding Judge, Court of Criminal Appeals,DEM,Maria T. (Terri) Jackson,687
-Comal,404,Presiding Judge, Court of Criminal Appeals,DEM,Maria T. (Terri) Jackson,472
-Comal,405,Presiding Judge, Court of Criminal Appeals,DEM,Maria T. (Terri) Jackson,478
-Comal,406,Presiding Judge, Court of Criminal Appeals,DEM,Maria T. (Terri) Jackson,824
-Comal,407,Presiding Judge, Court of Criminal Appeals,DEM,Maria T. (Terri) Jackson,392
-Comal,101,Presiding Judge, Court of Criminal Appeals,LIB,William Bryan Strange III,76
-Comal,102,Presiding Judge, Court of Criminal Appeals,LIB,William Bryan Strange III,55
-Comal,103,Presiding Judge, Court of Criminal Appeals,LIB,William Bryan Strange III,44
-Comal,104,Presiding Judge, Court of Criminal Appeals,LIB,William Bryan Strange III,37
-Comal,105,Presiding Judge, Court of Criminal Appeals,LIB,William Bryan Strange III,77
-Comal,106,Presiding Judge, Court of Criminal Appeals,LIB,William Bryan Strange III,69
-Comal,107,Presiding Judge, Court of Criminal Appeals,LIB,William Bryan Strange III,29
-Comal,201,Presiding Judge, Court of Criminal Appeals,LIB,William Bryan Strange III,75
-Comal,202,Presiding Judge, Court of Criminal Appeals,LIB,William Bryan Strange III,17
-Comal,203,Presiding Judge, Court of Criminal Appeals,LIB,William Bryan Strange III,49
-Comal,204,Presiding Judge, Court of Criminal Appeals,LIB,William Bryan Strange III,51
-Comal,205,Presiding Judge, Court of Criminal Appeals,LIB,William Bryan Strange III,78
-Comal,206,Presiding Judge, Court of Criminal Appeals,LIB,William Bryan Strange III,77
-Comal,207,Presiding Judge, Court of Criminal Appeals,LIB,William Bryan Strange III,22
-Comal,208,Presiding Judge, Court of Criminal Appeals,LIB,William Bryan Strange III,16
-Comal,301,Presiding Judge, Court of Criminal Appeals,LIB,William Bryan Strange III,56
-Comal,302,Presiding Judge, Court of Criminal Appeals,LIB,William Bryan Strange III,89
-Comal,303,Presiding Judge, Court of Criminal Appeals,LIB,William Bryan Strange III,19
-Comal,304,Presiding Judge, Court of Criminal Appeals,LIB,William Bryan Strange III,55
-Comal,305,Presiding Judge, Court of Criminal Appeals,LIB,William Bryan Strange III,40
-Comal,306,Presiding Judge, Court of Criminal Appeals,LIB,William Bryan Strange III,29
-Comal,401,Presiding Judge, Court of Criminal Appeals,LIB,William Bryan Strange III,36
-Comal,402,Presiding Judge, Court of Criminal Appeals,LIB,William Bryan Strange III,79
-Comal,403,Presiding Judge, Court of Criminal Appeals,LIB,William Bryan Strange III,70
-Comal,404,Presiding Judge, Court of Criminal Appeals,LIB,William Bryan Strange III,45
-Comal,405,Presiding Judge, Court of Criminal Appeals,LIB,William Bryan Strange III,64
-Comal,406,Presiding Judge, Court of Criminal Appeals,LIB,William Bryan Strange III,71
-Comal,407,Presiding Judge, Court of Criminal Appeals,LIB,William Bryan Strange III,44
-Comal,101,Judge, Court of Criminal Appeals,REP,Barbara Parker Hervey,1698
-Comal,102,Judge, Court of Criminal Appeals,REP,Barbara Parker Hervey,1991
-Comal,103,Judge, Court of Criminal Appeals,REP,Barbara Parker Hervey,1914
-Comal,104,Judge, Court of Criminal Appeals,REP,Barbara Parker Hervey,1063
-Comal,105,Judge, Court of Criminal Appeals,REP,Barbara Parker Hervey,2480
-Comal,106,Judge, Court of Criminal Appeals,REP,Barbara Parker Hervey,2608
-Comal,107,Judge, Court of Criminal Appeals,REP,Barbara Parker Hervey,1136
-Comal,201,Judge, Court of Criminal Appeals,REP,Barbara Parker Hervey,1777
-Comal,202,Judge, Court of Criminal Appeals,REP,Barbara Parker Hervey,473
-Comal,203,Judge, Court of Criminal Appeals,REP,Barbara Parker Hervey,2209
-Comal,204,Judge, Court of Criminal Appeals,REP,Barbara Parker Hervey,1803
-Comal,205,Judge, Court of Criminal Appeals,REP,Barbara Parker Hervey,2773
-Comal,206,Judge, Court of Criminal Appeals,REP,Barbara Parker Hervey,2697
-Comal,207,Judge, Court of Criminal Appeals,REP,Barbara Parker Hervey,1123
-Comal,208,Judge, Court of Criminal Appeals,REP,Barbara Parker Hervey,1053
-Comal,301,Judge, Court of Criminal Appeals,REP,Barbara Parker Hervey,878
-Comal,302,Judge, Court of Criminal Appeals,REP,Barbara Parker Hervey,1713
-Comal,303,Judge, Court of Criminal Appeals,REP,Barbara Parker Hervey,217
-Comal,304,Judge, Court of Criminal Appeals,REP,Barbara Parker Hervey,1235
-Comal,305,Judge, Court of Criminal Appeals,REP,Barbara Parker Hervey,871
-Comal,306,Judge, Court of Criminal Appeals,REP,Barbara Parker Hervey,519
-Comal,401,Judge, Court of Criminal Appeals,REP,Barbara Parker Hervey,954
-Comal,402,Judge, Court of Criminal Appeals,REP,Barbara Parker Hervey,2169
-Comal,403,Judge, Court of Criminal Appeals,REP,Barbara Parker Hervey,2664
-Comal,404,Judge, Court of Criminal Appeals,REP,Barbara Parker Hervey,1778
-Comal,405,Judge, Court of Criminal Appeals,REP,Barbara Parker Hervey,1854
-Comal,406,Judge, Court of Criminal Appeals,REP,Barbara Parker Hervey,2269
-Comal,407,Judge, Court of Criminal Appeals,REP,Barbara Parker Hervey,1545
-Comal,101,Judge, Court of Criminal Appeals,DEM,Ramona Franklin,720
-Comal,102,Judge, Court of Criminal Appeals,DEM,Ramona Franklin,435
-Comal,103,Judge, Court of Criminal Appeals,DEM,Ramona Franklin,458
-Comal,104,Judge, Court of Criminal Appeals,DEM,Ramona Franklin,300
-Comal,105,Judge, Court of Criminal Appeals,DEM,Ramona Franklin,688
-Comal,106,Judge, Court of Criminal Appeals,DEM,Ramona Franklin,537
-Comal,107,Judge, Court of Criminal Appeals,DEM,Ramona Franklin,297
-Comal,201,Judge, Court of Criminal Appeals,DEM,Ramona Franklin,822
-Comal,202,Judge, Court of Criminal Appeals,DEM,Ramona Franklin,188
-Comal,203,Judge, Court of Criminal Appeals,DEM,Ramona Franklin,623
-Comal,204,Judge, Court of Criminal Appeals,DEM,Ramona Franklin,476
-Comal,205,Judge, Court of Criminal Appeals,DEM,Ramona Franklin,888
-Comal,206,Judge, Court of Criminal Appeals,DEM,Ramona Franklin,655
-Comal,207,Judge, Court of Criminal Appeals,DEM,Ramona Franklin,250
-Comal,208,Judge, Court of Criminal Appeals,DEM,Ramona Franklin,246
-Comal,301,Judge, Court of Criminal Appeals,DEM,Ramona Franklin,900
-Comal,302,Judge, Court of Criminal Appeals,DEM,Ramona Franklin,991
-Comal,303,Judge, Court of Criminal Appeals,DEM,Ramona Franklin,254
-Comal,304,Judge, Court of Criminal Appeals,DEM,Ramona Franklin,797
-Comal,305,Judge, Court of Criminal Appeals,DEM,Ramona Franklin,386
-Comal,306,Judge, Court of Criminal Appeals,DEM,Ramona Franklin,298
-Comal,401,Judge, Court of Criminal Appeals,DEM,Ramona Franklin,381
-Comal,402,Judge, Court of Criminal Appeals,DEM,Ramona Franklin,720
-Comal,403,Judge, Court of Criminal Appeals,DEM,Ramona Franklin,682
-Comal,404,Judge, Court of Criminal Appeals,DEM,Ramona Franklin,472
-Comal,405,Judge, Court of Criminal Appeals,DEM,Ramona Franklin,470
-Comal,406,Judge, Court of Criminal Appeals,DEM,Ramona Franklin,837
-Comal,407,Judge, Court of Criminal Appeals,DEM,Ramona Franklin,399
-Comal,101,Judge, Court of Criminal Appeals,REP,Michelle Slaughter,1762
-Comal,102,Judge, Court of Criminal Appeals,REP,Michelle Slaughter,2029
-Comal,103,Judge, Court of Criminal Appeals,REP,Michelle Slaughter,1954
-Comal,104,Judge, Court of Criminal Appeals,REP,Michelle Slaughter,1079
-Comal,105,Judge, Court of Criminal Appeals,REP,Michelle Slaughter,2513
-Comal,106,Judge, Court of Criminal Appeals,REP,Michelle Slaughter,2653
-Comal,107,Judge, Court of Criminal Appeals,REP,Michelle Slaughter,1161
-Comal,201,Judge, Court of Criminal Appeals,REP,Michelle Slaughter,1852
-Comal,202,Judge, Court of Criminal Appeals,REP,Michelle Slaughter,494
-Comal,203,Judge, Court of Criminal Appeals,REP,Michelle Slaughter,2272
-Comal,204,Judge, Court of Criminal Appeals,REP,Michelle Slaughter,1826
-Comal,205,Judge, Court of Criminal Appeals,REP,Michelle Slaughter,2867
-Comal,206,Judge, Court of Criminal Appeals,REP,Michelle Slaughter,2752
-Comal,207,Judge, Court of Criminal Appeals,REP,Michelle Slaughter,1161
-Comal,208,Judge, Court of Criminal Appeals,REP,Michelle Slaughter,1070
-Comal,301,Judge, Court of Criminal Appeals,REP,Michelle Slaughter,945
-Comal,302,Judge, Court of Criminal Appeals,REP,Michelle Slaughter,1799
-Comal,303,Judge, Court of Criminal Appeals,REP,Michelle Slaughter,233
-Comal,304,Judge, Court of Criminal Appeals,REP,Michelle Slaughter,1308
-Comal,305,Judge, Court of Criminal Appeals,REP,Michelle Slaughter,892
-Comal,306,Judge, Court of Criminal Appeals,REP,Michelle Slaughter,553
-Comal,401,Judge, Court of Criminal Appeals,REP,Michelle Slaughter,979
-Comal,402,Judge, Court of Criminal Appeals,REP,Michelle Slaughter,2214
-Comal,403,Judge, Court of Criminal Appeals,REP,Michelle Slaughter,2694
-Comal,404,Judge, Court of Criminal Appeals,REP,Michelle Slaughter,1805
-Comal,405,Judge, Court of Criminal Appeals,REP,Michelle Slaughter,1864
-Comal,406,Judge, Court of Criminal Appeals,REP,Michelle Slaughter,2331
-Comal,407,Judge, Court of Criminal Appeals,REP,Michelle Slaughter,1571
-Comal,101,Judge, Court of Criminal Appeals,LIB,Mark Ash,329
-Comal,102,Judge, Court of Criminal Appeals,LIB,Mark Ash,193
-Comal,103,Judge, Court of Criminal Appeals,LIB,Mark Ash,221
-Comal,104,Judge, Court of Criminal Appeals,LIB,Mark Ash,116
-Comal,105,Judge, Court of Criminal Appeals,LIB,Mark Ash,285
-Comal,106,Judge, Court of Criminal Appeals,LIB,Mark Ash,228
-Comal,107,Judge, Court of Criminal Appeals,LIB,Mark Ash,149
-Comal,201,Judge, Court of Criminal Appeals,LIB,Mark Ash,367
-Comal,202,Judge, Court of Criminal Appeals,LIB,Mark Ash,76
-Comal,203,Judge, Court of Criminal Appeals,LIB,Mark Ash,262
-Comal,204,Judge, Court of Criminal Appeals,LIB,Mark Ash,228
-Comal,205,Judge, Court of Criminal Appeals,LIB,Mark Ash,383
-Comal,206,Judge, Court of Criminal Appeals,LIB,Mark Ash,307
-Comal,207,Judge, Court of Criminal Appeals,LIB,Mark Ash,104
-Comal,208,Judge, Court of Criminal Appeals,LIB,Mark Ash,105
-Comal,301,Judge, Court of Criminal Appeals,LIB,Mark Ash,342
-Comal,302,Judge, Court of Criminal Appeals,LIB,Mark Ash,404
-Comal,303,Judge, Court of Criminal Appeals,LIB,Mark Ash,95
-Comal,304,Judge, Court of Criminal Appeals,LIB,Mark Ash,330
-Comal,305,Judge, Court of Criminal Appeals,LIB,Mark Ash,212
-Comal,306,Judge, Court of Criminal Appeals,LIB,Mark Ash,128
-Comal,401,Judge, Court of Criminal Appeals,LIB,Mark Ash,178
-Comal,402,Judge, Court of Criminal Appeals,LIB,Mark Ash,310
-Comal,403,Judge, Court of Criminal Appeals,LIB,Mark Ash,282
-Comal,404,Judge, Court of Criminal Appeals,LIB,Mark Ash,227
-Comal,405,Judge, Court of Criminal Appeals,LIB,Mark Ash,226
-Comal,406,Judge, Court of Criminal Appeals,LIB,Mark Ash,363
-Comal,407,Judge, Court of Criminal Appeals,LIB,Mark Ash,216
-Comal,101,State Senator,No. 25,REP,Donna Campbell,1657
-Comal,102,State Senator,No. 25,REP,Donna Campbell,1998
-Comal,103,State Senator,No. 25,REP,Donna Campbell,1908
-Comal,104,State Senator,No. 25,REP,Donna Campbell,1069
-Comal,105,State Senator,No. 25,REP,Donna Campbell,2480
-Comal,106,State Senator,No. 25,REP,Donna Campbell,2606
-Comal,107,State Senator,No. 25,REP,Donna Campbell,1100
-Comal,201,State Senator,No. 25,REP,Donna Campbell,1797
-Comal,202,State Senator,No. 25,REP,Donna Campbell,480
-Comal,203,State Senator,No. 25,REP,Donna Campbell,2183
-Comal,204,State Senator,No. 25,REP,Donna Campbell,1781
-Comal,205,State Senator,No. 25,REP,Donna Campbell,2725
-Comal,206,State Senator,No. 25,REP,Donna Campbell,2665
-Comal,207,State Senator,No. 25,REP,Donna Campbell,1116
-Comal,208,State Senator,No. 25,REP,Donna Campbell,1045
-Comal,301,State Senator,No. 25,REP,Donna Campbell,900
-Comal,302,State Senator,No. 25,REP,Donna Campbell,1716
-Comal,303,State Senator,No. 25,REP,Donna Campbell,218
-Comal,304,State Senator,No. 25,REP,Donna Campbell,1253
-Comal,305,State Senator,No. 25,REP,Donna Campbell,869
-Comal,306,State Senator,No. 25,REP,Donna Campbell,521
-Comal,401,State Senator,No. 25,REP,Donna Campbell,947
-Comal,402,State Senator,No. 25,REP,Donna Campbell,2154
-Comal,403,State Senator,No. 25,REP,Donna Campbell,2673
-Comal,404,State Senator,No. 25,REP,Donna Campbell,1773
-Comal,405,State Senator,No. 25,REP,Donna Campbell,1861
-Comal,406,State Senator,No. 25,REP,Donna Campbell,2247
-Comal,407,State Senator,No. 25,REP,Donna Campbell,1527
-Comal,101,State Senator,No. 25,DEM,Steven Kling,810
-Comal,102,State Senator,No. 25,DEM,Steven Kling,444
-Comal,103,State Senator,No. 25,DEM,Steven Kling,497
-Comal,104,State Senator,No. 25,DEM,Steven Kling,307
-Comal,105,State Senator,No. 25,DEM,Steven Kling,714
-Comal,106,State Senator,No. 25,DEM,Steven Kling,564
-Comal,107,State Senator,No. 25,DEM,Steven Kling,337
-Comal,201,State Senator,No. 25,DEM,Steven Kling,827
-Comal,202,State Senator,No. 25,DEM,Steven Kling,194
-Comal,203,State Senator,No. 25,DEM,Steven Kling,669
-Comal,204,State Senator,No. 25,DEM,Steven Kling,502
-Comal,205,State Senator,No. 25,DEM,Steven Kling,955
-Comal,206,State Senator,No. 25,DEM,Steven Kling,707
-Comal,207,State Senator,No. 25,DEM,Steven Kling,279
-Comal,208,State Senator,No. 25,DEM,Steven Kling,267
-Comal,301,State Senator,No. 25,DEM,Steven Kling,891
-Comal,302,State Senator,No. 25,DEM,Steven Kling,1023
-Comal,303,State Senator,No. 25,DEM,Steven Kling,265
-Comal,304,State Senator,No. 25,DEM,Steven Kling,792
-Comal,305,State Senator,No. 25,DEM,Steven Kling,404
-Comal,306,State Senator,No. 25,DEM,Steven Kling,301
-Comal,401,State Senator,No. 25,DEM,Steven Kling,416
-Comal,402,State Senator,No. 25,DEM,Steven Kling,746
-Comal,403,State Senator,No. 25,DEM,Steven Kling,712
-Comal,404,State Senator,No. 25,DEM,Steven Kling,504
-Comal,405,State Senator,No. 25,DEM,Steven Kling,482
-Comal,406,State Senator,No. 25,DEM,Steven Kling,892
-Comal,407,State Senator,No. 25,DEM,Steven Kling,444
-Comal,101,State Representative,No. 73,REP,Kyle Biedermann,1619
-Comal,102,State Representative,No. 73,REP,Kyle Biedermann,1981
-Comal,103,State Representative,No. 73,REP,Kyle Biedermann,1867
-Comal,104,State Representative,No. 73,REP,Kyle Biedermann,1061
-Comal,105,State Representative,No. 73,REP,Kyle Biedermann,2462
-Comal,106,State Representative,No. 73,REP,Kyle Biedermann,2598
-Comal,107,State Representative,No. 73,REP,Kyle Biedermann,1125
-Comal,201,State Representative,No. 73,REP,Kyle Biedermann,1738
-Comal,202,State Representative,No. 73,REP,Kyle Biedermann,476
-Comal,203,State Representative,No. 73,REP,Kyle Biedermann,2146
-Comal,204,State Representative,No. 73,REP,Kyle Biedermann,1775
-Comal,205,State Representative,No. 73,REP,Kyle Biedermann,2711
-Comal,206,State Representative,No. 73,REP,Kyle Biedermann,2682
-Comal,207,State Representative,No. 73,REP,Kyle Biedermann,1094
-Comal,208,State Representative,No. 73,REP,Kyle Biedermann,1040
-Comal,301,State Representative,No. 73,REP,Kyle Biedermann,879
-Comal,302,State Representative,No. 73,REP,Kyle Biedermann,1674
-Comal,303,State Representative,No. 73,REP,Kyle Biedermann,218
-Comal,304,State Representative,No. 73,REP,Kyle Biedermann,1224
-Comal,305,State Representative,No. 73,REP,Kyle Biedermann,860
-Comal,306,State Representative,No. 73,REP,Kyle Biedermann,507
-Comal,401,State Representative,No. 73,REP,Kyle Biedermann,942
-Comal,402,State Representative,No. 73,REP,Kyle Biedermann,2146
-Comal,403,State Representative,No. 73,REP,Kyle Biedermann,2631
-Comal,404,State Representative,No. 73,REP,Kyle Biedermann,1728
-Comal,405,State Representative,No. 73,REP,Kyle Biedermann,1837
-Comal,406,State Representative,No. 73,REP,Kyle Biedermann,2216
-Comal,407,State Representative,No. 73,REP,Kyle Biedermann,1522
-Comal,101,State Representative,No. 73,DEM,Stephanie Phillips,830
-Comal,102,State Representative,No. 73,DEM,Stephanie Phillips,448
-Comal,103,State Representative,No. 73,DEM,Stephanie Phillips,519
-Comal,104,State Representative,No. 73,DEM,Stephanie Phillips,313
-Comal,105,State Representative,No. 73,DEM,Stephanie Phillips,726
-Comal,106,State Representative,No. 73,DEM,Stephanie Phillips,562
-Comal,107,State Representative,No. 73,DEM,Stephanie Phillips,311
-Comal,201,State Representative,No. 73,DEM,Stephanie Phillips,866
-Comal,202,State Representative,No. 73,DEM,Stephanie Phillips,190
-Comal,203,State Representative,No. 73,DEM,Stephanie Phillips,690
-Comal,204,State Representative,No. 73,DEM,Stephanie Phillips,510
-Comal,205,State Representative,No. 73,DEM,Stephanie Phillips,956
-Comal,206,State Representative,No. 73,DEM,Stephanie Phillips,691
-Comal,207,State Representative,No. 73,DEM,Stephanie Phillips,296
-Comal,208,State Representative,No. 73,DEM,Stephanie Phillips,267
-Comal,301,State Representative,No. 73,DEM,Stephanie Phillips,911
-Comal,302,State Representative,No. 73,DEM,Stephanie Phillips,1055
-Comal,303,State Representative,No. 73,DEM,Stephanie Phillips,260
-Comal,304,State Representative,No. 73,DEM,Stephanie Phillips,807
-Comal,305,State Representative,No. 73,DEM,Stephanie Phillips,406
-Comal,306,State Representative,No. 73,DEM,Stephanie Phillips,314
-Comal,401,State Representative,No. 73,DEM,Stephanie Phillips,415
-Comal,402,State Representative,No. 73,DEM,Stephanie Phillips,756
-Comal,403,State Representative,No. 73,DEM,Stephanie Phillips,737
-Comal,404,State Representative,No. 73,DEM,Stephanie Phillips,531
-Comal,405,State Representative,No. 73,DEM,Stephanie Phillips,499
-Comal,406,State Representative,No. 73,DEM,Stephanie Phillips,921
-Comal,407,State Representative,No. 73,DEM,Stephanie Phillips,438
-Comal,101,Justice, 3rd Court of Appeals District,REP,Cindy Olson Bourland,1706
-Comal,102,Justice, 3rd Court of Appeals District,REP,Cindy Olson Bourland,2000
-Comal,103,Justice, 3rd Court of Appeals District,REP,Cindy Olson Bourland,1920
-Comal,104,Justice, 3rd Court of Appeals District,REP,Cindy Olson Bourland,1079
-Comal,105,Justice, 3rd Court of Appeals District,REP,Cindy Olson Bourland,2480
-Comal,106,Justice, 3rd Court of Appeals District,REP,Cindy Olson Bourland,2619
-Comal,107,Justice, 3rd Court of Appeals District,REP,Cindy Olson Bourland,1131
-Comal,201,Justice, 3rd Court of Appeals District,REP,Cindy Olson Bourland,1809
-Comal,202,Justice, 3rd Court of Appeals District,REP,Cindy Olson Bourland,477
-Comal,203,Justice, 3rd Court of Appeals District,REP,Cindy Olson Bourland,2228
-Comal,204,Justice, 3rd Court of Appeals District,REP,Cindy Olson Bourland,1800
-Comal,205,Justice, 3rd Court of Appeals District,REP,Cindy Olson Bourland,2791
-Comal,206,Justice, 3rd Court of Appeals District,REP,Cindy Olson Bourland,2701
-Comal,207,Justice, 3rd Court of Appeals District,REP,Cindy Olson Bourland,1133
-Comal,208,Justice, 3rd Court of Appeals District,REP,Cindy Olson Bourland,1049
-Comal,301,Justice, 3rd Court of Appeals District,REP,Cindy Olson Bourland,889
-Comal,302,Justice, 3rd Court of Appeals District,REP,Cindy Olson Bourland,1718
-Comal,303,Justice, 3rd Court of Appeals District,REP,Cindy Olson Bourland,220
-Comal,304,Justice, 3rd Court of Appeals District,REP,Cindy Olson Bourland,1250
-Comal,305,Justice, 3rd Court of Appeals District,REP,Cindy Olson Bourland,871
-Comal,306,Justice, 3rd Court of Appeals District,REP,Cindy Olson Bourland,535
-Comal,401,Justice, 3rd Court of Appeals District,REP,Cindy Olson Bourland,959
-Comal,402,Justice, 3rd Court of Appeals District,REP,Cindy Olson Bourland,2179
-Comal,403,Justice, 3rd Court of Appeals District,REP,Cindy Olson Bourland,2686
-Comal,404,Justice, 3rd Court of Appeals District,REP,Cindy Olson Bourland,1785
-Comal,405,Justice, 3rd Court of Appeals District,REP,Cindy Olson Bourland,1864
-Comal,406,Justice, 3rd Court of Appeals District,REP,Cindy Olson Bourland,2275
-Comal,407,Justice, 3rd Court of Appeals District,REP,Cindy Olson Bourland,1556
-Comal,101,Justice, 3rd Court of Appeals District,DEM,Edward Smith,713
-Comal,102,Justice, 3rd Court of Appeals District,DEM,Edward Smith,426
-Comal,103,Justice, 3rd Court of Appeals District,DEM,Edward Smith,448
-Comal,104,Justice, 3rd Court of Appeals District,DEM,Edward Smith,281
-Comal,105,Justice, 3rd Court of Appeals District,DEM,Edward Smith,688
-Comal,106,Justice, 3rd Court of Appeals District,DEM,Edward Smith,528
-Comal,107,Justice, 3rd Court of Appeals District,DEM,Edward Smith,302
-Comal,201,Justice, 3rd Court of Appeals District,DEM,Edward Smith,792
-Comal,202,Justice, 3rd Court of Appeals District,DEM,Edward Smith,188
-Comal,203,Justice, 3rd Court of Appeals District,DEM,Edward Smith,602
-Comal,204,Justice, 3rd Court of Appeals District,DEM,Edward Smith,474
-Comal,205,Justice, 3rd Court of Appeals District,DEM,Edward Smith,866
-Comal,206,Justice, 3rd Court of Appeals District,DEM,Edward Smith,652
-Comal,207,Justice, 3rd Court of Appeals District,DEM,Edward Smith,245
-Comal,208,Justice, 3rd Court of Appeals District,DEM,Edward Smith,250
-Comal,301,Justice, 3rd Court of Appeals District,DEM,Edward Smith,893
-Comal,302,Justice, 3rd Court of Appeals District,DEM,Edward Smith,996
-Comal,303,Justice, 3rd Court of Appeals District,DEM,Edward Smith,256
-Comal,304,Justice, 3rd Court of Appeals District,DEM,Edward Smith,777
-Comal,305,Justice, 3rd Court of Appeals District,DEM,Edward Smith,383
-Comal,306,Justice, 3rd Court of Appeals District,DEM,Edward Smith,288
-Comal,401,Justice, 3rd Court of Appeals District,DEM,Edward Smith,374
-Comal,402,Justice, 3rd Court of Appeals District,DEM,Edward Smith,713
-Comal,403,Justice, 3rd Court of Appeals District,DEM,Edward Smith,665
-Comal,404,Justice, 3rd Court of Appeals District,DEM,Edward Smith,462
-Comal,405,Justice, 3rd Court of Appeals District,DEM,Edward Smith,466
-Comal,406,Justice, 3rd Court of Appeals District,DEM,Edward Smith,828
-Comal,407,Justice, 3rd Court of Appeals District,DEM,Edward Smith,390
-Comal,101,Justice, 3rd Court of Appeals District,REP,Scott Field,1676
-Comal,102,Justice, 3rd Court of Appeals District,REP,Scott Field,1980
-Comal,103,Justice, 3rd Court of Appeals District,REP,Scott Field,1888
-Comal,104,Justice, 3rd Court of Appeals District,REP,Scott Field,1058
-Comal,105,Justice, 3rd Court of Appeals District,REP,Scott Field,2445
-Comal,106,Justice, 3rd Court of Appeals District,REP,Scott Field,2596
-Comal,107,Justice, 3rd Court of Appeals District,REP,Scott Field,1126
-Comal,201,Justice, 3rd Court of Appeals District,REP,Scott Field,1754
-Comal,202,Justice, 3rd Court of Appeals District,REP,Scott Field,464
-Comal,203,Justice, 3rd Court of Appeals District,REP,Scott Field,2198
-Comal,204,Justice, 3rd Court of Appeals District,REP,Scott Field,1779
-Comal,205,Justice, 3rd Court of Appeals District,REP,Scott Field,2739
-Comal,206,Justice, 3rd Court of Appeals District,REP,Scott Field,2671
-Comal,207,Justice, 3rd Court of Appeals District,REP,Scott Field,1108
-Comal,208,Justice, 3rd Court of Appeals District,REP,Scott Field,1042
-Comal,301,Justice, 3rd Court of Appeals District,REP,Scott Field,879
-Comal,302,Justice, 3rd Court of Appeals District,REP,Scott Field,1712
-Comal,303,Justice, 3rd Court of Appeals District,REP,Scott Field,222
-Comal,304,Justice, 3rd Court of Appeals District,REP,Scott Field,1226
-Comal,305,Justice, 3rd Court of Appeals District,REP,Scott Field,858
-Comal,306,Justice, 3rd Court of Appeals District,REP,Scott Field,519
-Comal,401,Justice, 3rd Court of Appeals District,REP,Scott Field,946
-Comal,402,Justice, 3rd Court of Appeals District,REP,Scott Field,2155
-Comal,403,Justice, 3rd Court of Appeals District,REP,Scott Field,2645
-Comal,404,Justice, 3rd Court of Appeals District,REP,Scott Field,1753
-Comal,405,Justice, 3rd Court of Appeals District,REP,Scott Field,1839
-Comal,406,Justice, 3rd Court of Appeals District,REP,Scott Field,2250
-Comal,407,Justice, 3rd Court of Appeals District,REP,Scott Field,1534
-Comal,101,Justice, 3rd Court of Appeals District,DEM,Chari Kelly,744
-Comal,102,Justice, 3rd Court of Appeals District,DEM,Chari Kelly,446
-Comal,103,Justice, 3rd Court of Appeals District,DEM,Chari Kelly,479
-Comal,104,Justice, 3rd Court of Appeals District,DEM,Chari Kelly,302
-Comal,105,Justice, 3rd Court of Appeals District,DEM,Chari Kelly,724
-Comal,106,Justice, 3rd Court of Appeals District,DEM,Chari Kelly,548
-Comal,107,Justice, 3rd Court of Appeals District,DEM,Chari Kelly,306
-Comal,201,Justice, 3rd Court of Appeals District,DEM,Chari Kelly,848
-Comal,202,Justice, 3rd Court of Appeals District,DEM,Chari Kelly,199
-Comal,203,Justice, 3rd Court of Appeals District,DEM,Chari Kelly,631
-Comal,204,Justice, 3rd Court of Appeals District,DEM,Chari Kelly,495
-Comal,205,Justice, 3rd Court of Appeals District,DEM,Chari Kelly,920
-Comal,206,Justice, 3rd Court of Appeals District,DEM,Chari Kelly,682
-Comal,207,Justice, 3rd Court of Appeals District,DEM,Chari Kelly,271
-Comal,208,Justice, 3rd Court of Appeals District,DEM,Chari Kelly,258
-Comal,301,Justice, 3rd Court of Appeals District,DEM,Chari Kelly,906
-Comal,302,Justice, 3rd Court of Appeals District,DEM,Chari Kelly,1002
-Comal,303,Justice, 3rd Court of Appeals District,DEM,Chari Kelly,255
-Comal,304,Justice, 3rd Court of Appeals District,DEM,Chari Kelly,804
-Comal,305,Justice, 3rd Court of Appeals District,DEM,Chari Kelly,401
-Comal,306,Justice, 3rd Court of Appeals District,DEM,Chari Kelly,306
-Comal,401,Justice, 3rd Court of Appeals District,DEM,Chari Kelly,388
-Comal,402,Justice, 3rd Court of Appeals District,DEM,Chari Kelly,738
-Comal,403,Justice, 3rd Court of Appeals District,DEM,Chari Kelly,706
-Comal,404,Justice, 3rd Court of Appeals District,DEM,Chari Kelly,495
-Comal,405,Justice, 3rd Court of Appeals District,DEM,Chari Kelly,490
-Comal,406,Justice, 3rd Court of Appeals District,DEM,Chari Kelly,856
-Comal,407,Justice, 3rd Court of Appeals District,DEM,Chari Kelly,413
-Comal,101,Justice, 3rd Court of Appeals District,REP,David Puryear,1682
-Comal,102,Justice, 3rd Court of Appeals District,REP,David Puryear,1989
-Comal,103,Justice, 3rd Court of Appeals District,REP,David Puryear,1904
-Comal,104,Justice, 3rd Court of Appeals District,REP,David Puryear,1075
-Comal,105,Justice, 3rd Court of Appeals District,REP,David Puryear,2455
-Comal,106,Justice, 3rd Court of Appeals District,REP,David Puryear,2601
-Comal,107,Justice, 3rd Court of Appeals District,REP,David Puryear,1120
-Comal,201,Justice, 3rd Court of Appeals District,REP,David Puryear,1757
-Comal,202,Justice, 3rd Court of Appeals District,REP,David Puryear,470
-Comal,203,Justice, 3rd Court of Appeals District,REP,David Puryear,2209
-Comal,204,Justice, 3rd Court of Appeals District,REP,David Puryear,1787
-Comal,205,Justice, 3rd Court of Appeals District,REP,David Puryear,2746
-Comal,206,Justice, 3rd Court of Appeals District,REP,David Puryear,2675
-Comal,207,Justice, 3rd Court of Appeals District,REP,David Puryear,1115
-Comal,208,Justice, 3rd Court of Appeals District,REP,David Puryear,1039
-Comal,301,Justice, 3rd Court of Appeals District,REP,David Puryear,871
-Comal,302,Justice, 3rd Court of Appeals District,REP,David Puryear,1716
-Comal,303,Justice, 3rd Court of Appeals District,REP,David Puryear,219
-Comal,304,Justice, 3rd Court of Appeals District,REP,David Puryear,1227
-Comal,305,Justice, 3rd Court of Appeals District,REP,David Puryear,862
-Comal,306,Justice, 3rd Court of Appeals District,REP,David Puryear,522
-Comal,401,Justice, 3rd Court of Appeals District,REP,David Puryear,957
-Comal,402,Justice, 3rd Court of Appeals District,REP,David Puryear,2164
-Comal,403,Justice, 3rd Court of Appeals District,REP,David Puryear,2671
-Comal,404,Justice, 3rd Court of Appeals District,REP,David Puryear,1767
-Comal,405,Justice, 3rd Court of Appeals District,REP,David Puryear,1846
-Comal,406,Justice, 3rd Court of Appeals District,REP,David Puryear,2268
-Comal,407,Justice, 3rd Court of Appeals District,REP,David Puryear,1543
-Comal,101,Justice, 3rd Court of Appeals District,DEM,Thomas J. Baker,736
-Comal,102,Justice, 3rd Court of Appeals District,DEM,Thomas J. Baker,435
-Comal,103,Justice, 3rd Court of Appeals District,DEM,Thomas J. Baker,459
-Comal,104,Justice, 3rd Court of Appeals District,DEM,Thomas J. Baker,287
-Comal,105,Justice, 3rd Court of Appeals District,DEM,Thomas J. Baker,717
-Comal,106,Justice, 3rd Court of Appeals District,DEM,Thomas J. Baker,548
-Comal,107,Justice, 3rd Court of Appeals District,DEM,Thomas J. Baker,311
-Comal,201,Justice, 3rd Court of Appeals District,DEM,Thomas J. Baker,843
-Comal,202,Justice, 3rd Court of Appeals District,DEM,Thomas J. Baker,193
-Comal,203,Justice, 3rd Court of Appeals District,DEM,Thomas J. Baker,625
-Comal,204,Justice, 3rd Court of Appeals District,DEM,Thomas J. Baker,492
-Comal,205,Justice, 3rd Court of Appeals District,DEM,Thomas J. Baker,906
-Comal,206,Justice, 3rd Court of Appeals District,DEM,Thomas J. Baker,674
-Comal,207,Justice, 3rd Court of Appeals District,DEM,Thomas J. Baker,260
-Comal,208,Justice, 3rd Court of Appeals District,DEM,Thomas J. Baker,261
-Comal,301,Justice, 3rd Court of Appeals District,DEM,Thomas J. Baker,913
-Comal,302,Justice, 3rd Court of Appeals District,DEM,Thomas J. Baker,1005
-Comal,303,Justice, 3rd Court of Appeals District,DEM,Thomas J. Baker,258
-Comal,304,Justice, 3rd Court of Appeals District,DEM,Thomas J. Baker,805
-Comal,305,Justice, 3rd Court of Appeals District,DEM,Thomas J. Baker,393
-Comal,306,Justice, 3rd Court of Appeals District,DEM,Thomas J. Baker,303
-Comal,401,Justice, 3rd Court of Appeals District,DEM,Thomas J. Baker,374
-Comal,402,Justice, 3rd Court of Appeals District,DEM,Thomas J. Baker,731
-Comal,403,Justice, 3rd Court of Appeals District,DEM,Thomas J. Baker,687
-Comal,404,Justice, 3rd Court of Appeals District,DEM,Thomas J. Baker,481
-Comal,405,Justice, 3rd Court of Appeals District,DEM,Thomas J. Baker,483
-Comal,406,Justice, 3rd Court of Appeals District,DEM,Thomas J. Baker,839
-Comal,407,Justice, 3rd Court of Appeals District,DEM,Thomas J. Baker,402
-Comal,101,Justice, 3rd Court of Appeals District,REP,"Michael ""Mike"" Toth",1683
-Comal,102,Justice, 3rd Court of Appeals District,REP,"Michael ""Mike"" Toth",1981
-Comal,103,Justice, 3rd Court of Appeals District,REP,"Michael ""Mike"" Toth",1893
-Comal,104,Justice, 3rd Court of Appeals District,REP,"Michael ""Mike"" Toth",1066
-Comal,105,Justice, 3rd Court of Appeals District,REP,"Michael ""Mike"" Toth",2465
-Comal,106,Justice, 3rd Court of Appeals District,REP,"Michael ""Mike"" Toth",2591
-Comal,107,Justice, 3rd Court of Appeals District,REP,"Michael ""Mike"" Toth",1123
-Comal,201,Justice, 3rd Court of Appeals District,REP,"Michael ""Mike"" Toth",1766
-Comal,202,Justice, 3rd Court of Appeals District,REP,"Michael ""Mike"" Toth",465
-Comal,203,Justice, 3rd Court of Appeals District,REP,"Michael ""Mike"" Toth",2199
-Comal,204,Justice, 3rd Court of Appeals District,REP,"Michael ""Mike"" Toth",1786
-Comal,205,Justice, 3rd Court of Appeals District,REP,"Michael ""Mike"" Toth",2741
-Comal,206,Justice, 3rd Court of Appeals District,REP,"Michael ""Mike"" Toth",2683
-Comal,207,Justice, 3rd Court of Appeals District,REP,"Michael ""Mike"" Toth",1116
-Comal,208,Justice, 3rd Court of Appeals District,REP,"Michael ""Mike"" Toth",1049
-Comal,301,Justice, 3rd Court of Appeals District,REP,"Michael ""Mike"" Toth",876
-Comal,302,Justice, 3rd Court of Appeals District,REP,"Michael ""Mike"" Toth",1718
-Comal,303,Justice, 3rd Court of Appeals District,REP,"Michael ""Mike"" Toth",219
-Comal,304,Justice, 3rd Court of Appeals District,REP,"Michael ""Mike"" Toth",1241
-Comal,305,Justice, 3rd Court of Appeals District,REP,"Michael ""Mike"" Toth",863
-Comal,306,Justice, 3rd Court of Appeals District,REP,"Michael ""Mike"" Toth",518
-Comal,401,Justice, 3rd Court of Appeals District,REP,"Michael ""Mike"" Toth",944
-Comal,402,Justice, 3rd Court of Appeals District,REP,"Michael ""Mike"" Toth",2159
-Comal,403,Justice, 3rd Court of Appeals District,REP,"Michael ""Mike"" Toth",2645
-Comal,404,Justice, 3rd Court of Appeals District,REP,"Michael ""Mike"" Toth",1769
-Comal,405,Justice, 3rd Court of Appeals District,REP,"Michael ""Mike"" Toth",1836
-Comal,406,Justice, 3rd Court of Appeals District,REP,"Michael ""Mike"" Toth",2261
-Comal,407,Justice, 3rd Court of Appeals District,REP,"Michael ""Mike"" Toth",1544
-Comal,101,Justice, 3rd Court of Appeals District,DEM,Gisela D. Triana,728
-Comal,102,Justice, 3rd Court of Appeals District,DEM,Gisela D. Triana,438
-Comal,103,Justice, 3rd Court of Appeals District,DEM,Gisela D. Triana,467
-Comal,104,Justice, 3rd Court of Appeals District,DEM,Gisela D. Triana,291
-Comal,105,Justice, 3rd Court of Appeals District,DEM,Gisela D. Triana,694
-Comal,106,Justice, 3rd Court of Appeals District,DEM,Gisela D. Triana,553
-Comal,107,Justice, 3rd Court of Appeals District,DEM,Gisela D. Triana,304
-Comal,201,Justice, 3rd Court of Appeals District,DEM,Gisela D. Triana,828
-Comal,202,Justice, 3rd Court of Appeals District,DEM,Gisela D. Triana,194
-Comal,203,Justice, 3rd Court of Appeals District,DEM,Gisela D. Triana,628
-Comal,204,Justice, 3rd Court of Appeals District,DEM,Gisela D. Triana,486
-Comal,205,Justice, 3rd Court of Appeals District,DEM,Gisela D. Triana,896
-Comal,206,Justice, 3rd Court of Appeals District,DEM,Gisela D. Triana,666
-Comal,207,Justice, 3rd Court of Appeals District,DEM,Gisela D. Triana,259
-Comal,208,Justice, 3rd Court of Appeals District,DEM,Gisela D. Triana,248
-Comal,301,Justice, 3rd Court of Appeals District,DEM,Gisela D. Triana,903
-Comal,302,Justice, 3rd Court of Appeals District,DEM,Gisela D. Triana,984
-Comal,303,Justice, 3rd Court of Appeals District,DEM,Gisela D. Triana,257
-Comal,304,Justice, 3rd Court of Appeals District,DEM,Gisela D. Triana,785
-Comal,305,Justice, 3rd Court of Appeals District,DEM,Gisela D. Triana,396
-Comal,306,Justice, 3rd Court of Appeals District,DEM,Gisela D. Triana,304
-Comal,401,Justice, 3rd Court of Appeals District,DEM,Gisela D. Triana,385
-Comal,402,Justice, 3rd Court of Appeals District,DEM,Gisela D. Triana,729
-Comal,403,Justice, 3rd Court of Appeals District,DEM,Gisela D. Triana,706
-Comal,404,Justice, 3rd Court of Appeals District,DEM,Gisela D. Triana,477
-Comal,405,Justice, 3rd Court of Appeals District,DEM,Gisela D. Triana,486
-Comal,406,Justice, 3rd Court of Appeals District,DEM,Gisela D. Triana,835
-Comal,407,Justice, 3rd Court of Appeals District,DEM,Gisela D. Triana,404
-Comal,101,Justice, 3rd Court of Appeals District,,Kerry O'Brien,5
-Comal,102,Justice, 3rd Court of Appeals District,,Kerry O'Brien,1
-Comal,103,Justice, 3rd Court of Appeals District,,Kerry O'Brien,3
-Comal,104,Justice, 3rd Court of Appeals District,,Kerry O'Brien,1
-Comal,105,Justice, 3rd Court of Appeals District,,Kerry O'Brien,2
-Comal,106,Justice, 3rd Court of Appeals District,,Kerry O'Brien,2
-Comal,107,Justice, 3rd Court of Appeals District,,Kerry O'Brien,0
-Comal,201,Justice, 3rd Court of Appeals District,,Kerry O'Brien,1
-Comal,202,Justice, 3rd Court of Appeals District,,Kerry O'Brien,0
-Comal,203,Justice, 3rd Court of Appeals District,,Kerry O'Brien,1
-Comal,204,Justice, 3rd Court of Appeals District,,Kerry O'Brien,0
-Comal,205,Justice, 3rd Court of Appeals District,,Kerry O'Brien,5
-Comal,206,Justice, 3rd Court of Appeals District,,Kerry O'Brien,3
-Comal,207,Justice, 3rd Court of Appeals District,,Kerry O'Brien,1
-Comal,208,Justice, 3rd Court of Appeals District,,Kerry O'Brien,0
-Comal,301,Justice, 3rd Court of Appeals District,,Kerry O'Brien,1
-Comal,302,Justice, 3rd Court of Appeals District,,Kerry O'Brien,5
-Comal,303,Justice, 3rd Court of Appeals District,,Kerry O'Brien,0
-Comal,304,Justice, 3rd Court of Appeals District,,Kerry O'Brien,2
-Comal,305,Justice, 3rd Court of Appeals District,,Kerry O'Brien,0
-Comal,306,Justice, 3rd Court of Appeals District,,Kerry O'Brien,1
-Comal,401,Justice, 3rd Court of Appeals District,,Kerry O'Brien,4
-Comal,402,Justice, 3rd Court of Appeals District,,Kerry O'Brien,1
-Comal,403,Justice, 3rd Court of Appeals District,,Kerry O'Brien,1
-Comal,404,Justice, 3rd Court of Appeals District,,Kerry O'Brien,0
-Comal,405,Justice, 3rd Court of Appeals District,,Kerry O'Brien,1
-Comal,406,Justice, 3rd Court of Appeals District,,Kerry O'Brien,3
-Comal,407,Justice, 3rd Court of Appeals District,,Kerry O'Brien,0
-Comal,101,District Judge, 207th Judicial District,REP,Jack Robison,1844
-Comal,102,District Judge, 207th Judicial District,REP,Jack Robison,2083
-Comal,103,District Judge, 207th Judicial District,REP,Jack Robison,2000
-Comal,104,District Judge, 207th Judicial District,REP,Jack Robison,1114
-Comal,105,District Judge, 207th Judicial District,REP,Jack Robison,2597
-Comal,106,District Judge, 207th Judicial District,REP,Jack Robison,2692
-Comal,107,District Judge, 207th Judicial District,REP,Jack Robison,1189
-Comal,201,District Judge, 207th Judicial District,REP,Jack Robison,1967
-Comal,202,District Judge, 207th Judicial District,REP,Jack Robison,506
-Comal,203,District Judge, 207th Judicial District,REP,Jack Robison,2348
-Comal,204,District Judge, 207th Judicial District,REP,Jack Robison,1890
-Comal,205,District Judge, 207th Judicial District,REP,Jack Robison,2949
-Comal,206,District Judge, 207th Judicial District,REP,Jack Robison,2840
-Comal,207,District Judge, 207th Judicial District,REP,Jack Robison,1180
-Comal,208,District Judge, 207th Judicial District,REP,Jack Robison,1088
-Comal,301,District Judge, 207th Judicial District,REP,Jack Robison,1065
-Comal,302,District Judge, 207th Judicial District,REP,Jack Robison,1937
-Comal,303,District Judge, 207th Judicial District,REP,Jack Robison,267
-Comal,304,District Judge, 207th Judicial District,REP,Jack Robison,1437
-Comal,305,District Judge, 207th Judicial District,REP,Jack Robison,978
-Comal,306,District Judge, 207th Judicial District,REP,Jack Robison,598
-Comal,401,District Judge, 207th Judicial District,REP,Jack Robison,1017
-Comal,402,District Judge, 207th Judicial District,REP,Jack Robison,2272
-Comal,403,District Judge, 207th Judicial District,REP,Jack Robison,2766
-Comal,404,District Judge, 207th Judicial District,REP,Jack Robison,1855
-Comal,405,District Judge, 207th Judicial District,REP,Jack Robison,1928
-Comal,406,District Judge, 207th Judicial District,REP,Jack Robison,2429
-Comal,407,District Judge, 207th Judicial District,REP,Jack Robison,1623
-Comal,101,District Judge, 274th Judicial District,REP,Gary L. Steel,1872
-Comal,102,District Judge, 274th Judicial District,REP,Gary L. Steel,2081
-Comal,103,District Judge, 274th Judicial District,REP,Gary L. Steel,2017
-Comal,104,District Judge, 274th Judicial District,REP,Gary L. Steel,1117
-Comal,105,District Judge, 274th Judicial District,REP,Gary L. Steel,2598
-Comal,106,District Judge, 274th Judicial District,REP,Gary L. Steel,2696
-Comal,107,District Judge, 274th Judicial District,REP,Gary L. Steel,1196
-Comal,201,District Judge, 274th Judicial District,REP,Gary L. Steel,1977
-Comal,202,District Judge, 274th Judicial District,REP,Gary L. Steel,508
-Comal,203,District Judge, 274th Judicial District,REP,Gary L. Steel,2360
-Comal,204,District Judge, 274th Judicial District,REP,Gary L. Steel,1887
-Comal,205,District Judge, 274th Judicial District,REP,Gary L. Steel,2948
-Comal,206,District Judge, 274th Judicial District,REP,Gary L. Steel,2843
-Comal,207,District Judge, 274th Judicial District,REP,Gary L. Steel,1178
-Comal,208,District Judge, 274th Judicial District,REP,Gary L. Steel,1085
-Comal,301,District Judge, 274th Judicial District,REP,Gary L. Steel,1069
-Comal,302,District Judge, 274th Judicial District,REP,Gary L. Steel,1944
-Comal,303,District Judge, 274th Judicial District,REP,Gary L. Steel,268
-Comal,304,District Judge, 274th Judicial District,REP,Gary L. Steel,1437
-Comal,305,District Judge, 274th Judicial District,REP,Gary L. Steel,977
-Comal,306,District Judge, 274th Judicial District,REP,Gary L. Steel,594
-Comal,401,District Judge, 274th Judicial District,REP,Gary L. Steel,1027
-Comal,402,District Judge, 274th Judicial District,REP,Gary L. Steel,2279
-Comal,403,District Judge, 274th Judicial District,REP,Gary L. Steel,2760
-Comal,404,District Judge, 274th Judicial District,REP,Gary L. Steel,1870
-Comal,405,District Judge, 274th Judicial District,REP,Gary L. Steel,1928
-Comal,406,District Judge, 274th Judicial District,REP,Gary L. Steel,2433
-Comal,407,District Judge, 274th Judicial District,REP,Gary L. Steel,1633
-Comal,101,Criminal District Attorney Comal County,,REP,Jennifer Anne Owens Tharp,1832
-Comal,102,Criminal District Attorney Comal County,,REP,Jennifer Anne Owens Tharp,2086
-Comal,103,Criminal District Attorney Comal County,,REP,Jennifer Anne Owens Tharp,1994
-Comal,104,Criminal District Attorney Comal County,,REP,Jennifer Anne Owens Tharp,1116
-Comal,105,Criminal District Attorney Comal County,,REP,Jennifer Anne Owens Tharp,2603
-Comal,106,Criminal District Attorney Comal County,,REP,Jennifer Anne Owens Tharp,2689
-Comal,107,Criminal District Attorney Comal County,,REP,Jennifer Anne Owens Tharp,1196
-Comal,201,Criminal District Attorney Comal County,,REP,Jennifer Anne Owens Tharp,1934
-Comal,202,Criminal District Attorney Comal County,,REP,Jennifer Anne Owens Tharp,507
-Comal,203,Criminal District Attorney Comal County,,REP,Jennifer Anne Owens Tharp,2330
-Comal,204,Criminal District Attorney Comal County,,REP,Jennifer Anne Owens Tharp,1869
-Comal,205,Criminal District Attorney Comal County,,REP,Jennifer Anne Owens Tharp,2937
-Comal,206,Criminal District Attorney Comal County,,REP,Jennifer Anne Owens Tharp,2831
-Comal,207,Criminal District Attorney Comal County,,REP,Jennifer Anne Owens Tharp,1170
-Comal,208,Criminal District Attorney Comal County,,REP,Jennifer Anne Owens Tharp,1087
-Comal,301,Criminal District Attorney Comal County,,REP,Jennifer Anne Owens Tharp,1029
-Comal,302,Criminal District Attorney Comal County,,REP,Jennifer Anne Owens Tharp,1921
-Comal,303,Criminal District Attorney Comal County,,REP,Jennifer Anne Owens Tharp,264
-Comal,304,Criminal District Attorney Comal County,,REP,Jennifer Anne Owens Tharp,1412
-Comal,305,Criminal District Attorney Comal County,,REP,Jennifer Anne Owens Tharp,959
-Comal,306,Criminal District Attorney Comal County,,REP,Jennifer Anne Owens Tharp,586
-Comal,401,Criminal District Attorney Comal County,,REP,Jennifer Anne Owens Tharp,1011
-Comal,402,Criminal District Attorney Comal County,,REP,Jennifer Anne Owens Tharp,2266
-Comal,403,Criminal District Attorney Comal County,,REP,Jennifer Anne Owens Tharp,2753
-Comal,404,Criminal District Attorney Comal County,,REP,Jennifer Anne Owens Tharp,1838
-Comal,405,Criminal District Attorney Comal County,,REP,Jennifer Anne Owens Tharp,1911
-Comal,406,Criminal District Attorney Comal County,,REP,Jennifer Anne Owens Tharp,2397
-Comal,407,Criminal District Attorney Comal County,,REP,Jennifer Anne Owens Tharp,1620
-Comal,101,County Judge,,REP,Sherman Krause,1872
-Comal,102,County Judge,,REP,Sherman Krause,2079
-Comal,103,County Judge,,REP,Sherman Krause,2022
-Comal,104,County Judge,,REP,Sherman Krause,1117
-Comal,105,County Judge,,REP,Sherman Krause,2609
-Comal,106,County Judge,,REP,Sherman Krause,2690
-Comal,107,County Judge,,REP,Sherman Krause,1192
-Comal,201,County Judge,,REP,Sherman Krause,1972
-Comal,202,County Judge,,REP,Sherman Krause,509
-Comal,203,County Judge,,REP,Sherman Krause,2344
-Comal,204,County Judge,,REP,Sherman Krause,1891
-Comal,205,County Judge,,REP,Sherman Krause,2959
-Comal,206,County Judge,,REP,Sherman Krause,2832
-Comal,207,County Judge,,REP,Sherman Krause,1179
-Comal,208,County Judge,,REP,Sherman Krause,1087
-Comal,301,County Judge,,REP,Sherman Krause,1061
-Comal,302,County Judge,,REP,Sherman Krause,1956
-Comal,303,County Judge,,REP,Sherman Krause,271
-Comal,304,County Judge,,REP,Sherman Krause,1435
-Comal,305,County Judge,,REP,Sherman Krause,974
-Comal,306,County Judge,,REP,Sherman Krause,590
-Comal,401,County Judge,,REP,Sherman Krause,1040
-Comal,402,County Judge,,REP,Sherman Krause,2290
-Comal,403,County Judge,,REP,Sherman Krause,2759
-Comal,404,County Judge,,REP,Sherman Krause,1876
-Comal,405,County Judge,,REP,Sherman Krause,1921
-Comal,406,County Judge,,REP,Sherman Krause,2444
-Comal,407,County Judge,,REP,Sherman Krause,1628
-Comal,101,Judge, County Court-at-Law No. 1,REP,Randy Gray,1857
-Comal,102,Judge, County Court-at-Law No. 1,REP,Randy Gray,2077
-Comal,103,Judge, County Court-at-Law No. 1,REP,Randy Gray,2014
-Comal,104,Judge, County Court-at-Law No. 1,REP,Randy Gray,1113
-Comal,105,Judge, County Court-at-Law No. 1,REP,Randy Gray,2605
-Comal,106,Judge, County Court-at-Law No. 1,REP,Randy Gray,2690
-Comal,107,Judge, County Court-at-Law No. 1,REP,Randy Gray,1190
-Comal,201,Judge, County Court-at-Law No. 1,REP,Randy Gray,1968
-Comal,202,Judge, County Court-at-Law No. 1,REP,Randy Gray,506
-Comal,203,Judge, County Court-at-Law No. 1,REP,Randy Gray,2351
-Comal,204,Judge, County Court-at-Law No. 1,REP,Randy Gray,1882
-Comal,205,Judge, County Court-at-Law No. 1,REP,Randy Gray,2951
-Comal,206,Judge, County Court-at-Law No. 1,REP,Randy Gray,2823
-Comal,207,Judge, County Court-at-Law No. 1,REP,Randy Gray,1176
-Comal,208,Judge, County Court-at-Law No. 1,REP,Randy Gray,1087
-Comal,301,Judge, County Court-at-Law No. 1,REP,Randy Gray,1055
-Comal,302,Judge, County Court-at-Law No. 1,REP,Randy Gray,1933
-Comal,303,Judge, County Court-at-Law No. 1,REP,Randy Gray,271
-Comal,304,Judge, County Court-at-Law No. 1,REP,Randy Gray,1420
-Comal,305,Judge, County Court-at-Law No. 1,REP,Randy Gray,970
-Comal,306,Judge, County Court-at-Law No. 1,REP,Randy Gray,593
-Comal,401,Judge, County Court-at-Law No. 1,REP,Randy Gray,1033
-Comal,402,Judge, County Court-at-Law No. 1,REP,Randy Gray,2272
-Comal,403,Judge, County Court-at-Law No. 1,REP,Randy Gray,2756
-Comal,404,Judge, County Court-at-Law No. 1,REP,Randy Gray,1860
-Comal,405,Judge, County Court-at-Law No. 1,REP,Randy Gray,1915
-Comal,406,Judge, County Court-at-Law No. 1,REP,Randy Gray,2416
-Comal,407,Judge, County Court-at-Law No. 1,REP,Randy Gray,1614
-Comal,101,District Clerk,,REP,Heather N. Kellar,1845
-Comal,102,District Clerk,,REP,Heather N. Kellar,2081
-Comal,103,District Clerk,,REP,Heather N. Kellar,2004
-Comal,104,District Clerk,,REP,Heather N. Kellar,1108
-Comal,105,District Clerk,,REP,Heather N. Kellar,2605
-Comal,106,District Clerk,,REP,Heather N. Kellar,2699
-Comal,107,District Clerk,,REP,Heather N. Kellar,1190
-Comal,201,District Clerk,,REP,Heather N. Kellar,1949
-Comal,202,District Clerk,,REP,Heather N. Kellar,505
-Comal,203,District Clerk,,REP,Heather N. Kellar,2334
-Comal,204,District Clerk,,REP,Heather N. Kellar,1886
-Comal,205,District Clerk,,REP,Heather N. Kellar,2944
-Comal,206,District Clerk,,REP,Heather N. Kellar,2831
-Comal,207,District Clerk,,REP,Heather N. Kellar,1169
-Comal,208,District Clerk,,REP,Heather N. Kellar,1085
-Comal,301,District Clerk,,REP,Heather N. Kellar,1052
-Comal,302,District Clerk,,REP,Heather N. Kellar,1920
-Comal,303,District Clerk,,REP,Heather N. Kellar,266
-Comal,304,District Clerk,,REP,Heather N. Kellar,1417
-Comal,305,District Clerk,,REP,Heather N. Kellar,968
-Comal,306,District Clerk,,REP,Heather N. Kellar,590
-Comal,401,District Clerk,,REP,Heather N. Kellar,1012
-Comal,402,District Clerk,,REP,Heather N. Kellar,2267
-Comal,403,District Clerk,,REP,Heather N. Kellar,2761
-Comal,404,District Clerk,,REP,Heather N. Kellar,1853
-Comal,405,District Clerk,,REP,Heather N. Kellar,1915
-Comal,406,District Clerk,,REP,Heather N. Kellar,2424
-Comal,407,District Clerk,,REP,Heather N. Kellar,1616
-Comal,101,County Clerk,,REP,Bobbie Koepp,1718
-Comal,102,County Clerk,,REP,Bobbie Koepp,1985
-Comal,103,County Clerk,,REP,Bobbie Koepp,1924
-Comal,104,County Clerk,,REP,Bobbie Koepp,1069
-Comal,105,County Clerk,,REP,Bobbie Koepp,2480
-Comal,106,County Clerk,,REP,Bobbie Koepp,2601
-Comal,107,County Clerk,,REP,Bobbie Koepp,1126
-Comal,201,County Clerk,,REP,Bobbie Koepp,1787
-Comal,202,County Clerk,,REP,Bobbie Koepp,468
-Comal,203,County Clerk,,REP,Bobbie Koepp,2233
-Comal,204,County Clerk,,REP,Bobbie Koepp,1787
-Comal,205,County Clerk,,REP,Bobbie Koepp,2750
-Comal,206,County Clerk,,REP,Bobbie Koepp,2682
-Comal,207,County Clerk,,REP,Bobbie Koepp,1118
-Comal,208,County Clerk,,REP,Bobbie Koepp,1041
-Comal,301,County Clerk,,REP,Bobbie Koepp,886
-Comal,302,County Clerk,,REP,Bobbie Koepp,1760
-Comal,303,County Clerk,,REP,Bobbie Koepp,227
-Comal,304,County Clerk,,REP,Bobbie Koepp,1247
-Comal,305,County Clerk,,REP,Bobbie Koepp,866
-Comal,306,County Clerk,,REP,Bobbie Koepp,518
-Comal,401,County Clerk,,REP,Bobbie Koepp,973
-Comal,402,County Clerk,,REP,Bobbie Koepp,2171
-Comal,403,County Clerk,,REP,Bobbie Koepp,2660
-Comal,404,County Clerk,,REP,Bobbie Koepp,1780
-Comal,405,County Clerk,,REP,Bobbie Koepp,1836
-Comal,406,County Clerk,,REP,Bobbie Koepp,2271
-Comal,407,County Clerk,,REP,Bobbie Koepp,1552
-Comal,101,County Clerk,,DEM,Gloria Meehan,706
-Comal,102,County Clerk,,DEM,Gloria Meehan,435
-Comal,103,County Clerk,,DEM,Gloria Meehan,436
-Comal,104,County Clerk,,DEM,Gloria Meehan,292
-Comal,105,County Clerk,,DEM,Gloria Meehan,695
-Comal,106,County Clerk,,DEM,Gloria Meehan,544
-Comal,107,County Clerk,,DEM,Gloria Meehan,305
-Comal,201,County Clerk,,DEM,Gloria Meehan,805
-Comal,202,County Clerk,,DEM,Gloria Meehan,188
-Comal,203,County Clerk,,DEM,Gloria Meehan,593
-Comal,204,County Clerk,,DEM,Gloria Meehan,480
-Comal,205,County Clerk,,DEM,Gloria Meehan,886
-Comal,206,County Clerk,,DEM,Gloria Meehan,666
-Comal,207,County Clerk,,DEM,Gloria Meehan,254
-Comal,208,County Clerk,,DEM,Gloria Meehan,257
-Comal,301,County Clerk,,DEM,Gloria Meehan,894
-Comal,302,County Clerk,,DEM,Gloria Meehan,949
-Comal,303,County Clerk,,DEM,Gloria Meehan,250
-Comal,304,County Clerk,,DEM,Gloria Meehan,779
-Comal,305,County Clerk,,DEM,Gloria Meehan,395
-Comal,306,County Clerk,,DEM,Gloria Meehan,297
-Comal,401,County Clerk,,DEM,Gloria Meehan,371
-Comal,402,County Clerk,,DEM,Gloria Meehan,711
-Comal,403,County Clerk,,DEM,Gloria Meehan,690
-Comal,404,County Clerk,,DEM,Gloria Meehan,472
-Comal,405,County Clerk,,DEM,Gloria Meehan,485
-Comal,406,County Clerk,,DEM,Gloria Meehan,840
-Comal,407,County Clerk,,DEM,Gloria Meehan,384
-Comal,101,County Treasurer,,REP,Renee L. Couch,1856
-Comal,102,County Treasurer,,REP,Renee L. Couch,2081
-Comal,103,County Treasurer,,REP,Renee L. Couch,2012
-Comal,104,County Treasurer,,REP,Renee L. Couch,1113
-Comal,105,County Treasurer,,REP,Renee L. Couch,2611
-Comal,106,County Treasurer,,REP,Renee L. Couch,2707
-Comal,107,County Treasurer,,REP,Renee L. Couch,1189
-Comal,201,County Treasurer,,REP,Renee L. Couch,1962
-Comal,202,County Treasurer,,REP,Renee L. Couch,510
-Comal,203,County Treasurer,,REP,Renee L. Couch,2341
-Comal,204,County Treasurer,,REP,Renee L. Couch,1887
-Comal,205,County Treasurer,,REP,Renee L. Couch,2950
-Comal,206,County Treasurer,,REP,Renee L. Couch,2825
-Comal,207,County Treasurer,,REP,Renee L. Couch,1176
-Comal,208,County Treasurer,,REP,Renee L. Couch,1090
-Comal,301,County Treasurer,,REP,Renee L. Couch,1057
-Comal,302,County Treasurer,,REP,Renee L. Couch,1940
-Comal,303,County Treasurer,,REP,Renee L. Couch,269
-Comal,304,County Treasurer,,REP,Renee L. Couch,1424
-Comal,305,County Treasurer,,REP,Renee L. Couch,966
-Comal,306,County Treasurer,,REP,Renee L. Couch,597
-Comal,401,County Treasurer,,REP,Renee L. Couch,1021
-Comal,402,County Treasurer,,REP,Renee L. Couch,2279
-Comal,403,County Treasurer,,REP,Renee L. Couch,2754
-Comal,404,County Treasurer,,REP,Renee L. Couch,1853
-Comal,405,County Treasurer,,REP,Renee L. Couch,1912
-Comal,406,County Treasurer,,REP,Renee L. Couch,2423
-Comal,407,County Treasurer,,REP,Renee L. Couch,1612
-Comal,201,County Commissioner, Precinct No. 2,REP,Scott Haag,1966
-Comal,202,County Commissioner, Precinct No. 2,REP,Scott Haag,505
-Comal,203,County Commissioner, Precinct No. 2,REP,Scott Haag,2282
-Comal,204,County Commissioner, Precinct No. 2,REP,Scott Haag,1874
-Comal,205,County Commissioner, Precinct No. 2,REP,Scott Haag,2839
-Comal,206,County Commissioner, Precinct No. 2,REP,Scott Haag,2707
-Comal,207,County Commissioner, Precinct No. 2,REP,Scott Haag,1104
-Comal,208,County Commissioner, Precinct No. 2,REP,Scott Haag,1085
-Comal,201,County Commissioner, Precinct No. 2,,Michael James Zimmerman,34
-Comal,202,County Commissioner, Precinct No. 2,,Michael James Zimmerman,10
-Comal,203,County Commissioner, Precinct No. 2,,Michael James Zimmerman,103
-Comal,204,County Commissioner, Precinct No. 2,,Michael James Zimmerman,35
-Comal,205,County Commissioner, Precinct No. 2,,Michael James Zimmerman,171
-Comal,206,County Commissioner, Precinct No. 2,,Michael James Zimmerman,173
-Comal,207,County Commissioner, Precinct No. 2,,Michael James Zimmerman,117
-Comal,208,County Commissioner, Precinct No. 2,,Michael James Zimmerman,16
-Comal,401,County Commissioner, Precinct No. 4,REP,Jen Crownover,975
-Comal,402,County Commissioner, Precinct No. 4,REP,Jen Crownover,2243
-Comal,403,County Commissioner, Precinct No. 4,REP,Jen Crownover,2743
-Comal,404,County Commissioner, Precinct No. 4,REP,Jen Crownover,1793
-Comal,405,County Commissioner, Precinct No. 4,REP,Jen Crownover,1880
-Comal,406,County Commissioner, Precinct No. 4,REP,Jen Crownover,2298
-Comal,407,County Commissioner, Precinct No. 4,REP,Jen Crownover,1591
-Comal,401,County Commissioner, Precinct No. 4,DEM,Dorothy Carroll,371
-Comal,402,County Commissioner, Precinct No. 4,DEM,Dorothy Carroll,658
-Comal,403,County Commissioner, Precinct No. 4,DEM,Dorothy Carroll,633
-Comal,404,County Commissioner, Precinct No. 4,DEM,Dorothy Carroll,465
-Comal,405,County Commissioner, Precinct No. 4,DEM,Dorothy Carroll,452
-Comal,406,County Commissioner, Precinct No. 4,DEM,Dorothy Carroll,809
-Comal,407,County Commissioner, Precinct No. 4,DEM,Dorothy Carroll,368
-Comal,101,Justice of the Peace, Precinct No. 1,REP,Tom Clark,1855
-Comal,102,Justice of the Peace, Precinct No. 1,REP,Tom Clark,2087
-Comal,103,Justice of the Peace, Precinct No. 1,REP,Tom Clark,2020
-Comal,104,Justice of the Peace, Precinct No. 1,REP,Tom Clark,1118
-Comal,105,Justice of the Peace, Precinct No. 1,REP,Tom Clark,2618
-Comal,106,Justice of the Peace, Precinct No. 1,REP,Tom Clark,2700
-Comal,107,Justice of the Peace, Precinct No. 1,REP,Tom Clark,1193
-Comal,201,Justice of the Peace, Precinct No. 2,REP,James Walker,1963
-Comal,202,Justice of the Peace, Precinct No. 2,REP,James Walker,507
-Comal,203,Justice of the Peace, Precinct No. 2,REP,James Walker,2333
-Comal,204,Justice of the Peace, Precinct No. 2,REP,James Walker,1893
-Comal,205,Justice of the Peace, Precinct No. 2,REP,James Walker,2952
-Comal,206,Justice of the Peace, Precinct No. 2,REP,James Walker,2851
-Comal,207,Justice of the Peace, Precinct No. 2,REP,James Walker,1175
-Comal,208,Justice of the Peace, Precinct No. 2,REP,James Walker,1092
-Comal,301,Justice of the Peace, Precinct No. 3,REP,Mike Rust,1069
-Comal,302,Justice of the Peace, Precinct No. 3,REP,Mike Rust,1959
-Comal,303,Justice of the Peace, Precinct No. 3,REP,Mike Rust,277
-Comal,304,Justice of the Peace, Precinct No. 3,REP,Mike Rust,1435
-Comal,305,Justice of the Peace, Precinct No. 3,REP,Mike Rust,971
-Comal,306,Justice of the Peace, Precinct No. 3,REP,Mike Rust,594
-Comal,401,Justice of the Peace, Precinct No. 4,REP,Jennifer Saunders,1022
-Comal,402,Justice of the Peace, Precinct No. 4,REP,Jennifer Saunders,2330
-Comal,403,Justice of the Peace, Precinct No. 4,REP,Jennifer Saunders,2800
-Comal,404,Justice of the Peace, Precinct No. 4,REP,Jennifer Saunders,1869
-Comal,405,Justice of the Peace, Precinct No. 4,REP,Jennifer Saunders,1935
-Comal,406,Justice of the Peace, Precinct No. 4,REP,Jennifer Saunders,2438
-Comal,407,Justice of the Peace, Precinct No. 4,REP,Jennifer Saunders,1631
+county,precinct,office,district,party,candidate,votes,early_voting,election_day,absentee
+Comal,101,Registered Voters,,,Registered Voters,3907,,,
+Comal,101,Ballots Cast,,,Ballots Cast,2534,,,
+Comal,102,Registered Voters,,,Registered Voters,3681,,,
+Comal,102,Ballots Cast,,,Ballots Cast,2471,,,
+Comal,103,Registered Voters,,,Registered Voters,3511,,,
+Comal,103,Ballots Cast,,,Ballots Cast,2442,,,
+Comal,104,Registered Voters,,,Registered Voters,0,,,
+Comal,104,Ballots Cast,,,Ballots Cast,1404,,,
+Comal,105,Registered Voters,,,Registered Voters,5553,,,
+Comal,105,Ballots Cast,,,Ballots Cast,3251,,,
+Comal,106,Registered Voters,,,Registered Voters,4781,,,
+Comal,106,Ballots Cast,,,Ballots Cast,3226,,,
+Comal,107,Registered Voters,,,Registered Voters,0,,,
+Comal,107,Ballots Cast,,,Ballots Cast,1457,,,
+Comal,201,Registered Voters,,,Registered Voters,4687,,,
+Comal,201,Ballots Cast,,,Ballots Cast,2682,,,
+Comal,202,Registered Voters,,,Registered Voters,1290,,,
+Comal,202,Ballots Cast,,,Ballots Cast,679,,,
+Comal,203,Registered Voters,,,Registered Voters,4160,,,
+Comal,203,Ballots Cast,,,Ballots Cast,2895,,,
+Comal,204,Registered Voters,,,Registered Voters,3732,,,
+Comal,204,Ballots Cast,,,Ballots Cast,2318,,,
+Comal,205,Registered Voters,,,Registered Voters,0,,,
+Comal,205,Ballots Cast,,,Ballots Cast,3719,,,
+Comal,206,Registered Voters,,,Registered Voters,0,,,
+Comal,206,Ballots Cast,,,Ballots Cast,3430,,,
+Comal,207,Registered Voters,,,Registered Voters,2005,,,
+Comal,207,Ballots Cast,,,Ballots Cast,1411,,,
+Comal,208,Registered Voters,,,Registered Voters,1894,,,
+Comal,208,Ballots Cast,,,Ballots Cast,1331,,,
+Comal,301,Registered Voters,,,Registered Voters,4888,,,
+Comal,301,Ballots Cast,,,Ballots Cast,1824,,,
+Comal,302,Registered Voters,,,Registered Voters,5250,,,
+Comal,302,Ballots Cast,,,Ballots Cast,2812,,,
+Comal,303,Registered Voters,,,Registered Voters,1031,,,
+Comal,303,Ballots Cast,,,Ballots Cast,490,,,
+Comal,304,Registered Voters,,,Registered Voters,4690,,,
+Comal,304,Ballots Cast,,,Ballots Cast,2095,,,
+Comal,305,Registered Voters,,,Registered Voters,2426,,,
+Comal,305,Ballots Cast,,,Ballots Cast,1294,,,
+Comal,306,Registered Voters,,,Registered Voters,1902,,,
+Comal,306,Ballots Cast,,,Ballots Cast,848,,,
+Comal,401,Registered Voters,,,Registered Voters,2239,,,
+Comal,401,Ballots Cast,,,Ballots Cast,1390,,,
+Comal,402,Registered Voters,,,Registered Voters,0,,,
+Comal,402,Ballots Cast,,,Ballots Cast,2962,,,
+Comal,403,Registered Voters,,,Registered Voters,5050,,,
+Comal,403,Ballots Cast,,,Ballots Cast,3439,,,
+Comal,404,Registered Voters,,,Registered Voters,3530,,,
+Comal,404,Ballots Cast,,,Ballots Cast,2302,,,
+Comal,405,Registered Voters,,,Registered Voters,4047,,,
+Comal,405,Ballots Cast,,,Ballots Cast,2389,,,
+Comal,406,Registered Voters,,,Registered Voters,5000,,,
+Comal,406,Ballots Cast,,,Ballots Cast,3199,,,
+Comal,407,Registered Voters,,,Registered Voters,2643,,,
+Comal,407,Ballots Cast,,,Ballots Cast,2002,,,
+Comal,101,Straight Party,,REP,Republican Party,1085,774,197,114
+Comal,102,Straight Party,,REP,Republican Party,1449,1123,206,120
+Comal,103,Straight Party,,REP,Republican Party,1294,911,289,94
+Comal,104,Straight Party,,REP,Republican Party,752,540,135,77
+Comal,105,Straight Party,,REP,Republican Party,1782,1220,398,164
+Comal,106,Straight Party,,REP,Republican Party,1890,1498,255,137
+Comal,107,Straight Party,,REP,Republican Party,775,516,214,45
+Comal,201,Straight Party,,REP,Republican Party,1182,775,314,93
+Comal,202,Straight Party,,REP,Republican Party,337,226,78,33
+Comal,203,Straight Party,,REP,Republican Party,1507,1130,255,122
+Comal,204,Straight Party,,REP,Republican Party,1247,916,231,100
+Comal,205,Straight Party,,REP,Republican Party,1887,1568,202,117
+Comal,206,Straight Party,,REP,Republican Party,1822,1399,283,140
+Comal,207,Straight Party,,REP,Republican Party,725,527,132,66
+Comal,208,Straight Party,,REP,Republican Party,746,515,155,76
+Comal,301,Straight Party,,REP,Republican Party,597,369,196,32
+Comal,302,Straight Party,,REP,Republican Party,1165,835,241,89
+Comal,303,Straight Party,,REP,Republican Party,144,96,39,9
+Comal,304,Straight Party,,REP,Republican Party,855,581,208,66
+Comal,305,Straight Party,,REP,Republican Party,551,373,147,31
+Comal,306,Straight Party,,REP,Republican Party,342,235,82,25
+Comal,401,Straight Party,,REP,Republican Party,638,397,150,91
+Comal,402,Straight Party,,REP,Republican Party,1498,1083,249,166
+Comal,403,Straight Party,,REP,Republican Party,1868,1298,410,160
+Comal,404,Straight Party,,REP,Republican Party,1196,848,256,92
+Comal,405,Straight Party,,REP,Republican Party,1358,874,364,120
+Comal,406,Straight Party,,REP,Republican Party,1561,1075,266,220
+Comal,407,Straight Party,,REP,Republican Party,1029,696,254,79
+Comal,101,Straight Party,,DEM,Democratic Party,385,251,93,41
+Comal,102,Straight Party,,DEM,Democratic Party,225,160,33,32
+Comal,103,Straight Party,,DEM,Democratic Party,231,173,39,19
+Comal,104,Straight Party,,DEM,Democratic Party,175,126,22,27
+Comal,105,Straight Party,,DEM,Democratic Party,415,281,88,46
+Comal,106,Straight Party,,DEM,Democratic Party,302,225,30,47
+Comal,107,Straight Party,,DEM,Democratic Party,154,102,34,18
+Comal,201,Straight Party,,DEM,Democratic Party,471,313,122,36
+Comal,202,Straight Party,,DEM,Democratic Party,127,86,25,16
+Comal,203,Straight Party,,DEM,Democratic Party,338,260,42,36
+Comal,204,Straight Party,,DEM,Democratic Party,252,187,45,20
+Comal,205,Straight Party,,DEM,Democratic Party,470,366,62,42
+Comal,206,Straight Party,,DEM,Democratic Party,340,235,62,43
+Comal,207,Straight Party,,DEM,Democratic Party,128,78,35,15
+Comal,208,Straight Party,,DEM,Democratic Party,139,85,29,25
+Comal,301,Straight Party,,DEM,Democratic Party,599,324,215,60
+Comal,302,Straight Party,,DEM,Democratic Party,553,381,113,59
+Comal,303,Straight Party,,DEM,Democratic Party,156,74,68,14
+Comal,304,Straight Party,,DEM,Democratic Party,473,321,120,32
+Comal,305,Straight Party,,DEM,Democratic Party,206,117,63,26
+Comal,306,Straight Party,,DEM,Democratic Party,178,111,58,9
+Comal,401,Straight Party,,DEM,Democratic Party,203,112,59,32
+Comal,402,Straight Party,,DEM,Democratic Party,401,298,56,47
+Comal,403,Straight Party,,DEM,Democratic Party,403,278,80,45
+Comal,404,Straight Party,,DEM,Democratic Party,262,168,67,27
+Comal,405,Straight Party,,DEM,Democratic Party,268,187,50,31
+Comal,406,Straight Party,,DEM,Democratic Party,476,315,83,78
+Comal,407,Straight Party,,DEM,Democratic Party,184,135,31,18
+Comal,101,Straight Party,,LIB,Libertarian Party,11,7,4,0
+Comal,102,Straight Party,,LIB,Libertarian Party,11,9,2,0
+Comal,103,Straight Party,,LIB,Libertarian Party,6,5,1,0
+Comal,104,Straight Party,,LIB,Libertarian Party,8,5,3,0
+Comal,105,Straight Party,,LIB,Libertarian Party,12,4,7,1
+Comal,106,Straight Party,,LIB,Libertarian Party,9,7,2,0
+Comal,107,Straight Party,,LIB,Libertarian Party,5,2,3,0
+Comal,201,Straight Party,,LIB,Libertarian Party,8,3,5,0
+Comal,202,Straight Party,,LIB,Libertarian Party,2,0,2,0
+Comal,203,Straight Party,,LIB,Libertarian Party,9,5,4,0
+Comal,204,Straight Party,,LIB,Libertarian Party,11,5,6,0
+Comal,205,Straight Party,,LIB,Libertarian Party,10,6,4,0
+Comal,206,Straight Party,,LIB,Libertarian Party,9,8,1,0
+Comal,207,Straight Party,,LIB,Libertarian Party,1,1,0,0
+Comal,208,Straight Party,,LIB,Libertarian Party,2,1,1,0
+Comal,301,Straight Party,,LIB,Libertarian Party,11,7,4,0
+Comal,302,Straight Party,,LIB,Libertarian Party,11,2,9,0
+Comal,303,Straight Party,,LIB,Libertarian Party,2,0,1,1
+Comal,304,Straight Party,,LIB,Libertarian Party,5,3,2,0
+Comal,305,Straight Party,,LIB,Libertarian Party,4,0,4,0
+Comal,306,Straight Party,,LIB,Libertarian Party,7,4,3,0
+Comal,401,Straight Party,,LIB,Libertarian Party,5,2,2,1
+Comal,402,Straight Party,,LIB,Libertarian Party,12,6,6,0
+Comal,403,Straight Party,,LIB,Libertarian Party,7,6,1,0
+Comal,404,Straight Party,,LIB,Libertarian Party,7,5,2,0
+Comal,405,Straight Party,,LIB,Libertarian Party,9,5,3,1
+Comal,406,Straight Party,,LIB,Libertarian Party,7,3,4,0
+Comal,407,Straight Party,,LIB,Libertarian Party,6,3,3,0
+Comal,101,U.S. Senate,,REP,Ted Cruz,1606,1135,299,172
+Comal,102,U.S. Senate,,REP,Ted Cruz,1951,1530,274,147
+Comal,103,U.S. Senate,,REP,Ted Cruz,1871,1320,415,136
+Comal,104,U.S. Senate,,REP,Ted Cruz,1036,747,179,110
+Comal,105,U.S. Senate,,REP,Ted Cruz,2390,1651,535,204
+Comal,106,U.S. Senate,,REP,Ted Cruz,2539,1988,367,184
+Comal,107,U.S. Senate,,REP,Ted Cruz,1088,692,333,63
+Comal,201,U.S. Senate,,REP,Ted Cruz,1725,1107,483,135
+Comal,202,U.S. Senate,,REP,Ted Cruz,469,308,115,46
+Comal,203,U.S. Senate,,REP,Ted Cruz,2128,1592,376,160
+Comal,204,U.S. Senate,,REP,Ted Cruz,1748,1311,303,134
+Comal,205,U.S. Senate,,REP,Ted Cruz,2651,2194,291,166
+Comal,206,U.S. Senate,,REP,Ted Cruz,2625,2009,414,202
+Comal,207,U.S. Senate,,REP,Ted Cruz,1088,783,213,92
+Comal,208,U.S. Senate,,REP,Ted Cruz,1020,708,213,99
+Comal,301,U.S. Senate,,REP,Ted Cruz,849,512,282,55
+Comal,302,U.S. Senate,,REP,Ted Cruz,1660,1184,346,130
+Comal,303,U.S. Senate,,REP,Ted Cruz,212,138,55,19
+Comal,304,U.S. Senate,,REP,Ted Cruz,1204,803,305,96
+Comal,305,U.S. Senate,,REP,Ted Cruz,832,549,231,52
+Comal,306,U.S. Senate,,REP,Ted Cruz,509,337,125,47
+Comal,401,U.S. Senate,,REP,Ted Cruz,924,581,222,121
+Comal,402,U.S. Senate,,REP,Ted Cruz,2106,1498,378,230
+Comal,403,U.S. Senate,,REP,Ted Cruz,2607,1785,600,222
+Comal,404,U.S. Senate,,REP,Ted Cruz,1720,1241,361,118
+Comal,405,U.S. Senate,,REP,Ted Cruz,1827,1189,471,167
+Comal,406,U.S. Senate,,REP,Ted Cruz,2194,1485,406,303
+Comal,407,U.S. Senate,,REP,Ted Cruz,1500,1043,353,104
+Comal,101,U.S. Senate,,DEM,Beto O'Rourke,858,564,211,83
+Comal,102,U.S. Senate,,DEM,Beto O'Rourke,461,337,67,57
+Comal,103,U.S. Senate,,DEM,Beto O'Rourke,527,364,114,49
+Comal,104,U.S. Senate,,DEM,Beto O'Rourke,325,226,45,54
+Comal,105,U.S. Senate,,DEM,Beto O'Rourke,772,523,165,84
+Comal,106,U.S. Senate,,DEM,Beto O'Rourke,613,457,84,72
+Comal,107,U.S. Senate,,DEM,Beto O'Rourke,341,234,79,28
+Comal,201,U.S. Senate,,DEM,Beto O'Rourke,889,558,254,77
+Comal,202,U.S. Senate,,DEM,Beto O'Rourke,201,124,52,25
+Comal,203,U.S. Senate,,DEM,Beto O'Rourke,703,524,107,72
+Comal,204,U.S. Senate,,DEM,Beto O'Rourke,518,390,79,49
+Comal,205,U.S. Senate,,DEM,Beto O'Rourke,998,779,141,78
+Comal,206,U.S. Senate,,DEM,Beto O'Rourke,723,500,150,73
+Comal,207,U.S. Senate,,DEM,Beto O'Rourke,308,215,67,26
+Comal,208,U.S. Senate,,DEM,Beto O'Rourke,289,167,75,47
+Comal,301,U.S. Senate,,DEM,Beto O'Rourke,935,530,320,85
+Comal,302,U.S. Senate,,DEM,Beto O'Rourke,1065,724,231,110
+Comal,303,U.S. Senate,,DEM,Beto O'Rourke,266,143,99,24
+Comal,304,U.S. Senate,,DEM,Beto O'Rourke,854,570,232,52
+Comal,305,U.S. Senate,,DEM,Beto O'Rourke,441,267,134,40
+Comal,306,U.S. Senate,,DEM,Beto O'Rourke,316,207,92,17
+Comal,401,U.S. Senate,,DEM,Beto O'Rourke,424,252,100,72
+Comal,402,U.S. Senate,,DEM,Beto O'Rourke,781,576,115,90
+Comal,403,U.S. Senate,,DEM,Beto O'Rourke,768,531,159,78
+Comal,404,U.S. Senate,,DEM,Beto O'Rourke,545,356,145,44
+Comal,405,U.S. Senate,,DEM,Beto O'Rourke,508,340,111,57
+Comal,406,U.S. Senate,,DEM,Beto O'Rourke,942,640,170,132
+Comal,407,U.S. Senate,,DEM,Beto O'Rourke,459,309,105,45
+Comal,101,U.S. Senate,,LIB,Neal M. Dikeman,26,17,8,1
+Comal,102,U.S. Senate,,LIB,Neal M. Dikeman,18,11,6,1
+Comal,103,U.S. Senate,,LIB,Neal M. Dikeman,22,12,9,1
+Comal,104,U.S. Senate,,LIB,Neal M. Dikeman,21,11,9,1
+Comal,105,U.S. Senate,,LIB,Neal M. Dikeman,34,18,13,3
+Comal,106,U.S. Senate,,LIB,Neal M. Dikeman,24,21,1,2
+Comal,107,U.S. Senate,,LIB,Neal M. Dikeman,12,4,6,2
+Comal,201,U.S. Senate,,LIB,Neal M. Dikeman,34,16,14,4
+Comal,202,U.S. Senate,,LIB,Neal M. Dikeman,4,2,2,0
+Comal,203,U.S. Senate,,LIB,Neal M. Dikeman,20,14,5,1
+Comal,204,U.S. Senate,,LIB,Neal M. Dikeman,23,12,11,0
+Comal,205,U.S. Senate,,LIB,Neal M. Dikeman,32,17,14,1
+Comal,206,U.S. Senate,,LIB,Neal M. Dikeman,36,26,8,2
+Comal,207,U.S. Senate,,LIB,Neal M. Dikeman,5,1,4,0
+Comal,208,U.S. Senate,,LIB,Neal M. Dikeman,3,2,1,0
+Comal,301,U.S. Senate,,LIB,Neal M. Dikeman,21,9,8,4
+Comal,302,U.S. Senate,,LIB,Neal M. Dikeman,42,21,20,1
+Comal,303,U.S. Senate,,LIB,Neal M. Dikeman,2,1,1,0
+Comal,304,U.S. Senate,,LIB,Neal M. Dikeman,18,11,6,1
+Comal,305,U.S. Senate,,LIB,Neal M. Dikeman,12,5,6,1
+Comal,306,U.S. Senate,,LIB,Neal M. Dikeman,13,6,5,2
+Comal,401,U.S. Senate,,LIB,Neal M. Dikeman,15,9,6,0
+Comal,402,U.S. Senate,,LIB,Neal M. Dikeman,39,23,16,0
+Comal,403,U.S. Senate,,LIB,Neal M. Dikeman,23,12,10,1
+Comal,404,U.S. Senate,,LIB,Neal M. Dikeman,17,10,7,0
+Comal,405,U.S. Senate,,LIB,Neal M. Dikeman,23,8,11,4
+Comal,406,U.S. Senate,,LIB,Neal M. Dikeman,21,12,7,2
+Comal,407,U.S. Senate,,LIB,Neal M. Dikeman,26,12,13,1
+Comal,101,U.S. House,21,REP,Chip Roy,1602,1143,299,160
+Comal,102,U.S. House,21,REP,Chip Roy,1966,1543,283,140
+Comal,103,U.S. House,21,REP,Chip Roy,1876,1325,424,127
+Comal,104,U.S. House,21,REP,Chip Roy,1036,747,186,103
+Comal,105,U.S. House,21,REP,Chip Roy,2405,1668,540,197
+Comal,106,U.S. House,21,REP,Chip Roy,2549,1992,379,178
+Comal,107,U.S. House,21,REP,Chip Roy,1091,698,334,59
+Comal,203,U.S. House,21,REP,Chip Roy,2151,1607,388,156
+Comal,204,U.S. House,21,REP,Chip Roy,1748,1306,309,133
+Comal,205,U.S. House,21,REP,Chip Roy,2658,2208,295,155
+Comal,206,U.S. House,21,REP,Chip Roy,2624,2008,426,190
+Comal,207,U.S. House,21,REP,Chip Roy,1104,795,221,88
+Comal,208,U.S. House,21,REP,Chip Roy,1023,715,214,94
+Comal,305,U.S. House,21,REP,Chip Roy,828,559,230,39
+Comal,401,U.S. House,21,REP,Chip Roy,925,591,219,115
+Comal,402,U.S. House,21,REP,Chip Roy,2090,1493,386,211
+Comal,403,U.S. House,21,REP,Chip Roy,2612,1795,605,212
+Comal,404,U.S. House,21,REP,Chip Roy,1715,1239,368,108
+Comal,405,U.S. House,21,REP,Chip Roy,1808,1178,474,156
+Comal,406,U.S. House,21,REP,Chip Roy,2201,1502,409,290
+Comal,407,U.S. House,21,REP,Chip Roy,1502,1035,366,101
+Comal,101,U.S. House,21,DEM,Joseph Kopser,812,547,186,79
+Comal,102,U.S. House,21,DEM,Joseph Kopser,440,327,58,55
+Comal,103,U.S. House,21,DEM,Joseph Kopser,500,350,100,50
+Comal,104,U.S. House,21,DEM,Joseph Kopser,312,219,40,53
+Comal,105,U.S. House,21,DEM,Joseph Kopser,744,514,149,81
+Comal,106,U.S. House,21,DEM,Joseph Kopser,587,450,66,71
+Comal,107,U.S. House,21,DEM,Joseph Kopser,329,226,77,26
+Comal,203,U.S. House,21,DEM,Joseph Kopser,669,515,93,61
+Comal,204,U.S. House,21,DEM,Joseph Kopser,515,391,78,46
+Comal,205,U.S. House,21,DEM,Joseph Kopser,965,760,131,74
+Comal,206,U.S. House,21,DEM,Joseph Kopser,713,504,138,71
+Comal,207,U.S. House,21,DEM,Joseph Kopser,284,199,60,25
+Comal,208,U.S. House,21,DEM,Joseph Kopser,273,159,68,46
+Comal,305,U.S. House,21,DEM,Joseph Kopser,414,248,123,43
+Comal,401,U.S. House,21,DEM,Joseph Kopser,417,242,103,72
+Comal,402,U.S. House,21,DEM,Joseph Kopser,769,564,112,93
+Comal,403,U.S. House,21,DEM,Joseph Kopser,741,518,147,76
+Comal,404,U.S. House,21,DEM,Joseph Kopser,515,350,120,45
+Comal,405,U.S. House,21,DEM,Joseph Kopser,505,339,105,61
+Comal,406,U.S. House,21,DEM,Joseph Kopser,909,625,154,130
+Comal,407,U.S. House,21,DEM,Joseph Kopser,442,311,86,45
+Comal,101,U.S. House,21,LIB,Lee Santos,69,35,31,3
+Comal,102,U.S. House,21,LIB,Lee Santos,41,27,11,3
+Comal,103,U.S. House,21,LIB,Lee Santos,31,22,9,0
+Comal,104,U.S. House,21,LIB,Lee Santos,27,19,7,1
+Comal,105,U.S. House,21,LIB,Lee Santos,53,27,21,5
+Comal,106,U.S. House,21,LIB,Lee Santos,42,33,9,0
+Comal,107,U.S. House,21,LIB,Lee Santos,22,12,9,1
+Comal,203,U.S. House,21,LIB,Lee Santos,26,19,7,0
+Comal,204,U.S. House,21,LIB,Lee Santos,33,20,12,1
+Comal,205,U.S. House,21,LIB,Lee Santos,55,37,18,0
+Comal,206,U.S. House,21,LIB,Lee Santos,56,43,12,1
+Comal,207,U.S. House,21,LIB,Lee Santos,11,7,4,0
+Comal,208,U.S. House,21,LIB,Lee Santos,14,8,5,1
+Comal,305,U.S. House,21,LIB,Lee Santos,34,14,18,2
+Comal,401,U.S. House,21,LIB,Lee Santos,27,20,6,1
+Comal,402,U.S. House,21,LIB,Lee Santos,57,44,12,1
+Comal,403,U.S. House,21,LIB,Lee Santos,43,24,16,3
+Comal,404,U.S. House,21,LIB,Lee Santos,39,18,21,0
+Comal,405,U.S. House,21,LIB,Lee Santos,44,23,18,3
+Comal,406,U.S. House,21,LIB,Lee Santos,49,24,22,3
+Comal,407,U.S. House,21,LIB,Lee Santos,34,18,16,0
+Comal,201,U.S. House,35,REP,David Smalling,1674,1087,467,120
+Comal,202,U.S. House,35,REP,David Smalling,453,303,107,43
+Comal,301,U.S. House,35,REP,David Smalling,812,508,261,43
+Comal,302,U.S. House,35,REP,David Smalling,1606,1154,340,112
+Comal,303,U.S. House,35,REP,David Smalling,199,134,52,13
+Comal,304,U.S. House,35,REP,David Smalling,1171,796,294,81
+Comal,306,U.S. House,35,REP,David Smalling,486,326,123,37
+Comal,201,U.S. House,35,DEM,Lloyd Doggett,888,564,245,79
+Comal,202,U.S. House,35,DEM,Lloyd Doggett,206,128,56,22
+Comal,301,U.S. House,35,DEM,Lloyd Doggett,919,521,310,88
+Comal,302,U.S. House,35,DEM,Lloyd Doggett,1048,724,214,110
+Comal,303,U.S. House,35,DEM,Lloyd Doggett,270,143,99,28
+Comal,304,U.S. House,35,DEM,Lloyd Doggett,820,550,221,49
+Comal,306,U.S. House,35,DEM,Lloyd Doggett,320,210,90,20
+Comal,201,U.S. House,35,LIB,Clark Patterson,61,33,27,1
+Comal,202,U.S. House,35,LIB,Clark Patterson,9,3,6,0
+Comal,301,U.S. House,35,LIB,Clark Patterson,49,21,25,3
+Comal,302,U.S. House,35,LIB,Clark Patterson,88,54,32,2
+Comal,303,U.S. House,35,LIB,Clark Patterson,13,9,4,0
+Comal,304,U.S. House,35,LIB,Clark Patterson,52,32,20,0
+Comal,306,U.S. House,35,LIB,Clark Patterson,23,16,7,0
+Comal,101,Governor,,REP,Greg Abbott,1743,1213,344,186
+Comal,102,Governor,,REP,Greg Abbott,2034,1583,292,159
+Comal,103,Governor,,REP,Greg Abbott,1962,1377,442,143
+Comal,104,Governor,,REP,Greg Abbott,1088,783,191,114
+Comal,105,Governor,,REP,Greg Abbott,2539,1749,575,215
+Comal,106,Governor,,REP,Greg Abbott,2657,2073,394,190
+Comal,107,Governor,,REP,Greg Abbott,1144,726,352,66
+Comal,201,Governor,,REP,Greg Abbott,1845,1169,531,145
+Comal,202,Governor,,REP,Greg Abbott,486,316,123,47
+Comal,203,Governor,,REP,Greg Abbott,2261,1676,411,174
+Comal,204,Governor,,REP,Greg Abbott,1830,1368,324,138
+Comal,205,Governor,,REP,Greg Abbott,2835,2338,328,169
+Comal,206,Governor,,REP,Greg Abbott,2772,2102,462,208
+Comal,207,Governor,,REP,Greg Abbott,1155,826,236,93
+Comal,208,Governor,,REP,Greg Abbott,1077,736,239,102
+Comal,301,Governor,,REP,Greg Abbott,945,571,315,59
+Comal,302,Governor,,REP,Greg Abbott,1789,1267,387,135
+Comal,303,Governor,,REP,Greg Abbott,233,146,66,21
+Comal,304,Governor,,REP,Greg Abbott,1281,851,331,99
+Comal,305,Governor,,REP,Greg Abbott,894,591,248,55
+Comal,306,Governor,,REP,Greg Abbott,549,357,141,51
+Comal,401,Governor,,REP,Greg Abbott,977,616,235,126
+Comal,402,Governor,,REP,Greg Abbott,2200,1568,398,234
+Comal,403,Governor,,REP,Greg Abbott,2711,1854,626,231
+Comal,404,Governor,,REP,Greg Abbott,1809,1298,392,119
+Comal,405,Governor,,REP,Greg Abbott,1892,1220,499,173
+Comal,406,Governor,,REP,Greg Abbott,2341,1584,445,312
+Comal,407,Governor,,REP,Greg Abbott,1586,1097,379,110
+Comal,101,Governor,,DEM,Lupe Valdez,690,465,158,67
+Comal,102,Governor,,DEM,Lupe Valdez,391,292,54,45
+Comal,103,Governor,,DEM,Lupe Valdez,438,310,85,43
+Comal,104,Governor,,DEM,Lupe Valdez,273,191,33,49
+Comal,105,Governor,,DEM,Lupe Valdez,634,436,130,68
+Comal,106,Governor,,DEM,Lupe Valdez,491,374,53,64
+Comal,107,Governor,,DEM,Lupe Valdez,282,196,60,26
+Comal,201,Governor,,DEM,Lupe Valdez,771,499,207,65
+Comal,202,Governor,,DEM,Lupe Valdez,183,116,43,24
+Comal,203,Governor,,DEM,Lupe Valdez,582,456,70,56
+Comal,204,Governor,,DEM,Lupe Valdez,446,340,65,41
+Comal,205,Governor,,DEM,Lupe Valdez,803,636,95,72
+Comal,206,Governor,,DEM,Lupe Valdez,598,425,106,67
+Comal,207,Governor,,DEM,Lupe Valdez,231,163,45,23
+Comal,208,Governor,,DEM,Lupe Valdez,234,146,45,43
+Comal,301,Governor,,DEM,Lupe Valdez,831,470,282,79
+Comal,302,Governor,,DEM,Lupe Valdez,922,638,187,97
+Comal,303,Governor,,DEM,Lupe Valdez,243,132,90,21
+Comal,304,Governor,,DEM,Lupe Valdez,756,509,198,49
+Comal,305,Governor,,DEM,Lupe Valdez,357,213,111,33
+Comal,306,Governor,,DEM,Lupe Valdez,277,184,78,15
+Comal,401,Governor,,DEM,Lupe Valdez,354,214,82,58
+Comal,402,Governor,,DEM,Lupe Valdez,671,489,98,84
+Comal,403,Governor,,DEM,Lupe Valdez,664,469,130,65
+Comal,404,Governor,,DEM,Lupe Valdez,440,292,106,42
+Comal,405,Governor,,DEM,Lupe Valdez,444,309,84,51
+Comal,406,Governor,,DEM,Lupe Valdez,774,534,120,120
+Comal,407,Governor,,DEM,Lupe Valdez,365,249,79,37
+Comal,101,Governor,,LIB,Mark Jay Tippetts,65,46,19,0
+Comal,102,Governor,,LIB,Mark Jay Tippetts,31,21,9,1
+Comal,103,Governor,,LIB,Mark Jay Tippetts,29,19,9,1
+Comal,104,Governor,,LIB,Mark Jay Tippetts,28,17,11,0
+Comal,105,Governor,,LIB,Mark Jay Tippetts,49,29,13,7
+Comal,106,Governor,,LIB,Mark Jay Tippetts,45,36,8,1
+Comal,107,Governor,,LIB,Mark Jay Tippetts,24,15,9,0
+Comal,201,Governor,,LIB,Mark Jay Tippetts,47,26,16,5
+Comal,202,Governor,,LIB,Mark Jay Tippetts,8,5,3,0
+Comal,203,Governor,,LIB,Mark Jay Tippetts,34,22,11,1
+Comal,204,Governor,,LIB,Mark Jay Tippetts,27,15,11,1
+Comal,205,Governor,,LIB,Mark Jay Tippetts,58,38,19,1
+Comal,206,Governor,,LIB,Mark Jay Tippetts,42,33,9,0
+Comal,207,Governor,,LIB,Mark Jay Tippetts,14,10,4,0
+Comal,208,Governor,,LIB,Mark Jay Tippetts,12,8,3,1
+Comal,301,Governor,,LIB,Mark Jay Tippetts,30,18,8,4
+Comal,302,Governor,,LIB,Mark Jay Tippetts,69,42,23,4
+Comal,303,Governor,,LIB,Mark Jay Tippetts,8,6,2,0
+Comal,304,Governor,,LIB,Mark Jay Tippetts,37,24,12,1
+Comal,305,Governor,,LIB,Mark Jay Tippetts,35,20,12,3
+Comal,306,Governor,,LIB,Mark Jay Tippetts,15,11,4,0
+Comal,401,Governor,,LIB,Mark Jay Tippetts,35,22,10,3
+Comal,402,Governor,,LIB,Mark Jay Tippetts,60,44,15,1
+Comal,403,Governor,,LIB,Mark Jay Tippetts,39,21,13,5
+Comal,404,Governor,,LIB,Mark Jay Tippetts,41,24,16,1
+Comal,405,Governor,,LIB,Mark Jay Tippetts,32,14,16,2
+Comal,406,Governor,,LIB,Mark Jay Tippetts,64,37,24,3
+Comal,407,Governor,,LIB,Mark Jay Tippetts,37,23,13,1
+Comal,101,Lieutenant Governor,,REP,Dan Patrick,1604,1119,310,175
+Comal,102,Lieutenant Governor,,REP,Dan Patrick,1963,1527,282,154
+Comal,103,Lieutenant Governor,,REP,Dan Patrick,1860,1303,419,138
+Comal,104,Lieutenant Governor,,REP,Dan Patrick,1047,749,186,112
+Comal,105,Lieutenant Governor,,REP,Dan Patrick,2447,1689,555,203
+Comal,106,Lieutenant Governor,,REP,Dan Patrick,2555,1999,372,184
+Comal,107,Lieutenant Governor,,REP,Dan Patrick,1094,696,333,65
+Comal,201,Lieutenant Governor,,REP,Dan Patrick,1751,1122,492,137
+Comal,202,Lieutenant Governor,,REP,Dan Patrick,468,311,111,46
+Comal,203,Lieutenant Governor,,REP,Dan Patrick,2148,1601,383,164
+Comal,204,Lieutenant Governor,,REP,Dan Patrick,1757,1312,311,134
+Comal,205,Lieutenant Governor,,REP,Dan Patrick,2683,2208,311,164
+Comal,206,Lieutenant Governor,,REP,Dan Patrick,2648,2017,432,199
+Comal,207,Lieutenant Governor,,REP,Dan Patrick,1105,793,219,93
+Comal,208,Lieutenant Governor,,REP,Dan Patrick,1039,719,223,97
+Comal,301,Lieutenant Governor,,REP,Dan Patrick,878,529,294,55
+Comal,302,Lieutenant Governor,,REP,Dan Patrick,1676,1191,360,125
+Comal,303,Lieutenant Governor,,REP,Dan Patrick,216,139,59,18
+Comal,304,Lieutenant Governor,,REP,Dan Patrick,1218,803,320,95
+Comal,305,Lieutenant Governor,,REP,Dan Patrick,841,554,236,51
+Comal,306,Lieutenant Governor,,REP,Dan Patrick,514,335,132,47
+Comal,401,Lieutenant Governor,,REP,Dan Patrick,906,573,214,119
+Comal,402,Lieutenant Governor,,REP,Dan Patrick,2109,1493,388,228
+Comal,403,Lieutenant Governor,,REP,Dan Patrick,2628,1790,612,226
+Comal,404,Lieutenant Governor,,REP,Dan Patrick,1715,1225,370,120
+Comal,405,Lieutenant Governor,,REP,Dan Patrick,1832,1184,483,165
+Comal,406,Lieutenant Governor,,REP,Dan Patrick,2214,1497,416,301
+Comal,407,Lieutenant Governor,,REP,Dan Patrick,1481,1028,351,102
+Comal,101,Lieutenant Governor,,DEM,Mike Collier,795,543,174,78
+Comal,102,Lieutenant Governor,,DEM,Mike Collier,432,325,59,48
+Comal,103,Lieutenant Governor,,DEM,Mike Collier,511,360,103,48
+Comal,104,Lieutenant Governor,,DEM,Mike Collier,304,212,43,49
+Comal,105,Lieutenant Governor,,DEM,Mike Collier,706,489,138,79
+Comal,106,Lieutenant Governor,,DEM,Mike Collier,577,437,72,68
+Comal,107,Lieutenant Governor,,DEM,Mike Collier,322,221,75,26
+Comal,201,Lieutenant Governor,,DEM,Mike Collier,829,527,229,73
+Comal,202,Lieutenant Governor,,DEM,Mike Collier,199,122,54,23
+Comal,203,Lieutenant Governor,,DEM,Mike Collier,671,516,93,62
+Comal,204,Lieutenant Governor,,DEM,Mike Collier,494,376,70,48
+Comal,205,Lieutenant Governor,,DEM,Mike Collier,951,759,116,76
+Comal,206,Lieutenant Governor,,DEM,Mike Collier,683,482,129,72
+Comal,207,Lieutenant Governor,,DEM,Mike Collier,276,192,60,24
+Comal,208,Lieutenant Governor,,DEM,Mike Collier,263,159,56,48
+Comal,301,Lieutenant Governor,,DEM,Mike Collier,869,498,287,84
+Comal,302,Lieutenant Governor,,DEM,Mike Collier,1008,693,201,114
+Comal,303,Lieutenant Governor,,DEM,Mike Collier,248,133,91,24
+Comal,304,Lieutenant Governor,,DEM,Mike Collier,797,541,203,53
+Comal,305,Lieutenant Governor,,DEM,Mike Collier,409,253,116,40
+Comal,306,Lieutenant Governor,,DEM,Mike Collier,306,204,83,19
+Comal,401,Lieutenant Governor,,DEM,Mike Collier,420,251,99,70
+Comal,402,Lieutenant Governor,,DEM,Mike Collier,747,556,104,87
+Comal,403,Lieutenant Governor,,DEM,Mike Collier,736,517,147,72
+Comal,404,Lieutenant Governor,,DEM,Mike Collier,523,361,119,43
+Comal,405,Lieutenant Governor,,DEM,Mike Collier,480,328,92,60
+Comal,406,Lieutenant Governor,,DEM,Mike Collier,893,617,142,134
+Comal,407,Lieutenant Governor,,DEM,Mike Collier,447,310,94,43
+Comal,101,Lieutenant Governor,,LIB,Kerry Douglas McKennon,90,61,29,0
+Comal,102,Lieutenant Governor,,LIB,Kerry Douglas McKennon,58,43,13,2
+Comal,103,Lieutenant Governor,,LIB,Kerry Douglas McKennon,50,37,11,2
+Comal,104,Lieutenant Governor,,LIB,Kerry Douglas McKennon,37,26,8,3
+Comal,105,Lieutenant Governor,,LIB,Kerry Douglas McKennon,69,37,24,8
+Comal,106,Lieutenant Governor,,LIB,Kerry Douglas McKennon,55,40,12,3
+Comal,107,Lieutenant Governor,,LIB,Kerry Douglas McKennon,28,16,12,0
+Comal,201,Lieutenant Governor,,LIB,Kerry Douglas McKennon,70,42,24,4
+Comal,202,Lieutenant Governor,,LIB,Kerry Douglas McKennon,8,3,4,1
+Comal,203,Lieutenant Governor,,LIB,Kerry Douglas McKennon,57,36,16,5
+Comal,204,Lieutenant Governor,,LIB,Kerry Douglas McKennon,49,29,18,2
+Comal,205,Lieutenant Governor,,LIB,Kerry Douglas McKennon,66,46,17,3
+Comal,206,Lieutenant Governor,,LIB,Kerry Douglas McKennon,78,59,15,4
+Comal,207,Lieutenant Governor,,LIB,Kerry Douglas McKennon,19,15,4,0
+Comal,208,Lieutenant Governor,,LIB,Kerry Douglas McKennon,18,10,8,0
+Comal,301,Lieutenant Governor,,LIB,Kerry Douglas McKennon,53,30,20,3
+Comal,302,Lieutenant Governor,,LIB,Kerry Douglas McKennon,88,56,29,3
+Comal,303,Lieutenant Governor,,LIB,Kerry Douglas McKennon,21,14,7,0
+Comal,304,Lieutenant Governor,,LIB,Kerry Douglas McKennon,57,35,19,3
+Comal,305,Lieutenant Governor,,LIB,Kerry Douglas McKennon,32,13,18,1
+Comal,306,Lieutenant Governor,,LIB,Kerry Douglas McKennon,21,14,7,0
+Comal,401,Lieutenant Governor,,LIB,Kerry Douglas McKennon,42,27,14,1
+Comal,402,Lieutenant Governor,,LIB,Kerry Douglas McKennon,75,56,16,3
+Comal,403,Lieutenant Governor,,LIB,Kerry Douglas McKennon,54,35,16,3
+Comal,404,Lieutenant Governor,,LIB,Kerry Douglas McKennon,46,24,21,1
+Comal,405,Lieutenant Governor,,LIB,Kerry Douglas McKennon,49,25,22,2
+Comal,406,Lieutenant Governor,,LIB,Kerry Douglas McKennon,65,36,25,4
+Comal,407,Lieutenant Governor,,LIB,Kerry Douglas McKennon,55,29,25,1
+Comal,101,Attorney General,,REP,Ken Paxton,1588,1115,302,171
+Comal,102,Attorney General,,REP,Ken Paxton,1949,1523,276,150
+Comal,103,Attorney General,,REP,Ken Paxton,1831,1280,418,133
+Comal,104,Attorney General,,REP,Ken Paxton,1016,724,181,111
+Comal,105,Attorney General,,REP,Ken Paxton,2391,1655,539,197
+Comal,106,Attorney General,,REP,Ken Paxton,2524,1969,371,184
+Comal,107,Attorney General,,REP,Ken Paxton,1098,701,334,63
+Comal,201,Attorney General,,REP,Ken Paxton,1705,1092,480,133
+Comal,202,Attorney General,,REP,Ken Paxton,462,306,111,45
+Comal,203,Attorney General,,REP,Ken Paxton,2128,1588,377,163
+Comal,204,Attorney General,,REP,Ken Paxton,1730,1290,309,131
+Comal,205,Attorney General,,REP,Ken Paxton,2627,2170,296,161
+Comal,206,Attorney General,,REP,Ken Paxton,2604,1985,424,195
+Comal,207,Attorney General,,REP,Ken Paxton,1082,774,216,92
+Comal,208,Attorney General,,REP,Ken Paxton,1011,704,211,96
+Comal,301,Attorney General,,REP,Ken Paxton,859,520,286,53
+Comal,302,Attorney General,,REP,Ken Paxton,1637,1171,343,123
+Comal,303,Attorney General,,REP,Ken Paxton,213,137,59,17
+Comal,304,Attorney General,,REP,Ken Paxton,1211,810,302,99
+Comal,305,Attorney General,,REP,Ken Paxton,832,552,227,53
+Comal,306,Attorney General,,REP,Ken Paxton,511,331,133,47
+Comal,401,Attorney General,,REP,Ken Paxton,894,558,216,120
+Comal,402,Attorney General,,REP,Ken Paxton,2079,1478,378,223
+Comal,403,Attorney General,,REP,Ken Paxton,2580,1771,592,217
+Comal,404,Attorney General,,REP,Ken Paxton,1688,1217,357,114
+Comal,405,Attorney General,,REP,Ken Paxton,1780,1164,460,156
+Comal,406,Attorney General,,REP,Ken Paxton,2184,1476,409,299
+Comal,407,Attorney General,,REP,Ken Paxton,1468,1012,355,101
+Comal,101,Attorney General,,DEM,Justin Nelson,813,546,188,79
+Comal,102,Attorney General,,DEM,Justin Nelson,448,332,65,51
+Comal,103,Attorney General,,DEM,Justin Nelson,523,363,106,54
+Comal,104,Attorney General,,DEM,Justin Nelson,319,227,40,52
+Comal,105,Attorney General,,DEM,Justin Nelson,758,518,152,88
+Comal,106,Attorney General,,DEM,Justin Nelson,604,460,75,69
+Comal,107,Attorney General,,DEM,Justin Nelson,320,219,73,28
+Comal,201,Attorney General,,DEM,Justin Nelson,856,548,233,75
+Comal,202,Attorney General,,DEM,Justin Nelson,201,124,53,24
+Comal,203,Attorney General,,DEM,Justin Nelson,689,528,98,63
+Comal,204,Attorney General,,DEM,Justin Nelson,515,392,72,51
+Comal,205,Attorney General,,DEM,Justin Nelson,991,783,129,79
+Comal,206,Attorney General,,DEM,Justin Nelson,719,511,135,73
+Comal,207,Attorney General,,DEM,Justin Nelson,292,210,58,24
+Comal,208,Attorney General,,DEM,Justin Nelson,285,169,69,47
+Comal,301,Attorney General,,DEM,Justin Nelson,889,506,298,85
+Comal,302,Attorney General,,DEM,Justin Nelson,1042,715,213,114
+Comal,303,Attorney General,,DEM,Justin Nelson,253,135,94,24
+Comal,304,Attorney General,,DEM,Justin Nelson,795,530,214,51
+Comal,305,Attorney General,,DEM,Justin Nelson,412,249,125,38
+Comal,306,Attorney General,,DEM,Justin Nelson,306,204,83,19
+Comal,401,Attorney General,,DEM,Justin Nelson,420,252,101,67
+Comal,402,Attorney General,,DEM,Justin Nelson,762,557,111,94
+Comal,403,Attorney General,,DEM,Justin Nelson,753,520,154,79
+Comal,404,Attorney General,,DEM,Justin Nelson,528,353,126,49
+Comal,405,Attorney General,,DEM,Justin Nelson,508,338,103,67
+Comal,406,Attorney General,,DEM,Justin Nelson,912,623,154,135
+Comal,407,Attorney General,,DEM,Justin Nelson,459,317,96,46
+Comal,101,Attorney General,,LIB,Michael Ray Harris,82,60,21,1
+Comal,102,Attorney General,,LIB,Michael Ray Harris,49,35,11,3
+Comal,103,Attorney General,,LIB,Michael Ray Harris,55,46,8,1
+Comal,104,Attorney General,,LIB,Michael Ray Harris,47,35,11,1
+Comal,105,Attorney General,,LIB,Michael Ray Harris,74,43,25,6
+Comal,106,Attorney General,,LIB,Michael Ray Harris,58,47,9,2
+Comal,107,Attorney General,,LIB,Michael Ray Harris,24,14,10,0
+Comal,201,Attorney General,,LIB,Michael Ray Harris,81,44,33,4
+Comal,202,Attorney General,,LIB,Michael Ray Harris,11,5,5,1
+Comal,203,Attorney General,,LIB,Michael Ray Harris,51,34,14,3
+Comal,204,Attorney General,,LIB,Michael Ray Harris,52,32,18,2
+Comal,205,Attorney General,,LIB,Michael Ray Harris,76,56,17,3
+Comal,206,Attorney General,,LIB,Michael Ray Harris,74,55,15,4
+Comal,207,Attorney General,,LIB,Michael Ray Harris,24,15,8,1
+Comal,208,Attorney General,,LIB,Michael Ray Harris,19,13,5,1
+Comal,301,Attorney General,,LIB,Michael Ray Harris,47,27,16,4
+Comal,302,Attorney General,,LIB,Michael Ray Harris,90,51,34,5
+Comal,303,Attorney General,,LIB,Michael Ray Harris,18,13,5,0
+Comal,304,Attorney General,,LIB,Michael Ray Harris,60,39,20,1
+Comal,305,Attorney General,,LIB,Michael Ray Harris,36,18,17,1
+Comal,306,Attorney General,,LIB,Michael Ray Harris,21,15,6,0
+Comal,401,Attorney General,,LIB,Michael Ray Harris,50,35,11,4
+Comal,402,Attorney General,,LIB,Michael Ray Harris,88,67,19,2
+Comal,403,Attorney General,,LIB,Michael Ray Harris,70,43,23,4
+Comal,404,Attorney General,,LIB,Michael Ray Harris,65,40,25,0
+Comal,405,Attorney General,,LIB,Michael Ray Harris,69,32,33,4
+Comal,406,Attorney General,,LIB,Michael Ray Harris,64,38,22,4
+Comal,407,Attorney General,,LIB,Michael Ray Harris,50,35,15,0
+Comal,101,Comptroller of Public Accounts,,REP,Glenn Hegar,1676,1184,315,177
+Comal,102,Comptroller of Public Accounts,,REP,Glenn Hegar,1970,1542,280,148
+Comal,103,Comptroller of Public Accounts,,REP,Glenn Hegar,1891,1330,423,138
+Comal,104,Comptroller of Public Accounts,,REP,Glenn Hegar,1063,762,189,112
+Comal,105,Comptroller of Public Accounts,,REP,Glenn Hegar,2448,1696,549,203
+Comal,106,Comptroller of Public Accounts,,REP,Glenn Hegar,2576,2019,373,184
+Comal,107,Comptroller of Public Accounts,,REP,Glenn Hegar,1120,722,336,62
+Comal,201,Comptroller of Public Accounts,,REP,Glenn Hegar,1749,1118,496,135
+Comal,202,Comptroller of Public Accounts,,REP,Glenn Hegar,472,310,113,49
+Comal,203,Comptroller of Public Accounts,,REP,Glenn Hegar,2193,1647,381,165
+Comal,204,Comptroller of Public Accounts,,REP,Glenn Hegar,1771,1322,314,135
+Comal,205,Comptroller of Public Accounts,,REP,Glenn Hegar,2749,2278,302,169
+Comal,206,Comptroller of Public Accounts,,REP,Glenn Hegar,2687,2046,437,204
+Comal,207,Comptroller of Public Accounts,,REP,Glenn Hegar,1116,805,220,91
+Comal,208,Comptroller of Public Accounts,,REP,Glenn Hegar,1044,728,217,99
+Comal,301,Comptroller of Public Accounts,,REP,Glenn Hegar,856,531,276,49
+Comal,302,Comptroller of Public Accounts,,REP,Glenn Hegar,1693,1210,355,128
+Comal,303,Comptroller of Public Accounts,,REP,Glenn Hegar,217,143,57,17
+Comal,304,Comptroller of Public Accounts,,REP,Glenn Hegar,1236,825,313,98
+Comal,305,Comptroller of Public Accounts,,REP,Glenn Hegar,845,554,238,53
+Comal,306,Comptroller of Public Accounts,,REP,Glenn Hegar,516,339,129,48
+Comal,401,Comptroller of Public Accounts,,REP,Glenn Hegar,957,604,229,124
+Comal,402,Comptroller of Public Accounts,,REP,Glenn Hegar,2149,1538,386,225
+Comal,403,Comptroller of Public Accounts,,REP,Glenn Hegar,2649,1815,611,223
+Comal,404,Comptroller of Public Accounts,,REP,Glenn Hegar,1766,1276,370,120
+Comal,405,Comptroller of Public Accounts,,REP,Glenn Hegar,1813,1183,467,163
+Comal,406,Comptroller of Public Accounts,,REP,Glenn Hegar,2259,1536,419,304
+Comal,407,Comptroller of Public Accounts,,REP,Glenn Hegar,1530,1066,364,100
+Comal,101,Comptroller of Public Accounts,,DEM,Joi Chevalier,685,462,154,69
+Comal,102,Comptroller of Public Accounts,,DEM,Joi Chevalier,406,299,58,49
+Comal,103,Comptroller of Public Accounts,,DEM,Joi Chevalier,434,302,88,44
+Comal,104,Comptroller of Public Accounts,,DEM,Joi Chevalier,274,192,33,49
+Comal,105,Comptroller of Public Accounts,,DEM,Joi Chevalier,651,444,131,76
+Comal,106,Comptroller of Public Accounts,,DEM,Joi Chevalier,517,386,64,67
+Comal,107,Comptroller of Public Accounts,,DEM,Joi Chevalier,283,194,63,26
+Comal,201,Comptroller of Public Accounts,,DEM,Joi Chevalier,791,512,208,71
+Comal,202,Comptroller of Public Accounts,,DEM,Joi Chevalier,184,116,47,21
+Comal,203,Comptroller of Public Accounts,,DEM,Joi Chevalier,595,454,86,55
+Comal,204,Comptroller of Public Accounts,,DEM,Joi Chevalier,440,336,61,43
+Comal,205,Comptroller of Public Accounts,,DEM,Joi Chevalier,821,646,103,72
+Comal,206,Comptroller of Public Accounts,,DEM,Joi Chevalier,612,432,113,67
+Comal,207,Comptroller of Public Accounts,,DEM,Joi Chevalier,236,164,48,24
+Comal,208,Comptroller of Public Accounts,,DEM,Joi Chevalier,244,143,60,41
+Comal,301,Comptroller of Public Accounts,,DEM,Joi Chevalier,863,482,293,88
+Comal,302,Comptroller of Public Accounts,,DEM,Joi Chevalier,914,626,187,101
+Comal,303,Comptroller of Public Accounts,,DEM,Joi Chevalier,244,126,93,25
+Comal,304,Comptroller of Public Accounts,,DEM,Joi Chevalier,736,502,187,47
+Comal,305,Comptroller of Public Accounts,,DEM,Joi Chevalier,381,230,113,38
+Comal,306,Comptroller of Public Accounts,,DEM,Joi Chevalier,275,182,76,17
+Comal,401,Comptroller of Public Accounts,,DEM,Joi Chevalier,341,199,86,56
+Comal,402,Comptroller of Public Accounts,,DEM,Joi Chevalier,678,496,100,82
+Comal,403,Comptroller of Public Accounts,,DEM,Joi Chevalier,654,453,130,71
+Comal,404,Comptroller of Public Accounts,,DEM,Joi Chevalier,431,280,109,42
+Comal,405,Comptroller of Public Accounts,,DEM,Joi Chevalier,450,303,91,56
+Comal,406,Comptroller of Public Accounts,,DEM,Joi Chevalier,794,542,128,124
+Comal,407,Comptroller of Public Accounts,,DEM,Joi Chevalier,370,254,75,41
+Comal,101,Comptroller of Public Accounts,,LIB,Ben Sanders,98,57,37,4
+Comal,102,Comptroller of Public Accounts,,LIB,Ben Sanders,62,45,13,4
+Comal,103,Comptroller of Public Accounts,,LIB,Ben Sanders,70,50,18,2
+Comal,104,Comptroller of Public Accounts,,LIB,Ben Sanders,47,34,11,2
+Comal,105,Comptroller of Public Accounts,,LIB,Ben Sanders,103,63,33,7
+Comal,106,Comptroller of Public Accounts,,LIB,Ben Sanders,79,57,18,4
+Comal,107,Comptroller of Public Accounts,,LIB,Ben Sanders,41,19,20,2
+Comal,201,Comptroller of Public Accounts,,LIB,Ben Sanders,93,50,36,7
+Comal,202,Comptroller of Public Accounts,,LIB,Ben Sanders,17,8,8,1
+Comal,203,Comptroller of Public Accounts,,LIB,Ben Sanders,64,39,18,7
+Comal,204,Comptroller of Public Accounts,,LIB,Ben Sanders,74,50,21,3
+Comal,205,Comptroller of Public Accounts,,LIB,Ben Sanders,109,76,32,1
+Comal,206,Comptroller of Public Accounts,,LIB,Ben Sanders,89,66,22,1
+Comal,207,Comptroller of Public Accounts,,LIB,Ben Sanders,35,20,13,2
+Comal,208,Comptroller of Public Accounts,,LIB,Ben Sanders,23,15,6,2
+Comal,301,Comptroller of Public Accounts,,LIB,Ben Sanders,73,39,30,4
+Comal,302,Comptroller of Public Accounts,,LIB,Ben Sanders,136,83,46,7
+Comal,303,Comptroller of Public Accounts,,LIB,Ben Sanders,23,16,7,0
+Comal,304,Comptroller of Public Accounts,,LIB,Ben Sanders,83,46,33,4
+Comal,305,Comptroller of Public Accounts,,LIB,Ben Sanders,47,27,19,1
+Comal,306,Comptroller of Public Accounts,,LIB,Ben Sanders,36,23,13,0
+Comal,401,Comptroller of Public Accounts,,LIB,Ben Sanders,57,39,11,7
+Comal,402,Comptroller of Public Accounts,,LIB,Ben Sanders,88,60,22,6
+Comal,403,Comptroller of Public Accounts,,LIB,Ben Sanders,79,51,23,5
+Comal,404,Comptroller of Public Accounts,,LIB,Ben Sanders,72,45,27,0
+Comal,405,Comptroller of Public Accounts,,LIB,Ben Sanders,84,42,35,7
+Comal,406,Comptroller of Public Accounts,,LIB,Ben Sanders,98,56,36,6
+Comal,407,Comptroller of Public Accounts,,LIB,Ben Sanders,66,37,25,4
+Comal,101,Commissioner of the General Land Office,,REP,George P. Bush,1713,1194,335,184
+Comal,102,Commissioner of the General Land Office,,REP,George P. Bush,1953,1515,282,156
+Comal,103,Commissioner of the General Land Office,,REP,George P. Bush,1899,1326,429,144
+Comal,104,Commissioner of the General Land Office,,REP,George P. Bush,1053,753,188,112
+Comal,105,Commissioner of the General Land Office,,REP,George P. Bush,2390,1640,543,207
+Comal,106,Commissioner of the General Land Office,,REP,George P. Bush,2549,1989,377,183
+Comal,107,Commissioner of the General Land Office,,REP,George P. Bush,1109,708,339,62
+Comal,201,Commissioner of the General Land Office,,REP,George P. Bush,1765,1115,508,142
+Comal,202,Commissioner of the General Land Office,,REP,George P. Bush,466,307,114,45
+Comal,203,Commissioner of the General Land Office,,REP,George P. Bush,2190,1626,395,169
+Comal,204,Commissioner of the General Land Office,,REP,George P. Bush,1733,1298,304,131
+Comal,205,Commissioner of the General Land Office,,REP,George P. Bush,2784,2291,319,174
+Comal,206,Commissioner of the General Land Office,,REP,George P. Bush,2648,2007,436,205
+Comal,207,Commissioner of the General Land Office,,REP,George P. Bush,1132,823,222,87
+Comal,208,Commissioner of the General Land Office,,REP,George P. Bush,1042,722,223,97
+Comal,301,Commissioner of the General Land Office,,REP,George P. Bush,876,530,290,56
+Comal,302,Commissioner of the General Land Office,,REP,George P. Bush,1730,1227,367,136
+Comal,303,Commissioner of the General Land Office,,REP,George P. Bush,227,146,63,18
+Comal,304,Commissioner of the General Land Office,,REP,George P. Bush,1225,815,313,97
+Comal,305,Commissioner of the General Land Office,,REP,George P. Bush,849,554,239,56
+Comal,306,Commissioner of the General Land Office,,REP,George P. Bush,529,347,132,50
+Comal,401,Commissioner of the General Land Office,,REP,George P. Bush,973,609,235,129
+Comal,402,Commissioner of the General Land Office,,REP,George P. Bush,2140,1516,390,234
+Comal,403,Commissioner of the General Land Office,,REP,George P. Bush,2604,1778,601,225
+Comal,404,Commissioner of the General Land Office,,REP,George P. Bush,1772,1269,382,121
+Comal,405,Commissioner of the General Land Office,,REP,George P. Bush,1797,1153,476,168
+Comal,406,Commissioner of the General Land Office,,REP,George P. Bush,2259,1521,429,309
+Comal,407,Commissioner of the General Land Office,,REP,George P. Bush,1548,1065,374,109
+Comal,101,Commissioner of the General Land Office,,DEM,Miguel Suazo,663,443,152,68
+Comal,102,Commissioner of the General Land Office,,DEM,Miguel Suazo,382,285,54,43
+Comal,103,Commissioner of the General Land Office,,DEM,Miguel Suazo,431,307,83,41
+Comal,104,Commissioner of the General Land Office,,DEM,Miguel Suazo,267,187,34,46
+Comal,105,Commissioner of the General Land Office,,DEM,Miguel Suazo,665,451,140,74
+Comal,106,Commissioner of the General Land Office,,DEM,Miguel Suazo,508,385,61,62
+Comal,107,Commissioner of the General Land Office,,DEM,Miguel Suazo,287,197,64,26
+Comal,201,Commissioner of the General Land Office,,DEM,Miguel Suazo,760,493,203,64
+Comal,202,Commissioner of the General Land Office,,DEM,Miguel Suazo,187,118,47,22
+Comal,203,Commissioner of the General Land Office,,DEM,Miguel Suazo,578,447,79,52
+Comal,204,Commissioner of the General Land Office,,DEM,Miguel Suazo,458,342,68,48
+Comal,205,Commissioner of the General Land Office,,DEM,Miguel Suazo,801,632,103,66
+Comal,206,Commissioner of the General Land Office,,DEM,Miguel Suazo,608,435,106,67
+Comal,207,Commissioner of the General Land Office,,DEM,Miguel Suazo,226,149,51,26
+Comal,208,Commissioner of the General Land Office,,DEM,Miguel Suazo,239,143,53,43
+Comal,301,Commissioner of the General Land Office,,DEM,Miguel Suazo,847,472,291,84
+Comal,302,Commissioner of the General Land Office,,DEM,Miguel Suazo,915,640,180,95
+Comal,303,Commissioner of the General Land Office,,DEM,Miguel Suazo,236,123,91,22
+Comal,304,Commissioner of the General Land Office,,DEM,Miguel Suazo,746,499,198,49
+Comal,305,Commissioner of the General Land Office,,DEM,Miguel Suazo,364,219,110,35
+Comal,306,Commissioner of the General Land Office,,DEM,Miguel Suazo,274,182,76,16
+Comal,401,Commissioner of the General Land Office,,DEM,Miguel Suazo,351,207,84,60
+Comal,402,Commissioner of the General Land Office,,DEM,Miguel Suazo,653,482,91,80
+Comal,403,Commissioner of the General Land Office,,DEM,Miguel Suazo,665,470,129,66
+Comal,404,Commissioner of the General Land Office,,DEM,Miguel Suazo,423,279,104,40
+Comal,405,Commissioner of the General Land Office,,DEM,Miguel Suazo,443,305,84,54
+Comal,406,Commissioner of the General Land Office,,DEM,Miguel Suazo,778,538,120,120
+Comal,407,Commissioner of the General Land Office,,DEM,Miguel Suazo,355,245,73,37
+Comal,101,Commissioner of the General Land Office,,LIB,Matt Piña,100,75,25,0
+Comal,102,Commissioner of the General Land Office,,LIB,Matt Piña,115,95,17,3
+Comal,103,Commissioner of the General Land Office,,LIB,Matt Piña,81,59,20,2
+Comal,104,Commissioner of the General Land Office,,LIB,Matt Piña,66,51,11,4
+Comal,105,Commissioner of the General Land Office,,LIB,Matt Piña,147,109,30,8
+Comal,106,Commissioner of the General Land Office,,LIB,Matt Piña,117,94,16,7
+Comal,107,Commissioner of the General Land Office,,LIB,Matt Piña,49,31,15,3
+Comal,201,Commissioner of the General Land Office,,LIB,Matt Piña,115,75,32,8
+Comal,202,Commissioner of the General Land Office,,LIB,Matt Piña,19,9,7,3
+Comal,203,Commissioner of the General Land Office,,LIB,Matt Piña,91,67,17,7
+Comal,204,Commissioner of the General Land Office,,LIB,Matt Piña,101,74,25,2
+Comal,205,Commissioner of the General Land Office,,LIB,Matt Piña,108,86,19,3
+Comal,206,Commissioner of the General Land Office,,LIB,Matt Piña,134,100,31,3
+Comal,207,Commissioner of the General Land Office,,LIB,Matt Piña,38,23,11,4
+Comal,208,Commissioner of the General Land Office,,LIB,Matt Piña,33,20,9,4
+Comal,301,Commissioner of the General Land Office,,LIB,Matt Piña,83,55,24,4
+Comal,302,Commissioner of the General Land Office,,LIB,Matt Piña,119,72,41,6
+Comal,303,Commissioner of the General Land Office,,LIB,Matt Piña,22,17,4,1
+Comal,304,Commissioner of the General Land Office,,LIB,Matt Piña,93,62,26,5
+Comal,305,Commissioner of the General Land Office,,LIB,Matt Piña,69,45,22,2
+Comal,306,Commissioner of the General Land Office,,LIB,Matt Piña,34,23,11,0
+Comal,401,Commissioner of the General Land Office,,LIB,Matt Piña,44,33,9,2
+Comal,402,Commissioner of the General Land Office,,LIB,Matt Piña,137,105,28,4
+Comal,403,Commissioner of the General Land Office,,LIB,Matt Piña,137,88,40,9
+Comal,404,Commissioner of the General Land Office,,LIB,Matt Piña,86,61,23,2
+Comal,405,Commissioner of the General Land Office,,LIB,Matt Piña,108,72,32,4
+Comal,406,Commissioner of the General Land Office,,LIB,Matt Piña,111,74,31,6
+Comal,407,Commissioner of the General Land Office,,LIB,Matt Piña,72,51,20,1
+Comal,101,Commissioner of Agriculture,,REP,Sid Miller,1599,1124,311,164
+Comal,102,Commissioner of Agriculture,,REP,Sid Miller,1945,1519,278,148
+Comal,103,Commissioner of Agriculture,,REP,Sid Miller,1857,1306,417,134
+Comal,104,Commissioner of Agriculture,,REP,Sid Miller,1032,733,186,113
+Comal,105,Commissioner of Agriculture,,REP,Sid Miller,2405,1673,534,198
+Comal,106,Commissioner of Agriculture,,REP,Sid Miller,2540,1982,376,182
+Comal,107,Commissioner of Agriculture,,REP,Sid Miller,1095,704,327,64
+Comal,201,Commissioner of Agriculture,,REP,Sid Miller,1707,1092,485,130
+Comal,202,Commissioner of Agriculture,,REP,Sid Miller,464,305,112,47
+Comal,203,Commissioner of Agriculture,,REP,Sid Miller,2155,1617,380,158
+Comal,204,Commissioner of Agriculture,,REP,Sid Miller,1752,1313,312,127
+Comal,205,Commissioner of Agriculture,,REP,Sid Miller,2634,2186,291,157
+Comal,206,Commissioner of Agriculture,,REP,Sid Miller,2611,1996,426,189
+Comal,207,Commissioner of Agriculture,,REP,Sid Miller,1096,788,217,91
+Comal,208,Commissioner of Agriculture,,REP,Sid Miller,1025,713,215,97
+Comal,301,Commissioner of Agriculture,,REP,Sid Miller,852,529,272,51
+Comal,302,Commissioner of Agriculture,,REP,Sid Miller,1657,1178,352,127
+Comal,303,Commissioner of Agriculture,,REP,Sid Miller,207,134,55,18
+Comal,304,Commissioner of Agriculture,,REP,Sid Miller,1214,807,309,98
+Comal,305,Commissioner of Agriculture,,REP,Sid Miller,838,555,234,49
+Comal,306,Commissioner of Agriculture,,REP,Sid Miller,509,334,129,46
+Comal,401,Commissioner of Agriculture,,REP,Sid Miller,918,584,217,117
+Comal,402,Commissioner of Agriculture,,REP,Sid Miller,2098,1495,380,223
+Comal,403,Commissioner of Agriculture,,REP,Sid Miller,2595,1784,595,216
+Comal,404,Commissioner of Agriculture,,REP,Sid Miller,1725,1252,359,114
+Comal,405,Commissioner of Agriculture,,REP,Sid Miller,1804,1168,479,157
+Comal,406,Commissioner of Agriculture,,REP,Sid Miller,2165,1465,402,298
+Comal,407,Commissioner of Agriculture,,REP,Sid Miller,1495,1038,358,99
+Comal,101,Commissioner of Agriculture,,DEM,Kim Olson,778,519,176,83
+Comal,102,Commissioner of Agriculture,,DEM,Kim Olson,446,333,64,49
+Comal,103,Commissioner of Agriculture,,DEM,Kim Olson,482,337,97,48
+Comal,104,Commissioner of Agriculture,,DEM,Kim Olson,305,220,35,50
+Comal,105,Commissioner of Agriculture,,DEM,Kim Olson,727,486,156,85
+Comal,106,Commissioner of Agriculture,,DEM,Kim Olson,574,436,69,69
+Comal,107,Commissioner of Agriculture,,DEM,Kim Olson,316,215,76,25
+Comal,201,Commissioner of Agriculture,,DEM,Kim Olson,847,540,232,75
+Comal,202,Commissioner of Agriculture,,DEM,Kim Olson,196,123,49,24
+Comal,203,Commissioner of Agriculture,,DEM,Kim Olson,645,489,90,66
+Comal,204,Commissioner of Agriculture,,DEM,Kim Olson,483,363,70,50
+Comal,205,Commissioner of Agriculture,,DEM,Kim Olson,964,762,123,79
+Comal,206,Commissioner of Agriculture,,DEM,Kim Olson,688,486,128,74
+Comal,207,Commissioner of Agriculture,,DEM,Kim Olson,274,192,58,24
+Comal,208,Commissioner of Agriculture,,DEM,Kim Olson,275,163,66,46
+Comal,301,Commissioner of Agriculture,,DEM,Kim Olson,886,496,305,85
+Comal,302,Commissioner of Agriculture,,DEM,Kim Olson,1013,699,206,108
+Comal,303,Commissioner of Agriculture,,DEM,Kim Olson,257,138,96,23
+Comal,304,Commissioner of Agriculture,,DEM,Kim Olson,794,537,206,51
+Comal,305,Commissioner of Agriculture,,DEM,Kim Olson,404,240,121,43
+Comal,306,Commissioner of Agriculture,,DEM,Kim Olson,303,198,85,20
+Comal,401,Commissioner of Agriculture,,DEM,Kim Olson,402,234,99,69
+Comal,402,Commissioner of Agriculture,,DEM,Kim Olson,741,544,109,88
+Comal,403,Commissioner of Agriculture,,DEM,Kim Olson,728,502,150,76
+Comal,404,Commissioner of Agriculture,,DEM,Kim Olson,500,329,127,44
+Comal,405,Commissioner of Agriculture,,DEM,Kim Olson,486,329,95,62
+Comal,406,Commissioner of Agriculture,,DEM,Kim Olson,907,622,153,132
+Comal,407,Commissioner of Agriculture,,DEM,Kim Olson,423,290,87,46
+Comal,101,Commissioner of Agriculture,,LIB,Richard Carpenter,77,55,21,1
+Comal,102,Commissioner of Agriculture,,LIB,Richard Carpenter,53,40,9,4
+Comal,103,Commissioner of Agriculture,,LIB,Richard Carpenter,52,38,11,3
+Comal,104,Commissioner of Agriculture,,LIB,Richard Carpenter,37,27,10,0
+Comal,105,Commissioner of Agriculture,,LIB,Richard Carpenter,71,48,20,3
+Comal,106,Commissioner of Agriculture,,LIB,Richard Carpenter,58,44,10,4
+Comal,107,Commissioner of Agriculture,,LIB,Richard Carpenter,32,14,15,3
+Comal,201,Commissioner of Agriculture,,LIB,Richard Carpenter,70,45,19,6
+Comal,202,Commissioner of Agriculture,,LIB,Richard Carpenter,14,7,7,0
+Comal,203,Commissioner of Agriculture,,LIB,Richard Carpenter,52,36,14,2
+Comal,204,Commissioner of Agriculture,,LIB,Richard Carpenter,55,36,15,4
+Comal,205,Commissioner of Agriculture,,LIB,Richard Carpenter,81,54,21,6
+Comal,206,Commissioner of Agriculture,,LIB,Richard Carpenter,80,56,17,7
+Comal,207,Commissioner of Agriculture,,LIB,Richard Carpenter,18,9,7,2
+Comal,208,Commissioner of Agriculture,,LIB,Richard Carpenter,13,9,4,0
+Comal,301,Commissioner of Agriculture,,LIB,Richard Carpenter,55,33,17,5
+Comal,302,Commissioner of Agriculture,,LIB,Richard Carpenter,83,45,33,5
+Comal,303,Commissioner of Agriculture,,LIB,Richard Carpenter,16,11,4,1
+Comal,304,Commissioner of Agriculture,,LIB,Richard Carpenter,51,32,18,1
+Comal,305,Commissioner of Agriculture,,LIB,Richard Carpenter,34,22,11,1
+Comal,306,Commissioner of Agriculture,,LIB,Richard Carpenter,21,16,5,0
+Comal,401,Commissioner of Agriculture,,LIB,Richard Carpenter,39,28,10,1
+Comal,402,Commissioner of Agriculture,,LIB,Richard Carpenter,85,62,19,4
+Comal,403,Commissioner of Agriculture,,LIB,Richard Carpenter,64,38,19,7
+Comal,404,Commissioner of Agriculture,,LIB,Richard Carpenter,45,24,16,5
+Comal,405,Commissioner of Agriculture,,LIB,Richard Carpenter,53,26,21,6
+Comal,406,Commissioner of Agriculture,,LIB,Richard Carpenter,73,39,29,5
+Comal,407,Commissioner of Agriculture,,LIB,Richard Carpenter,43,26,17,0
+Comal,101,Railroad Commissioner,,REP,Christi Craddick,1668,1180,315,173
+Comal,102,Railroad Commissioner,,REP,Christi Craddick,1976,1544,281,151
+Comal,103,Railroad Commissioner,,REP,Christi Craddick,1895,1331,422,142
+Comal,104,Railroad Commissioner,,REP,Christi Craddick,1067,763,188,116
+Comal,105,Railroad Commissioner,,REP,Christi Craddick,2435,1686,549,200
+Comal,106,Railroad Commissioner,,REP,Christi Craddick,2577,2015,378,184
+Comal,107,Railroad Commissioner,,REP,Christi Craddick,1122,718,340,64
+Comal,201,Railroad Commissioner,,REP,Christi Craddick,1753,1121,497,135
+Comal,202,Railroad Commissioner,,REP,Christi Craddick,474,311,115,48
+Comal,203,Railroad Commissioner,,REP,Christi Craddick,2191,1633,391,167
+Comal,204,Railroad Commissioner,,REP,Christi Craddick,1783,1337,314,132
+Comal,205,Railroad Commissioner,,REP,Christi Craddick,2748,2277,302,169
+Comal,206,Railroad Commissioner,,REP,Christi Craddick,2683,2045,433,205
+Comal,207,Railroad Commissioner,,REP,Christi Craddick,1122,810,220,92
+Comal,208,Railroad Commissioner,,REP,Christi Craddick,1051,731,221,99
+Comal,301,Railroad Commissioner,,REP,Christi Craddick,860,535,272,53
+Comal,302,Railroad Commissioner,,REP,Christi Craddick,1714,1222,362,130
+Comal,303,Railroad Commissioner,,REP,Christi Craddick,217,142,58,17
+Comal,304,Railroad Commissioner,,REP,Christi Craddick,1239,827,316,96
+Comal,305,Railroad Commissioner,,REP,Christi Craddick,852,560,240,52
+Comal,306,Railroad Commissioner,,REP,Christi Craddick,520,338,134,48
+Comal,401,Railroad Commissioner,,REP,Christi Craddick,944,597,226,121
+Comal,402,Railroad Commissioner,,REP,Christi Craddick,2156,1529,392,235
+Comal,403,Railroad Commissioner,,REP,Christi Craddick,2649,1828,600,221
+Comal,404,Railroad Commissioner,,REP,Christi Craddick,1775,1280,374,121
+Comal,405,Railroad Commissioner,,REP,Christi Craddick,1841,1192,480,169
+Comal,406,Railroad Commissioner,,REP,Christi Craddick,2253,1534,414,305
+Comal,407,Railroad Commissioner,,REP,Christi Craddick,1535,1071,363,101
+Comal,101,Railroad Commissioner,,DEM,Roman McAllen,694,457,165,72
+Comal,102,Railroad Commissioner,,DEM,Roman McAllen,400,294,59,47
+Comal,103,Railroad Commissioner,,DEM,Roman McAllen,434,303,91,40
+Comal,104,Railroad Commissioner,,DEM,Roman McAllen,268,190,33,45
+Comal,105,Railroad Commissioner,,DEM,Roman McAllen,658,455,123,80
+Comal,106,Railroad Commissioner,,DEM,Roman McAllen,517,389,61,67
+Comal,107,Railroad Commissioner,,DEM,Roman McAllen,290,199,66,25
+Comal,201,Railroad Commissioner,,DEM,Roman McAllen,782,493,217,72
+Comal,202,Railroad Commissioner,,DEM,Roman McAllen,183,117,43,23
+Comal,203,Railroad Commissioner,,DEM,Roman McAllen,597,461,80,56
+Comal,204,Railroad Commissioner,,DEM,Roman McAllen,437,328,63,46
+Comal,205,Railroad Commissioner,,DEM,Roman McAllen,824,652,104,68
+Comal,206,Railroad Commissioner,,DEM,Roman McAllen,621,431,124,66
+Comal,207,Railroad Commissioner,,DEM,Roman McAllen,239,164,51,24
+Comal,208,Railroad Commissioner,,DEM,Roman McAllen,234,142,53,39
+Comal,301,Railroad Commissioner,,DEM,Roman McAllen,855,479,293,83
+Comal,302,Railroad Commissioner,,DEM,Roman McAllen,920,638,184,98
+Comal,303,Railroad Commissioner,,DEM,Roman McAllen,242,130,90,22
+Comal,304,Railroad Commissioner,,DEM,Roman McAllen,748,510,189,49
+Comal,305,Railroad Commissioner,,DEM,Roman McAllen,369,223,108,38
+Comal,306,Railroad Commissioner,,DEM,Roman McAllen,281,188,76,17
+Comal,401,Railroad Commissioner,,DEM,Roman McAllen,360,212,87,61
+Comal,402,Railroad Commissioner,,DEM,Roman McAllen,682,508,94,80
+Comal,403,Railroad Commissioner,,DEM,Roman McAllen,656,446,134,76
+Comal,404,Railroad Commissioner,,DEM,Roman McAllen,438,288,108,42
+Comal,405,Railroad Commissioner,,DEM,Roman McAllen,439,301,86,52
+Comal,406,Railroad Commissioner,,DEM,Roman McAllen,801,544,134,123
+Comal,407,Railroad Commissioner,,DEM,Roman McAllen,377,260,78,39
+Comal,101,Railroad Commissioner,,LIB,Mike Wright,86,59,26,1
+Comal,102,Railroad Commissioner,,LIB,Mike Wright,63,49,10,4
+Comal,103,Railroad Commissioner,,LIB,Mike Wright,63,46,14,3
+Comal,104,Railroad Commissioner,,LIB,Mike Wright,46,33,11,2
+Comal,105,Railroad Commissioner,,LIB,Mike Wright,102,60,37,5
+Comal,106,Railroad Commissioner,,LIB,Mike Wright,75,59,13,3
+Comal,107,Railroad Commissioner,,LIB,Mike Wright,31,16,14,1
+Comal,201,Railroad Commissioner,,LIB,Mike Wright,92,63,25,4
+Comal,202,Railroad Commissioner,,LIB,Mike Wright,15,6,9,0
+Comal,203,Railroad Commissioner,,LIB,Mike Wright,62,41,16,5
+Comal,204,Railroad Commissioner,,LIB,Mike Wright,65,43,19,3
+Comal,205,Railroad Commissioner,,LIB,Mike Wright,107,73,29,5
+Comal,206,Railroad Commissioner,,LIB,Mike Wright,76,59,14,3
+Comal,207,Railroad Commissioner,,LIB,Mike Wright,26,15,10,1
+Comal,208,Railroad Commissioner,,LIB,Mike Wright,25,10,10,5
+Comal,301,Railroad Commissioner,,LIB,Mike Wright,73,37,32,4
+Comal,302,Railroad Commissioner,,LIB,Mike Wright,104,54,42,8
+Comal,303,Railroad Commissioner,,LIB,Mike Wright,20,11,7,2
+Comal,304,Railroad Commissioner,,LIB,Mike Wright,70,39,27,4
+Comal,305,Railroad Commissioner,,LIB,Mike Wright,52,31,19,2
+Comal,306,Railroad Commissioner,,LIB,Mike Wright,31,22,8,1
+Comal,401,Railroad Commissioner,,LIB,Mike Wright,45,31,9,5
+Comal,402,Railroad Commissioner,,LIB,Mike Wright,90,64,23,3
+Comal,403,Railroad Commissioner,,LIB,Mike Wright,80,48,30,2
+Comal,404,Railroad Commissioner,,LIB,Mike Wright,61,39,22,0
+Comal,405,Railroad Commissioner,,LIB,Mike Wright,63,32,29,2
+Comal,406,Railroad Commissioner,,LIB,Mike Wright,88,50,32,6
+Comal,407,Railroad Commissioner,,LIB,Mike Wright,52,25,23,4
+Comal,101,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1669,1185,324,160
+Comal,102,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1986,1561,284,141
+Comal,103,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1895,1335,432,128
+Comal,104,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1059,766,191,102
+Comal,105,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,2444,1697,551,196
+Comal,106,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,2595,2041,383,171
+Comal,107,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1118,717,345,56
+Comal,201,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1762,1143,499,120
+Comal,202,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,468,311,113,44
+Comal,203,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,2182,1637,391,154
+Comal,204,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1789,1342,317,130
+Comal,205,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,2720,2257,306,157
+Comal,206,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,2671,2054,432,185
+Comal,207,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1105,798,220,87
+Comal,208,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1044,732,221,91
+Comal,301,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,870,532,290,48
+Comal,302,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1695,1220,361,114
+Comal,303,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,212,141,57,14
+Comal,304,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1227,827,318,82
+Comal,305,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,869,579,245,45
+Comal,306,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,511,339,132,40
+Comal,401,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,950,610,223,117
+Comal,402,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,2149,1546,389,214
+Comal,403,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,2660,1834,620,206
+Comal,404,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1764,1273,382,109
+Comal,405,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1837,1201,486,150
+Comal,406,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,2241,1522,429,290
+Comal,407,"Justice, Supreme Court, Place 2",,REP,Jimmy Blacklock,1533,1064,372,97
+Comal,101,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,760,503,183,74
+Comal,102,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,443,324,68,51
+Comal,103,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,482,345,96,41
+Comal,104,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,310,215,44,51
+Comal,105,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,726,497,155,74
+Comal,106,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,551,417,68,66
+Comal,107,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,318,217,75,26
+Comal,201,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,837,534,236,67
+Comal,202,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,194,122,53,19
+Comal,203,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,656,506,93,57
+Comal,204,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,489,365,77,47
+Comal,205,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,942,744,129,69
+Comal,206,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,687,484,138,65
+Comal,207,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,268,187,60,21
+Comal,208,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,259,151,63,45
+Comal,301,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,909,520,306,83
+Comal,302,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,1021,700,220,101
+Comal,303,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,262,142,97,23
+Comal,304,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,808,547,214,47
+Comal,305,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,392,236,119,37
+Comal,306,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,310,209,87,14
+Comal,401,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,389,233,94,62
+Comal,402,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,749,547,116,86
+Comal,403,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,705,487,144,74
+Comal,404,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,493,328,123,42
+Comal,405,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,486,322,103,61
+Comal,406,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,878,604,148,126
+Comal,407,"Justice, Supreme Court, Place 2",,DEM,Steven Kirkland,416,287,88,41
+Comal,101,"Justice, Supreme Court, Place 4",,REP,John Devine,1691,1201,331,159
+Comal,102,"Justice, Supreme Court, Place 4",,REP,John Devine,1989,1560,286,143
+Comal,103,"Justice, Supreme Court, Place 4",,REP,John Devine,1899,1342,431,126
+Comal,104,"Justice, Supreme Court, Place 4",,REP,John Devine,1071,770,196,105
+Comal,105,"Justice, Supreme Court, Place 4",,REP,John Devine,2471,1710,560,201
+Comal,106,"Justice, Supreme Court, Place 4",,REP,John Devine,2599,2041,386,172
+Comal,107,"Justice, Supreme Court, Place 4",,REP,John Devine,1126,724,346,56
+Comal,201,"Justice, Supreme Court, Place 4",,REP,John Devine,1773,1147,503,123
+Comal,202,"Justice, Supreme Court, Place 4",,REP,John Devine,472,313,115,44
+Comal,203,"Justice, Supreme Court, Place 4",,REP,John Devine,2203,1652,393,158
+Comal,204,"Justice, Supreme Court, Place 4",,REP,John Devine,1800,1347,320,133
+Comal,205,"Justice, Supreme Court, Place 4",,REP,John Devine,2760,2294,309,157
+Comal,206,"Justice, Supreme Court, Place 4",,REP,John Devine,2693,2065,442,186
+Comal,207,"Justice, Supreme Court, Place 4",,REP,John Devine,1111,803,221,87
+Comal,208,"Justice, Supreme Court, Place 4",,REP,John Devine,1039,728,221,90
+Comal,301,"Justice, Supreme Court, Place 4",,REP,John Devine,880,542,291,47
+Comal,302,"Justice, Supreme Court, Place 4",,REP,John Devine,1713,1229,365,119
+Comal,303,"Justice, Supreme Court, Place 4",,REP,John Devine,220,145,61,14
+Comal,304,"Justice, Supreme Court, Place 4",,REP,John Devine,1234,834,316,84
+Comal,305,"Justice, Supreme Court, Place 4",,REP,John Devine,865,578,246,41
+Comal,306,"Justice, Supreme Court, Place 4",,REP,John Devine,518,343,134,41
+Comal,401,"Justice, Supreme Court, Place 4",,REP,John Devine,951,610,223,118
+Comal,402,"Justice, Supreme Court, Place 4",,REP,John Devine,2163,1554,394,215
+Comal,403,"Justice, Supreme Court, Place 4",,REP,John Devine,2648,1823,621,204
+Comal,404,"Justice, Supreme Court, Place 4",,REP,John Devine,1766,1280,377,109
+Comal,405,"Justice, Supreme Court, Place 4",,REP,John Devine,1847,1206,488,153
+Comal,406,"Justice, Supreme Court, Place 4",,REP,John Devine,2263,1541,430,292
+Comal,407,"Justice, Supreme Court, Place 4",,REP,John Devine,1544,1074,374,96
+Comal,101,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,731,483,175,73
+Comal,102,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,438,323,66,49
+Comal,103,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,472,332,96,44
+Comal,104,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,296,210,38,48
+Comal,105,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,701,483,146,72
+Comal,106,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,546,414,65,67
+Comal,107,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,310,210,74,26
+Comal,201,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,825,531,230,64
+Comal,202,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,190,120,51,19
+Comal,203,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,632,489,90,53
+Comal,204,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,481,360,76,45
+Comal,205,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,898,703,128,67
+Comal,206,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,658,467,126,65
+Comal,207,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,260,182,57,21
+Comal,208,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,262,154,62,46
+Comal,301,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,897,510,305,82
+Comal,302,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,995,685,215,95
+Comal,303,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,251,136,92,23
+Comal,304,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,798,539,214,45
+Comal,305,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,392,235,120,37
+Comal,306,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,301,203,85,13
+Comal,401,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,383,230,91,62
+Comal,402,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,734,538,112,84
+Comal,403,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,706,491,142,73
+Comal,404,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,486,317,127,42
+Comal,405,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,476,317,101,58
+Comal,406,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,846,577,147,122
+Comal,407,"Justice, Supreme Court, Place 4",,DEM,R.K. Sandill,406,279,85,42
+Comal,101,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1684,1197,326,161
+Comal,102,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1986,1553,289,144
+Comal,103,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1899,1341,430,128
+Comal,104,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1074,776,194,104
+Comal,105,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,2457,1709,554,194
+Comal,106,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,2607,2052,384,171
+Comal,107,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1122,720,346,56
+Comal,201,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1765,1146,497,122
+Comal,202,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,470,312,114,44
+Comal,203,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,2194,1642,395,157
+Comal,204,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1795,1341,324,130
+Comal,205,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,2739,2273,311,155
+Comal,206,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,2684,2066,431,187
+Comal,207,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1106,802,218,86
+Comal,208,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1039,724,224,91
+Comal,301,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,876,540,288,48
+Comal,302,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1717,1233,365,119
+Comal,303,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,216,142,59,15
+Comal,304,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1229,833,311,85
+Comal,305,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,869,576,246,47
+Comal,306,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,508,337,131,40
+Comal,401,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,954,614,225,115
+Comal,402,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,2154,1545,397,212
+Comal,403,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,2651,1832,614,205
+Comal,404,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1767,1276,380,111
+Comal,405,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1840,1199,486,155
+Comal,406,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,2259,1537,433,289
+Comal,407,"Justice, Supreme Court, Place 6",,REP,Jeff Brown,1535,1069,371,95
+Comal,101,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,737,487,178,72
+Comal,102,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,442,331,63,48
+Comal,103,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,476,336,97,43
+Comal,104,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,295,205,41,49
+Comal,105,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,715,485,151,79
+Comal,106,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,542,410,65,67
+Comal,107,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,314,214,74,26
+Comal,201,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,829,526,238,65
+Comal,202,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,193,121,52,20
+Comal,203,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,643,499,87,57
+Comal,204,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,488,370,72,46
+Comal,205,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,920,722,128,70
+Comal,206,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,674,471,138,65
+Comal,207,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,264,181,62,21
+Comal,208,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,260,155,61,44
+Comal,301,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,905,514,309,82
+Comal,302,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,1000,689,217,94
+Comal,303,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,255,139,94,22
+Comal,304,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,808,542,221,45
+Comal,305,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,392,239,120,33
+Comal,306,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,312,211,87,14
+Comal,401,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,381,226,92,63
+Comal,402,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,744,549,108,87
+Comal,403,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,710,486,150,74
+Comal,404,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,487,323,124,40
+Comal,405,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,486,327,103,56
+Comal,406,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,854,585,144,125
+Comal,407,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,414,286,87,41
+Comal,101,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1637,1164,313,160
+Comal,102,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1952,1535,278,139
+Comal,103,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1875,1323,426,126
+Comal,104,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1041,751,187,103
+Comal,105,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,2405,1673,540,192
+Comal,106,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,2559,2010,380,169
+Comal,107,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1100,712,330,58
+Comal,201,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1732,1122,491,119
+Comal,202,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,463,309,110,44
+Comal,203,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,2165,1622,389,154
+Comal,204,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1768,1327,312,129
+Comal,205,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,2688,2237,297,154
+Comal,206,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,2635,2024,428,183
+Comal,207,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1105,803,216,86
+Comal,208,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1035,725,219,91
+Comal,301,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,852,528,279,45
+Comal,302,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1677,1205,355,117
+Comal,303,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,216,141,59,16
+Comal,304,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1203,813,307,83
+Comal,305,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,842,562,235,45
+Comal,306,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,506,339,127,40
+Comal,401,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,940,597,225,118
+Comal,402,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,2113,1514,384,215
+Comal,403,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,2611,1802,606,203
+Comal,404,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1744,1262,374,108
+Comal,405,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1798,1178,469,151
+Comal,406,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,2222,1520,413,289
+Comal,407,"Presiding Judge, Court of Criminal Appeals",,REP,Sharon Keller,1515,1054,367,94
+Comal,101,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,725,485,166,74
+Comal,102,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,428,311,65,52
+Comal,103,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,459,327,89,43
+Comal,104,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,292,206,37,49
+Comal,105,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,706,482,146,78
+Comal,106,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,530,402,64,64
+Comal,107,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,308,209,75,24
+Comal,201,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,800,514,220,66
+Comal,202,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,185,118,48,19
+Comal,203,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,624,485,85,54
+Comal,204,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,471,353,71,47
+Comal,205,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,895,704,123,68
+Comal,206,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,651,458,127,66
+Comal,207,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,252,175,56,21
+Comal,208,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,254,151,59,44
+Comal,301,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,881,496,301,84
+Comal,302,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,970,675,200,95
+Comal,303,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,243,131,91,21
+Comal,304,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,785,527,212,46
+Comal,305,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,381,229,116,36
+Comal,306,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,288,193,81,14
+Comal,401,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,376,225,90,61
+Comal,402,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,711,523,106,82
+Comal,403,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,687,478,136,73
+Comal,404,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,472,313,116,43
+Comal,405,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,478,322,98,58
+Comal,406,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,824,563,141,120
+Comal,407,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Jackson,392,274,77,41
+Comal,101,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,76,49,26,1
+Comal,102,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,55,44,10,1
+Comal,103,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,44,30,13,1
+Comal,104,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,37,27,10,0
+Comal,105,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,77,49,24,4
+Comal,106,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,69,51,13,5
+Comal,107,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,29,14,15,0
+Comal,201,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,75,48,25,2
+Comal,202,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,17,7,9,1
+Comal,203,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,49,32,12,5
+Comal,204,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,51,34,14,3
+Comal,205,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,78,56,19,3
+Comal,206,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,77,60,14,3
+Comal,207,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,22,12,9,1
+Comal,208,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,16,8,7,1
+Comal,301,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,56,35,19,2
+Comal,302,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,89,51,36,2
+Comal,303,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,19,13,5,1
+Comal,304,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,55,38,16,1
+Comal,305,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,40,24,15,1
+Comal,306,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,29,18,11,0
+Comal,401,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,36,27,7,2
+Comal,402,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,79,61,17,1
+Comal,403,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,70,43,25,2
+Comal,404,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,45,28,17,0
+Comal,405,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,64,34,27,3
+Comal,406,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,71,38,26,7
+Comal,407,"Presiding Judge, Court of Criminal Appeals",,LIB,William Bryan Strange III,44,27,15,2
+Comal,101,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1698,1205,328,165
+Comal,102,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1991,1561,286,144
+Comal,103,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1914,1353,431,130
+Comal,104,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1063,767,192,104
+Comal,105,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,2480,1722,561,197
+Comal,106,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,2608,2046,391,171
+Comal,107,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1136,726,352,58
+Comal,201,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1777,1153,503,121
+Comal,202,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,473,313,116,44
+Comal,203,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,2209,1652,401,156
+Comal,204,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1803,1347,324,132
+Comal,205,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,2773,2299,316,158
+Comal,206,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,2697,2069,440,188
+Comal,207,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1123,814,221,88
+Comal,208,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1053,734,227,92
+Comal,301,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,878,538,291,49
+Comal,302,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1713,1234,367,112
+Comal,303,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,217,144,60,13
+Comal,304,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1235,839,312,84
+Comal,305,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,871,576,249,46
+Comal,306,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,519,348,130,41
+Comal,401,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,954,610,224,120
+Comal,402,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,2169,1560,395,214
+Comal,403,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,2664,1836,622,206
+Comal,404,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1778,1286,382,110
+Comal,405,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1854,1207,492,155
+Comal,406,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,2269,1547,432,290
+Comal,407,"Judge, Court of Criminal Appeals, Place 7",,REP,Barbara Parker Hervey,1545,1079,371,95
+Comal,101,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,720,477,172,71
+Comal,102,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,435,323,65,47
+Comal,103,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,458,325,94,39
+Comal,104,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,300,210,42,48
+Comal,105,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,688,469,145,74
+Comal,106,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,537,410,61,66
+Comal,107,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,297,205,68,24
+Comal,201,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,822,522,232,68
+Comal,202,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,188,119,51,18
+Comal,203,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,623,480,85,58
+Comal,204,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,476,358,72,46
+Comal,205,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,888,698,122,68
+Comal,206,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,655,462,129,64
+Comal,207,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,250,171,59,20
+Comal,208,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,246,146,56,44
+Comal,301,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,900,515,303,82
+Comal,302,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,991,684,210,97
+Comal,303,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,254,136,94,24
+Comal,304,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,797,530,220,47
+Comal,305,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,386,235,116,35
+Comal,306,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,298,199,86,13
+Comal,401,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,381,230,92,59
+Comal,402,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,720,527,110,83
+Comal,403,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,682,475,136,71
+Comal,404,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,472,312,119,41
+Comal,405,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,470,318,97,55
+Comal,406,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,837,570,142,125
+Comal,407,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,399,272,86,41
+Comal,101,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1762,1239,349,174
+Comal,102,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,2029,1579,296,154
+Comal,103,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1954,1382,441,131
+Comal,104,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1079,773,197,109
+Comal,105,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,2513,1753,563,197
+Comal,106,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,2653,2082,394,177
+Comal,107,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1161,751,351,59
+Comal,201,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1852,1192,532,128
+Comal,202,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,494,320,127,47
+Comal,203,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,2272,1696,408,168
+Comal,204,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1826,1373,316,137
+Comal,205,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,2867,2368,333,166
+Comal,206,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,2752,2108,452,192
+Comal,207,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1161,842,230,89
+Comal,208,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1070,744,235,91
+Comal,301,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,945,576,312,57
+Comal,302,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1799,1291,379,129
+Comal,303,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,233,153,64,16
+Comal,304,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1308,879,339,90
+Comal,305,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,892,586,256,50
+Comal,306,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,553,373,137,43
+Comal,401,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,979,622,232,125
+Comal,402,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,2214,1590,406,218
+Comal,403,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,2694,1850,629,215
+Comal,404,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1805,1309,381,115
+Comal,405,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1864,1213,493,158
+Comal,406,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,2331,1594,436,301
+Comal,407,"Judge, Court of Criminal Appeals, Place 8",,REP,Michelle Slaughter,1571,1096,375,100
+Comal,101,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,329,222,82,25
+Comal,102,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,193,154,30,9
+Comal,103,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,221,145,56,20
+Comal,104,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,116,83,20,13
+Comal,105,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,285,186,71,28
+Comal,106,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,228,175,33,20
+Comal,107,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,149,95,45,9
+Comal,201,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,367,224,116,27
+Comal,202,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,76,46,25,5
+Comal,203,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,262,207,41,14
+Comal,204,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,228,163,47,18
+Comal,205,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,383,303,54,26
+Comal,206,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,307,205,79,23
+Comal,207,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,104,74,25,5
+Comal,208,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,105,62,28,15
+Comal,301,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,342,211,111,20
+Comal,302,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,404,267,113,24
+Comal,303,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,95,57,28,10
+Comal,304,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,330,227,88,15
+Comal,305,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,212,132,67,13
+Comal,306,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,128,92,34,2
+Comal,401,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,178,112,44,22
+Comal,402,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,310,225,52,33
+Comal,403,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,282,199,64,19
+Comal,404,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,227,150,67,10
+Comal,405,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,226,140,62,24
+Comal,406,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,363,244,77,42
+Comal,407,"Judge, Court of Criminal Appeals, Place 8",,LIB,Mark Ash,216,137,58,21
+Comal,101,State Senator,25,REP,Donna Campbell,1657,1165,325,167
+Comal,102,State Senator,25,REP,Donna Campbell,1998,1562,286,150
+Comal,103,State Senator,25,REP,Donna Campbell,1908,1339,436,133
+Comal,104,State Senator,25,REP,Donna Campbell,1069,773,189,107
+Comal,105,State Senator,25,REP,Donna Campbell,2480,1722,564,194
+Comal,106,State Senator,25,REP,Donna Campbell,2606,2035,395,176
+Comal,107,State Senator,25,REP,Donna Campbell,1100,696,342,62
+Comal,201,State Senator,25,REP,Donna Campbell,1797,1155,510,132
+Comal,202,State Senator,25,REP,Donna Campbell,480,314,120,46
+Comal,203,State Senator,25,REP,Donna Campbell,2183,1622,397,164
+Comal,204,State Senator,25,REP,Donna Campbell,1781,1328,320,133
+Comal,205,State Senator,25,REP,Donna Campbell,2725,2253,311,161
+Comal,206,State Senator,25,REP,Donna Campbell,2665,2031,443,191
+Comal,207,State Senator,25,REP,Donna Campbell,1116,802,222,92
+Comal,208,State Senator,25,REP,Donna Campbell,1045,730,220,95
+Comal,301,State Senator,25,REP,Donna Campbell,900,549,298,53
+Comal,302,State Senator,25,REP,Donna Campbell,1716,1212,377,127
+Comal,303,State Senator,25,REP,Donna Campbell,218,138,64,16
+Comal,304,State Senator,25,REP,Donna Campbell,1253,841,324,88
+Comal,305,State Senator,25,REP,Donna Campbell,869,576,242,51
+Comal,306,State Senator,25,REP,Donna Campbell,521,347,131,43
+Comal,401,State Senator,25,REP,Donna Campbell,947,603,224,120
+Comal,402,State Senator,25,REP,Donna Campbell,2154,1542,394,218
+Comal,403,State Senator,25,REP,Donna Campbell,2673,1837,627,209
+Comal,404,State Senator,25,REP,Donna Campbell,1773,1279,380,114
+Comal,405,State Senator,25,REP,Donna Campbell,1861,1210,493,158
+Comal,406,State Senator,25,REP,Donna Campbell,2247,1527,425,295
+Comal,407,State Senator,25,REP,Donna Campbell,1527,1056,370,101
+Comal,101,State Senator,25,DEM,Steven Kling,810,546,184,80
+Comal,102,State Senator,25,DEM,Steven Kling,444,331,66,47
+Comal,103,State Senator,25,DEM,Steven Kling,497,356,94,47
+Comal,104,State Senator,25,DEM,Steven Kling,307,211,45,51
+Comal,105,State Senator,25,DEM,Steven Kling,714,484,145,85
+Comal,106,State Senator,25,DEM,Steven Kling,564,432,63,69
+Comal,107,State Senator,25,DEM,Steven Kling,337,235,75,27
+Comal,201,State Senator,25,DEM,Steven Kling,827,527,233,67
+Comal,202,State Senator,25,DEM,Steven Kling,194,122,48,24
+Comal,203,State Senator,25,DEM,Steven Kling,669,519,91,59
+Comal,204,State Senator,25,DEM,Steven Kling,502,379,77,46
+Comal,205,State Senator,25,DEM,Steven Kling,955,751,131,73
+Comal,206,State Senator,25,DEM,Steven Kling,707,508,130,69
+Comal,207,State Senator,25,DEM,Steven Kling,279,196,58,25
+Comal,208,State Senator,25,DEM,Steven Kling,267,156,65,46
+Comal,301,State Senator,25,DEM,Steven Kling,891,506,302,83
+Comal,302,State Senator,25,DEM,Steven Kling,1023,713,210,100
+Comal,303,State Senator,25,DEM,Steven Kling,265,146,94,25
+Comal,304,State Senator,25,DEM,Steven Kling,792,533,210,49
+Comal,305,State Senator,25,DEM,Steven Kling,404,242,125,37
+Comal,306,State Senator,25,DEM,Steven Kling,301,202,87,12
+Comal,401,State Senator,25,DEM,Steven Kling,416,248,99,69
+Comal,402,State Senator,25,DEM,Steven Kling,746,550,112,84
+Comal,403,State Senator,25,DEM,Steven Kling,712,496,139,77
+Comal,404,State Senator,25,DEM,Steven Kling,504,333,130,41
+Comal,405,State Senator,25,DEM,Steven Kling,482,325,99,58
+Comal,406,State Senator,25,DEM,Steven Kling,892,610,153,129
+Comal,407,State Senator,25,DEM,Steven Kling,444,305,96,43
+Comal,101,State Representative,73,REP,Kyle Biedermann,1619,1148,315,156
+Comal,102,State Representative,73,REP,Kyle Biedermann,1981,1555,282,144
+Comal,103,State Representative,73,REP,Kyle Biedermann,1867,1316,424,127
+Comal,104,State Representative,73,REP,Kyle Biedermann,1061,769,189,103
+Comal,105,State Representative,73,REP,Kyle Biedermann,2462,1708,558,196
+Comal,106,State Representative,73,REP,Kyle Biedermann,2598,2034,393,171
+Comal,107,State Representative,73,REP,Kyle Biedermann,1125,715,351,59
+Comal,201,State Representative,73,REP,Kyle Biedermann,1738,1121,494,123
+Comal,202,State Representative,73,REP,Kyle Biedermann,476,314,116,46
+Comal,203,State Representative,73,REP,Kyle Biedermann,2146,1610,388,148
+Comal,204,State Representative,73,REP,Kyle Biedermann,1775,1324,321,130
+Comal,205,State Representative,73,REP,Kyle Biedermann,2711,2253,303,155
+Comal,206,State Representative,73,REP,Kyle Biedermann,2682,2046,444,192
+Comal,207,State Representative,73,REP,Kyle Biedermann,1094,789,220,85
+Comal,208,State Representative,73,REP,Kyle Biedermann,1040,726,223,91
+Comal,301,State Representative,73,REP,Kyle Biedermann,879,537,291,51
+Comal,302,State Representative,73,REP,Kyle Biedermann,1674,1195,362,117
+Comal,303,State Representative,73,REP,Kyle Biedermann,218,140,61,17
+Comal,304,State Representative,73,REP,Kyle Biedermann,1224,824,314,86
+Comal,305,State Representative,73,REP,Kyle Biedermann,860,574,242,44
+Comal,306,State Representative,73,REP,Kyle Biedermann,507,337,130,40
+Comal,401,State Representative,73,REP,Kyle Biedermann,942,595,225,122
+Comal,402,State Representative,73,REP,Kyle Biedermann,2146,1544,390,212
+Comal,403,State Representative,73,REP,Kyle Biedermann,2631,1819,611,201
+Comal,404,State Representative,73,REP,Kyle Biedermann,1728,1255,368,105
+Comal,405,State Representative,73,REP,Kyle Biedermann,1837,1201,482,154
+Comal,406,State Representative,73,REP,Kyle Biedermann,2216,1505,422,289
+Comal,407,State Representative,73,REP,Kyle Biedermann,1522,1060,364,98
+Comal,101,State Representative,73,DEM,Stephanie Phillips,830,551,195,84
+Comal,102,State Representative,73,DEM,Stephanie Phillips,448,332,68,48
+Comal,103,State Representative,73,DEM,Stephanie Phillips,519,366,105,48
+Comal,104,State Representative,73,DEM,Stephanie Phillips,313,218,47,48
+Comal,105,State Representative,73,DEM,Stephanie Phillips,726,494,153,79
+Comal,106,State Representative,73,DEM,Stephanie Phillips,562,432,63,67
+Comal,107,State Representative,73,DEM,Stephanie Phillips,311,217,69,25
+Comal,201,State Representative,73,DEM,Stephanie Phillips,866,557,244,65
+Comal,202,State Representative,73,DEM,Stephanie Phillips,190,121,51,18
+Comal,203,State Representative,73,DEM,Stephanie Phillips,690,529,96,65
+Comal,204,State Representative,73,DEM,Stephanie Phillips,510,384,77,49
+Comal,205,State Representative,73,DEM,Stephanie Phillips,956,747,138,71
+Comal,206,State Representative,73,DEM,Stephanie Phillips,691,495,130,66
+Comal,207,State Representative,73,DEM,Stephanie Phillips,296,208,65,23
+Comal,208,State Representative,73,DEM,Stephanie Phillips,267,159,62,46
+Comal,301,State Representative,73,DEM,Stephanie Phillips,911,520,309,82
+Comal,302,State Representative,73,DEM,Stephanie Phillips,1055,730,227,98
+Comal,303,State Representative,73,DEM,Stephanie Phillips,260,143,96,21
+Comal,304,State Representative,73,DEM,Stephanie Phillips,807,546,216,45
+Comal,305,State Representative,73,DEM,Stephanie Phillips,406,244,126,36
+Comal,306,State Representative,73,DEM,Stephanie Phillips,314,211,89,14
+Comal,401,State Representative,73,DEM,Stephanie Phillips,415,253,97,65
+Comal,402,State Representative,73,DEM,Stephanie Phillips,756,551,117,88
+Comal,403,State Representative,73,DEM,Stephanie Phillips,737,509,152,76
+Comal,404,State Representative,73,DEM,Stephanie Phillips,531,348,136,47
+Comal,405,State Representative,73,DEM,Stephanie Phillips,499,333,110,56
+Comal,406,State Representative,73,DEM,Stephanie Phillips,921,636,153,132
+Comal,407,State Representative,73,DEM,Stephanie Phillips,438,298,98,42
+Comal,101,"Justice, 3rd Court of Appeals District, Place No. 2",,REP,Cindy Olson Bourland,1706,1214,329,163
+Comal,102,"Justice, 3rd Court of Appeals District, Place No. 2",,REP,Cindy Olson Bourland,2000,1570,288,142
+Comal,103,"Justice, 3rd Court of Appeals District, Place No. 2",,REP,Cindy Olson Bourland,1920,1355,434,131
+Comal,104,"Justice, 3rd Court of Appeals District, Place No. 2",,REP,Cindy Olson Bourland,1079,776,197,106
+Comal,105,"Justice, 3rd Court of Appeals District, Place No. 2",,REP,Cindy Olson Bourland,2480,1725,561,194
+Comal,106,"Justice, 3rd Court of Appeals District, Place No. 2",,REP,Cindy Olson Bourland,2619,2056,391,172
+Comal,107,"Justice, 3rd Court of Appeals District, Place No. 2",,REP,Cindy Olson Bourland,1131,725,347,59
+Comal,201,"Justice, 3rd Court of Appeals District, Place No. 2",,REP,Cindy Olson Bourland,1809,1166,510,133
+Comal,202,"Justice, 3rd Court of Appeals District, Place No. 2",,REP,Cindy Olson Bourland,477,315,120,42
+Comal,203,"Justice, 3rd Court of Appeals District, Place No. 2",,REP,Cindy Olson Bourland,2228,1670,399,159
+Comal,204,"Justice, 3rd Court of Appeals District, Place No. 2",,REP,Cindy Olson Bourland,1800,1343,323,134
+Comal,205,"Justice, 3rd Court of Appeals District, Place No. 2",,REP,Cindy Olson Bourland,2791,2309,323,159
+Comal,206,"Justice, 3rd Court of Appeals District, Place No. 2",,REP,Cindy Olson Bourland,2701,2065,444,192
+Comal,207,"Justice, 3rd Court of Appeals District, Place No. 2",,REP,Cindy Olson Bourland,1133,819,225,89
+Comal,208,"Justice, 3rd Court of Appeals District, Place No. 2",,REP,Cindy Olson Bourland,1049,730,227,92
+Comal,301,"Justice, 3rd Court of Appeals District, Place No. 2",,REP,Cindy Olson Bourland,889,547,292,50
+Comal,302,"Justice, 3rd Court of Appeals District, Place No. 2",,REP,Cindy Olson Bourland,1718,1236,362,120
+Comal,303,"Justice, 3rd Court of Appeals District, Place No. 2",,REP,Cindy Olson Bourland,220,142,63,15
+Comal,304,"Justice, 3rd Court of Appeals District, Place No. 2",,REP,Cindy Olson Bourland,1250,849,317,84
+Comal,305,"Justice, 3rd Court of Appeals District, Place No. 2",,REP,Cindy Olson Bourland,871,576,249,46
+Comal,306,"Justice, 3rd Court of Appeals District, Place No. 2",,REP,Cindy Olson Bourland,535,355,136,44
+Comal,401,"Justice, 3rd Court of Appeals District, Place No. 2",,REP,Cindy Olson Bourland,959,613,226,120
+Comal,402,"Justice, 3rd Court of Appeals District, Place No. 2",,REP,Cindy Olson Bourland,2179,1561,396,222
+Comal,403,"Justice, 3rd Court of Appeals District, Place No. 2",,REP,Cindy Olson Bourland,2686,1847,626,213
+Comal,404,"Justice, 3rd Court of Appeals District, Place No. 2",,REP,Cindy Olson Bourland,1785,1285,385,115
+Comal,405,"Justice, 3rd Court of Appeals District, Place No. 2",,REP,Cindy Olson Bourland,1864,1215,496,153
+Comal,406,"Justice, 3rd Court of Appeals District, Place No. 2",,REP,Cindy Olson Bourland,2275,1543,435,297
+Comal,407,"Justice, 3rd Court of Appeals District, Place No. 2",,REP,Cindy Olson Bourland,1556,1080,377,99
+Comal,101,"Justice, 3rd Court of Appeals District, Place No. 2",,DEM,Edward Smith,713,470,171,72
+Comal,102,"Justice, 3rd Court of Appeals District, Place No. 2",,DEM,Edward Smith,426,313,64,49
+Comal,103,"Justice, 3rd Court of Appeals District, Place No. 2",,DEM,Edward Smith,448,320,89,39
+Comal,104,"Justice, 3rd Court of Appeals District, Place No. 2",,DEM,Edward Smith,281,200,35,46
+Comal,105,"Justice, 3rd Court of Appeals District, Place No. 2",,DEM,Edward Smith,688,465,143,80
+Comal,106,"Justice, 3rd Court of Appeals District, Place No. 2",,DEM,Edward Smith,528,402,61,65
+Comal,107,"Justice, 3rd Court of Appeals District, Place No. 2",,DEM,Edward Smith,302,207,72,23
+Comal,201,"Justice, 3rd Court of Appeals District, Place No. 2",,DEM,Edward Smith,792,505,225,62
+Comal,202,"Justice, 3rd Court of Appeals District, Place No. 2",,DEM,Edward Smith,188,118,47,23
+Comal,203,"Justice, 3rd Court of Appeals District, Place No. 2",,DEM,Edward Smith,602,463,83,56
+Comal,204,"Justice, 3rd Court of Appeals District, Place No. 2",,DEM,Edward Smith,474,357,73,44
+Comal,205,"Justice, 3rd Court of Appeals District, Place No. 2",,DEM,Edward Smith,866,685,115,66
+Comal,206,"Justice, 3rd Court of Appeals District, Place No. 2",,DEM,Edward Smith,652,463,126,63
+Comal,207,"Justice, 3rd Court of Appeals District, Place No. 2",,DEM,Edward Smith,245,168,54,23
+Comal,208,"Justice, 3rd Court of Appeals District, Place No. 2",,DEM,Edward Smith,250,150,57,43
+Comal,301,"Justice, 3rd Court of Appeals District, Place No. 2",,DEM,Edward Smith,893,508,302,83
+Comal,302,"Justice, 3rd Court of Appeals District, Place No. 2",,DEM,Edward Smith,996,678,217,101
+Comal,303,"Justice, 3rd Court of Appeals District, Place No. 2",,DEM,Edward Smith,256,140,92,24
+Comal,304,"Justice, 3rd Court of Appeals District, Place No. 2",,DEM,Edward Smith,777,516,212,49
+Comal,305,"Justice, 3rd Court of Appeals District, Place No. 2",,DEM,Edward Smith,383,230,118,35
+Comal,306,"Justice, 3rd Court of Appeals District, Place No. 2",,DEM,Edward Smith,288,191,82,15
+Comal,401,"Justice, 3rd Court of Appeals District, Place No. 2",,DEM,Edward Smith,374,227,88,59
+Comal,402,"Justice, 3rd Court of Appeals District, Place No. 2",,DEM,Edward Smith,713,523,109,81
+Comal,403,"Justice, 3rd Court of Appeals District, Place No. 2",,DEM,Edward Smith,665,464,132,69
+Comal,404,"Justice, 3rd Court of Appeals District, Place No. 2",,DEM,Edward Smith,462,309,114,39
+Comal,405,"Justice, 3rd Court of Appeals District, Place No. 2",,DEM,Edward Smith,466,313,95,58
+Comal,406,"Justice, 3rd Court of Appeals District, Place No. 2",,DEM,Edward Smith,828,570,137,121
+Comal,407,"Justice, 3rd Court of Appeals District, Place No. 2",,DEM,Edward Smith,390,271,78,41
+Comal,101,"Justice, 3rd Court of Appeals District, Place No. 3",,REP,Scott Field,1676,1186,326,164
+Comal,102,"Justice, 3rd Court of Appeals District, Place No. 3",,REP,Scott Field,1980,1558,284,138
+Comal,103,"Justice, 3rd Court of Appeals District, Place No. 3",,REP,Scott Field,1888,1335,425,128
+Comal,104,"Justice, 3rd Court of Appeals District, Place No. 3",,REP,Scott Field,1058,761,193,104
+Comal,105,"Justice, 3rd Court of Appeals District, Place No. 3",,REP,Scott Field,2445,1701,552,192
+Comal,106,"Justice, 3rd Court of Appeals District, Place No. 3",,REP,Scott Field,2596,2038,387,171
+Comal,107,"Justice, 3rd Court of Appeals District, Place No. 3",,REP,Scott Field,1126,720,347,59
+Comal,201,"Justice, 3rd Court of Appeals District, Place No. 3",,REP,Scott Field,1754,1132,498,124
+Comal,202,"Justice, 3rd Court of Appeals District, Place No. 3",,REP,Scott Field,464,309,113,42
+Comal,203,"Justice, 3rd Court of Appeals District, Place No. 3",,REP,Scott Field,2198,1648,392,158
+Comal,204,"Justice, 3rd Court of Appeals District, Place No. 3",,REP,Scott Field,1779,1327,320,132
+Comal,205,"Justice, 3rd Court of Appeals District, Place No. 3",,REP,Scott Field,2739,2271,312,156
+Comal,206,"Justice, 3rd Court of Appeals District, Place No. 3",,REP,Scott Field,2671,2046,434,191
+Comal,207,"Justice, 3rd Court of Appeals District, Place No. 3",,REP,Scott Field,1108,800,219,89
+Comal,208,"Justice, 3rd Court of Appeals District, Place No. 3",,REP,Scott Field,1042,728,222,92
+Comal,301,"Justice, 3rd Court of Appeals District, Place No. 3",,REP,Scott Field,879,544,288,47
+Comal,302,"Justice, 3rd Court of Appeals District, Place No. 3",,REP,Scott Field,1712,1232,361,119
+Comal,303,"Justice, 3rd Court of Appeals District, Place No. 3",,REP,Scott Field,222,145,60,17
+Comal,304,"Justice, 3rd Court of Appeals District, Place No. 3",,REP,Scott Field,1226,828,310,88
+Comal,305,"Justice, 3rd Court of Appeals District, Place No. 3",,REP,Scott Field,858,570,244,44
+Comal,306,"Justice, 3rd Court of Appeals District, Place No. 3",,REP,Scott Field,519,340,136,43
+Comal,401,"Justice, 3rd Court of Appeals District, Place No. 3",,REP,Scott Field,946,610,222,114
+Comal,402,"Justice, 3rd Court of Appeals District, Place No. 3",,REP,Scott Field,2155,1548,391,216
+Comal,403,"Justice, 3rd Court of Appeals District, Place No. 3",,REP,Scott Field,2645,1818,616,211
+Comal,404,"Justice, 3rd Court of Appeals District, Place No. 3",,REP,Scott Field,1753,1267,375,111
+Comal,405,"Justice, 3rd Court of Appeals District, Place No. 3",,REP,Scott Field,1839,1203,485,151
+Comal,406,"Justice, 3rd Court of Appeals District, Place No. 3",,REP,Scott Field,2250,1530,425,295
+Comal,407,"Justice, 3rd Court of Appeals District, Place No. 3",,REP,Scott Field,1534,1066,371,97
+Comal,101,"Justice, 3rd Court of Appeals District, Place No. 3",,DEM,Chari Kelly,744,498,175,71
+Comal,102,"Justice, 3rd Court of Appeals District, Place No. 3",,DEM,Chari Kelly,446,326,67,53
+Comal,103,"Justice, 3rd Court of Appeals District, Place No. 3",,DEM,Chari Kelly,479,339,97,43
+Comal,104,"Justice, 3rd Court of Appeals District, Place No. 3",,DEM,Chari Kelly,302,214,40,48
+Comal,105,"Justice, 3rd Court of Appeals District, Place No. 3",,DEM,Chari Kelly,724,491,151,82
+Comal,106,"Justice, 3rd Court of Appeals District, Place No. 3",,DEM,Chari Kelly,548,417,65,66
+Comal,107,"Justice, 3rd Court of Appeals District, Place No. 3",,DEM,Chari Kelly,306,211,72,23
+Comal,201,"Justice, 3rd Court of Appeals District, Place No. 3",,DEM,Chari Kelly,848,539,238,71
+Comal,202,"Justice, 3rd Court of Appeals District, Place No. 3",,DEM,Chari Kelly,199,123,53,23
+Comal,203,"Justice, 3rd Court of Appeals District, Place No. 3",,DEM,Chari Kelly,631,486,88,57
+Comal,204,"Justice, 3rd Court of Appeals District, Place No. 3",,DEM,Chari Kelly,495,375,75,45
+Comal,205,"Justice, 3rd Court of Appeals District, Place No. 3",,DEM,Chari Kelly,920,725,126,69
+Comal,206,"Justice, 3rd Court of Appeals District, Place No. 3",,DEM,Chari Kelly,682,485,134,63
+Comal,207,"Justice, 3rd Court of Appeals District, Place No. 3",,DEM,Chari Kelly,271,188,60,23
+Comal,208,"Justice, 3rd Court of Appeals District, Place No. 3",,DEM,Chari Kelly,258,152,62,44
+Comal,301,"Justice, 3rd Court of Appeals District, Place No. 3",,DEM,Chari Kelly,906,510,310,86
+Comal,302,"Justice, 3rd Court of Appeals District, Place No. 3",,DEM,Chari Kelly,1002,682,220,100
+Comal,303,"Justice, 3rd Court of Appeals District, Place No. 3",,DEM,Chari Kelly,255,138,95,22
+Comal,304,"Justice, 3rd Court of Appeals District, Place No. 3",,DEM,Chari Kelly,804,539,220,45
+Comal,305,"Justice, 3rd Court of Appeals District, Place No. 3",,DEM,Chari Kelly,401,239,124,38
+Comal,306,"Justice, 3rd Court of Appeals District, Place No. 3",,DEM,Chari Kelly,306,207,83,16
+Comal,401,"Justice, 3rd Court of Appeals District, Place No. 3",,DEM,Chari Kelly,388,231,93,64
+Comal,402,"Justice, 3rd Court of Appeals District, Place No. 3",,DEM,Chari Kelly,738,536,114,88
+Comal,403,"Justice, 3rd Court of Appeals District, Place No. 3",,DEM,Chari Kelly,706,492,143,71
+Comal,404,"Justice, 3rd Court of Appeals District, Place No. 3",,DEM,Chari Kelly,495,326,125,44
+Comal,405,"Justice, 3rd Court of Appeals District, Place No. 3",,DEM,Chari Kelly,490,325,106,59
+Comal,406,"Justice, 3rd Court of Appeals District, Place No. 3",,DEM,Chari Kelly,856,583,147,126
+Comal,407,"Justice, 3rd Court of Appeals District, Place No. 3",,DEM,Chari Kelly,413,283,86,44
+Comal,101,"Justice, 3rd Court of Appeals District, Place No. 5",,REP,David Puryear,1682,1196,324,162
+Comal,102,"Justice, 3rd Court of Appeals District, Place No. 5",,REP,David Puryear,1989,1563,284,142
+Comal,103,"Justice, 3rd Court of Appeals District, Place No. 5",,REP,David Puryear,1904,1346,430,128
+Comal,104,"Justice, 3rd Court of Appeals District, Place No. 5",,REP,David Puryear,1075,777,194,104
+Comal,105,"Justice, 3rd Court of Appeals District, Place No. 5",,REP,David Puryear,2455,1712,551,192
+Comal,106,"Justice, 3rd Court of Appeals District, Place No. 5",,REP,David Puryear,2601,2041,388,172
+Comal,107,"Justice, 3rd Court of Appeals District, Place No. 5",,REP,David Puryear,1120,722,343,55
+Comal,201,"Justice, 3rd Court of Appeals District, Place No. 5",,REP,David Puryear,1757,1136,499,122
+Comal,202,"Justice, 3rd Court of Appeals District, Place No. 5",,REP,David Puryear,470,314,115,41
+Comal,203,"Justice, 3rd Court of Appeals District, Place No. 5",,REP,David Puryear,2209,1654,395,160
+Comal,204,"Justice, 3rd Court of Appeals District, Place No. 5",,REP,David Puryear,1787,1340,318,129
+Comal,205,"Justice, 3rd Court of Appeals District, Place No. 5",,REP,David Puryear,2746,2275,313,158
+Comal,206,"Justice, 3rd Court of Appeals District, Place No. 5",,REP,David Puryear,2675,2051,435,189
+Comal,207,"Justice, 3rd Court of Appeals District, Place No. 5",,REP,David Puryear,1115,807,219,89
+Comal,208,"Justice, 3rd Court of Appeals District, Place No. 5",,REP,David Puryear,1039,727,220,92
+Comal,301,"Justice, 3rd Court of Appeals District, Place No. 5",,REP,David Puryear,871,535,289,47
+Comal,302,"Justice, 3rd Court of Appeals District, Place No. 5",,REP,David Puryear,1716,1235,360,121
+Comal,303,"Justice, 3rd Court of Appeals District, Place No. 5",,REP,David Puryear,219,144,59,16
+Comal,304,"Justice, 3rd Court of Appeals District, Place No. 5",,REP,David Puryear,1227,831,312,84
+Comal,305,"Justice, 3rd Court of Appeals District, Place No. 5",,REP,David Puryear,862,574,244,44
+Comal,306,"Justice, 3rd Court of Appeals District, Place No. 5",,REP,David Puryear,522,345,134,43
+Comal,401,"Justice, 3rd Court of Appeals District, Place No. 5",,REP,David Puryear,957,614,227,116
+Comal,402,"Justice, 3rd Court of Appeals District, Place No. 5",,REP,David Puryear,2164,1551,396,217
+Comal,403,"Justice, 3rd Court of Appeals District, Place No. 5",,REP,David Puryear,2671,1831,628,212
+Comal,404,"Justice, 3rd Court of Appeals District, Place No. 5",,REP,David Puryear,1767,1277,377,113
+Comal,405,"Justice, 3rd Court of Appeals District, Place No. 5",,REP,David Puryear,1846,1205,491,150
+Comal,406,"Justice, 3rd Court of Appeals District, Place No. 5",,REP,David Puryear,2268,1540,435,293
+Comal,407,"Justice, 3rd Court of Appeals District, Place No. 5",,REP,David Puryear,1543,1074,373,96
+Comal,101,"Justice, 3rd Court of Appeals District, Place No. 5",,DEM,Thomas J. Baker,736,486,178,72
+Comal,102,"Justice, 3rd Court of Appeals District, Place No. 5",,DEM,Thomas J. Baker,435,320,67,48
+Comal,103,"Justice, 3rd Court of Appeals District, Place No. 5",,DEM,Thomas J. Baker,459,325,93,41
+Comal,104,"Justice, 3rd Court of Appeals District, Place No. 5",,DEM,Thomas J. Baker,287,201,39,47
+Comal,105,"Justice, 3rd Court of Appeals District, Place No. 5",,DEM,Thomas J. Baker,717,483,152,82
+Comal,106,"Justice, 3rd Court of Appeals District, Place No. 5",,DEM,Thomas J. Baker,548,417,66,65
+Comal,107,"Justice, 3rd Court of Appeals District, Place No. 5",,DEM,Thomas J. Baker,311,209,76,26
+Comal,201,"Justice, 3rd Court of Appeals District, Place No. 5",,DEM,Thomas J. Baker,843,535,235,73
+Comal,202,"Justice, 3rd Court of Appeals District, Place No. 5",,DEM,Thomas J. Baker,193,118,51,24
+Comal,203,"Justice, 3rd Court of Appeals District, Place No. 5",,DEM,Thomas J. Baker,625,483,87,55
+Comal,204,"Justice, 3rd Court of Appeals District, Place No. 5",,DEM,Thomas J. Baker,492,365,78,49
+Comal,205,"Justice, 3rd Court of Appeals District, Place No. 5",,DEM,Thomas J. Baker,906,714,126,66
+Comal,206,"Justice, 3rd Court of Appeals District, Place No. 5",,DEM,Thomas J. Baker,674,479,130,65
+Comal,207,"Justice, 3rd Court of Appeals District, Place No. 5",,DEM,Thomas J. Baker,260,177,60,23
+Comal,208,"Justice, 3rd Court of Appeals District, Place No. 5",,DEM,Thomas J. Baker,261,153,64,44
+Comal,301,"Justice, 3rd Court of Appeals District, Place No. 5",,DEM,Thomas J. Baker,913,518,309,86
+Comal,302,"Justice, 3rd Court of Appeals District, Place No. 5",,DEM,Thomas J. Baker,1005,688,218,99
+Comal,303,"Justice, 3rd Court of Appeals District, Place No. 5",,DEM,Thomas J. Baker,258,139,96,23
+Comal,304,"Justice, 3rd Court of Appeals District, Place No. 5",,DEM,Thomas J. Baker,805,537,219,49
+Comal,305,"Justice, 3rd Court of Appeals District, Place No. 5",,DEM,Thomas J. Baker,393,235,121,37
+Comal,306,"Justice, 3rd Court of Appeals District, Place No. 5",,DEM,Thomas J. Baker,303,201,86,16
+Comal,401,"Justice, 3rd Court of Appeals District, Place No. 5",,DEM,Thomas J. Baker,374,224,88,62
+Comal,402,"Justice, 3rd Court of Appeals District, Place No. 5",,DEM,Thomas J. Baker,731,535,109,87
+Comal,403,"Justice, 3rd Court of Appeals District, Place No. 5",,DEM,Thomas J. Baker,687,482,135,70
+Comal,404,"Justice, 3rd Court of Appeals District, Place No. 5",,DEM,Thomas J. Baker,481,318,122,41
+Comal,405,"Justice, 3rd Court of Appeals District, Place No. 5",,DEM,Thomas J. Baker,483,323,100,60
+Comal,406,"Justice, 3rd Court of Appeals District, Place No. 5",,DEM,Thomas J. Baker,839,578,137,124
+Comal,407,"Justice, 3rd Court of Appeals District, Place No. 5",,DEM,Thomas J. Baker,402,276,83,43
+Comal,101,"Justice, 3rd Court of Appeals District, Place No. 6",,REP,"Michael ""Mike"" Toth",1683,1190,329,164
+Comal,102,"Justice, 3rd Court of Appeals District, Place No. 6",,REP,"Michael ""Mike"" Toth",1981,1560,280,141
+Comal,103,"Justice, 3rd Court of Appeals District, Place No. 6",,REP,"Michael ""Mike"" Toth",1893,1339,429,125
+Comal,104,"Justice, 3rd Court of Appeals District, Place No. 6",,REP,"Michael ""Mike"" Toth",1066,767,194,105
+Comal,105,"Justice, 3rd Court of Appeals District, Place No. 6",,REP,"Michael ""Mike"" Toth",2465,1713,559,193
+Comal,106,"Justice, 3rd Court of Appeals District, Place No. 6",,REP,"Michael ""Mike"" Toth",2591,2037,385,169
+Comal,107,"Justice, 3rd Court of Appeals District, Place No. 6",,REP,"Michael ""Mike"" Toth",1123,722,344,57
+Comal,201,"Justice, 3rd Court of Appeals District, Place No. 6",,REP,"Michael ""Mike"" Toth",1766,1138,502,126
+Comal,202,"Justice, 3rd Court of Appeals District, Place No. 6",,REP,"Michael ""Mike"" Toth",465,310,111,44
+Comal,203,"Justice, 3rd Court of Appeals District, Place No. 6",,REP,"Michael ""Mike"" Toth",2199,1650,391,158
+Comal,204,"Justice, 3rd Court of Appeals District, Place No. 6",,REP,"Michael ""Mike"" Toth",1786,1338,317,131
+Comal,205,"Justice, 3rd Court of Appeals District, Place No. 6",,REP,"Michael ""Mike"" Toth",2741,2275,313,153
+Comal,206,"Justice, 3rd Court of Appeals District, Place No. 6",,REP,"Michael ""Mike"" Toth",2683,2058,438,187
+Comal,207,"Justice, 3rd Court of Appeals District, Place No. 6",,REP,"Michael ""Mike"" Toth",1116,804,223,89
+Comal,208,"Justice, 3rd Court of Appeals District, Place No. 6",,REP,"Michael ""Mike"" Toth",1049,735,224,90
+Comal,301,"Justice, 3rd Court of Appeals District, Place No. 6",,REP,"Michael ""Mike"" Toth",876,540,290,46
+Comal,302,"Justice, 3rd Court of Appeals District, Place No. 6",,REP,"Michael ""Mike"" Toth",1718,1231,366,121
+Comal,303,"Justice, 3rd Court of Appeals District, Place No. 6",,REP,"Michael ""Mike"" Toth",219,143,60,16
+Comal,304,"Justice, 3rd Court of Appeals District, Place No. 6",,REP,"Michael ""Mike"" Toth",1241,838,316,87
+Comal,305,"Justice, 3rd Court of Appeals District, Place No. 6",,REP,"Michael ""Mike"" Toth",863,574,246,43
+Comal,306,"Justice, 3rd Court of Appeals District, Place No. 6",,REP,"Michael ""Mike"" Toth",518,343,134,41
+Comal,401,"Justice, 3rd Court of Appeals District, Place No. 6",,REP,"Michael ""Mike"" Toth",944,605,223,116
+Comal,402,"Justice, 3rd Court of Appeals District, Place No. 6",,REP,"Michael ""Mike"" Toth",2159,1547,394,218
+Comal,403,"Justice, 3rd Court of Appeals District, Place No. 6",,REP,"Michael ""Mike"" Toth",2645,1818,619,208
+Comal,404,"Justice, 3rd Court of Appeals District, Place No. 6",,REP,"Michael ""Mike"" Toth",1769,1279,378,112
+Comal,405,"Justice, 3rd Court of Appeals District, Place No. 6",,REP,"Michael ""Mike"" Toth",1836,1200,486,150
+Comal,406,"Justice, 3rd Court of Appeals District, Place No. 6",,REP,"Michael ""Mike"" Toth",2261,1542,425,294
+Comal,407,"Justice, 3rd Court of Appeals District, Place No. 6",,REP,"Michael ""Mike"" Toth",1544,1070,375,99
+Comal,101,"Justice, 3rd Court of Appeals District, Place No. 6",,DEM,Gisela D. Triana,728,487,171,70
+Comal,102,"Justice, 3rd Court of Appeals District, Place No. 6",,DEM,Gisela D. Triana,438,321,69,48
+Comal,103,"Justice, 3rd Court of Appeals District, Place No. 6",,DEM,Gisela D. Triana,467,332,92,43
+Comal,104,"Justice, 3rd Court of Appeals District, Place No. 6",,DEM,Gisela D. Triana,291,206,38,47
+Comal,105,"Justice, 3rd Court of Appeals District, Place No. 6",,DEM,Gisela D. Triana,694,472,144,78
+Comal,106,"Justice, 3rd Court of Appeals District, Place No. 6",,DEM,Gisela D. Triana,553,416,70,67
+Comal,107,"Justice, 3rd Court of Appeals District, Place No. 6",,DEM,Gisela D. Triana,304,207,74,23
+Comal,201,"Justice, 3rd Court of Appeals District, Place No. 6",,DEM,Gisela D. Triana,828,531,229,68
+Comal,202,"Justice, 3rd Court of Appeals District, Place No. 6",,DEM,Gisela D. Triana,194,120,53,21
+Comal,203,"Justice, 3rd Court of Appeals District, Place No. 6",,DEM,Gisela D. Triana,628,482,90,56
+Comal,204,"Justice, 3rd Court of Appeals District, Place No. 6",,DEM,Gisela D. Triana,486,366,75,45
+Comal,205,"Justice, 3rd Court of Appeals District, Place No. 6",,DEM,Gisela D. Triana,896,710,118,68
+Comal,206,"Justice, 3rd Court of Appeals District, Place No. 6",,DEM,Gisela D. Triana,666,471,130,65
+Comal,207,"Justice, 3rd Court of Appeals District, Place No. 6",,DEM,Gisela D. Triana,259,179,57,23
+Comal,208,"Justice, 3rd Court of Appeals District, Place No. 6",,DEM,Gisela D. Triana,248,146,56,46
+Comal,301,"Justice, 3rd Court of Appeals District, Place No. 6",,DEM,Gisela D. Triana,903,511,306,86
+Comal,302,"Justice, 3rd Court of Appeals District, Place No. 6",,DEM,Gisela D. Triana,984,676,212,96
+Comal,303,"Justice, 3rd Court of Appeals District, Place No. 6",,DEM,Gisela D. Triana,257,139,95,23
+Comal,304,"Justice, 3rd Court of Appeals District, Place No. 6",,DEM,Gisela D. Triana,785,529,211,45
+Comal,305,"Justice, 3rd Court of Appeals District, Place No. 6",,DEM,Gisela D. Triana,396,239,120,37
+Comal,306,"Justice, 3rd Court of Appeals District, Place No. 6",,DEM,Gisela D. Triana,304,202,84,18
+Comal,401,"Justice, 3rd Court of Appeals District, Place No. 6",,DEM,Gisela D. Triana,385,231,92,62
+Comal,402,"Justice, 3rd Court of Appeals District, Place No. 6",,DEM,Gisela D. Triana,729,533,110,86
+Comal,403,"Justice, 3rd Court of Appeals District, Place No. 6",,DEM,Gisela D. Triana,706,491,142,73
+Comal,404,"Justice, 3rd Court of Appeals District, Place No. 6",,DEM,Gisela D. Triana,477,314,121,42
+Comal,405,"Justice, 3rd Court of Appeals District, Place No. 6",,DEM,Gisela D. Triana,486,323,104,59
+Comal,406,"Justice, 3rd Court of Appeals District, Place No. 6",,DEM,Gisela D. Triana,835,569,145,121
+Comal,407,"Justice, 3rd Court of Appeals District, Place No. 6",,DEM,Gisela D. Triana,404,285,79,40
+Comal,101,"Justice, 3rd Court of Appeals District, Place No. 6",,,Kerry O'Brien,5,4,0,1
+Comal,102,"Justice, 3rd Court of Appeals District, Place No. 6",,,Kerry O'Brien,1,0,0,1
+Comal,103,"Justice, 3rd Court of Appeals District, Place No. 6",,,Kerry O'Brien,3,1,0,2
+Comal,104,"Justice, 3rd Court of Appeals District, Place No. 6",,,Kerry O'Brien,1,1,0,0
+Comal,105,"Justice, 3rd Court of Appeals District, Place No. 6",,,Kerry O'Brien,2,0,0,2
+Comal,106,"Justice, 3rd Court of Appeals District, Place No. 6",,,Kerry O'Brien,2,0,0,2
+Comal,107,"Justice, 3rd Court of Appeals District, Place No. 6",,,Kerry O'Brien,0,0,0,0
+Comal,201,"Justice, 3rd Court of Appeals District, Place No. 6",,,Kerry O'Brien,1,1,0,0
+Comal,202,"Justice, 3rd Court of Appeals District, Place No. 6",,,Kerry O'Brien,0,0,0,0
+Comal,203,"Justice, 3rd Court of Appeals District, Place No. 6",,,Kerry O'Brien,1,1,0,0
+Comal,204,"Justice, 3rd Court of Appeals District, Place No. 6",,,Kerry O'Brien,0,0,0,0
+Comal,205,"Justice, 3rd Court of Appeals District, Place No. 6",,,Kerry O'Brien,5,3,2,0
+Comal,206,"Justice, 3rd Court of Appeals District, Place No. 6",,,Kerry O'Brien,3,2,0,1
+Comal,207,"Justice, 3rd Court of Appeals District, Place No. 6",,,Kerry O'Brien,1,1,0,0
+Comal,208,"Justice, 3rd Court of Appeals District, Place No. 6",,,Kerry O'Brien,0,0,0,0
+Comal,301,"Justice, 3rd Court of Appeals District, Place No. 6",,,Kerry O'Brien,1,0,0,1
+Comal,302,"Justice, 3rd Court of Appeals District, Place No. 6",,,Kerry O'Brien,5,2,0,3
+Comal,303,"Justice, 3rd Court of Appeals District, Place No. 6",,,Kerry O'Brien,0,0,0,0
+Comal,304,"Justice, 3rd Court of Appeals District, Place No. 6",,,Kerry O'Brien,2,0,0,2
+Comal,305,"Justice, 3rd Court of Appeals District, Place No. 6",,,Kerry O'Brien,0,0,0,0
+Comal,306,"Justice, 3rd Court of Appeals District, Place No. 6",,,Kerry O'Brien,1,0,1,0
+Comal,401,"Justice, 3rd Court of Appeals District, Place No. 6",,,Kerry O'Brien,4,1,1,2
+Comal,402,"Justice, 3rd Court of Appeals District, Place No. 6",,,Kerry O'Brien,1,1,0,0
+Comal,403,"Justice, 3rd Court of Appeals District, Place No. 6",,,Kerry O'Brien,1,1,0,0
+Comal,404,"Justice, 3rd Court of Appeals District, Place No. 6",,,Kerry O'Brien,0,0,0,0
+Comal,405,"Justice, 3rd Court of Appeals District, Place No. 6",,,Kerry O'Brien,1,0,0,1
+Comal,406,"Justice, 3rd Court of Appeals District, Place No. 6",,,Kerry O'Brien,3,0,0,3
+Comal,407,"Justice, 3rd Court of Appeals District, Place No. 6",,,Kerry O'Brien,0,0,0,0
+Comal,101,"District Judge, 207th Judicial District",,REP,Jack Robison,1844,1286,375,183
+Comal,102,"District Judge, 207th Judicial District",,REP,Jack Robison,2083,1627,306,150
+Comal,103,"District Judge, 207th Judicial District",,REP,Jack Robison,2000,1405,456,139
+Comal,104,"District Judge, 207th Judicial District",,REP,Jack Robison,1114,806,197,111
+Comal,105,"District Judge, 207th Judicial District",,REP,Jack Robison,2597,1798,597,202
+Comal,106,"District Judge, 207th Judicial District",,REP,Jack Robison,2692,2113,402,177
+Comal,107,"District Judge, 207th Judicial District",,REP,Jack Robison,1189,765,365,59
+Comal,201,"District Judge, 207th Judicial District",,REP,Jack Robison,1967,1239,588,140
+Comal,202,"District Judge, 207th Judicial District",,REP,Jack Robison,506,330,131,45
+Comal,203,"District Judge, 207th Judicial District",,REP,Jack Robison,2348,1752,427,169
+Comal,204,"District Judge, 207th Judicial District",,REP,Jack Robison,1890,1412,339,139
+Comal,205,"District Judge, 207th Judicial District",,REP,Jack Robison,2949,2441,346,162
+Comal,206,"District Judge, 207th Judicial District",,REP,Jack Robison,2840,2163,484,193
+Comal,207,"District Judge, 207th Judicial District",,REP,Jack Robison,1180,846,245,89
+Comal,208,"District Judge, 207th Judicial District",,REP,Jack Robison,1088,753,240,95
+Comal,301,"District Judge, 207th Judicial District",,REP,Jack Robison,1065,653,350,62
+Comal,302,"District Judge, 207th Judicial District",,REP,Jack Robison,1937,1363,436,138
+Comal,303,"District Judge, 207th Judicial District",,REP,Jack Robison,267,167,77,23
+Comal,304,"District Judge, 207th Judicial District",,REP,Jack Robison,1437,961,380,96
+Comal,305,"District Judge, 207th Judicial District",,REP,Jack Robison,978,630,291,57
+Comal,306,"District Judge, 207th Judicial District",,REP,Jack Robison,598,393,159,46
+Comal,401,"District Judge, 207th Judicial District",,REP,Jack Robison,1017,646,242,129
+Comal,402,"District Judge, 207th Judicial District",,REP,Jack Robison,2272,1620,425,227
+Comal,403,"District Judge, 207th Judicial District",,REP,Jack Robison,2766,1906,648,212
+Comal,404,"District Judge, 207th Judicial District",,REP,Jack Robison,1855,1335,404,116
+Comal,405,"District Judge, 207th Judicial District",,REP,Jack Robison,1928,1251,513,164
+Comal,406,"District Judge, 207th Judicial District",,REP,Jack Robison,2429,1649,468,312
+Comal,407,"District Judge, 207th Judicial District",,REP,Jack Robison,1623,1128,394,101
+Comal,101,"District Judge, 274th Judicial District",,REP,Gary L. Steel,1872,1303,380,189
+Comal,102,"District Judge, 274th Judicial District",,REP,Gary L. Steel,2081,1622,308,151
+Comal,103,"District Judge, 274th Judicial District",,REP,Gary L. Steel,2017,1412,461,144
+Comal,104,"District Judge, 274th Judicial District",,REP,Gary L. Steel,1117,804,198,115
+Comal,105,"District Judge, 274th Judicial District",,REP,Gary L. Steel,2598,1799,595,204
+Comal,106,"District Judge, 274th Judicial District",,REP,Gary L. Steel,2696,2110,406,180
+Comal,107,"District Judge, 274th Judicial District",,REP,Gary L. Steel,1196,772,365,59
+Comal,201,"District Judge, 274th Judicial District",,REP,Gary L. Steel,1977,1242,589,146
+Comal,202,"District Judge, 274th Judicial District",,REP,Gary L. Steel,508,330,132,46
+Comal,203,"District Judge, 274th Judicial District",,REP,Gary L. Steel,2360,1758,430,172
+Comal,204,"District Judge, 274th Judicial District",,REP,Gary L. Steel,1887,1410,338,139
+Comal,205,"District Judge, 274th Judicial District",,REP,Gary L. Steel,2948,2440,343,165
+Comal,206,"District Judge, 274th Judicial District",,REP,Gary L. Steel,2843,2159,488,196
+Comal,207,"District Judge, 274th Judicial District",,REP,Gary L. Steel,1178,843,244,91
+Comal,208,"District Judge, 274th Judicial District",,REP,Gary L. Steel,1085,751,239,95
+Comal,301,"District Judge, 274th Judicial District",,REP,Gary L. Steel,1069,652,352,65
+Comal,302,"District Judge, 274th Judicial District",,REP,Gary L. Steel,1944,1364,442,138
+Comal,303,"District Judge, 274th Judicial District",,REP,Gary L. Steel,268,169,75,24
+Comal,304,"District Judge, 274th Judicial District",,REP,Gary L. Steel,1437,960,380,97
+Comal,305,"District Judge, 274th Judicial District",,REP,Gary L. Steel,977,628,291,58
+Comal,306,"District Judge, 274th Judicial District",,REP,Gary L. Steel,594,391,156,47
+Comal,401,"District Judge, 274th Judicial District",,REP,Gary L. Steel,1027,653,243,131
+Comal,402,"District Judge, 274th Judicial District",,REP,Gary L. Steel,2279,1630,422,227
+Comal,403,"District Judge, 274th Judicial District",,REP,Gary L. Steel,2760,1902,647,211
+Comal,404,"District Judge, 274th Judicial District",,REP,Gary L. Steel,1870,1345,405,120
+Comal,405,"District Judge, 274th Judicial District",,REP,Gary L. Steel,1928,1248,513,167
+Comal,406,"District Judge, 274th Judicial District",,REP,Gary L. Steel,2433,1649,467,317
+Comal,407,"District Judge, 274th Judicial District",,REP,Gary L. Steel,1633,1135,395,103
+Comal,101,Criminal District Attorney,,REP,Jennifer Anne Owens Tharp,1832,1278,370,184
+Comal,102,Criminal District Attorney,,REP,Jennifer Anne Owens Tharp,2086,1628,306,152
+Comal,103,Criminal District Attorney,,REP,Jennifer Anne Owens Tharp,1994,1397,451,146
+Comal,104,Criminal District Attorney,,REP,Jennifer Anne Owens Tharp,1116,805,199,112
+Comal,105,Criminal District Attorney,,REP,Jennifer Anne Owens Tharp,2603,1798,598,207
+Comal,106,Criminal District Attorney,,REP,Jennifer Anne Owens Tharp,2689,2111,401,177
+Comal,107,Criminal District Attorney,,REP,Jennifer Anne Owens Tharp,1196,774,362,60
+Comal,201,Criminal District Attorney,,REP,Jennifer Anne Owens Tharp,1934,1214,586,134
+Comal,202,Criminal District Attorney,,REP,Jennifer Anne Owens Tharp,507,330,132,45
+Comal,203,Criminal District Attorney,,REP,Jennifer Anne Owens Tharp,2330,1742,420,168
+Comal,204,Criminal District Attorney,,REP,Jennifer Anne Owens Tharp,1869,1397,335,137
+Comal,205,Criminal District Attorney,,REP,Jennifer Anne Owens Tharp,2937,2433,344,160
+Comal,206,Criminal District Attorney,,REP,Jennifer Anne Owens Tharp,2831,2152,487,192
+Comal,207,Criminal District Attorney,,REP,Jennifer Anne Owens Tharp,1170,841,241,88
+Comal,208,Criminal District Attorney,,REP,Jennifer Anne Owens Tharp,1087,752,239,96
+Comal,301,Criminal District Attorney,,REP,Jennifer Anne Owens Tharp,1029,632,337,60
+Comal,302,Criminal District Attorney,,REP,Jennifer Anne Owens Tharp,1921,1356,433,132
+Comal,303,Criminal District Attorney,,REP,Jennifer Anne Owens Tharp,264,167,74,23
+Comal,304,Criminal District Attorney,,REP,Jennifer Anne Owens Tharp,1412,944,375,93
+Comal,305,Criminal District Attorney,,REP,Jennifer Anne Owens Tharp,959,612,291,56
+Comal,306,Criminal District Attorney,,REP,Jennifer Anne Owens Tharp,586,387,155,44
+Comal,401,Criminal District Attorney,,REP,Jennifer Anne Owens Tharp,1011,646,237,128
+Comal,402,Criminal District Attorney,,REP,Jennifer Anne Owens Tharp,2266,1623,418,225
+Comal,403,Criminal District Attorney,,REP,Jennifer Anne Owens Tharp,2753,1896,645,212
+Comal,404,Criminal District Attorney,,REP,Jennifer Anne Owens Tharp,1838,1322,406,110
+Comal,405,Criminal District Attorney,,REP,Jennifer Anne Owens Tharp,1911,1236,510,165
+Comal,406,Criminal District Attorney,,REP,Jennifer Anne Owens Tharp,2397,1629,463,305
+Comal,407,Criminal District Attorney,,REP,Jennifer Anne Owens Tharp,1620,1128,394,98
+Comal,101,County Judge,,REP,Sherman Krause,1872,1307,380,185
+Comal,102,County Judge,,REP,Sherman Krause,2079,1624,306,149
+Comal,103,County Judge,,REP,Sherman Krause,2022,1415,461,146
+Comal,104,County Judge,,REP,Sherman Krause,1117,809,199,109
+Comal,105,County Judge,,REP,Sherman Krause,2609,1804,600,205
+Comal,106,County Judge,,REP,Sherman Krause,2690,2110,402,178
+Comal,107,County Judge,,REP,Sherman Krause,1192,766,367,59
+Comal,201,County Judge,,REP,Sherman Krause,1972,1249,588,135
+Comal,202,County Judge,,REP,Sherman Krause,509,331,133,45
+Comal,203,County Judge,,REP,Sherman Krause,2344,1750,426,168
+Comal,204,County Judge,,REP,Sherman Krause,1891,1414,339,138
+Comal,205,County Judge,,REP,Sherman Krause,2959,2446,351,162
+Comal,206,County Judge,,REP,Sherman Krause,2832,2157,485,190
+Comal,207,County Judge,,REP,Sherman Krause,1179,846,245,88
+Comal,208,County Judge,,REP,Sherman Krause,1087,752,239,96
+Comal,301,County Judge,,REP,Sherman Krause,1061,650,350,61
+Comal,302,County Judge,,REP,Sherman Krause,1956,1380,440,136
+Comal,303,County Judge,,REP,Sherman Krause,271,171,76,24
+Comal,304,County Judge,,REP,Sherman Krause,1435,955,383,97
+Comal,305,County Judge,,REP,Sherman Krause,974,625,293,56
+Comal,306,County Judge,,REP,Sherman Krause,590,392,154,44
+Comal,401,County Judge,,REP,Sherman Krause,1040,663,247,130
+Comal,402,County Judge,,REP,Sherman Krause,2290,1639,425,226
+Comal,403,County Judge,,REP,Sherman Krause,2759,1900,646,213
+Comal,404,County Judge,,REP,Sherman Krause,1876,1355,405,116
+Comal,405,County Judge,,REP,Sherman Krause,1921,1245,511,165
+Comal,406,County Judge,,REP,Sherman Krause,2444,1668,470,306
+Comal,407,County Judge,,REP,Sherman Krause,1628,1133,393,102
+Comal,101,"Judge, County Court-at-Law No. 1",,REP,Randy Gray,1857,1300,375,182
+Comal,102,"Judge, County Court-at-Law No. 1",,REP,Randy Gray,2077,1619,308,150
+Comal,103,"Judge, County Court-at-Law No. 1",,REP,Randy Gray,2014,1410,461,143
+Comal,104,"Judge, County Court-at-Law No. 1",,REP,Randy Gray,1113,805,199,109
+Comal,105,"Judge, County Court-at-Law No. 1",,REP,Randy Gray,2605,1803,598,204
+Comal,106,"Judge, County Court-at-Law No. 1",,REP,Randy Gray,2690,2109,405,176
+Comal,107,"Judge, County Court-at-Law No. 1",,REP,Randy Gray,1190,768,365,57
+Comal,201,"Judge, County Court-at-Law No. 1",,REP,Randy Gray,1968,1248,587,133
+Comal,202,"Judge, County Court-at-Law No. 1",,REP,Randy Gray,506,331,130,45
+Comal,203,"Judge, County Court-at-Law No. 1",,REP,Randy Gray,2351,1755,427,169
+Comal,204,"Judge, County Court-at-Law No. 1",,REP,Randy Gray,1882,1406,338,138
+Comal,205,"Judge, County Court-at-Law No. 1",,REP,Randy Gray,2951,2439,348,164
+Comal,206,"Judge, County Court-at-Law No. 1",,REP,Randy Gray,2823,2151,481,191
+Comal,207,"Judge, County Court-at-Law No. 1",,REP,Randy Gray,1176,843,244,89
+Comal,208,"Judge, County Court-at-Law No. 1",,REP,Randy Gray,1087,753,239,95
+Comal,301,"Judge, County Court-at-Law No. 1",,REP,Randy Gray,1055,649,345,61
+Comal,302,"Judge, County Court-at-Law No. 1",,REP,Randy Gray,1933,1365,436,132
+Comal,303,"Judge, County Court-at-Law No. 1",,REP,Randy Gray,271,173,74,24
+Comal,304,"Judge, County Court-at-Law No. 1",,REP,Randy Gray,1420,949,376,95
+Comal,305,"Judge, County Court-at-Law No. 1",,REP,Randy Gray,970,626,289,55
+Comal,306,"Judge, County Court-at-Law No. 1",,REP,Randy Gray,593,389,160,44
+Comal,401,"Judge, County Court-at-Law No. 1",,REP,Randy Gray,1033,661,247,125
+Comal,402,"Judge, County Court-at-Law No. 1",,REP,Randy Gray,2272,1625,423,224
+Comal,403,"Judge, County Court-at-Law No. 1",,REP,Randy Gray,2756,1899,647,210
+Comal,404,"Judge, County Court-at-Law No. 1",,REP,Randy Gray,1860,1343,401,116
+Comal,405,"Judge, County Court-at-Law No. 1",,REP,Randy Gray,1915,1241,510,164
+Comal,406,"Judge, County Court-at-Law No. 1",,REP,Randy Gray,2416,1646,467,303
+Comal,407,"Judge, County Court-at-Law No. 1",,REP,Randy Gray,1614,1123,393,98
+Comal,101,District Clerk,,REP,Heather N. Kellar,1845,1288,375,182
+Comal,102,District Clerk,,REP,Heather N. Kellar,2081,1622,307,152
+Comal,103,District Clerk,,REP,Heather N. Kellar,2004,1405,457,142
+Comal,104,District Clerk,,REP,Heather N. Kellar,1108,803,196,109
+Comal,105,District Clerk,,REP,Heather N. Kellar,2605,1802,600,203
+Comal,106,District Clerk,,REP,Heather N. Kellar,2699,2115,407,177
+Comal,107,District Clerk,,REP,Heather N. Kellar,1190,768,366,56
+Comal,201,District Clerk,,REP,Heather N. Kellar,1949,1237,580,132
+Comal,202,District Clerk,,REP,Heather N. Kellar,505,330,130,45
+Comal,203,District Clerk,,REP,Heather N. Kellar,2334,1740,428,166
+Comal,204,District Clerk,,REP,Heather N. Kellar,1886,1410,338,138
+Comal,205,District Clerk,,REP,Heather N. Kellar,2944,2433,347,164
+Comal,206,District Clerk,,REP,Heather N. Kellar,2831,2155,486,190
+Comal,207,District Clerk,,REP,Heather N. Kellar,1169,839,243,87
+Comal,208,District Clerk,,REP,Heather N. Kellar,1085,753,237,95
+Comal,301,District Clerk,,REP,Heather N. Kellar,1052,645,345,62
+Comal,302,District Clerk,,REP,Heather N. Kellar,1920,1351,436,133
+Comal,303,District Clerk,,REP,Heather N. Kellar,266,169,73,24
+Comal,304,District Clerk,,REP,Heather N. Kellar,1417,948,376,93
+Comal,305,District Clerk,,REP,Heather N. Kellar,968,623,289,56
+Comal,306,District Clerk,,REP,Heather N. Kellar,590,389,158,43
+Comal,401,District Clerk,,REP,Heather N. Kellar,1012,646,242,124
+Comal,402,District Clerk,,REP,Heather N. Kellar,2267,1624,420,223
+Comal,403,District Clerk,,REP,Heather N. Kellar,2761,1901,646,214
+Comal,404,District Clerk,,REP,Heather N. Kellar,1853,1337,401,115
+Comal,405,District Clerk,,REP,Heather N. Kellar,1915,1237,513,165
+Comal,406,District Clerk,,REP,Heather N. Kellar,2424,1647,470,307
+Comal,407,District Clerk,,REP,Heather N. Kellar,1616,1122,394,100
+Comal,101,County Clerk,,REP,Bobbie Koepp,1718,1213,340,165
+Comal,102,County Clerk,,REP,Bobbie Koepp,1985,1555,284,146
+Comal,103,County Clerk,,REP,Bobbie Koepp,1924,1363,431,130
+Comal,104,County Clerk,,REP,Bobbie Koepp,1069,773,195,101
+Comal,105,County Clerk,,REP,Bobbie Koepp,2480,1723,560,197
+Comal,106,County Clerk,,REP,Bobbie Koepp,2601,2046,381,174
+Comal,107,County Clerk,,REP,Bobbie Koepp,1126,724,346,56
+Comal,201,County Clerk,,REP,Bobbie Koepp,1787,1152,513,122
+Comal,202,County Clerk,,REP,Bobbie Koepp,468,312,114,42
+Comal,203,County Clerk,,REP,Bobbie Koepp,2233,1673,397,163
+Comal,204,County Clerk,,REP,Bobbie Koepp,1787,1337,319,131
+Comal,205,County Clerk,,REP,Bobbie Koepp,2750,2274,317,159
+Comal,206,County Clerk,,REP,Bobbie Koepp,2682,2055,440,187
+Comal,207,County Clerk,,REP,Bobbie Koepp,1118,809,222,87
+Comal,208,County Clerk,,REP,Bobbie Koepp,1041,729,224,88
+Comal,301,County Clerk,,REP,Bobbie Koepp,886,547,288,51
+Comal,302,County Clerk,,REP,Bobbie Koepp,1760,1265,374,121
+Comal,303,County Clerk,,REP,Bobbie Koepp,227,147,61,19
+Comal,304,County Clerk,,REP,Bobbie Koepp,1247,843,318,86
+Comal,305,County Clerk,,REP,Bobbie Koepp,866,574,244,48
+Comal,306,County Clerk,,REP,Bobbie Koepp,518,344,134,40
+Comal,401,County Clerk,,REP,Bobbie Koepp,973,620,228,125
+Comal,402,County Clerk,,REP,Bobbie Koepp,2171,1561,395,215
+Comal,403,County Clerk,,REP,Bobbie Koepp,2660,1834,616,210
+Comal,404,County Clerk,,REP,Bobbie Koepp,1780,1291,380,109
+Comal,405,County Clerk,,REP,Bobbie Koepp,1836,1196,488,152
+Comal,406,County Clerk,,REP,Bobbie Koepp,2271,1551,432,288
+Comal,407,County Clerk,,REP,Bobbie Koepp,1552,1084,372,96
+Comal,101,County Clerk,,DEM,Gloria Meehan,706,470,162,74
+Comal,102,County Clerk,,DEM,Gloria Meehan,435,322,66,47
+Comal,103,County Clerk,,DEM,Gloria Meehan,436,308,88,40
+Comal,104,County Clerk,,DEM,Gloria Meehan,292,204,39,49
+Comal,105,County Clerk,,DEM,Gloria Meehan,695,466,151,78
+Comal,106,County Clerk,,DEM,Gloria Meehan,544,409,69,66
+Comal,107,County Clerk,,DEM,Gloria Meehan,305,207,73,25
+Comal,201,County Clerk,,DEM,Gloria Meehan,805,519,221,65
+Comal,202,County Clerk,,DEM,Gloria Meehan,188,118,50,20
+Comal,203,County Clerk,,DEM,Gloria Meehan,593,456,86,51
+Comal,204,County Clerk,,DEM,Gloria Meehan,480,358,75,47
+Comal,205,County Clerk,,DEM,Gloria Meehan,886,702,116,68
+Comal,206,County Clerk,,DEM,Gloria Meehan,666,474,128,64
+Comal,207,County Clerk,,DEM,Gloria Meehan,254,173,60,21
+Comal,208,County Clerk,,DEM,Gloria Meehan,257,152,60,45
+Comal,301,County Clerk,,DEM,Gloria Meehan,894,504,310,80
+Comal,302,County Clerk,,DEM,Gloria Meehan,949,649,207,93
+Comal,303,County Clerk,,DEM,Gloria Meehan,250,134,95,21
+Comal,304,County Clerk,,DEM,Gloria Meehan,779,525,209,45
+Comal,305,County Clerk,,DEM,Gloria Meehan,395,239,122,34
+Comal,306,County Clerk,,DEM,Gloria Meehan,297,200,85,12
+Comal,401,County Clerk,,DEM,Gloria Meehan,371,220,91,60
+Comal,402,County Clerk,,DEM,Gloria Meehan,711,520,109,82
+Comal,403,County Clerk,,DEM,Gloria Meehan,690,477,144,69
+Comal,404,County Clerk,,DEM,Gloria Meehan,472,309,121,42
+Comal,405,County Clerk,,DEM,Gloria Meehan,485,325,99,61
+Comal,406,County Clerk,,DEM,Gloria Meehan,840,571,140,129
+Comal,407,County Clerk,,DEM,Gloria Meehan,384,263,81,40
+Comal,101,County Treasurer,,REP,Renee L. Couch,1856,1299,374,183
+Comal,102,County Treasurer,,REP,Renee L. Couch,2081,1625,306,150
+Comal,103,County Treasurer,,REP,Renee L. Couch,2012,1410,459,143
+Comal,104,County Treasurer,,REP,Renee L. Couch,1113,804,197,112
+Comal,105,County Treasurer,,REP,Renee L. Couch,2611,1808,599,204
+Comal,106,County Treasurer,,REP,Renee L. Couch,2707,2122,407,178
+Comal,107,County Treasurer,,REP,Renee L. Couch,1189,767,366,56
+Comal,201,County Treasurer,,REP,Renee L. Couch,1962,1243,586,133
+Comal,202,County Treasurer,,REP,Renee L. Couch,510,332,133,45
+Comal,203,County Treasurer,,REP,Renee L. Couch,2341,1749,424,168
+Comal,204,County Treasurer,,REP,Renee L. Couch,1887,1412,338,137
+Comal,205,County Treasurer,,REP,Renee L. Couch,2950,2435,351,164
+Comal,206,County Treasurer,,REP,Renee L. Couch,2825,2150,485,190
+Comal,207,County Treasurer,,REP,Renee L. Couch,1176,844,245,87
+Comal,208,County Treasurer,,REP,Renee L. Couch,1090,757,238,95
+Comal,301,County Treasurer,,REP,Renee L. Couch,1057,649,346,62
+Comal,302,County Treasurer,,REP,Renee L. Couch,1940,1363,443,134
+Comal,303,County Treasurer,,REP,Renee L. Couch,269,172,73,24
+Comal,304,County Treasurer,,REP,Renee L. Couch,1424,951,380,93
+Comal,305,County Treasurer,,REP,Renee L. Couch,966,621,288,57
+Comal,306,County Treasurer,,REP,Renee L. Couch,597,395,158,44
+Comal,401,County Treasurer,,REP,Renee L. Couch,1021,652,243,126
+Comal,402,County Treasurer,,REP,Renee L. Couch,2279,1629,425,225
+Comal,403,County Treasurer,,REP,Renee L. Couch,2754,1900,643,211
+Comal,404,County Treasurer,,REP,Renee L. Couch,1853,1338,400,115
+Comal,405,County Treasurer,,REP,Renee L. Couch,1912,1240,510,162
+Comal,406,County Treasurer,,REP,Renee L. Couch,2423,1649,468,306
+Comal,407,County Treasurer,,REP,Renee L. Couch,1612,1121,393,98
+Comal,201,"County Commissioner, Precinct 2",,REP,Scott Haag,1966,1252,584,130
+Comal,202,"County Commissioner, Precinct 2",,REP,Scott Haag,505,329,129,47
+Comal,203,"County Commissioner, Precinct 2",,REP,Scott Haag,2282,1701,416,165
+Comal,204,"County Commissioner, Precinct 2",,REP,Scott Haag,1874,1406,334,134
+Comal,205,"County Commissioner, Precinct 2",,REP,Scott Haag,2839,2369,309,161
+Comal,206,"County Commissioner, Precinct 2",,REP,Scott Haag,2707,2055,477,175
+Comal,207,"County Commissioner, Precinct 2",,REP,Scott Haag,1104,788,232,84
+Comal,208,"County Commissioner, Precinct 2",,REP,Scott Haag,1085,750,239,96
+Comal,201,"County Commissioner, Precinct 2",,,Michael James Zimmerman,34,19,3,12
+Comal,202,"County Commissioner, Precinct 2",,,Michael James Zimmerman,10,7,2,1
+Comal,203,"County Commissioner, Precinct 2",,,Michael James Zimmerman,103,82,12,9
+Comal,204,"County Commissioner, Precinct 2",,,Michael James Zimmerman,35,21,4,10
+Comal,205,"County Commissioner, Precinct 2",,,Michael James Zimmerman,171,113,49,9
+Comal,206,"County Commissioner, Precinct 2",,,Michael James Zimmerman,173,129,15,29
+Comal,207,"County Commissioner, Precinct 2",,,Michael James Zimmerman,117,89,20,8
+Comal,208,"County Commissioner, Precinct 2",,,Michael James Zimmerman,16,10,0,6
+Comal,401,"County Commissioner, Precinct 4",,REP,Jen Crownover,975,622,230,123
+Comal,402,"County Commissioner, Precinct 4",,REP,Jen Crownover,2243,1617,399,227
+Comal,403,"County Commissioner, Precinct 4",,REP,Jen Crownover,2743,1891,636,216
+Comal,404,"County Commissioner, Precinct 4",,REP,Jen Crownover,1793,1301,381,111
+Comal,405,"County Commissioner, Precinct 4",,REP,Jen Crownover,1880,1229,498,153
+Comal,406,"County Commissioner, Precinct 4",,REP,Jen Crownover,2298,1570,433,295
+Comal,407,"County Commissioner, Precinct 4",,REP,Jen Crownover,1591,1106,386,99
+Comal,401,"County Commissioner, Precinct 4",,DEM,Dorothy Carroll,371,217,93,61
+Comal,402,"County Commissioner, Precinct 4",,DEM,Dorothy Carroll,658,478,107,73
+Comal,403,"County Commissioner, Precinct 4",,DEM,Dorothy Carroll,633,441,131,61
+Comal,404,"County Commissioner, Precinct 4",,DEM,Dorothy Carroll,465,305,119,41
+Comal,405,"County Commissioner, Precinct 4",,DEM,Dorothy Carroll,452,303,90,59
+Comal,406,"County Commissioner, Precinct 4",,DEM,Dorothy Carroll,809,548,140,121
+Comal,407,"County Commissioner, Precinct 4",,DEM,Dorothy Carroll,368,255,77,36
+Comal,101,"Justice of the Peace, Precinct 1",,REP,Tom Clark,1855,1296,376,183
+Comal,102,"Justice of the Peace, Precinct 1",,REP,Tom Clark,2087,1629,308,150
+Comal,103,"Justice of the Peace, Precinct 1",,REP,Tom Clark,2020,1413,464,143
+Comal,104,"Justice of the Peace, Precinct 1",,REP,Tom Clark,1118,809,199,110
+Comal,105,"Justice of the Peace, Precinct 1",,REP,Tom Clark,2618,1815,596,207
+Comal,106,"Justice of the Peace, Precinct 1",,REP,Tom Clark,2700,2117,407,176
+Comal,107,"Justice of the Peace, Precinct 1",,REP,Tom Clark,1193,770,366,57
+Comal,201,"Justice of the Peace, Precinct 2",,REP,James Walker,1963,1245,586,132
+Comal,202,"Justice of the Peace, Precinct 2",,REP,James Walker,507,332,130,45
+Comal,203,"Justice of the Peace, Precinct 2",,REP,James Walker,2333,1745,423,165
+Comal,204,"Justice of the Peace, Precinct 2",,REP,James Walker,1893,1416,339,138
+Comal,205,"Justice of the Peace, Precinct 2",,REP,James Walker,2952,2440,349,163
+Comal,206,"Justice of the Peace, Precinct 2",,REP,James Walker,2851,2174,485,192
+Comal,207,"Justice of the Peace, Precinct 2",,REP,James Walker,1175,843,244,88
+Comal,208,"Justice of the Peace, Precinct 2",,REP,James Walker,1092,757,240,95
+Comal,301,"Justice of the Peace, Precinct 3",,REP,Mike Rust,1069,658,348,63
+Comal,302,"Justice of the Peace, Precinct 3",,REP,Mike Rust,1959,1378,447,134
+Comal,303,"Justice of the Peace, Precinct 3",,REP,Mike Rust,277,179,73,25
+Comal,304,"Justice of the Peace, Precinct 3",,REP,Mike Rust,1435,956,384,95
+Comal,305,"Justice of the Peace, Precinct 3",,REP,Mike Rust,971,625,289,57
+Comal,306,"Justice of the Peace, Precinct 3",,REP,Mike Rust,594,390,161,43
+Comal,401,"Justice of the Peace, Precinct 4",,REP,Jennifer Saunders,1022,651,246,125
+Comal,402,"Justice of the Peace, Precinct 4",,REP,Jennifer Saunders,2330,1671,432,227
+Comal,403,"Justice of the Peace, Precinct 4",,REP,Jennifer Saunders,2800,1933,654,213
+Comal,404,"Justice of the Peace, Precinct 4",,REP,Jennifer Saunders,1869,1348,406,115
+Comal,405,"Justice of the Peace, Precinct 4",,REP,Jennifer Saunders,1935,1258,513,164
+Comal,406,"Justice of the Peace, Precinct 4",,REP,Jennifer Saunders,2438,1657,474,307
+Comal,407,"Justice of the Peace, Precinct 4",,REP,Jennifer Saunders,1631,1131,399,101


### PR DESCRIPTION
Clarity again had no information on over and undervotes.
Precincts 104, 107, 205, 206, and 402 are missing information on registered voters.