### PR TITLE
2018 Young primary - Many records have a \r that should really be a space.

### DIFF
--- a/2018/20180306__tx__primary__young__precinct.csv
+++ b/2018/20180306__tx__primary__young__precinct.csv
@@ -43,13 +43,13 @@ Young,5,County Judge,,REP,Paul M. Hemphill,97,19,126,242
 Young,5,District Clerk,,REP,Jamie Freeze Land,248,88,311,647
 Young,5,County Clerk,,REP,Kay Jennings Hardin,250,88,318,656
 Young,5,County Treasurer,,REP,Ann B. Daily,246,86,312,644
-Young,5,"County Commissioner,Precinct No. 2",,REP,Matt Pruitt,119,52,195,366
-Young,5,"County Commissioner,Precinct No. 2",,REP,Larry Pratt,97,28,111,236
-Young,5,"County Commissioner,Precinct No. 2",,REP,Les Remington,63,14,45,122
-Young,5,"Justice of the Peace,Precinct No. 1",,REP,Jason Hearne,93,25,167,285
-Young,5,"Justice of the Peace,Precinct No. 1",,REP,Randy Saylor,72,21,78,171
-Young,5,"Justice of the Peace,Precinct No. 1",,REP,Norman B. Carpenter,54,19,60,133
-Young,5,"Justice of the Peace,Precinct No. 1",,REP,Jabe Underwood,60,17,49,126
+Young,5,"County Commissioner, Precinct No. 2",,REP,Matt Pruitt,119,52,195,366
+Young,5,"County Commissioner, Precinct No. 2",,REP,Larry Pratt,97,28,111,236
+Young,5,"County Commissioner, Precinct No. 2",,REP,Les Remington,63,14,45,122
+Young,5,"Justice of the Peace, Precinct No. 1",,REP,Jason Hearne,93,25,167,285
+Young,5,"Justice of the Peace, Precinct No. 1",,REP,Randy Saylor,72,21,78,171
+Young,5,"Justice of the Peace, Precinct No. 1",,REP,Norman B. Carpenter,54,19,60,133
+Young,5,"Justice of the Peace, Precinct No. 1",,REP,Jabe Underwood,60,17,49,126
 Young,5,County Chairman,,REP,Kyle Zohn Milam,245,84,326,655
 Young,5,U.S. Senate,,DEM,Edward Kimbrough,6,4,3,13
 Young,5,U.S. Senate,,DEM,Beto O'Rourke,7,4,11,22
@@ -172,13 +172,13 @@ Young,6,County Judge,,REP,Paul M. Hemphill,12,3,13,28
 Young,6,District Clerk,,REP,Jamie Freeze Land,29,8,23,60
 Young,6,County Clerk,,REP,Kay Jennings Hardin,29,8,22,59
 Young,6,County Treasurer,,REP,Ann B. Daily,29,8,23,60
-Young,6,"County Commissioner,Precinct No. 2",,REP,Matt Pruitt,13,1,8,22
-Young,6,"County Commissioner,Precinct No. 2",,REP,Larry Pratt,16,5,14,35
-Young,6,"County Commissioner,Precinct No. 2",,REP,Les Remington,7,2,5,14
-Young,6,"Justice of the Peace,Precinct No. 1",,REP,Jason Hearne,10,1,7,18
-Young,6,"Justice of the Peace,Precinct No. 1",,REP,Randy Saylor,10,1,5,16
-Young,6,"Justice of the Peace,Precinct No. 1",,REP,Norman B. Carpenter,5,3,11,19
-Young,6,"Justice of the Peace,Precinct No. 1",,REP,Jabe Underwood,11,3,3,17
+Young,6,"County Commissioner, Precinct No. 2",,REP,Matt Pruitt,13,1,8,22
+Young,6,"County Commissioner, Precinct No. 2",,REP,Larry Pratt,16,5,14,35
+Young,6,"County Commissioner, Precinct No. 2",,REP,Les Remington,7,2,5,14
+Young,6,"Justice of the Peace, Precinct No. 1",,REP,Jason Hearne,10,1,7,18
+Young,6,"Justice of the Peace, Precinct No. 1",,REP,Randy Saylor,10,1,5,16
+Young,6,"Justice of the Peace, Precinct No. 1",,REP,Norman B. Carpenter,5,3,11,19
+Young,6,"Justice of the Peace, Precinct No. 1",,REP,Jabe Underwood,11,3,3,17
 Young,6,County Chairman,,REP,Kyle Zohn Milam,31,8,22,61
 Young,6,U.S. Senate,,DEM,Edward Kimbrough,0,1,0,1
 Young,6,U.S. Senate,,DEM,Beto O'Rourke,0,0,0,0
@@ -301,13 +301,13 @@ Young,7,County Judge,,REP,Paul M. Hemphill,6,2,7,15
 Young,7,District Clerk,,REP,Jamie Freeze Land,26,3,17,46
 Young,7,County Clerk,,REP,Kay Jennings Hardin,27,2,16,45
 Young,7,County Treasurer,,REP,Ann B. Daily,26,3,17,46
-Young,7,"County Commissioner,Precinct No. 2",,REP,Matt Pruitt,16,1,13,30
-Young,7,"County Commissioner,Precinct No. 2",,REP,Larry Pratt,15,2,8,25
-Young,7,"County Commissioner,Precinct No. 2",,REP,Les Remington,2,1,1,4
-Young,7,"Justice of the Peace,Precinct No. 3",,REP,Stan G. Mahler,13,2,7,22
-Young,7,"Justice of the Peace,Precinct No. 3",,REP,Becky Perez,17,3,15,35
-Young,7,"Constable, Precinct No. 3Unexpired Term",,REP,Cliff Blackstock,18,2,16,36
-Young,7,"Constable, Precinct No. 3Unexpired Term",,REP,Larry Thacker,14,2,3,19
+Young,7,"County Commissioner, Precinct No. 2",,REP,Matt Pruitt,16,1,13,30
+Young,7,"County Commissioner, Precinct No. 2",,REP,Larry Pratt,15,2,8,25
+Young,7,"County Commissioner, Precinct No. 2",,REP,Les Remington,2,1,1,4
+Young,7,"Justice of the Peace, Precinct No. 3",,REP,Stan G. Mahler,13,2,7,22
+Young,7,"Justice of the Peace, Precinct No. 3",,REP,Becky Perez,17,3,15,35
+Young,7,"Constable, Precinct No. 3 Unexpired Term",,REP,Cliff Blackstock,18,2,16,36
+Young,7,"Constable, Precinct No. 3 Unexpired Term",,REP,Larry Thacker,14,2,3,19
 Young,7,County Chairman,,REP,Kyle Zohn Milam,24,2,18,44
 Young,7,U.S. Senate,,DEM,Edward Kimbrough,1,0,0,1
 Young,7,U.S. Senate,,DEM,Beto O'Rourke,1,0,2,3
@@ -430,10 +430,10 @@ Young,10,County Judge,,REP,Paul M. Hemphill,20,3,4,27
 Young,10,District Clerk,,REP,Jamie Freeze Land,62,13,10,85
 Young,10,County Clerk,,REP,Kay Jennings Hardin,62,13,10,85
 Young,10,County Treasurer,,REP,Ann B. Daily,63,13,10,86
-Young,10,"Justice of the Peace,Precinct No. 3",,REP,Stan G. Mahler,31,7,4,42
-Young,10,"Justice of the Peace,Precinct No. 3",,REP,Becky Perez,49,12,9,70
-Young,10,"Constable, Precinct No. 3Unexpired Term",,REP,Cliff Blackstock,44,10,6,60
-Young,10,"Constable, Precinct No. 3Unexpired Term",,REP,Larry Thacker,24,8,5,37
+Young,10,"Justice of the Peace, Precinct No. 3",,REP,Stan G. Mahler,31,7,4,42
+Young,10,"Justice of the Peace, Precinct No. 3",,REP,Becky Perez,49,12,9,70
+Young,10,"Constable, Precinct No. 3 Unexpired Term",,REP,Cliff Blackstock,44,10,6,60
+Young,10,"Constable, Precinct No. 3 Unexpired Term",,REP,Larry Thacker,24,8,5,37
 Young,10,County Chairman,,REP,Kyle Zohn Milam,59,12,10,81
 Young,10,U.S. Senate,,REP,Edward Kimbrough,2,0,0,2
 Young,10,U.S. Senate,,REP,Beto O'Rourke,2,0,0,2
@@ -556,11 +556,11 @@ Young,16,County Judge,,REP,Paul M. Hemphill,22,0,4,26
 Young,16,District Clerk,,REP,Jamie Freeze Land,50,3,10,63
 Young,16,County Clerk,,REP,Kay Jennings Hardin,54,3,12,69
 Young,16,County Treasurer,,REP,Ann B. Daily,55,3,10,68
-Young,16,"County Commissioner,Precinct No. 4",,REP,Jimmy Ray Wiley,56,3,14,73
-Young,16,"Justice of the Peace,Precinct No. 3",,REP,Stan G. Mahler,42,3,12,57
-Young,16,"Justice of the Peace,Precinct No. 3",,REP,Becky Perez,15,0,2,17
-Young,16,"Constable, Precinct No. 3Unexpired Term",,REP,Cliff Blackstock,34,2,11,47
-Young,16,"Constable, Precinct No. 3Unexpired Term",,REP,Larry Thacker,20,1,2,23
+Young,16,"County Commissioner, Precinct No. 4",,REP,Jimmy Ray Wiley,56,3,14,73
+Young,16,"Justice of the Peace, Precinct No. 3",,REP,Stan G. Mahler,42,3,12,57
+Young,16,"Justice of the Peace, Precinct No. 3",,REP,Becky Perez,15,0,2,17
+Young,16,"Constable, Precinct No. 3 Unexpired Term",,REP,Cliff Blackstock,34,2,11,47
+Young,16,"Constable, Precinct No. 3 Unexpired Term",,REP,Larry Thacker,20,1,2,23
 Young,16,County Chairman,,REP,Kyle Zohn Milam,55,2,12,69
 Young,16,U.S. Senate,,DEM,Edward Kimbrough,0,0,0,0
 Young,16,U.S. Senate,,DEM,Beto O'Rourke,0,0,0,0
@@ -683,11 +683,11 @@ Young,20,County Judge,,REP,Paul M. Hemphill,9,0,5,14
 Young,20,District Clerk,,REP,Jamie Freeze Land,13,2,14,29
 Young,20,County Clerk,,REP,Kay Jennings Hardin,14,2,14,30
 Young,20,County Treasurer,,REP,Ann B. Daily,13,2,14,29
-Young,20,"County Commissioner,Precinct No. 4",,REP,Jimmy Ray Wiley,12,2,17,31
-Young,20,"Justice of the Peace,Precinct No. 3",,REP,Stan G. Mahler,13,0,11,24
-Young,20,"Justice of the Peace,Precinct No. 3",,REP,Becky Perez,2,3,8,13
-Young,20,"Constable, Precinct No. 3Unexpired Term",,REP,Cliff Blackstock,6,2,8,16
-Young,20,"Constable, Precinct No. 3Unexpired Term",,REP,Larry Thacker,6,1,6,13
+Young,20,"County Commissioner, Precinct No. 4",,REP,Jimmy Ray Wiley,12,2,17,31
+Young,20,"Justice of the Peace, Precinct No. 3",,REP,Stan G. Mahler,13,0,11,24
+Young,20,"Justice of the Peace, Precinct No. 3",,REP,Becky Perez,2,3,8,13
+Young,20,"Constable, Precinct No. 3 Unexpired Term",,REP,Cliff Blackstock,6,2,8,16
+Young,20,"Constable, Precinct No. 3 Unexpired Term",,REP,Larry Thacker,6,1,6,13
 Young,20,County Chairman,,REP,Kyle Zohn Milam,13,2,15,30
 Young,20,U.S. Senate,,DEM,Edward Kimbrough,0,2,0,2
 Young,20,U.S. Senate,,DEM,Beto O'Rourke,2,1,0,3
@@ -810,10 +810,10 @@ Young,22,County Judge,,REP,Paul M. Hemphill,114,39,125,278
 Young,22,District Clerk,,REP,Jamie Freeze Land,296,112,304,712
 Young,22,County Clerk,,REP,Kay Jennings Hardin,291,114,308,713
 Young,22,County Treasurer,,REP,Ann B. Daily,292,115,310,717
-Young,22,"Justice of the Peace,Precinct No. 1",,REP,Jason Hearne,116,36,150,302
-Young,22,"Justice of the Peace,Precinct No. 1",,REP,Randy Saylor,94,32,77,203
-Young,22,"Justice of the Peace,Precinct No. 1",,REP,Norman B. Carpenter,66,37,82,185
-Young,22,"Justice of the Peace,Precinct No. 1",,REP,Jabe Underwood,62,24,60,146
+Young,22,"Justice of the Peace, Precinct No. 1",,REP,Jason Hearne,116,36,150,302
+Young,22,"Justice of the Peace, Precinct No. 1",,REP,Randy Saylor,94,32,77,203
+Young,22,"Justice of the Peace, Precinct No. 1",,REP,Norman B. Carpenter,66,37,82,185
+Young,22,"Justice of the Peace, Precinct No. 1",,REP,Jabe Underwood,62,24,60,146
 Young,22,County Chairman,,REP,Kyle Zohn Milam,297,113,315,725
 Young,22,U.S. Senate,,DEM,Edward Kimbrough,2,7,2,11
 Young,22,U.S. Senate,,DEM,Beto O'Rourke,6,6,12,24
@@ -936,10 +936,10 @@ Young,23,County Judge,,REP,Paul M. Hemphill,47,13,67,127
 Young,23,District Clerk,,REP,Jamie Freeze Land,188,49,201,438
 Young,23,County Clerk,,REP,Kay Jennings Hardin,191,49,208,448
 Young,23,County Treasurer,,REP,Ann B. Daily,191,52,202,445
-Young,23,"Justice of the Peace,Precinct No. 3",,REP,Stan G. Mahler,149,47,174,370
-Young,23,"Justice of the Peace,Precinct No. 3",,REP,Becky Perez,81,20,76,177
-Young,23,"Constable, Precinct No. 3Unexpired Term",,REP,Cliff Blackstock,141,38,154,333
-Young,23,"Constable, Precinct No. 3Unexpired Term",,REP,Larry Thacker,79,22,80,181
+Young,23,"Justice of the Peace, Precinct No. 3",,REP,Stan G. Mahler,149,47,174,370
+Young,23,"Justice of the Peace, Precinct No. 3",,REP,Becky Perez,81,20,76,177
+Young,23,"Constable, Precinct No. 3 Unexpired Term",,REP,Cliff Blackstock,141,38,154,333
+Young,23,"Constable, Precinct No. 3 Unexpired Term",,REP,Larry Thacker,79,22,80,181
 Young,23,County Chairman,,REP,Kyle Zohn Milam,184,47,197,428
 Young,23,U.S. Senate,,DEM,Edward Kimbrough,2,8,5,15
 Young,23,U.S. Senate,,DEM,Beto O'Rourke,11,4,5,20
@@ -1062,11 +1062,11 @@ Young,24,County Judge,,REP,Paul M. Hemphill,39,9,37,85
 Young,24,District Clerk,,REP,Jamie Freeze Land,90,40,107,237
 Young,24,County Clerk,,REP,Kay Jennings Hardin,89,40,112,241
 Young,24,County Treasurer,,REP,Ann B. Daily,87,41,112,240
-Young,24,"County Commissioner,Precinct No. 4",,REP,Jimmy Ray Wiley,92,41,110,243
-Young,24,"Justice of the Peace,Precinct No. 1",,REP,Jason Hearne,44,15,42,101
-Young,24,"Justice of the Peace,Precinct No. 1",,REP,Randy Saylor,14,12,33,59
-Young,24,"Justice of the Peace,Precinct No. 1",,REP,Norman B. Carpenter,21,6,24,51
-Young,24,"Justice of the Peace,Precinct No. 1",,REP,Jabe Underwood,23,12,25,60
+Young,24,"County Commissioner, Precinct No. 4",,REP,Jimmy Ray Wiley,92,41,110,243
+Young,24,"Justice of the Peace, Precinct No. 1",,REP,Jason Hearne,44,15,42,101
+Young,24,"Justice of the Peace, Precinct No. 1",,REP,Randy Saylor,14,12,33,59
+Young,24,"Justice of the Peace, Precinct No. 1",,REP,Norman B. Carpenter,21,6,24,51
+Young,24,"Justice of the Peace, Precinct No. 1",,REP,Jabe Underwood,23,12,25,60
 Young,24,County Chairman,,REP,Kyle Zohn Milam,88,40,111,239
 Young,24,U.S. Senate,,DEM,Edward Kimbrough,4,3,2,9
 Young,24,U.S. Senate,,DEM,Beto O'Rourke,6,6,16,28


### PR DESCRIPTION
The file `2018/20180306__tx__primary__young__precinct.csv` has records where the office has a `\r`but it should really be a space.  Or are we okay with multiline values in records?