### PR TITLE
2018 Lubbock primary - fix extra carriage return chars

### DIFF
--- a/2018/20180306__tx__primary__lubbock__precinct.csv
+++ b/2018/20180306__tx__primary__lubbock__precinct.csv
@@ -9763,82 +9763,30 @@ Lubbock,1,State Representative,84,DEM,Austin Michael Carrizales,57,35,22
 Lubbock,1,State Representative,84,DEM,Samantha Carrillo Fields,59,33,26
 Lubbock,1,"Justice of the Peace, Precinct 3",,DEM,Aurora Chaides-Hernandez,116,67,49
 Lubbock,1,County Party Chair,,DEM,Stuart Williams,111,63,48
-Lubbock,1,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,111,63,48
-Lubbock,1,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,8,8,0
-Lubbock,1,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,116,65,51
-Lubbock,1,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,8,7,1
-Lubbock,1,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,115,65,50
-Lubbock,1,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,6,5,1
-Lubbock,1,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,119,67,52
-Lubbock,1,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,4,4,0
-Lubbock,1,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,114,65,49
-Lubbock,1,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,8,6,2
-Lubbock,1,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,120,69,51
-Lubbock,1,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,3,3,0
-Lubbock,1,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,119,69,50
-Lubbock,1,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,4,3,1
-Lubbock,1,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,113,63,50
-Lubbock,1,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,10,9,1
-Lubbock,1,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,112,64,48
-Lubbock,1,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,9,7,2
-Lubbock,1,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,117,66,51
-Lubbock,1,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,7,6,1
-Lubbock,1,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,118,67,51
-Lubbock,1,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,6,5,1
-Lubbock,1,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,119,69,50
-Lubbock,1,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,3,3,0
+Lubbock,1,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,111,63,48
+Lubbock,1,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,8,8,0
+Lubbock,1,"Democratic Proposition #2 Student Loan Debt",,DEM,For,116,65,51
+Lubbock,1,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,8,7,1
+Lubbock,1,"Democratic Proposition #3 Right to Healthcare",,DEM,For,115,65,50
+Lubbock,1,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,6,5,1
+Lubbock,1,"Democratic Proposition #4 Right to Economic Security",,DEM,For,119,67,52
+Lubbock,1,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,4,4,0
+Lubbock,1,"Democratic Proposition #5 National Jobs Program",,DEM,For,114,65,49
+Lubbock,1,"Democratic Proposition #5 National Jobs Program",,DEM,Against,8,6,2
+Lubbock,1,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,120,69,51
+Lubbock,1,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,3,3,0
+Lubbock,1,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,119,69,50
+Lubbock,1,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,4,3,1
+Lubbock,1,"Democratic Proposition #8 Right to Housing",,DEM,For,113,63,50
+Lubbock,1,"Democratic Proposition #8 Right to Housing",,DEM,Against,10,9,1
+Lubbock,1,"Democratic Proposition #9 Right to Vote",,DEM,For,112,64,48
+Lubbock,1,"Democratic Proposition #9 Right to Vote",,DEM,Against,9,7,2
+Lubbock,1,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,117,66,51
+Lubbock,1,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,7,6,1
+Lubbock,1,"Democratic Proposition #11 Immigrant Rights",,DEM,For,118,67,51
+Lubbock,1,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,6,5,1
+Lubbock,1,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,119,69,50
+Lubbock,1,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,3,3,0
 Lubbock,2,Registered Voters,,,,2134,,
 Lubbock,2,U.S. Senate,,DEM,Beto O'Rourke,54,24,30
 Lubbock,2,U.S. Senate,,DEM,Sema Hernandez,44,21,23
@@ -9871,82 +9819,30 @@ Lubbock,2,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,99,48
 Lubbock,2,State Representative,83,DEM,Drew Landry,101,50,51
 Lubbock,2,"Justice of the Peace, Precinct 3",,DEM,Aurora Chaides-Hernandez,101,50,51
 Lubbock,2,County Party Chair,,DEM,Stuart Williams,97,49,48
-Lubbock,2,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,102,53,49
-Lubbock,2,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,5,0,5
-Lubbock,2,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,102,52,50
-Lubbock,2,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,5,2,3
-Lubbock,2,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,107,53,54
-Lubbock,2,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,1,1,0
-Lubbock,2,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,108,56,52
-Lubbock,2,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,2,0,2
-Lubbock,2,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,96,52,44
-Lubbock,2,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,13,4,9
-Lubbock,2,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,107,53,54
-Lubbock,2,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,1,1,0
-Lubbock,2,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,107,54,53
-Lubbock,2,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,2,1,1
-Lubbock,2,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,101,53,48
-Lubbock,2,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,8,2,6
-Lubbock,2,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,103,54,49
-Lubbock,2,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,4,0,4
-Lubbock,2,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,103,53,50
-Lubbock,2,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,4,2,2
-Lubbock,2,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,104,52,52
-Lubbock,2,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,4,3,1
-Lubbock,2,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,104,54,50
-Lubbock,2,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,2,1,1
+Lubbock,2,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,102,53,49
+Lubbock,2,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,5,0,5
+Lubbock,2,"Democratic Proposition #2 Student Loan Debt",,DEM,For,102,52,50
+Lubbock,2,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,5,2,3
+Lubbock,2,"Democratic Proposition #3 Right to Healthcare",,DEM,For,107,53,54
+Lubbock,2,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,1,1,0
+Lubbock,2,"Democratic Proposition #4 Right to Economic Security",,DEM,For,108,56,52
+Lubbock,2,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,2,0,2
+Lubbock,2,"Democratic Proposition #5 National Jobs Program",,DEM,For,96,52,44
+Lubbock,2,"Democratic Proposition #5 National Jobs Program",,DEM,Against,13,4,9
+Lubbock,2,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,107,53,54
+Lubbock,2,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,1,1,0
+Lubbock,2,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,107,54,53
+Lubbock,2,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,2,1,1
+Lubbock,2,"Democratic Proposition #8 Right to Housing",,DEM,For,101,53,48
+Lubbock,2,"Democratic Proposition #8 Right to Housing",,DEM,Against,8,2,6
+Lubbock,2,"Democratic Proposition #9 Right to Vote",,DEM,For,103,54,49
+Lubbock,2,"Democratic Proposition #9 Right to Vote",,DEM,Against,4,0,4
+Lubbock,2,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,103,53,50
+Lubbock,2,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,4,2,2
+Lubbock,2,"Democratic Proposition #11 Immigrant Rights",,DEM,For,104,52,52
+Lubbock,2,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,4,3,1
+Lubbock,2,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,104,54,50
+Lubbock,2,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,2,1,1
 Lubbock,3,Registered Voters,,,,2934,,
 Lubbock,3,U.S. Senate,,DEM,Beto O'Rourke,54,32,22
 Lubbock,3,U.S. Senate,,DEM,Sema Hernandez,53,32,21
@@ -9980,82 +9876,30 @@ Lubbock,3,State Representative,84,DEM,Austin Michael Carrizales,54,31,23
 Lubbock,3,State Representative,84,DEM,Samantha Carrillo Fields,51,33,18
 Lubbock,3,"Justice of the Peace, Precinct 3",,DEM,Aurora Chaides-Hernandez,107,65,42
 Lubbock,3,County Party Chair,,DEM,Stuart Williams,95,58,37
-Lubbock,3,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,104,63,41
-Lubbock,3,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,2,2,0
-Lubbock,3,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,102,61,41
-Lubbock,3,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,5,5,0
-Lubbock,3,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,104,62,42
-Lubbock,3,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,3,2,1
-Lubbock,3,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,105,63,42
-Lubbock,3,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,1,0,1
-Lubbock,3,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,102,62,40
-Lubbock,3,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,6,4,2
-Lubbock,3,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,107,64,43
-Lubbock,3,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,3,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,104,64,40
-Lubbock,3,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,5,2,3
-Lubbock,3,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,103,64,39
-Lubbock,3,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,6,2,4
-Lubbock,3,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,104,63,41
-Lubbock,3,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,4,2,2
-Lubbock,3,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,106,64,42
-Lubbock,3,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,2,1,1
-Lubbock,3,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,106,64,42
-Lubbock,3,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,1,0,1
-Lubbock,3,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,106,65,41
-Lubbock,3,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,2,0,2
+Lubbock,3,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,104,63,41
+Lubbock,3,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,2,2,0
+Lubbock,3,"Democratic Proposition #2 Student Loan Debt",,DEM,For,102,61,41
+Lubbock,3,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,5,5,0
+Lubbock,3,"Democratic Proposition #3 Right to Healthcare",,DEM,For,104,62,42
+Lubbock,3,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,3,2,1
+Lubbock,3,"Democratic Proposition #4 Right to Economic Security",,DEM,For,105,63,42
+Lubbock,3,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,1,0,1
+Lubbock,3,"Democratic Proposition #5 National Jobs Program",,DEM,For,102,62,40
+Lubbock,3,"Democratic Proposition #5 National Jobs Program",,DEM,Against,6,4,2
+Lubbock,3,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,107,64,43
+Lubbock,3,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,3,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,104,64,40
+Lubbock,3,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,5,2,3
+Lubbock,3,"Democratic Proposition #8 Right to Housing",,DEM,For,103,64,39
+Lubbock,3,"Democratic Proposition #8 Right to Housing",,DEM,Against,6,2,4
+Lubbock,3,"Democratic Proposition #9 Right to Vote",,DEM,For,104,63,41
+Lubbock,3,"Democratic Proposition #9 Right to Vote",,DEM,Against,4,2,2
+Lubbock,3,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,106,64,42
+Lubbock,3,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,2,1,1
+Lubbock,3,"Democratic Proposition #11 Immigrant Rights",,DEM,For,106,64,42
+Lubbock,3,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,1,0,1
+Lubbock,3,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,106,65,41
+Lubbock,3,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,2,0,2
 Lubbock,4,Registered Voters,,,,1272,,
 Lubbock,4,U.S. Senate,,DEM,Beto O'Rourke,18,8,10
 Lubbock,4,U.S. Senate,,DEM,Sema Hernandez,26,18,8
@@ -10089,82 +9933,30 @@ Lubbock,4,State Representative,84,DEM,Austin Michael Carrizales,38,25,13
 Lubbock,4,State Representative,84,DEM,Samantha Carrillo Fields,14,9,5
 Lubbock,4,"Justice of the Peace, Precinct 3",,DEM,Aurora Chaides-Hernandez,47,30,17
 Lubbock,4,County Party Chair,,DEM,Stuart Williams,44,29,15
-Lubbock,4,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,50,33,17
-Lubbock,4,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,3,2,1
-Lubbock,4,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,51,34,17
-Lubbock,4,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,1,1,0
-Lubbock,4,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,48,30,18
-Lubbock,4,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,4,3,1
-Lubbock,4,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,52,33,19
-Lubbock,4,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,4,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,51,32,19
-Lubbock,4,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,2,2,0
-Lubbock,4,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,51,32,19
-Lubbock,4,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,4,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,50,32,18
-Lubbock,4,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,3,2,1
-Lubbock,4,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,47,30,17
-Lubbock,4,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,3,2,1
-Lubbock,4,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,51,32,19
-Lubbock,4,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,2,2,0
-Lubbock,4,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,50,32,18
-Lubbock,4,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,4,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,51,32,19
-Lubbock,4,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,2,2,0
-Lubbock,4,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,52,34,18
-Lubbock,4,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,1,0,1
+Lubbock,4,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,50,33,17
+Lubbock,4,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,3,2,1
+Lubbock,4,"Democratic Proposition #2 Student Loan Debt",,DEM,For,51,34,17
+Lubbock,4,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,1,1,0
+Lubbock,4,"Democratic Proposition #3 Right to Healthcare",,DEM,For,48,30,18
+Lubbock,4,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,4,3,1
+Lubbock,4,"Democratic Proposition #4 Right to Economic Security",,DEM,For,52,33,19
+Lubbock,4,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,4,"Democratic Proposition #5 National Jobs Program",,DEM,For,51,32,19
+Lubbock,4,"Democratic Proposition #5 National Jobs Program",,DEM,Against,2,2,0
+Lubbock,4,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,51,32,19
+Lubbock,4,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,4,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,50,32,18
+Lubbock,4,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,3,2,1
+Lubbock,4,"Democratic Proposition #8 Right to Housing",,DEM,For,47,30,17
+Lubbock,4,"Democratic Proposition #8 Right to Housing",,DEM,Against,3,2,1
+Lubbock,4,"Democratic Proposition #9 Right to Vote",,DEM,For,51,32,19
+Lubbock,4,"Democratic Proposition #9 Right to Vote",,DEM,Against,2,2,0
+Lubbock,4,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,50,32,18
+Lubbock,4,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,4,"Democratic Proposition #11 Immigrant Rights",,DEM,For,51,32,19
+Lubbock,4,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,2,2,0
+Lubbock,4,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,52,34,18
+Lubbock,4,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,1,0,1
 Lubbock,5,Registered Voters,,,,699,,
 Lubbock,5,U.S. Senate,,DEM,Beto O'Rourke,32,18,14
 Lubbock,5,U.S. Senate,,DEM,Sema Hernandez,36,22,14
@@ -10198,82 +9990,30 @@ Lubbock,5,State Representative,84,DEM,Austin Michael Carrizales,48,30,18
 Lubbock,5,State Representative,84,DEM,Samantha Carrillo Fields,22,13,9
 Lubbock,5,"Justice of the Peace, Precinct 3",,DEM,Aurora Chaides-Hernandez,65,40,25
 Lubbock,5,County Party Chair,,DEM,Stuart Williams,61,38,23
-Lubbock,5,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,68,41,27
-Lubbock,5,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,4,3,1
-Lubbock,5,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,68,41,27
-Lubbock,5,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,5,3,2
-Lubbock,5,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,71,42,29
-Lubbock,5,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,3,2,1
-Lubbock,5,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,70,41,29
-Lubbock,5,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,4,3,1
-Lubbock,5,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,66,40,26
-Lubbock,5,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,4,1,3
-Lubbock,5,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,72,43,29
-Lubbock,5,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,1,0,1
-Lubbock,5,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,73,43,30
-Lubbock,5,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,1,1,0
-Lubbock,5,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,67,39,28
-Lubbock,5,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,6,5,1
-Lubbock,5,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,66,40,26
-Lubbock,5,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,6,3,3
-Lubbock,5,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,70,41,29
-Lubbock,5,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,2,1,1
-Lubbock,5,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,68,40,28
-Lubbock,5,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,5,3,2
-Lubbock,5,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,73,43,30
-Lubbock,5,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,1,1,0
+Lubbock,5,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,68,41,27
+Lubbock,5,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,4,3,1
+Lubbock,5,"Democratic Proposition #2 Student Loan Debt",,DEM,For,68,41,27
+Lubbock,5,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,5,3,2
+Lubbock,5,"Democratic Proposition #3 Right to Healthcare",,DEM,For,71,42,29
+Lubbock,5,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,3,2,1
+Lubbock,5,"Democratic Proposition #4 Right to Economic Security",,DEM,For,70,41,29
+Lubbock,5,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,4,3,1
+Lubbock,5,"Democratic Proposition #5 National Jobs Program",,DEM,For,66,40,26
+Lubbock,5,"Democratic Proposition #5 National Jobs Program",,DEM,Against,4,1,3
+Lubbock,5,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,72,43,29
+Lubbock,5,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,1,0,1
+Lubbock,5,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,73,43,30
+Lubbock,5,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,1,1,0
+Lubbock,5,"Democratic Proposition #8 Right to Housing",,DEM,For,67,39,28
+Lubbock,5,"Democratic Proposition #8 Right to Housing",,DEM,Against,6,5,1
+Lubbock,5,"Democratic Proposition #9 Right to Vote",,DEM,For,66,40,26
+Lubbock,5,"Democratic Proposition #9 Right to Vote",,DEM,Against,6,3,3
+Lubbock,5,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,70,41,29
+Lubbock,5,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,2,1,1
+Lubbock,5,"Democratic Proposition #11 Immigrant Rights",,DEM,For,68,40,28
+Lubbock,5,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,5,3,2
+Lubbock,5,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,73,43,30
+Lubbock,5,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,1,1,0
 Lubbock,6,Registered Voters,,,,1705,,
 Lubbock,6,U.S. Senate,,DEM,Beto O'Rourke,23,15,8
 Lubbock,6,U.S. Senate,,DEM,Sema Hernandez,29,19,10
@@ -10307,82 +10047,30 @@ Lubbock,6,State Representative,84,DEM,Austin Michael Carrizales,32,22,10
 Lubbock,6,State Representative,84,DEM,Samantha Carrillo Fields,41,29,12
 Lubbock,6,"Justice of the Peace, Precinct 3",,DEM,Aurora Chaides-Hernandez,63,43,20
 Lubbock,6,County Party Chair,,DEM,Stuart Williams,68,47,21
-Lubbock,6,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,72,50,22
-Lubbock,6,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,4,2,2
-Lubbock,6,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,67,45,22
-Lubbock,6,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,5,4,1
-Lubbock,6,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,70,48,22
-Lubbock,6,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,4,3,1
-Lubbock,6,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,71,49,22
-Lubbock,6,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,3,2,1
-Lubbock,6,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,69,48,21
-Lubbock,6,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,5,3,2
-Lubbock,6,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,73,50,23
-Lubbock,6,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,2,2,0
-Lubbock,6,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,71,48,23
-Lubbock,6,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,3,3,0
-Lubbock,6,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,67,48,19
-Lubbock,6,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,7,3,4
-Lubbock,6,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,70,49,21
-Lubbock,6,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,2,1,1
-Lubbock,6,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,69,48,21
-Lubbock,6,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,3,2,1
-Lubbock,6,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,70,47,23
-Lubbock,6,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,4,3,1
-Lubbock,6,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,69,47,22
-Lubbock,6,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,4,3,1
+Lubbock,6,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,72,50,22
+Lubbock,6,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,4,2,2
+Lubbock,6,"Democratic Proposition #2 Student Loan Debt",,DEM,For,67,45,22
+Lubbock,6,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,5,4,1
+Lubbock,6,"Democratic Proposition #3 Right to Healthcare",,DEM,For,70,48,22
+Lubbock,6,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,4,3,1
+Lubbock,6,"Democratic Proposition #4 Right to Economic Security",,DEM,For,71,49,22
+Lubbock,6,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,3,2,1
+Lubbock,6,"Democratic Proposition #5 National Jobs Program",,DEM,For,69,48,21
+Lubbock,6,"Democratic Proposition #5 National Jobs Program",,DEM,Against,5,3,2
+Lubbock,6,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,73,50,23
+Lubbock,6,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,2,2,0
+Lubbock,6,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,71,48,23
+Lubbock,6,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,3,3,0
+Lubbock,6,"Democratic Proposition #8 Right to Housing",,DEM,For,67,48,19
+Lubbock,6,"Democratic Proposition #8 Right to Housing",,DEM,Against,7,3,4
+Lubbock,6,"Democratic Proposition #9 Right to Vote",,DEM,For,70,49,21
+Lubbock,6,"Democratic Proposition #9 Right to Vote",,DEM,Against,2,1,1
+Lubbock,6,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,69,48,21
+Lubbock,6,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,3,2,1
+Lubbock,6,"Democratic Proposition #11 Immigrant Rights",,DEM,For,70,47,23
+Lubbock,6,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,4,3,1
+Lubbock,6,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,69,47,22
+Lubbock,6,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,4,3,1
 Lubbock,7,Registered Voters,,,,2223,,
 Lubbock,7,U.S. Senate,,DEM,Beto O'Rourke,49,30,19
 Lubbock,7,U.S. Senate,,DEM,Sema Hernandez,16,10,6
@@ -10416,82 +10104,30 @@ Lubbock,7,State Representative,84,DEM,Austin Michael Carrizales,25,14,11
 Lubbock,7,State Representative,84,DEM,Samantha Carrillo Fields,46,27,19
 Lubbock,7,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,71,42,29
 Lubbock,7,County Party Chair,,DEM,Stuart Williams,71,41,30
-Lubbock,7,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,71,42,29
-Lubbock,7,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,4,3,1
-Lubbock,7,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,69,40,29
-Lubbock,7,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,4,3,1
-Lubbock,7,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,72,42,30
-Lubbock,7,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,1,1,0
-Lubbock,7,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,71,41,30
-Lubbock,7,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,2,2,0
-Lubbock,7,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,72,44,28
-Lubbock,7,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,2,0,2
-Lubbock,7,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,73,43,30
-Lubbock,7,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,7,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,70,41,29
-Lubbock,7,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,2,1,1
-Lubbock,7,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,64,37,27
-Lubbock,7,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,6,3,3
-Lubbock,7,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,71,41,30
-Lubbock,7,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,3,3,0
-Lubbock,7,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,72,43,29
-Lubbock,7,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,3,2,1
-Lubbock,7,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,70,42,28
-Lubbock,7,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,3,1,2
-Lubbock,7,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,71,41,30
-Lubbock,7,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,2,2,0
+Lubbock,7,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,71,42,29
+Lubbock,7,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,4,3,1
+Lubbock,7,"Democratic Proposition #2 Student Loan Debt",,DEM,For,69,40,29
+Lubbock,7,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,4,3,1
+Lubbock,7,"Democratic Proposition #3 Right to Healthcare",,DEM,For,72,42,30
+Lubbock,7,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,1,1,0
+Lubbock,7,"Democratic Proposition #4 Right to Economic Security",,DEM,For,71,41,30
+Lubbock,7,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,2,2,0
+Lubbock,7,"Democratic Proposition #5 National Jobs Program",,DEM,For,72,44,28
+Lubbock,7,"Democratic Proposition #5 National Jobs Program",,DEM,Against,2,0,2
+Lubbock,7,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,73,43,30
+Lubbock,7,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,7,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,70,41,29
+Lubbock,7,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,2,1,1
+Lubbock,7,"Democratic Proposition #8 Right to Housing",,DEM,For,64,37,27
+Lubbock,7,"Democratic Proposition #8 Right to Housing",,DEM,Against,6,3,3
+Lubbock,7,"Democratic Proposition #9 Right to Vote",,DEM,For,71,41,30
+Lubbock,7,"Democratic Proposition #9 Right to Vote",,DEM,Against,3,3,0
+Lubbock,7,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,72,43,29
+Lubbock,7,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,3,2,1
+Lubbock,7,"Democratic Proposition #11 Immigrant Rights",,DEM,For,70,42,28
+Lubbock,7,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,3,1,2
+Lubbock,7,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,71,41,30
+Lubbock,7,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,2,2,0
 Lubbock,8,Registered Voters,,,,1833,,
 Lubbock,8,U.S. Senate,,DEM,Beto O'Rourke,43,18,25
 Lubbock,8,U.S. Senate,,DEM,Sema Hernandez,8,4,4
@@ -10525,82 +10161,30 @@ Lubbock,8,State Representative,84,DEM,Austin Michael Carrizales,10,7,3
 Lubbock,8,State Representative,84,DEM,Samantha Carrillo Fields,39,13,26
 Lubbock,8,"Justice of the Peace, Precinct 3",,DEM,Aurora Chaides-Hernandez,47,20,27
 Lubbock,8,County Party Chair,,DEM,Stuart Williams,47,20,27
-Lubbock,8,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,56,24,32
-Lubbock,8,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,8,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,53,23,30
-Lubbock,8,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,2,0,2
-Lubbock,8,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,53,22,31
-Lubbock,8,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,2,1,1
-Lubbock,8,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,54,23,31
-Lubbock,8,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,2,1,1
-Lubbock,8,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,52,23,29
-Lubbock,8,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,3,1,2
-Lubbock,8,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,56,24,32
-Lubbock,8,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,8,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,55,23,32
-Lubbock,8,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,1,1,0
-Lubbock,8,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,54,23,31
-Lubbock,8,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,2,1,1
-Lubbock,8,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,55,23,32
-Lubbock,8,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,1,1,0
-Lubbock,8,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,55,23,32
-Lubbock,8,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,8,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,53,23,30
-Lubbock,8,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,1,0,1
-Lubbock,8,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,56,24,32
-Lubbock,8,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,8,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,56,24,32
+Lubbock,8,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,8,"Democratic Proposition #2 Student Loan Debt",,DEM,For,53,23,30
+Lubbock,8,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,2,0,2
+Lubbock,8,"Democratic Proposition #3 Right to Healthcare",,DEM,For,53,22,31
+Lubbock,8,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,2,1,1
+Lubbock,8,"Democratic Proposition #4 Right to Economic Security",,DEM,For,54,23,31
+Lubbock,8,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,2,1,1
+Lubbock,8,"Democratic Proposition #5 National Jobs Program",,DEM,For,52,23,29
+Lubbock,8,"Democratic Proposition #5 National Jobs Program",,DEM,Against,3,1,2
+Lubbock,8,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,56,24,32
+Lubbock,8,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,8,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,55,23,32
+Lubbock,8,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,1,1,0
+Lubbock,8,"Democratic Proposition #8 Right to Housing",,DEM,For,54,23,31
+Lubbock,8,"Democratic Proposition #8 Right to Housing",,DEM,Against,2,1,1
+Lubbock,8,"Democratic Proposition #9 Right to Vote",,DEM,For,55,23,32
+Lubbock,8,"Democratic Proposition #9 Right to Vote",,DEM,Against,1,1,0
+Lubbock,8,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,55,23,32
+Lubbock,8,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,8,"Democratic Proposition #11 Immigrant Rights",,DEM,For,53,23,30
+Lubbock,8,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,1,0,1
+Lubbock,8,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,56,24,32
+Lubbock,8,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,9,Registered Voters,,,,2263,,
 Lubbock,9,U.S. Senate,,DEM,Beto O'Rourke,103,66,37
 Lubbock,9,U.S. Senate,,DEM,Sema Hernandez,13,11,2
@@ -10634,82 +10218,30 @@ Lubbock,9,State Representative,84,DEM,Austin Michael Carrizales,40,28,12
 Lubbock,9,State Representative,84,DEM,Samantha Carrillo Fields,75,50,25
 Lubbock,9,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,109,72,37
 Lubbock,9,County Party Chair,,DEM,Stuart Williams,109,72,37
-Lubbock,9,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,117,79,38
-Lubbock,9,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,3,2,1
-Lubbock,9,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,107,71,36
-Lubbock,9,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,10,6,4
-Lubbock,9,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,109,72,37
-Lubbock,9,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,8,6,2
-Lubbock,9,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,110,71,39
-Lubbock,9,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,8,7,1
-Lubbock,9,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,113,74,39
-Lubbock,9,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,6,5,1
-Lubbock,9,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,117,78,39
-Lubbock,9,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,1,1,0
-Lubbock,9,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,117,78,39
-Lubbock,9,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,2,1,1
-Lubbock,9,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,108,70,38
-Lubbock,9,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,8,6,2
-Lubbock,9,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,118,78,40
-Lubbock,9,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,2,2,0
-Lubbock,9,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,119,79,40
-Lubbock,9,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,2,2,0
-Lubbock,9,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,117,77,40
-Lubbock,9,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,2,2,0
-Lubbock,9,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,116,78,38
-Lubbock,9,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,2,1,1
+Lubbock,9,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,117,79,38
+Lubbock,9,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,3,2,1
+Lubbock,9,"Democratic Proposition #2 Student Loan Debt",,DEM,For,107,71,36
+Lubbock,9,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,10,6,4
+Lubbock,9,"Democratic Proposition #3 Right to Healthcare",,DEM,For,109,72,37
+Lubbock,9,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,8,6,2
+Lubbock,9,"Democratic Proposition #4 Right to Economic Security",,DEM,For,110,71,39
+Lubbock,9,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,8,7,1
+Lubbock,9,"Democratic Proposition #5 National Jobs Program",,DEM,For,113,74,39
+Lubbock,9,"Democratic Proposition #5 National Jobs Program",,DEM,Against,6,5,1
+Lubbock,9,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,117,78,39
+Lubbock,9,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,1,1,0
+Lubbock,9,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,117,78,39
+Lubbock,9,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,2,1,1
+Lubbock,9,"Democratic Proposition #8 Right to Housing",,DEM,For,108,70,38
+Lubbock,9,"Democratic Proposition #8 Right to Housing",,DEM,Against,8,6,2
+Lubbock,9,"Democratic Proposition #9 Right to Vote",,DEM,For,118,78,40
+Lubbock,9,"Democratic Proposition #9 Right to Vote",,DEM,Against,2,2,0
+Lubbock,9,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,119,79,40
+Lubbock,9,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,2,2,0
+Lubbock,9,"Democratic Proposition #11 Immigrant Rights",,DEM,For,117,77,40
+Lubbock,9,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,2,2,0
+Lubbock,9,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,116,78,38
+Lubbock,9,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,2,1,1
 Lubbock,10,Registered Voters,,,,1215,,
 Lubbock,10,U.S. Senate,,DEM,Beto O'Rourke,55,28,27
 Lubbock,10,U.S. Senate,,DEM,Sema Hernandez,7,2,5
@@ -10743,82 +10275,30 @@ Lubbock,10,State Representative,84,DEM,Austin Michael Carrizales,28,15,13
 Lubbock,10,State Representative,84,DEM,Samantha Carrillo Fields,30,14,16
 Lubbock,10,"Justice of the Peace, Precinct 3",,DEM,Aurora Chaides-Hernandez,54,27,27
 Lubbock,10,County Party Chair,,DEM,Stuart Williams,54,27,27
-Lubbock,10,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,63,31,32
-Lubbock,10,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,10,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,58,29,29
-Lubbock,10,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,5,2,3
-Lubbock,10,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,60,30,30
-Lubbock,10,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,3,1,2
-Lubbock,10,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,62,30,32
-Lubbock,10,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,10,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,58,27,31
-Lubbock,10,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,3,3,0
-Lubbock,10,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,63,31,32
-Lubbock,10,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,10,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,63,31,32
-Lubbock,10,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,10,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,56,28,28
-Lubbock,10,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,7,3,4
-Lubbock,10,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,61,29,32
-Lubbock,10,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,1,1,0
-Lubbock,10,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,62,30,32
-Lubbock,10,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,10,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,59,29,30
-Lubbock,10,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,3,1,2
-Lubbock,10,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,62,31,31
-Lubbock,10,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,1,0,1
+Lubbock,10,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,63,31,32
+Lubbock,10,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,10,"Democratic Proposition #2 Student Loan Debt",,DEM,For,58,29,29
+Lubbock,10,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,5,2,3
+Lubbock,10,"Democratic Proposition #3 Right to Healthcare",,DEM,For,60,30,30
+Lubbock,10,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,3,1,2
+Lubbock,10,"Democratic Proposition #4 Right to Economic Security",,DEM,For,62,30,32
+Lubbock,10,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,10,"Democratic Proposition #5 National Jobs Program",,DEM,For,58,27,31
+Lubbock,10,"Democratic Proposition #5 National Jobs Program",,DEM,Against,3,3,0
+Lubbock,10,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,63,31,32
+Lubbock,10,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,10,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,63,31,32
+Lubbock,10,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,10,"Democratic Proposition #8 Right to Housing",,DEM,For,56,28,28
+Lubbock,10,"Democratic Proposition #8 Right to Housing",,DEM,Against,7,3,4
+Lubbock,10,"Democratic Proposition #9 Right to Vote",,DEM,For,61,29,32
+Lubbock,10,"Democratic Proposition #9 Right to Vote",,DEM,Against,1,1,0
+Lubbock,10,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,62,30,32
+Lubbock,10,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,10,"Democratic Proposition #11 Immigrant Rights",,DEM,For,59,29,30
+Lubbock,10,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,3,1,2
+Lubbock,10,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,62,31,31
+Lubbock,10,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,1,0,1
 Lubbock,12,Registered Voters,,,,1802,,
 Lubbock,12,U.S. Senate,,DEM,Beto O'Rourke,69,37,32
 Lubbock,12,U.S. Senate,,DEM,Sema Hernandez,18,14,4
@@ -10853,82 +10333,30 @@ Lubbock,12,State Representative,84,DEM,Samantha Carrillo Fields,62,37,25
 Lubbock,12,"County Commissioner, Precinct 2",,DEM,Nick Harpster,89,51,38
 Lubbock,12,"Justice of the Peace, Precinct 2",,DEM,Daylan J. Flowers,90,52,38
 Lubbock,12,County Party Chair,,DEM,Stuart Williams,90,52,38
-Lubbock,12,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,89,53,36
-Lubbock,12,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,5,2,3
-Lubbock,12,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,88,53,35
-Lubbock,12,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,5,1,4
-Lubbock,12,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,89,52,37
-Lubbock,12,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,4,3,1
-Lubbock,12,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,89,52,37
-Lubbock,12,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,3,2,1
-Lubbock,12,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,90,51,39
-Lubbock,12,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,6,6,0
-Lubbock,12,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,93,56,37
-Lubbock,12,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,2,1,1
-Lubbock,12,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,94,55,39
-Lubbock,12,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,1,1,0
-Lubbock,12,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,88,51,37
-Lubbock,12,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,6,4,2
-Lubbock,12,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,91,53,38
-Lubbock,12,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,3,3,0
-Lubbock,12,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,93,55,38
-Lubbock,12,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,2,1,1
-Lubbock,12,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,93,54,39
-Lubbock,12,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,3,3,0
-Lubbock,12,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,93,54,39
-Lubbock,12,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,3,3,0
+Lubbock,12,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,89,53,36
+Lubbock,12,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,5,2,3
+Lubbock,12,"Democratic Proposition #2 Student Loan Debt",,DEM,For,88,53,35
+Lubbock,12,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,5,1,4
+Lubbock,12,"Democratic Proposition #3 Right to Healthcare",,DEM,For,89,52,37
+Lubbock,12,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,4,3,1
+Lubbock,12,"Democratic Proposition #4 Right to Economic Security",,DEM,For,89,52,37
+Lubbock,12,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,3,2,1
+Lubbock,12,"Democratic Proposition #5 National Jobs Program",,DEM,For,90,51,39
+Lubbock,12,"Democratic Proposition #5 National Jobs Program",,DEM,Against,6,6,0
+Lubbock,12,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,93,56,37
+Lubbock,12,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,2,1,1
+Lubbock,12,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,94,55,39
+Lubbock,12,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,1,1,0
+Lubbock,12,"Democratic Proposition #8 Right to Housing",,DEM,For,88,51,37
+Lubbock,12,"Democratic Proposition #8 Right to Housing",,DEM,Against,6,4,2
+Lubbock,12,"Democratic Proposition #9 Right to Vote",,DEM,For,91,53,38
+Lubbock,12,"Democratic Proposition #9 Right to Vote",,DEM,Against,3,3,0
+Lubbock,12,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,93,55,38
+Lubbock,12,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,2,1,1
+Lubbock,12,"Democratic Proposition #11 Immigrant Rights",,DEM,For,93,54,39
+Lubbock,12,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,3,3,0
+Lubbock,12,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,93,54,39
+Lubbock,12,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,3,3,0
 Lubbock,13,Registered Voters,,,,1815,,
 Lubbock,13,U.S. Senate,,DEM,Beto O'Rourke,73,49,24
 Lubbock,13,U.S. Senate,,DEM,Sema Hernandez,17,9,8
@@ -10962,82 +10390,30 @@ Lubbock,13,State Representative,84,DEM,Austin Michael Carrizales,34,22,12
 Lubbock,13,State Representative,84,DEM,Samantha Carrillo Fields,62,38,24
 Lubbock,13,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,91,58,33
 Lubbock,13,County Party Chair,,DEM,Stuart Williams,90,58,32
-Lubbock,13,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,95,60,35
-Lubbock,13,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,3,2,1
-Lubbock,13,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,90,57,33
-Lubbock,13,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,8,5,3
-Lubbock,13,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,94,61,33
-Lubbock,13,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,2,2,0
-Lubbock,13,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,93,58,35
-Lubbock,13,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,3,2,1
-Lubbock,13,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,94,59,35
-Lubbock,13,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,4,3,1
-Lubbock,13,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,98,62,36
-Lubbock,13,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,13,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,98,62,36
-Lubbock,13,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,1,1,0
-Lubbock,13,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,93,58,35
-Lubbock,13,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,4,4,0
-Lubbock,13,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,95,60,35
-Lubbock,13,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,2,1,1
-Lubbock,13,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,97,62,35
-Lubbock,13,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,1,0,1
-Lubbock,13,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,98,62,36
-Lubbock,13,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,1,1,0
-Lubbock,13,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,95,59,36
-Lubbock,13,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,2,2,0
+Lubbock,13,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,95,60,35
+Lubbock,13,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,3,2,1
+Lubbock,13,"Democratic Proposition #2 Student Loan Debt",,DEM,For,90,57,33
+Lubbock,13,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,8,5,3
+Lubbock,13,"Democratic Proposition #3 Right to Healthcare",,DEM,For,94,61,33
+Lubbock,13,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,2,2,0
+Lubbock,13,"Democratic Proposition #4 Right to Economic Security",,DEM,For,93,58,35
+Lubbock,13,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,3,2,1
+Lubbock,13,"Democratic Proposition #5 National Jobs Program",,DEM,For,94,59,35
+Lubbock,13,"Democratic Proposition #5 National Jobs Program",,DEM,Against,4,3,1
+Lubbock,13,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,98,62,36
+Lubbock,13,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,13,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,98,62,36
+Lubbock,13,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,1,1,0
+Lubbock,13,"Democratic Proposition #8 Right to Housing",,DEM,For,93,58,35
+Lubbock,13,"Democratic Proposition #8 Right to Housing",,DEM,Against,4,4,0
+Lubbock,13,"Democratic Proposition #9 Right to Vote",,DEM,For,95,60,35
+Lubbock,13,"Democratic Proposition #9 Right to Vote",,DEM,Against,2,1,1
+Lubbock,13,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,97,62,35
+Lubbock,13,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,1,0,1
+Lubbock,13,"Democratic Proposition #11 Immigrant Rights",,DEM,For,98,62,36
+Lubbock,13,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,1,1,0
+Lubbock,13,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,95,59,36
+Lubbock,13,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,2,2,0
 Lubbock,14,Registered Voters,,,,1207,,
 Lubbock,14,U.S. Senate,,DEM,Beto O'Rourke,48,27,21
 Lubbock,14,U.S. Senate,,DEM,Sema Hernandez,10,6,4
@@ -11071,82 +10447,30 @@ Lubbock,14,State Representative,84,DEM,Austin Michael Carrizales,27,15,12
 Lubbock,14,State Representative,84,DEM,Samantha Carrillo Fields,37,24,13
 Lubbock,14,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,64,39,25
 Lubbock,14,County Party Chair,,DEM,Stuart Williams,63,38,25
-Lubbock,14,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,62,38,24
-Lubbock,14,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,2,2,0
-Lubbock,14,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,61,36,25
-Lubbock,14,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,5,4,1
-Lubbock,14,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,65,40,25
-Lubbock,14,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,2,1,1
-Lubbock,14,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,63,40,23
-Lubbock,14,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,2,1,1
-Lubbock,14,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,63,38,25
-Lubbock,14,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,2,1,1
-Lubbock,14,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,66,40,26
-Lubbock,14,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,14,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,63,39,24
-Lubbock,14,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,2,1,1
-Lubbock,14,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,59,36,23
-Lubbock,14,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,6,4,2
-Lubbock,14,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,65,39,26
-Lubbock,14,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,1,1,0
-Lubbock,14,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,64,39,25
-Lubbock,14,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
-Lubbock,14,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,65,39,26
-Lubbock,14,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,1,1,0
-Lubbock,14,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,65,40,25
-Lubbock,14,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,1,1,0
+Lubbock,14,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,62,38,24
+Lubbock,14,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,2,2,0
+Lubbock,14,"Democratic Proposition #2 Student Loan Debt",,DEM,For,61,36,25
+Lubbock,14,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,5,4,1
+Lubbock,14,"Democratic Proposition #3 Right to Healthcare",,DEM,For,65,40,25
+Lubbock,14,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,2,1,1
+Lubbock,14,"Democratic Proposition #4 Right to Economic Security",,DEM,For,63,40,23
+Lubbock,14,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,2,1,1
+Lubbock,14,"Democratic Proposition #5 National Jobs Program",,DEM,For,63,38,25
+Lubbock,14,"Democratic Proposition #5 National Jobs Program",,DEM,Against,2,1,1
+Lubbock,14,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,66,40,26
+Lubbock,14,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,14,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,63,39,24
+Lubbock,14,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,2,1,1
+Lubbock,14,"Democratic Proposition #8 Right to Housing",,DEM,For,59,36,23
+Lubbock,14,"Democratic Proposition #8 Right to Housing",,DEM,Against,6,4,2
+Lubbock,14,"Democratic Proposition #9 Right to Vote",,DEM,For,65,39,26
+Lubbock,14,"Democratic Proposition #9 Right to Vote",,DEM,Against,1,1,0
+Lubbock,14,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,64,39,25
+Lubbock,14,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
+Lubbock,14,"Democratic Proposition #11 Immigrant Rights",,DEM,For,65,39,26
+Lubbock,14,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,1,1,0
+Lubbock,14,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,65,40,25
+Lubbock,14,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,1,1,0
 Lubbock,15,Registered Voters,,,,1647,,
 Lubbock,15,U.S. Senate,,DEM,Beto O'Rourke,175,83,92
 Lubbock,15,U.S. Senate,,DEM,Sema Hernandez,14,5,9
@@ -11179,82 +10503,30 @@ Lubbock,15,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,184,
 Lubbock,15,State Representative,83,DEM,Drew Landry,183,87,96
 Lubbock,15,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,180,84,96
 Lubbock,15,County Party Chair,,DEM,Stuart Williams,183,86,97
-Lubbock,15,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,191,91,100
-Lubbock,15,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,5,3,2
-Lubbock,15,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,186,89,97
-Lubbock,15,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,9,4,5
-Lubbock,15,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,190,93,97
-Lubbock,15,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,5,1,4
-Lubbock,15,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,191,91,100
-Lubbock,15,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,4,2,2
-Lubbock,15,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,182,87,95
-Lubbock,15,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,9,5,4
-Lubbock,15,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,196,94,102
-Lubbock,15,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,15,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,192,91,101
-Lubbock,15,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,2,1,1
-Lubbock,15,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,181,88,93
-Lubbock,15,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,8,3,5
-Lubbock,15,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,194,95,99
-Lubbock,15,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,1,0,1
-Lubbock,15,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,192,91,101
-Lubbock,15,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,2,2,0
-Lubbock,15,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,193,91,102
-Lubbock,15,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,15,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,194,93,101
-Lubbock,15,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,2,1,1
+Lubbock,15,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,191,91,100
+Lubbock,15,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,5,3,2
+Lubbock,15,"Democratic Proposition #2 Student Loan Debt",,DEM,For,186,89,97
+Lubbock,15,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,9,4,5
+Lubbock,15,"Democratic Proposition #3 Right to Healthcare",,DEM,For,190,93,97
+Lubbock,15,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,5,1,4
+Lubbock,15,"Democratic Proposition #4 Right to Economic Security",,DEM,For,191,91,100
+Lubbock,15,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,4,2,2
+Lubbock,15,"Democratic Proposition #5 National Jobs Program",,DEM,For,182,87,95
+Lubbock,15,"Democratic Proposition #5 National Jobs Program",,DEM,Against,9,5,4
+Lubbock,15,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,196,94,102
+Lubbock,15,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,15,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,192,91,101
+Lubbock,15,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,2,1,1
+Lubbock,15,"Democratic Proposition #8 Right to Housing",,DEM,For,181,88,93
+Lubbock,15,"Democratic Proposition #8 Right to Housing",,DEM,Against,8,3,5
+Lubbock,15,"Democratic Proposition #9 Right to Vote",,DEM,For,194,95,99
+Lubbock,15,"Democratic Proposition #9 Right to Vote",,DEM,Against,1,0,1
+Lubbock,15,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,192,91,101
+Lubbock,15,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,2,2,0
+Lubbock,15,"Democratic Proposition #11 Immigrant Rights",,DEM,For,193,91,102
+Lubbock,15,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,15,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,194,93,101
+Lubbock,15,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,2,1,1
 Lubbock,16,Registered Voters,,,,1145,,
 Lubbock,16,U.S. Senate,,DEM,Beto O'Rourke,83,40,43
 Lubbock,16,U.S. Senate,,DEM,Sema Hernandez,6,1,5
@@ -11289,82 +10561,30 @@ Lubbock,16,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,85,41,44
 Lubbock,16,County Party Chair,,DEM,Stuart Williams,83,42,41
 Lubbock,16,"Precinct Chair, Precinct 16",,DEM,Angela Martinez,68,33,35
 Lubbock,16,"Precinct Chair, Precinct 16",,DEM,Charles L. Clair,20,11,9
-Lubbock,16,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,92,46,46
-Lubbock,16,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,1,1,0
-Lubbock,16,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,91,45,46
-Lubbock,16,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,3,2,1
-Lubbock,16,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,93,45,48
-Lubbock,16,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,3,3,0
-Lubbock,16,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,93,47,46
-Lubbock,16,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,1,0,1
-Lubbock,16,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,84,42,42
-Lubbock,16,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,6,2,4
-Lubbock,16,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,95,47,48
-Lubbock,16,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,16,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,92,44,48
-Lubbock,16,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,3,3,0
-Lubbock,16,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,89,43,46
-Lubbock,16,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,6,4,2
-Lubbock,16,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,91,46,45
-Lubbock,16,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,3,1,2
-Lubbock,16,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,95,47,48
-Lubbock,16,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
-Lubbock,16,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,94,46,48
-Lubbock,16,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,16,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,93,46,47
-Lubbock,16,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,16,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,92,46,46
+Lubbock,16,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,1,1,0
+Lubbock,16,"Democratic Proposition #2 Student Loan Debt",,DEM,For,91,45,46
+Lubbock,16,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,3,2,1
+Lubbock,16,"Democratic Proposition #3 Right to Healthcare",,DEM,For,93,45,48
+Lubbock,16,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,3,3,0
+Lubbock,16,"Democratic Proposition #4 Right to Economic Security",,DEM,For,93,47,46
+Lubbock,16,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,1,0,1
+Lubbock,16,"Democratic Proposition #5 National Jobs Program",,DEM,For,84,42,42
+Lubbock,16,"Democratic Proposition #5 National Jobs Program",,DEM,Against,6,2,4
+Lubbock,16,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,95,47,48
+Lubbock,16,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,16,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,92,44,48
+Lubbock,16,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,3,3,0
+Lubbock,16,"Democratic Proposition #8 Right to Housing",,DEM,For,89,43,46
+Lubbock,16,"Democratic Proposition #8 Right to Housing",,DEM,Against,6,4,2
+Lubbock,16,"Democratic Proposition #9 Right to Vote",,DEM,For,91,46,45
+Lubbock,16,"Democratic Proposition #9 Right to Vote",,DEM,Against,3,1,2
+Lubbock,16,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,95,47,48
+Lubbock,16,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
+Lubbock,16,"Democratic Proposition #11 Immigrant Rights",,DEM,For,94,46,48
+Lubbock,16,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,16,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,93,46,47
+Lubbock,16,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,17,Registered Voters,,,,1027,,
 Lubbock,17,U.S. Senate,,DEM,Beto O'Rourke,27,9,18
 Lubbock,17,U.S. Senate,,DEM,Sema Hernandez,11,7,4
@@ -11398,82 +10618,30 @@ Lubbock,17,State Representative,84,DEM,Austin Michael Carrizales,15,7,8
 Lubbock,17,State Representative,84,DEM,Samantha Carrillo Fields,21,9,12
 Lubbock,17,"Justice of the Peace, Precinct 3",,DEM,Aurora Chaides-Hernandez,37,15,22
 Lubbock,17,County Party Chair,,DEM,Stuart Williams,37,15,22
-Lubbock,17,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,37,16,21
-Lubbock,17,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,1,1,0
-Lubbock,17,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,38,17,21
-Lubbock,17,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,17,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,37,17,20
-Lubbock,17,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,2,0,2
-Lubbock,17,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,39,17,22
-Lubbock,17,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,17,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,36,16,20
-Lubbock,17,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,3,1,2
-Lubbock,17,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,38,17,21
-Lubbock,17,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,1,0,1
-Lubbock,17,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,37,17,20
-Lubbock,17,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,2,0,2
-Lubbock,17,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,36,17,19
-Lubbock,17,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,2,0,2
-Lubbock,17,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,36,15,21
-Lubbock,17,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,3,2,1
-Lubbock,17,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,38,17,21
-Lubbock,17,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,1,0,1
-Lubbock,17,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,37,17,20
-Lubbock,17,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,1,0,1
-Lubbock,17,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,39,17,22
-Lubbock,17,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,17,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,37,16,21
+Lubbock,17,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,1,1,0
+Lubbock,17,"Democratic Proposition #2 Student Loan Debt",,DEM,For,38,17,21
+Lubbock,17,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,17,"Democratic Proposition #3 Right to Healthcare",,DEM,For,37,17,20
+Lubbock,17,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,2,0,2
+Lubbock,17,"Democratic Proposition #4 Right to Economic Security",,DEM,For,39,17,22
+Lubbock,17,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,17,"Democratic Proposition #5 National Jobs Program",,DEM,For,36,16,20
+Lubbock,17,"Democratic Proposition #5 National Jobs Program",,DEM,Against,3,1,2
+Lubbock,17,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,38,17,21
+Lubbock,17,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,1,0,1
+Lubbock,17,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,37,17,20
+Lubbock,17,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,2,0,2
+Lubbock,17,"Democratic Proposition #8 Right to Housing",,DEM,For,36,17,19
+Lubbock,17,"Democratic Proposition #8 Right to Housing",,DEM,Against,2,0,2
+Lubbock,17,"Democratic Proposition #9 Right to Vote",,DEM,For,36,15,21
+Lubbock,17,"Democratic Proposition #9 Right to Vote",,DEM,Against,3,2,1
+Lubbock,17,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,38,17,21
+Lubbock,17,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,1,0,1
+Lubbock,17,"Democratic Proposition #11 Immigrant Rights",,DEM,For,37,17,20
+Lubbock,17,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,1,0,1
+Lubbock,17,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,39,17,22
+Lubbock,17,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,18,Registered Voters,,,,1298,,
 Lubbock,18,U.S. Senate,,DEM,Beto O'Rourke,79,44,35
 Lubbock,18,U.S. Senate,,DEM,Sema Hernandez,8,5,3
@@ -11507,82 +10675,30 @@ Lubbock,18,State Representative,84,DEM,Austin Michael Carrizales,38,23,15
 Lubbock,18,State Representative,84,DEM,Samantha Carrillo Fields,45,24,21
 Lubbock,18,"Justice of the Peace, Precinct 3",,DEM,Aurora Chaides-Hernandez,85,45,40
 Lubbock,18,County Party Chair,,DEM,Stuart Williams,81,41,40
-Lubbock,18,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,89,50,39
-Lubbock,18,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,1,0,1
-Lubbock,18,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,86,46,40
-Lubbock,18,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,4,4,0
-Lubbock,18,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,89,49,40
-Lubbock,18,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,2,2,0
-Lubbock,18,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,88,48,40
-Lubbock,18,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,1,1,0
-Lubbock,18,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,88,49,39
-Lubbock,18,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,2,2,0
-Lubbock,18,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,91,51,40
-Lubbock,18,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,18,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,87,48,39
-Lubbock,18,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,18,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,84,47,37
-Lubbock,18,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,3,2,1
-Lubbock,18,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,88,50,38
-Lubbock,18,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,2,1,1
-Lubbock,18,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,89,50,39
-Lubbock,18,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,18,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,89,50,39
-Lubbock,18,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,18,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,87,49,38
-Lubbock,18,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,1,1,0
+Lubbock,18,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,89,50,39
+Lubbock,18,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,1,0,1
+Lubbock,18,"Democratic Proposition #2 Student Loan Debt",,DEM,For,86,46,40
+Lubbock,18,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,4,4,0
+Lubbock,18,"Democratic Proposition #3 Right to Healthcare",,DEM,For,89,49,40
+Lubbock,18,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,2,2,0
+Lubbock,18,"Democratic Proposition #4 Right to Economic Security",,DEM,For,88,48,40
+Lubbock,18,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,1,1,0
+Lubbock,18,"Democratic Proposition #5 National Jobs Program",,DEM,For,88,49,39
+Lubbock,18,"Democratic Proposition #5 National Jobs Program",,DEM,Against,2,2,0
+Lubbock,18,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,91,51,40
+Lubbock,18,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,18,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,87,48,39
+Lubbock,18,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,18,"Democratic Proposition #8 Right to Housing",,DEM,For,84,47,37
+Lubbock,18,"Democratic Proposition #8 Right to Housing",,DEM,Against,3,2,1
+Lubbock,18,"Democratic Proposition #9 Right to Vote",,DEM,For,88,50,38
+Lubbock,18,"Democratic Proposition #9 Right to Vote",,DEM,Against,2,1,1
+Lubbock,18,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,89,50,39
+Lubbock,18,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,18,"Democratic Proposition #11 Immigrant Rights",,DEM,For,89,50,39
+Lubbock,18,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,18,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,87,49,38
+Lubbock,18,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,1,1,0
 Lubbock,19,Registered Voters,,,,2451,,
 Lubbock,19,U.S. Senate,,DEM,Beto O'Rourke,30,19,11
 Lubbock,19,U.S. Senate,,DEM,Sema Hernandez,29,18,11
@@ -11616,82 +10732,30 @@ Lubbock,19,State Representative,84,DEM,Austin Michael Carrizales,32,19,13
 Lubbock,19,State Representative,84,DEM,Samantha Carrillo Fields,32,21,11
 Lubbock,19,"Justice of the Peace, Precinct 3",,DEM,Aurora Chaides-Hernandez,63,40,23
 Lubbock,19,County Party Chair,,DEM,Stuart Williams,59,37,22
-Lubbock,19,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,60,38,22
-Lubbock,19,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,3,2,1
-Lubbock,19,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,56,34,22
-Lubbock,19,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,6,4,2
-Lubbock,19,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,60,38,22
-Lubbock,19,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,3,2,1
-Lubbock,19,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,62,38,24
-Lubbock,19,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,2,2,0
-Lubbock,19,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,62,38,24
-Lubbock,19,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,2,2,0
-Lubbock,19,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,62,38,24
-Lubbock,19,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,2,2,0
-Lubbock,19,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,61,38,23
-Lubbock,19,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,1,1,0
-Lubbock,19,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,59,37,22
-Lubbock,19,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,5,3,2
-Lubbock,19,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,59,36,23
-Lubbock,19,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,3,3,0
-Lubbock,19,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,61,38,23
-Lubbock,19,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
-Lubbock,19,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,62,38,24
-Lubbock,19,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,1,1,0
-Lubbock,19,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,58,35,23
-Lubbock,19,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,5,4,1
+Lubbock,19,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,60,38,22
+Lubbock,19,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,3,2,1
+Lubbock,19,"Democratic Proposition #2 Student Loan Debt",,DEM,For,56,34,22
+Lubbock,19,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,6,4,2
+Lubbock,19,"Democratic Proposition #3 Right to Healthcare",,DEM,For,60,38,22
+Lubbock,19,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,3,2,1
+Lubbock,19,"Democratic Proposition #4 Right to Economic Security",,DEM,For,62,38,24
+Lubbock,19,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,2,2,0
+Lubbock,19,"Democratic Proposition #5 National Jobs Program",,DEM,For,62,38,24
+Lubbock,19,"Democratic Proposition #5 National Jobs Program",,DEM,Against,2,2,0
+Lubbock,19,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,62,38,24
+Lubbock,19,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,2,2,0
+Lubbock,19,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,61,38,23
+Lubbock,19,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,1,1,0
+Lubbock,19,"Democratic Proposition #8 Right to Housing",,DEM,For,59,37,22
+Lubbock,19,"Democratic Proposition #8 Right to Housing",,DEM,Against,5,3,2
+Lubbock,19,"Democratic Proposition #9 Right to Vote",,DEM,For,59,36,23
+Lubbock,19,"Democratic Proposition #9 Right to Vote",,DEM,Against,3,3,0
+Lubbock,19,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,61,38,23
+Lubbock,19,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
+Lubbock,19,"Democratic Proposition #11 Immigrant Rights",,DEM,For,62,38,24
+Lubbock,19,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,1,1,0
+Lubbock,19,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,58,35,23
+Lubbock,19,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,5,4,1
 Lubbock,20,Registered Voters,,,,1335,,
 Lubbock,20,U.S. Senate,,DEM,Beto O'Rourke,33,19,14
 Lubbock,20,U.S. Senate,,DEM,Sema Hernandez,45,33,12
@@ -11725,82 +10789,30 @@ Lubbock,20,State Representative,84,DEM,Austin Michael Carrizales,36,24,12
 Lubbock,20,State Representative,84,DEM,Samantha Carrillo Fields,75,49,26
 Lubbock,20,"Justice of the Peace, Precinct 3",,DEM,Aurora Chaides-Hernandez,104,67,37
 Lubbock,20,County Party Chair,,DEM,Stuart Williams,107,69,38
-Lubbock,20,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,112,76,36
-Lubbock,20,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,3,1,2
-Lubbock,20,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,103,66,37
-Lubbock,20,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,6,6,0
-Lubbock,20,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,111,73,38
-Lubbock,20,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,4,3,1
-Lubbock,20,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,113,75,38
-Lubbock,20,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,1,1,0
-Lubbock,20,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,106,72,34
-Lubbock,20,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,7,5,2
-Lubbock,20,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,114,77,37
-Lubbock,20,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,20,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,112,75,37
-Lubbock,20,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,20,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,112,77,35
-Lubbock,20,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,5,1,4
-Lubbock,20,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,107,69,38
-Lubbock,20,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,6,6,0
-Lubbock,20,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,111,73,38
-Lubbock,20,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,4,3,1
-Lubbock,20,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,108,72,36
-Lubbock,20,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,5,3,2
-Lubbock,20,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,112,74,38
-Lubbock,20,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,3,2,1
+Lubbock,20,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,112,76,36
+Lubbock,20,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,3,1,2
+Lubbock,20,"Democratic Proposition #2 Student Loan Debt",,DEM,For,103,66,37
+Lubbock,20,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,6,6,0
+Lubbock,20,"Democratic Proposition #3 Right to Healthcare",,DEM,For,111,73,38
+Lubbock,20,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,4,3,1
+Lubbock,20,"Democratic Proposition #4 Right to Economic Security",,DEM,For,113,75,38
+Lubbock,20,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,1,1,0
+Lubbock,20,"Democratic Proposition #5 National Jobs Program",,DEM,For,106,72,34
+Lubbock,20,"Democratic Proposition #5 National Jobs Program",,DEM,Against,7,5,2
+Lubbock,20,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,114,77,37
+Lubbock,20,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,20,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,112,75,37
+Lubbock,20,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,20,"Democratic Proposition #8 Right to Housing",,DEM,For,112,77,35
+Lubbock,20,"Democratic Proposition #8 Right to Housing",,DEM,Against,5,1,4
+Lubbock,20,"Democratic Proposition #9 Right to Vote",,DEM,For,107,69,38
+Lubbock,20,"Democratic Proposition #9 Right to Vote",,DEM,Against,6,6,0
+Lubbock,20,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,111,73,38
+Lubbock,20,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,4,3,1
+Lubbock,20,"Democratic Proposition #11 Immigrant Rights",,DEM,For,108,72,36
+Lubbock,20,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,5,3,2
+Lubbock,20,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,112,74,38
+Lubbock,20,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,3,2,1
 Lubbock,21,Registered Voters,,,,2139,,
 Lubbock,21,U.S. Senate,,DEM,Beto O'Rourke,41,25,16
 Lubbock,21,U.S. Senate,,DEM,Sema Hernandez,16,9,7
@@ -11835,82 +10847,30 @@ Lubbock,21,State Representative,84,DEM,Samantha Carrillo Fields,37,22,15
 Lubbock,21,"County Commissioner, Precinct 2",,DEM,Nick Harpster,60,37,23
 Lubbock,21,"Justice of the Peace, Precinct 2",,DEM,Daylan J. Flowers,58,35,23
 Lubbock,21,County Party Chair,,DEM,Stuart Williams,58,36,22
-Lubbock,21,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,64,38,26
-Lubbock,21,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,2,2,0
-Lubbock,21,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,60,36,24
-Lubbock,21,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,5,4,1
-Lubbock,21,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,60,35,25
-Lubbock,21,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,5,4,1
-Lubbock,21,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,61,36,25
-Lubbock,21,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,3,3,0
-Lubbock,21,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,58,36,22
-Lubbock,21,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,5,3,2
-Lubbock,21,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,62,37,25
-Lubbock,21,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,2,2,0
-Lubbock,21,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,63,37,26
-Lubbock,21,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,2,2,0
-Lubbock,21,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,61,37,24
-Lubbock,21,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,3,2,1
-Lubbock,21,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,61,38,23
-Lubbock,21,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,3,2,1
-Lubbock,21,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,63,37,26
-Lubbock,21,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,3,3,0
-Lubbock,21,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,63,38,25
-Lubbock,21,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,3,2,1
-Lubbock,21,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,65,39,26
-Lubbock,21,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,1,1,0
+Lubbock,21,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,64,38,26
+Lubbock,21,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,2,2,0
+Lubbock,21,"Democratic Proposition #2 Student Loan Debt",,DEM,For,60,36,24
+Lubbock,21,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,5,4,1
+Lubbock,21,"Democratic Proposition #3 Right to Healthcare",,DEM,For,60,35,25
+Lubbock,21,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,5,4,1
+Lubbock,21,"Democratic Proposition #4 Right to Economic Security",,DEM,For,61,36,25
+Lubbock,21,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,3,3,0
+Lubbock,21,"Democratic Proposition #5 National Jobs Program",,DEM,For,58,36,22
+Lubbock,21,"Democratic Proposition #5 National Jobs Program",,DEM,Against,5,3,2
+Lubbock,21,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,62,37,25
+Lubbock,21,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,2,2,0
+Lubbock,21,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,63,37,26
+Lubbock,21,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,2,2,0
+Lubbock,21,"Democratic Proposition #8 Right to Housing",,DEM,For,61,37,24
+Lubbock,21,"Democratic Proposition #8 Right to Housing",,DEM,Against,3,2,1
+Lubbock,21,"Democratic Proposition #9 Right to Vote",,DEM,For,61,38,23
+Lubbock,21,"Democratic Proposition #9 Right to Vote",,DEM,Against,3,2,1
+Lubbock,21,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,63,37,26
+Lubbock,21,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,3,3,0
+Lubbock,21,"Democratic Proposition #11 Immigrant Rights",,DEM,For,63,38,25
+Lubbock,21,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,3,2,1
+Lubbock,21,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,65,39,26
+Lubbock,21,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,1,1,0
 Lubbock,22,Registered Voters,,,,2022,,
 Lubbock,22,U.S. Senate,,DEM,Beto O'Rourke,76,33,43
 Lubbock,22,U.S. Senate,,DEM,Sema Hernandez,10,8,2
@@ -11945,82 +10905,30 @@ Lubbock,22,State Representative,84,DEM,Samantha Carrillo Fields,53,21,32
 Lubbock,22,"County Commissioner, Precinct 2",,DEM,Nick Harpster,86,40,46
 Lubbock,22,"Justice of the Peace, Precinct 2",,DEM,Daylan J. Flowers,86,40,46
 Lubbock,22,County Party Chair,,DEM,Stuart Williams,88,41,47
-Lubbock,22,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,93,44,49
-Lubbock,22,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,22,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,91,43,48
-Lubbock,22,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,1,0,1
-Lubbock,22,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,91,43,48
-Lubbock,22,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,1,0,1
-Lubbock,22,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,92,44,48
-Lubbock,22,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,1,0,1
-Lubbock,22,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,90,42,48
-Lubbock,22,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,2,1,1
-Lubbock,22,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,94,44,50
-Lubbock,22,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,22,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,91,43,48
-Lubbock,22,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,1,0,1
-Lubbock,22,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,90,43,47
-Lubbock,22,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,1,0,1
-Lubbock,22,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,92,44,48
-Lubbock,22,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,2,0,2
-Lubbock,22,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,90,42,48
-Lubbock,22,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,22,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,92,44,48
-Lubbock,22,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,1,0,1
-Lubbock,22,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,92,43,49
-Lubbock,22,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,2,1,1
+Lubbock,22,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,93,44,49
+Lubbock,22,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,22,"Democratic Proposition #2 Student Loan Debt",,DEM,For,91,43,48
+Lubbock,22,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,1,0,1
+Lubbock,22,"Democratic Proposition #3 Right to Healthcare",,DEM,For,91,43,48
+Lubbock,22,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,1,0,1
+Lubbock,22,"Democratic Proposition #4 Right to Economic Security",,DEM,For,92,44,48
+Lubbock,22,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,1,0,1
+Lubbock,22,"Democratic Proposition #5 National Jobs Program",,DEM,For,90,42,48
+Lubbock,22,"Democratic Proposition #5 National Jobs Program",,DEM,Against,2,1,1
+Lubbock,22,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,94,44,50
+Lubbock,22,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,22,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,91,43,48
+Lubbock,22,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,1,0,1
+Lubbock,22,"Democratic Proposition #8 Right to Housing",,DEM,For,90,43,47
+Lubbock,22,"Democratic Proposition #8 Right to Housing",,DEM,Against,1,0,1
+Lubbock,22,"Democratic Proposition #9 Right to Vote",,DEM,For,92,44,48
+Lubbock,22,"Democratic Proposition #9 Right to Vote",,DEM,Against,2,0,2
+Lubbock,22,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,90,42,48
+Lubbock,22,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,22,"Democratic Proposition #11 Immigrant Rights",,DEM,For,92,44,48
+Lubbock,22,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,1,0,1
+Lubbock,22,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,92,43,49
+Lubbock,22,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,2,1,1
 Lubbock,23,Registered Voters,,,,1319,,
 Lubbock,23,U.S. Senate,,DEM,Beto O'Rourke,67,31,36
 Lubbock,23,U.S. Senate,,DEM,Sema Hernandez,6,2,4
@@ -12055,82 +10963,30 @@ Lubbock,23,State Representative,84,DEM,Samantha Carrillo Fields,42,18,24
 Lubbock,23,"County Commissioner, Precinct 2",,DEM,Nick Harpster,70,33,37
 Lubbock,23,"Justice of the Peace, Precinct 2",,DEM,Daylan J. Flowers,73,32,41
 Lubbock,23,County Party Chair,,DEM,Stuart Williams,71,34,37
-Lubbock,23,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,78,37,41
-Lubbock,23,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,2,0,2
-Lubbock,23,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,74,35,39
-Lubbock,23,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,3,1,2
-Lubbock,23,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,74,32,42
-Lubbock,23,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,3,2,1
-Lubbock,23,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,78,36,42
-Lubbock,23,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,1,0,1
-Lubbock,23,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,75,34,41
-Lubbock,23,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,5,3,2
-Lubbock,23,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,80,37,43
-Lubbock,23,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,23,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,77,36,41
-Lubbock,23,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,2,1,1
-Lubbock,23,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,76,34,42
-Lubbock,23,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,4,3,1
-Lubbock,23,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,78,36,42
-Lubbock,23,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,1,1,0
-Lubbock,23,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,80,37,43
-Lubbock,23,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,23,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,78,36,42
-Lubbock,23,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,2,1,1
-Lubbock,23,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,77,35,42
-Lubbock,23,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,2,2,0
+Lubbock,23,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,78,37,41
+Lubbock,23,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,2,0,2
+Lubbock,23,"Democratic Proposition #2 Student Loan Debt",,DEM,For,74,35,39
+Lubbock,23,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,3,1,2
+Lubbock,23,"Democratic Proposition #3 Right to Healthcare",,DEM,For,74,32,42
+Lubbock,23,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,3,2,1
+Lubbock,23,"Democratic Proposition #4 Right to Economic Security",,DEM,For,78,36,42
+Lubbock,23,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,1,0,1
+Lubbock,23,"Democratic Proposition #5 National Jobs Program",,DEM,For,75,34,41
+Lubbock,23,"Democratic Proposition #5 National Jobs Program",,DEM,Against,5,3,2
+Lubbock,23,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,80,37,43
+Lubbock,23,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,23,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,77,36,41
+Lubbock,23,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,2,1,1
+Lubbock,23,"Democratic Proposition #8 Right to Housing",,DEM,For,76,34,42
+Lubbock,23,"Democratic Proposition #8 Right to Housing",,DEM,Against,4,3,1
+Lubbock,23,"Democratic Proposition #9 Right to Vote",,DEM,For,78,36,42
+Lubbock,23,"Democratic Proposition #9 Right to Vote",,DEM,Against,1,1,0
+Lubbock,23,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,80,37,43
+Lubbock,23,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,23,"Democratic Proposition #11 Immigrant Rights",,DEM,For,78,36,42
+Lubbock,23,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,2,1,1
+Lubbock,23,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,77,35,42
+Lubbock,23,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,2,2,0
 Lubbock,24,Registered Voters,,,,1919,,
 Lubbock,24,U.S. Senate,,DEM,Beto O'Rourke,67,43,24
 Lubbock,24,U.S. Senate,,DEM,Sema Hernandez,21,14,7
@@ -12164,82 +11020,30 @@ Lubbock,24,State Representative,83,DEM,Drew Landry,89,58,31
 Lubbock,24,"County Commissioner, Precinct 2",,DEM,Nick Harpster,88,57,31
 Lubbock,24,"Justice of the Peace, Precinct 2",,DEM,Daylan J. Flowers,89,58,31
 Lubbock,24,County Party Chair,,DEM,Stuart Williams,90,59,31
-Lubbock,24,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,90,58,32
-Lubbock,24,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,3,2,1
-Lubbock,24,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,93,61,32
-Lubbock,24,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,1,0,1
-Lubbock,24,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,91,60,31
-Lubbock,24,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,2,1,1
-Lubbock,24,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,92,60,32
-Lubbock,24,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,2,1,1
-Lubbock,24,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,89,59,30
-Lubbock,24,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,4,1,3
-Lubbock,24,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,93,61,32
-Lubbock,24,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,1,0,1
-Lubbock,24,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,88,57,31
-Lubbock,24,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,4,2,2
-Lubbock,24,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,91,60,31
-Lubbock,24,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,2,1,1
-Lubbock,24,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,92,60,32
-Lubbock,24,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,2,1,1
-Lubbock,24,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,92,59,33
-Lubbock,24,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,24,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,93,60,33
-Lubbock,24,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,1,1,0
-Lubbock,24,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,93,61,32
-Lubbock,24,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,24,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,90,58,32
+Lubbock,24,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,3,2,1
+Lubbock,24,"Democratic Proposition #2 Student Loan Debt",,DEM,For,93,61,32
+Lubbock,24,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,1,0,1
+Lubbock,24,"Democratic Proposition #3 Right to Healthcare",,DEM,For,91,60,31
+Lubbock,24,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,2,1,1
+Lubbock,24,"Democratic Proposition #4 Right to Economic Security",,DEM,For,92,60,32
+Lubbock,24,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,2,1,1
+Lubbock,24,"Democratic Proposition #5 National Jobs Program",,DEM,For,89,59,30
+Lubbock,24,"Democratic Proposition #5 National Jobs Program",,DEM,Against,4,1,3
+Lubbock,24,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,93,61,32
+Lubbock,24,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,1,0,1
+Lubbock,24,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,88,57,31
+Lubbock,24,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,4,2,2
+Lubbock,24,"Democratic Proposition #8 Right to Housing",,DEM,For,91,60,31
+Lubbock,24,"Democratic Proposition #8 Right to Housing",,DEM,Against,2,1,1
+Lubbock,24,"Democratic Proposition #9 Right to Vote",,DEM,For,92,60,32
+Lubbock,24,"Democratic Proposition #9 Right to Vote",,DEM,Against,2,1,1
+Lubbock,24,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,92,59,33
+Lubbock,24,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,24,"Democratic Proposition #11 Immigrant Rights",,DEM,For,93,60,33
+Lubbock,24,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,1,1,0
+Lubbock,24,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,93,61,32
+Lubbock,24,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,25,Registered Voters,,,,1936,,
 Lubbock,25,U.S. Senate,,DEM,Beto O'Rourke,30,18,12
 Lubbock,25,U.S. Senate,,DEM,Sema Hernandez,29,18,11
@@ -12273,82 +11077,30 @@ Lubbock,25,State Representative,84,DEM,Austin Michael Carrizales,32,20,12
 Lubbock,25,State Representative,84,DEM,Samantha Carrillo Fields,29,19,10
 Lubbock,25,"Justice of the Peace, Precinct 3",,DEM,Aurora Chaides-Hernandez,59,39,20
 Lubbock,25,County Party Chair,,DEM,Stuart Williams,54,35,19
-Lubbock,25,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,60,38,22
-Lubbock,25,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,2,1,1
-Lubbock,25,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,58,36,22
-Lubbock,25,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,3,2,1
-Lubbock,25,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,60,37,23
-Lubbock,25,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,2,2,0
-Lubbock,25,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,60,38,22
-Lubbock,25,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,2,1,1
-Lubbock,25,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,59,37,22
-Lubbock,25,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,4,3,1
-Lubbock,25,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,63,40,23
-Lubbock,25,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,25,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,62,39,23
-Lubbock,25,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,25,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,60,38,22
-Lubbock,25,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,2,2,0
-Lubbock,25,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,59,39,20
-Lubbock,25,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,3,1,2
-Lubbock,25,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,62,40,22
-Lubbock,25,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
-Lubbock,25,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,60,37,23
-Lubbock,25,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,3,3,0
-Lubbock,25,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,59,38,21
-Lubbock,25,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,4,2,2
+Lubbock,25,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,60,38,22
+Lubbock,25,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,2,1,1
+Lubbock,25,"Democratic Proposition #2 Student Loan Debt",,DEM,For,58,36,22
+Lubbock,25,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,3,2,1
+Lubbock,25,"Democratic Proposition #3 Right to Healthcare",,DEM,For,60,37,23
+Lubbock,25,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,2,2,0
+Lubbock,25,"Democratic Proposition #4 Right to Economic Security",,DEM,For,60,38,22
+Lubbock,25,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,2,1,1
+Lubbock,25,"Democratic Proposition #5 National Jobs Program",,DEM,For,59,37,22
+Lubbock,25,"Democratic Proposition #5 National Jobs Program",,DEM,Against,4,3,1
+Lubbock,25,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,63,40,23
+Lubbock,25,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,25,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,62,39,23
+Lubbock,25,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,25,"Democratic Proposition #8 Right to Housing",,DEM,For,60,38,22
+Lubbock,25,"Democratic Proposition #8 Right to Housing",,DEM,Against,2,2,0
+Lubbock,25,"Democratic Proposition #9 Right to Vote",,DEM,For,59,39,20
+Lubbock,25,"Democratic Proposition #9 Right to Vote",,DEM,Against,3,1,2
+Lubbock,25,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,62,40,22
+Lubbock,25,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
+Lubbock,25,"Democratic Proposition #11 Immigrant Rights",,DEM,For,60,37,23
+Lubbock,25,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,3,3,0
+Lubbock,25,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,59,38,21
+Lubbock,25,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,4,2,2
 Lubbock,26,Registered Voters,,,,2901,,
 Lubbock,26,U.S. Senate,,DEM,Beto O'Rourke,38,19,19
 Lubbock,26,U.S. Senate,,DEM,Sema Hernandez,28,16,12
@@ -12382,82 +11134,30 @@ Lubbock,26,State Representative,84,DEM,Austin Michael Carrizales,40,25,15
 Lubbock,26,State Representative,84,DEM,Samantha Carrillo Fields,33,14,19
 Lubbock,26,"Justice of the Peace, Precinct 3",,DEM,Aurora Chaides-Hernandez,70,39,31
 Lubbock,26,County Party Chair,,DEM,Stuart Williams,68,37,31
-Lubbock,26,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,70,38,32
-Lubbock,26,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,2,2,0
-Lubbock,26,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,71,38,33
-Lubbock,26,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,5,3,2
-Lubbock,26,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,71,38,33
-Lubbock,26,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,3,3,0
-Lubbock,26,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,75,40,35
-Lubbock,26,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,1,1,0
-Lubbock,26,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,61,35,26
-Lubbock,26,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,16,7,9
-Lubbock,26,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,75,41,34
-Lubbock,26,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,1,1,0
-Lubbock,26,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,72,39,33
-Lubbock,26,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,1,1,0
-Lubbock,26,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,71,39,32
-Lubbock,26,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,3,2,1
-Lubbock,26,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,71,39,32
-Lubbock,26,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,5,3,2
-Lubbock,26,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,71,36,35
-Lubbock,26,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,4,4,0
-Lubbock,26,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,71,38,33
-Lubbock,26,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,3,2,1
-Lubbock,26,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,73,40,33
-Lubbock,26,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,2,0,2
+Lubbock,26,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,70,38,32
+Lubbock,26,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,2,2,0
+Lubbock,26,"Democratic Proposition #2 Student Loan Debt",,DEM,For,71,38,33
+Lubbock,26,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,5,3,2
+Lubbock,26,"Democratic Proposition #3 Right to Healthcare",,DEM,For,71,38,33
+Lubbock,26,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,3,3,0
+Lubbock,26,"Democratic Proposition #4 Right to Economic Security",,DEM,For,75,40,35
+Lubbock,26,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,1,1,0
+Lubbock,26,"Democratic Proposition #5 National Jobs Program",,DEM,For,61,35,26
+Lubbock,26,"Democratic Proposition #5 National Jobs Program",,DEM,Against,16,7,9
+Lubbock,26,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,75,41,34
+Lubbock,26,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,1,1,0
+Lubbock,26,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,72,39,33
+Lubbock,26,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,1,1,0
+Lubbock,26,"Democratic Proposition #8 Right to Housing",,DEM,For,71,39,32
+Lubbock,26,"Democratic Proposition #8 Right to Housing",,DEM,Against,3,2,1
+Lubbock,26,"Democratic Proposition #9 Right to Vote",,DEM,For,71,39,32
+Lubbock,26,"Democratic Proposition #9 Right to Vote",,DEM,Against,5,3,2
+Lubbock,26,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,71,36,35
+Lubbock,26,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,4,4,0
+Lubbock,26,"Democratic Proposition #11 Immigrant Rights",,DEM,For,71,38,33
+Lubbock,26,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,3,2,1
+Lubbock,26,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,73,40,33
+Lubbock,26,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,2,0,2
 Lubbock,27,Registered Voters,,,,3292,,
 Lubbock,27,U.S. Senate,,DEM,Beto O'Rourke,101,49,52
 Lubbock,27,U.S. Senate,,DEM,Sema Hernandez,25,13,12
@@ -12490,82 +11190,30 @@ Lubbock,27,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,116,
 Lubbock,27,State Representative,84,DEM,Austin Michael Carrizales,41,25,16
 Lubbock,27,State Representative,84,DEM,Samantha Carrillo Fields,87,38,49
 Lubbock,27,County Party Chair,,DEM,Stuart Williams,117,53,64
-Lubbock,27,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,130,65,65
-Lubbock,27,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,3,2,1
-Lubbock,27,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,129,66,63
-Lubbock,27,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,6,4,2
-Lubbock,27,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,132,68,64
-Lubbock,27,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,4,2,2
-Lubbock,27,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,136,69,67
-Lubbock,27,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,1,1,0
-Lubbock,27,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,128,64,64
-Lubbock,27,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,6,4,2
-Lubbock,27,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,137,70,67
-Lubbock,27,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,27,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,135,70,65
-Lubbock,27,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,1,0,1
-Lubbock,27,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,131,69,62
-Lubbock,27,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,4,1,3
-Lubbock,27,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,132,68,64
-Lubbock,27,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,2,1,1
-Lubbock,27,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,132,68,64
-Lubbock,27,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,3,2,1
-Lubbock,27,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,126,64,62
-Lubbock,27,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,7,4,3
-Lubbock,27,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,133,68,65
-Lubbock,27,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,27,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,130,65,65
+Lubbock,27,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,3,2,1
+Lubbock,27,"Democratic Proposition #2 Student Loan Debt",,DEM,For,129,66,63
+Lubbock,27,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,6,4,2
+Lubbock,27,"Democratic Proposition #3 Right to Healthcare",,DEM,For,132,68,64
+Lubbock,27,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,4,2,2
+Lubbock,27,"Democratic Proposition #4 Right to Economic Security",,DEM,For,136,69,67
+Lubbock,27,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,1,1,0
+Lubbock,27,"Democratic Proposition #5 National Jobs Program",,DEM,For,128,64,64
+Lubbock,27,"Democratic Proposition #5 National Jobs Program",,DEM,Against,6,4,2
+Lubbock,27,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,137,70,67
+Lubbock,27,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,27,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,135,70,65
+Lubbock,27,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,1,0,1
+Lubbock,27,"Democratic Proposition #8 Right to Housing",,DEM,For,131,69,62
+Lubbock,27,"Democratic Proposition #8 Right to Housing",,DEM,Against,4,1,3
+Lubbock,27,"Democratic Proposition #9 Right to Vote",,DEM,For,132,68,64
+Lubbock,27,"Democratic Proposition #9 Right to Vote",,DEM,Against,2,1,1
+Lubbock,27,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,132,68,64
+Lubbock,27,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,3,2,1
+Lubbock,27,"Democratic Proposition #11 Immigrant Rights",,DEM,For,126,64,62
+Lubbock,27,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,7,4,3
+Lubbock,27,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,133,68,65
+Lubbock,27,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,28,Registered Voters,,,,2503,,
 Lubbock,28,U.S. Senate,,DEM,Beto O'Rourke,86,44,42
 Lubbock,28,U.S. Senate,,DEM,Sema Hernandez,20,14,6
@@ -12599,82 +11247,30 @@ Lubbock,28,State Representative,83,DEM,Drew Landry,110,62,48
 Lubbock,28,"County Commissioner, Precinct 2",,DEM,Nick Harpster,113,64,49
 Lubbock,28,"Justice of the Peace, Precinct 2",,DEM,Daylan J. Flowers,108,60,48
 Lubbock,28,County Party Chair,,DEM,Stuart Williams,112,63,49
-Lubbock,28,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,115,65,50
-Lubbock,28,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,1,1,0
-Lubbock,28,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,113,63,50
-Lubbock,28,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,4,3,1
-Lubbock,28,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,112,61,51
-Lubbock,28,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,4,3,1
-Lubbock,28,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,115,63,52
-Lubbock,28,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,1,1,0
-Lubbock,28,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,105,59,46
-Lubbock,28,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,8,5,3
-Lubbock,28,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,116,64,52
-Lubbock,28,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,1,1,0
-Lubbock,28,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,115,64,51
-Lubbock,28,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,2,1,1
-Lubbock,28,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,112,62,50
-Lubbock,28,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,6,4,2
-Lubbock,28,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,115,63,52
-Lubbock,28,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,3,3,0
-Lubbock,28,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,113,63,50
-Lubbock,28,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,4,2,2
-Lubbock,28,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,113,63,50
-Lubbock,28,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,2,1,1
-Lubbock,28,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,112,62,50
-Lubbock,28,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,1,1,0
+Lubbock,28,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,115,65,50
+Lubbock,28,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,1,1,0
+Lubbock,28,"Democratic Proposition #2 Student Loan Debt",,DEM,For,113,63,50
+Lubbock,28,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,4,3,1
+Lubbock,28,"Democratic Proposition #3 Right to Healthcare",,DEM,For,112,61,51
+Lubbock,28,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,4,3,1
+Lubbock,28,"Democratic Proposition #4 Right to Economic Security",,DEM,For,115,63,52
+Lubbock,28,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,1,1,0
+Lubbock,28,"Democratic Proposition #5 National Jobs Program",,DEM,For,105,59,46
+Lubbock,28,"Democratic Proposition #5 National Jobs Program",,DEM,Against,8,5,3
+Lubbock,28,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,116,64,52
+Lubbock,28,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,1,1,0
+Lubbock,28,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,115,64,51
+Lubbock,28,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,2,1,1
+Lubbock,28,"Democratic Proposition #8 Right to Housing",,DEM,For,112,62,50
+Lubbock,28,"Democratic Proposition #8 Right to Housing",,DEM,Against,6,4,2
+Lubbock,28,"Democratic Proposition #9 Right to Vote",,DEM,For,115,63,52
+Lubbock,28,"Democratic Proposition #9 Right to Vote",,DEM,Against,3,3,0
+Lubbock,28,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,113,63,50
+Lubbock,28,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,4,2,2
+Lubbock,28,"Democratic Proposition #11 Immigrant Rights",,DEM,For,113,63,50
+Lubbock,28,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,2,1,1
+Lubbock,28,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,112,62,50
+Lubbock,28,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,1,1,0
 Lubbock,29,Registered Voters,,,,2088,,
 Lubbock,29,U.S. Senate,,DEM,Beto O'Rourke,31,19,12
 Lubbock,29,U.S. Senate,,DEM,Sema Hernandez,25,14,11
@@ -12709,82 +11305,30 @@ Lubbock,29,State Representative,84,DEM,Samantha Carrillo Fields,33,22,11
 Lubbock,29,"County Commissioner, Precinct 2",,DEM,Nick Harpster,63,39,24
 Lubbock,29,"Justice of the Peace, Precinct 2",,DEM,Daylan J. Flowers,64,40,24
 Lubbock,29,County Party Chair,,DEM,Stuart Williams,64,40,24
-Lubbock,29,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,66,40,26
-Lubbock,29,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,2,1,1
-Lubbock,29,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,62,38,24
-Lubbock,29,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,4,2,2
-Lubbock,29,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,64,39,25
-Lubbock,29,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,2,1,1
-Lubbock,29,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,62,37,25
-Lubbock,29,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,4,2,2
-Lubbock,29,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,62,38,24
-Lubbock,29,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,6,3,3
-Lubbock,29,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,67,41,26
-Lubbock,29,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,1,0,1
-Lubbock,29,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,68,42,26
-Lubbock,29,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,1,0,1
-Lubbock,29,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,61,37,24
-Lubbock,29,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,6,3,3
-Lubbock,29,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,63,38,25
-Lubbock,29,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,5,3,2
-Lubbock,29,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,65,40,25
-Lubbock,29,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,3,2,1
-Lubbock,29,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,64,38,26
-Lubbock,29,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,4,3,1
-Lubbock,29,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,66,40,26
-Lubbock,29,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,3,2,1
+Lubbock,29,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,66,40,26
+Lubbock,29,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,2,1,1
+Lubbock,29,"Democratic Proposition #2 Student Loan Debt",,DEM,For,62,38,24
+Lubbock,29,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,4,2,2
+Lubbock,29,"Democratic Proposition #3 Right to Healthcare",,DEM,For,64,39,25
+Lubbock,29,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,2,1,1
+Lubbock,29,"Democratic Proposition #4 Right to Economic Security",,DEM,For,62,37,25
+Lubbock,29,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,4,2,2
+Lubbock,29,"Democratic Proposition #5 National Jobs Program",,DEM,For,62,38,24
+Lubbock,29,"Democratic Proposition #5 National Jobs Program",,DEM,Against,6,3,3
+Lubbock,29,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,67,41,26
+Lubbock,29,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,1,0,1
+Lubbock,29,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,68,42,26
+Lubbock,29,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,1,0,1
+Lubbock,29,"Democratic Proposition #8 Right to Housing",,DEM,For,61,37,24
+Lubbock,29,"Democratic Proposition #8 Right to Housing",,DEM,Against,6,3,3
+Lubbock,29,"Democratic Proposition #9 Right to Vote",,DEM,For,63,38,25
+Lubbock,29,"Democratic Proposition #9 Right to Vote",,DEM,Against,5,3,2
+Lubbock,29,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,65,40,25
+Lubbock,29,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,3,2,1
+Lubbock,29,"Democratic Proposition #11 Immigrant Rights",,DEM,For,64,38,26
+Lubbock,29,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,4,3,1
+Lubbock,29,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,66,40,26
+Lubbock,29,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,3,2,1
 Lubbock,30,Registered Voters,,,,2762,,
 Lubbock,30,U.S. Senate,,DEM,Beto O'Rourke,78,46,32
 Lubbock,30,U.S. Senate,,DEM,Sema Hernandez,14,4,10
@@ -12819,82 +11363,30 @@ Lubbock,30,State Representative,84,DEM,Samantha Carrillo Fields,66,35,31
 Lubbock,30,"County Commissioner, Precinct 2",,DEM,Nick Harpster,101,60,41
 Lubbock,30,"Justice of the Peace, Precinct 2",,DEM,Daylan J. Flowers,100,60,40
 Lubbock,30,County Party Chair,,DEM,Stuart Williams,101,60,41
-Lubbock,30,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,103,59,44
-Lubbock,30,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,1,1,0
-Lubbock,30,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,102,58,44
-Lubbock,30,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,1,1,0
-Lubbock,30,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,102,58,44
-Lubbock,30,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,1,0,1
-Lubbock,30,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,100,57,43
-Lubbock,30,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,3,1,2
-Lubbock,30,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,97,57,40
-Lubbock,30,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,7,3,4
-Lubbock,30,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,105,60,45
-Lubbock,30,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,30,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,103,59,44
-Lubbock,30,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,30,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,100,57,43
-Lubbock,30,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,2,1,1
-Lubbock,30,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,102,57,45
-Lubbock,30,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,2,2,0
-Lubbock,30,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,104,59,45
-Lubbock,30,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,30,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,101,58,43
-Lubbock,30,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,4,2,2
-Lubbock,30,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,102,57,45
-Lubbock,30,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,30,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,103,59,44
+Lubbock,30,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,1,1,0
+Lubbock,30,"Democratic Proposition #2 Student Loan Debt",,DEM,For,102,58,44
+Lubbock,30,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,1,1,0
+Lubbock,30,"Democratic Proposition #3 Right to Healthcare",,DEM,For,102,58,44
+Lubbock,30,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,1,0,1
+Lubbock,30,"Democratic Proposition #4 Right to Economic Security",,DEM,For,100,57,43
+Lubbock,30,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,3,1,2
+Lubbock,30,"Democratic Proposition #5 National Jobs Program",,DEM,For,97,57,40
+Lubbock,30,"Democratic Proposition #5 National Jobs Program",,DEM,Against,7,3,4
+Lubbock,30,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,105,60,45
+Lubbock,30,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,30,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,103,59,44
+Lubbock,30,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,30,"Democratic Proposition #8 Right to Housing",,DEM,For,100,57,43
+Lubbock,30,"Democratic Proposition #8 Right to Housing",,DEM,Against,2,1,1
+Lubbock,30,"Democratic Proposition #9 Right to Vote",,DEM,For,102,57,45
+Lubbock,30,"Democratic Proposition #9 Right to Vote",,DEM,Against,2,2,0
+Lubbock,30,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,104,59,45
+Lubbock,30,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,30,"Democratic Proposition #11 Immigrant Rights",,DEM,For,101,58,43
+Lubbock,30,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,4,2,2
+Lubbock,30,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,102,57,45
+Lubbock,30,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,31,Registered Voters,,,,1528,,
 Lubbock,31,U.S. Senate,,DEM,Beto O'Rourke,19,9,10
 Lubbock,31,U.S. Senate,,DEM,Sema Hernandez,7,1,6
@@ -12927,82 +11419,30 @@ Lubbock,31,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,26,9
 Lubbock,31,State Representative,83,DEM,Drew Landry,26,10,16
 Lubbock,31,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,27,10,17
 Lubbock,31,County Party Chair,,DEM,Stuart Williams,27,10,17
-Lubbock,31,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,25,10,15
-Lubbock,31,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,2,0,2
-Lubbock,31,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,26,10,16
-Lubbock,31,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,31,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,25,9,16
-Lubbock,31,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,2,1,1
-Lubbock,31,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,26,10,16
-Lubbock,31,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,1,0,1
-Lubbock,31,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,26,10,16
-Lubbock,31,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,1,0,1
-Lubbock,31,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,27,10,17
-Lubbock,31,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,31,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,27,10,17
-Lubbock,31,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,31,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,25,10,15
-Lubbock,31,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,1,0,1
-Lubbock,31,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,26,10,16
-Lubbock,31,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,1,0,1
-Lubbock,31,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,26,9,17
-Lubbock,31,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,31,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,26,10,16
-Lubbock,31,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,1,0,1
-Lubbock,31,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,26,9,17
-Lubbock,31,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,1,1,0
+Lubbock,31,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,25,10,15
+Lubbock,31,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,2,0,2
+Lubbock,31,"Democratic Proposition #2 Student Loan Debt",,DEM,For,26,10,16
+Lubbock,31,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,31,"Democratic Proposition #3 Right to Healthcare",,DEM,For,25,9,16
+Lubbock,31,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,2,1,1
+Lubbock,31,"Democratic Proposition #4 Right to Economic Security",,DEM,For,26,10,16
+Lubbock,31,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,1,0,1
+Lubbock,31,"Democratic Proposition #5 National Jobs Program",,DEM,For,26,10,16
+Lubbock,31,"Democratic Proposition #5 National Jobs Program",,DEM,Against,1,0,1
+Lubbock,31,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,27,10,17
+Lubbock,31,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,31,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,27,10,17
+Lubbock,31,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,31,"Democratic Proposition #8 Right to Housing",,DEM,For,25,10,15
+Lubbock,31,"Democratic Proposition #8 Right to Housing",,DEM,Against,1,0,1
+Lubbock,31,"Democratic Proposition #9 Right to Vote",,DEM,For,26,10,16
+Lubbock,31,"Democratic Proposition #9 Right to Vote",,DEM,Against,1,0,1
+Lubbock,31,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,26,9,17
+Lubbock,31,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,31,"Democratic Proposition #11 Immigrant Rights",,DEM,For,26,10,16
+Lubbock,31,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,1,0,1
+Lubbock,31,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,26,9,17
+Lubbock,31,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,1,1,0
 Lubbock,33,Registered Voters,,,,3503,,
 Lubbock,33,U.S. Senate,,DEM,Beto O'Rourke,34,18,16
 Lubbock,33,U.S. Senate,,DEM,Sema Hernandez,10,7,3
@@ -13034,82 +11474,30 @@ Lubbock,33,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Ja
 Lubbock,33,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,45,27,18
 Lubbock,33,State Representative,83,DEM,Drew Landry,44,27,17
 Lubbock,33,County Party Chair,,DEM,Stuart Williams,44,27,17
-Lubbock,33,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,50,31,19
-Lubbock,33,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,1,1,0
-Lubbock,33,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,47,30,17
-Lubbock,33,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,5,3,2
-Lubbock,33,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,43,25,18
-Lubbock,33,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,8,7,1
-Lubbock,33,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,47,30,17
-Lubbock,33,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,1,0,1
-Lubbock,33,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,43,27,16
-Lubbock,33,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,5,2,3
-Lubbock,33,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,51,32,19
-Lubbock,33,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,33,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,47,28,19
-Lubbock,33,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,2,2,0
-Lubbock,33,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,44,27,17
-Lubbock,33,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,5,3,2
-Lubbock,33,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,44,28,16
-Lubbock,33,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,6,3,3
-Lubbock,33,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,48,30,18
-Lubbock,33,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
-Lubbock,33,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,46,28,18
-Lubbock,33,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,2,2,0
-Lubbock,33,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,49,31,18
-Lubbock,33,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,33,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,50,31,19
+Lubbock,33,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,1,1,0
+Lubbock,33,"Democratic Proposition #2 Student Loan Debt",,DEM,For,47,30,17
+Lubbock,33,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,5,3,2
+Lubbock,33,"Democratic Proposition #3 Right to Healthcare",,DEM,For,43,25,18
+Lubbock,33,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,8,7,1
+Lubbock,33,"Democratic Proposition #4 Right to Economic Security",,DEM,For,47,30,17
+Lubbock,33,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,1,0,1
+Lubbock,33,"Democratic Proposition #5 National Jobs Program",,DEM,For,43,27,16
+Lubbock,33,"Democratic Proposition #5 National Jobs Program",,DEM,Against,5,2,3
+Lubbock,33,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,51,32,19
+Lubbock,33,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,33,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,47,28,19
+Lubbock,33,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,2,2,0
+Lubbock,33,"Democratic Proposition #8 Right to Housing",,DEM,For,44,27,17
+Lubbock,33,"Democratic Proposition #8 Right to Housing",,DEM,Against,5,3,2
+Lubbock,33,"Democratic Proposition #9 Right to Vote",,DEM,For,44,28,16
+Lubbock,33,"Democratic Proposition #9 Right to Vote",,DEM,Against,6,3,3
+Lubbock,33,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,48,30,18
+Lubbock,33,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
+Lubbock,33,"Democratic Proposition #11 Immigrant Rights",,DEM,For,46,28,18
+Lubbock,33,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,2,2,0
+Lubbock,33,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,49,31,18
+Lubbock,33,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,34,Registered Voters,,,,641,,
 Lubbock,34,U.S. Senate,,DEM,Beto O'Rourke,6,3,3
 Lubbock,34,U.S. Senate,,DEM,Sema Hernandez,2,0,2
@@ -13143,82 +11531,30 @@ Lubbock,34,State Representative,83,DEM,Drew Landry,10,4,6
 Lubbock,34,"County Commissioner, Precinct 2",,DEM,Nick Harpster,9,3,6
 Lubbock,34,"Justice of the Peace, Precinct 2",,DEM,Daylan J. Flowers,9,4,5
 Lubbock,34,County Party Chair,,DEM,Stuart Williams,10,4,6
-Lubbock,34,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,10,4,6
-Lubbock,34,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,34,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,10,4,6
-Lubbock,34,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,34,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,9,3,6
-Lubbock,34,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,1,1,0
-Lubbock,34,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,10,4,6
-Lubbock,34,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,34,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,10,4,6
-Lubbock,34,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,34,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,10,4,6
-Lubbock,34,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,34,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,10,4,6
-Lubbock,34,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,34,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,10,4,6
-Lubbock,34,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,34,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,9,4,5
-Lubbock,34,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,34,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,10,4,6
-Lubbock,34,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,34,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,10,4,6
-Lubbock,34,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,34,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,10,4,6
-Lubbock,34,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,34,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,10,4,6
+Lubbock,34,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,34,"Democratic Proposition #2 Student Loan Debt",,DEM,For,10,4,6
+Lubbock,34,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,34,"Democratic Proposition #3 Right to Healthcare",,DEM,For,9,3,6
+Lubbock,34,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,1,1,0
+Lubbock,34,"Democratic Proposition #4 Right to Economic Security",,DEM,For,10,4,6
+Lubbock,34,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,34,"Democratic Proposition #5 National Jobs Program",,DEM,For,10,4,6
+Lubbock,34,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,34,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,10,4,6
+Lubbock,34,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,34,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,10,4,6
+Lubbock,34,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,34,"Democratic Proposition #8 Right to Housing",,DEM,For,10,4,6
+Lubbock,34,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,34,"Democratic Proposition #9 Right to Vote",,DEM,For,9,4,5
+Lubbock,34,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,34,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,10,4,6
+Lubbock,34,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,34,"Democratic Proposition #11 Immigrant Rights",,DEM,For,10,4,6
+Lubbock,34,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,34,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,10,4,6
+Lubbock,34,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,35,Registered Voters,,,,611,,
 Lubbock,35,U.S. Senate,,DEM,Beto O'Rourke,10,7,3
 Lubbock,35,U.S. Senate,,DEM,Sema Hernandez,2,1,1
@@ -13252,82 +11588,30 @@ Lubbock,35,State Representative,83,DEM,Drew Landry,15,11,4
 Lubbock,35,"County Commissioner, Precinct 2",,DEM,Nick Harpster,16,12,4
 Lubbock,35,"Justice of the Peace, Precinct 2",,DEM,Daylan J. Flowers,15,11,4
 Lubbock,35,County Party Chair,,DEM,Stuart Williams,15,11,4
-Lubbock,35,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,15,11,4
-Lubbock,35,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,35,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,12,9,3
-Lubbock,35,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,4,3,1
-Lubbock,35,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,15,11,4
-Lubbock,35,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,1,1,0
-Lubbock,35,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,17,13,4
-Lubbock,35,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,35,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,15,11,4
-Lubbock,35,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,1,1,0
-Lubbock,35,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,17,13,4
-Lubbock,35,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,35,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,16,12,4
-Lubbock,35,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,35,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,15,11,4
-Lubbock,35,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,1,1,0
-Lubbock,35,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,16,12,4
-Lubbock,35,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,1,1,0
-Lubbock,35,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,16,12,4
-Lubbock,35,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,35,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,15,11,4
-Lubbock,35,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,1,1,0
-Lubbock,35,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,16,12,4
-Lubbock,35,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,35,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,15,11,4
+Lubbock,35,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,35,"Democratic Proposition #2 Student Loan Debt",,DEM,For,12,9,3
+Lubbock,35,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,4,3,1
+Lubbock,35,"Democratic Proposition #3 Right to Healthcare",,DEM,For,15,11,4
+Lubbock,35,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,1,1,0
+Lubbock,35,"Democratic Proposition #4 Right to Economic Security",,DEM,For,17,13,4
+Lubbock,35,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,35,"Democratic Proposition #5 National Jobs Program",,DEM,For,15,11,4
+Lubbock,35,"Democratic Proposition #5 National Jobs Program",,DEM,Against,1,1,0
+Lubbock,35,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,17,13,4
+Lubbock,35,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,35,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,16,12,4
+Lubbock,35,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,35,"Democratic Proposition #8 Right to Housing",,DEM,For,15,11,4
+Lubbock,35,"Democratic Proposition #8 Right to Housing",,DEM,Against,1,1,0
+Lubbock,35,"Democratic Proposition #9 Right to Vote",,DEM,For,16,12,4
+Lubbock,35,"Democratic Proposition #9 Right to Vote",,DEM,Against,1,1,0
+Lubbock,35,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,16,12,4
+Lubbock,35,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,35,"Democratic Proposition #11 Immigrant Rights",,DEM,For,15,11,4
+Lubbock,35,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,1,1,0
+Lubbock,35,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,16,12,4
+Lubbock,35,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,36,Registered Voters,,,,2131,,
 Lubbock,36,U.S. Senate,,DEM,Beto O'Rourke,28,14,14
 Lubbock,36,U.S. Senate,,DEM,Sema Hernandez,16,11,5
@@ -13361,82 +11645,30 @@ Lubbock,36,State Representative,83,DEM,Drew Landry,50,28,22
 Lubbock,36,"County Commissioner, Precinct 2",,DEM,Nick Harpster,49,28,21
 Lubbock,36,"Justice of the Peace, Precinct 2",,DEM,Daylan J. Flowers,48,28,20
 Lubbock,36,County Party Chair,,DEM,Stuart Williams,51,28,23
-Lubbock,36,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,54,30,24
-Lubbock,36,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,2,1,1
-Lubbock,36,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,55,32,23
-Lubbock,36,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,1,0,1
-Lubbock,36,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,55,30,25
-Lubbock,36,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,2,2,0
-Lubbock,36,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,56,31,25
-Lubbock,36,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,36,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,55,31,24
-Lubbock,36,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,2,1,1
-Lubbock,36,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,56,32,24
-Lubbock,36,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,36,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,56,31,25
-Lubbock,36,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,1,1,0
-Lubbock,36,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,52,29,23
-Lubbock,36,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,4,2,2
-Lubbock,36,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,52,32,20
-Lubbock,36,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,4,0,4
-Lubbock,36,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,53,28,25
-Lubbock,36,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,4,4,0
-Lubbock,36,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,52,29,23
-Lubbock,36,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,4,2,2
-Lubbock,36,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,52,30,22
-Lubbock,36,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,3,1,2
+Lubbock,36,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,54,30,24
+Lubbock,36,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,2,1,1
+Lubbock,36,"Democratic Proposition #2 Student Loan Debt",,DEM,For,55,32,23
+Lubbock,36,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,1,0,1
+Lubbock,36,"Democratic Proposition #3 Right to Healthcare",,DEM,For,55,30,25
+Lubbock,36,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,2,2,0
+Lubbock,36,"Democratic Proposition #4 Right to Economic Security",,DEM,For,56,31,25
+Lubbock,36,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,36,"Democratic Proposition #5 National Jobs Program",,DEM,For,55,31,24
+Lubbock,36,"Democratic Proposition #5 National Jobs Program",,DEM,Against,2,1,1
+Lubbock,36,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,56,32,24
+Lubbock,36,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,36,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,56,31,25
+Lubbock,36,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,1,1,0
+Lubbock,36,"Democratic Proposition #8 Right to Housing",,DEM,For,52,29,23
+Lubbock,36,"Democratic Proposition #8 Right to Housing",,DEM,Against,4,2,2
+Lubbock,36,"Democratic Proposition #9 Right to Vote",,DEM,For,52,32,20
+Lubbock,36,"Democratic Proposition #9 Right to Vote",,DEM,Against,4,0,4
+Lubbock,36,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,53,28,25
+Lubbock,36,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,4,4,0
+Lubbock,36,"Democratic Proposition #11 Immigrant Rights",,DEM,For,52,29,23
+Lubbock,36,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,4,2,2
+Lubbock,36,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,52,30,22
+Lubbock,36,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,3,1,2
 Lubbock,38,Registered Voters,,,,1595,,
 Lubbock,38,U.S. Senate,,DEM,Beto O'Rourke,17,8,9
 Lubbock,38,U.S. Senate,,DEM,Sema Hernandez,32,24,8
@@ -13470,82 +11702,30 @@ Lubbock,38,State Representative,83,DEM,Drew Landry,53,33,20
 Lubbock,38,"County Commissioner, Precinct 2",,DEM,Nick Harpster,51,33,18
 Lubbock,38,"Justice of the Peace, Precinct 2",,DEM,Daylan J. Flowers,53,35,18
 Lubbock,38,County Party Chair,,DEM,Stuart Williams,51,32,19
-Lubbock,38,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,55,35,20
-Lubbock,38,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,4,3,1
-Lubbock,38,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,56,36,20
-Lubbock,38,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,3,3,0
-Lubbock,38,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,57,36,21
-Lubbock,38,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,2,2,0
-Lubbock,38,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,57,36,21
-Lubbock,38,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,2,2,0
-Lubbock,38,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,53,33,20
-Lubbock,38,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,7,6,1
-Lubbock,38,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,59,38,21
-Lubbock,38,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,2,2,0
-Lubbock,38,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,57,36,21
-Lubbock,38,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,4,4,0
-Lubbock,38,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,54,34,20
-Lubbock,38,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,6,5,1
-Lubbock,38,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,57,36,21
-Lubbock,38,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,4,3,1
-Lubbock,38,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,59,38,21
-Lubbock,38,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,2,2,0
-Lubbock,38,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,54,33,21
-Lubbock,38,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,3,3,0
-Lubbock,38,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,55,34,21
-Lubbock,38,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,5,5,0
+Lubbock,38,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,55,35,20
+Lubbock,38,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,4,3,1
+Lubbock,38,"Democratic Proposition #2 Student Loan Debt",,DEM,For,56,36,20
+Lubbock,38,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,3,3,0
+Lubbock,38,"Democratic Proposition #3 Right to Healthcare",,DEM,For,57,36,21
+Lubbock,38,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,2,2,0
+Lubbock,38,"Democratic Proposition #4 Right to Economic Security",,DEM,For,57,36,21
+Lubbock,38,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,2,2,0
+Lubbock,38,"Democratic Proposition #5 National Jobs Program",,DEM,For,53,33,20
+Lubbock,38,"Democratic Proposition #5 National Jobs Program",,DEM,Against,7,6,1
+Lubbock,38,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,59,38,21
+Lubbock,38,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,2,2,0
+Lubbock,38,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,57,36,21
+Lubbock,38,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,4,4,0
+Lubbock,38,"Democratic Proposition #8 Right to Housing",,DEM,For,54,34,20
+Lubbock,38,"Democratic Proposition #8 Right to Housing",,DEM,Against,6,5,1
+Lubbock,38,"Democratic Proposition #9 Right to Vote",,DEM,For,57,36,21
+Lubbock,38,"Democratic Proposition #9 Right to Vote",,DEM,Against,4,3,1
+Lubbock,38,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,59,38,21
+Lubbock,38,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,2,2,0
+Lubbock,38,"Democratic Proposition #11 Immigrant Rights",,DEM,For,54,33,21
+Lubbock,38,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,3,3,0
+Lubbock,38,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,55,34,21
+Lubbock,38,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,5,5,0
 Lubbock,39,Registered Voters,,,,1834,,
 Lubbock,39,U.S. Senate,,DEM,Beto O'Rourke,21,13,8
 Lubbock,39,U.S. Senate,,DEM,Sema Hernandez,9,6,3
@@ -13579,82 +11759,30 @@ Lubbock,39,State Representative,83,DEM,Drew Landry,41,26,15
 Lubbock,39,"County Commissioner, Precinct 2",,DEM,Nick Harpster,40,25,15
 Lubbock,39,"Justice of the Peace, Precinct 2",,DEM,Daylan J. Flowers,41,26,15
 Lubbock,39,County Party Chair,,DEM,Stuart Williams,40,25,15
-Lubbock,39,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,38,25,13
-Lubbock,39,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,3,1,2
-Lubbock,39,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,37,25,12
-Lubbock,39,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,5,2,3
-Lubbock,39,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,39,26,13
-Lubbock,39,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,3,1,2
-Lubbock,39,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,38,25,13
-Lubbock,39,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,3,1,2
-Lubbock,39,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,39,25,14
-Lubbock,39,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,3,2,1
-Lubbock,39,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,42,27,15
-Lubbock,39,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,39,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,40,26,14
-Lubbock,39,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,39,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,35,23,12
-Lubbock,39,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,4,2,2
-Lubbock,39,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,38,25,13
-Lubbock,39,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,2,1,1
-Lubbock,39,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,40,26,14
-Lubbock,39,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
-Lubbock,39,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,40,27,13
-Lubbock,39,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,2,0,2
-Lubbock,39,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,42,27,15
-Lubbock,39,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,39,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,38,25,13
+Lubbock,39,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,3,1,2
+Lubbock,39,"Democratic Proposition #2 Student Loan Debt",,DEM,For,37,25,12
+Lubbock,39,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,5,2,3
+Lubbock,39,"Democratic Proposition #3 Right to Healthcare",,DEM,For,39,26,13
+Lubbock,39,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,3,1,2
+Lubbock,39,"Democratic Proposition #4 Right to Economic Security",,DEM,For,38,25,13
+Lubbock,39,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,3,1,2
+Lubbock,39,"Democratic Proposition #5 National Jobs Program",,DEM,For,39,25,14
+Lubbock,39,"Democratic Proposition #5 National Jobs Program",,DEM,Against,3,2,1
+Lubbock,39,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,42,27,15
+Lubbock,39,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,39,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,40,26,14
+Lubbock,39,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,39,"Democratic Proposition #8 Right to Housing",,DEM,For,35,23,12
+Lubbock,39,"Democratic Proposition #8 Right to Housing",,DEM,Against,4,2,2
+Lubbock,39,"Democratic Proposition #9 Right to Vote",,DEM,For,38,25,13
+Lubbock,39,"Democratic Proposition #9 Right to Vote",,DEM,Against,2,1,1
+Lubbock,39,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,40,26,14
+Lubbock,39,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
+Lubbock,39,"Democratic Proposition #11 Immigrant Rights",,DEM,For,40,27,13
+Lubbock,39,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,2,0,2
+Lubbock,39,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,42,27,15
+Lubbock,39,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,40,Registered Voters,,,,1224,,
 Lubbock,40,U.S. Senate,,DEM,Beto O'Rourke,4,4,0
 Lubbock,40,U.S. Senate,,DEM,Sema Hernandez,22,14,8
@@ -13688,82 +11816,30 @@ Lubbock,40,State Representative,84,DEM,Austin Michael Carrizales,23,17,6
 Lubbock,40,State Representative,84,DEM,Samantha Carrillo Fields,11,8,3
 Lubbock,40,"Justice of the Peace, Precinct 3",,DEM,Aurora Chaides-Hernandez,32,23,9
 Lubbock,40,County Party Chair,,DEM,Stuart Williams,32,23,9
-Lubbock,40,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,36,27,9
-Lubbock,40,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,1,1,0
-Lubbock,40,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,36,27,9
-Lubbock,40,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,40,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,38,29,9
-Lubbock,40,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,1,1,0
-Lubbock,40,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,38,28,10
-Lubbock,40,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,1,1,0
-Lubbock,40,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,37,28,9
-Lubbock,40,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,2,2,0
-Lubbock,40,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,39,29,10
-Lubbock,40,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,1,1,0
-Lubbock,40,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,37,27,10
-Lubbock,40,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,1,1,0
-Lubbock,40,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,37,27,10
-Lubbock,40,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,1,1,0
-Lubbock,40,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,39,29,10
-Lubbock,40,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,1,1,0
-Lubbock,40,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,37,28,9
-Lubbock,40,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
-Lubbock,40,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,35,25,10
-Lubbock,40,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,2,2,0
-Lubbock,40,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,38,28,10
-Lubbock,40,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,1,1,0
+Lubbock,40,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,36,27,9
+Lubbock,40,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,1,1,0
+Lubbock,40,"Democratic Proposition #2 Student Loan Debt",,DEM,For,36,27,9
+Lubbock,40,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,40,"Democratic Proposition #3 Right to Healthcare",,DEM,For,38,29,9
+Lubbock,40,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,1,1,0
+Lubbock,40,"Democratic Proposition #4 Right to Economic Security",,DEM,For,38,28,10
+Lubbock,40,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,1,1,0
+Lubbock,40,"Democratic Proposition #5 National Jobs Program",,DEM,For,37,28,9
+Lubbock,40,"Democratic Proposition #5 National Jobs Program",,DEM,Against,2,2,0
+Lubbock,40,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,39,29,10
+Lubbock,40,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,1,1,0
+Lubbock,40,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,37,27,10
+Lubbock,40,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,1,1,0
+Lubbock,40,"Democratic Proposition #8 Right to Housing",,DEM,For,37,27,10
+Lubbock,40,"Democratic Proposition #8 Right to Housing",,DEM,Against,1,1,0
+Lubbock,40,"Democratic Proposition #9 Right to Vote",,DEM,For,39,29,10
+Lubbock,40,"Democratic Proposition #9 Right to Vote",,DEM,Against,1,1,0
+Lubbock,40,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,37,28,9
+Lubbock,40,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
+Lubbock,40,"Democratic Proposition #11 Immigrant Rights",,DEM,For,35,25,10
+Lubbock,40,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,2,2,0
+Lubbock,40,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,38,28,10
+Lubbock,40,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,1,1,0
 Lubbock,41,Registered Voters,,,,2298,,
 Lubbock,41,U.S. Senate,,DEM,Beto O'Rourke,22,11,11
 Lubbock,41,U.S. Senate,,DEM,Sema Hernandez,17,5,12
@@ -13796,82 +11872,30 @@ Lubbock,41,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,40,1
 Lubbock,41,State Representative,83,DEM,Drew Landry,38,16,22
 Lubbock,41,"Justice of the Peace, Precinct 3",,DEM,Aurora Chaides-Hernandez,41,19,22
 Lubbock,41,County Party Chair,,DEM,Stuart Williams,38,15,23
-Lubbock,41,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,48,22,26
-Lubbock,41,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,41,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,41,17,24
-Lubbock,41,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,5,3,2
-Lubbock,41,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,43,19,24
-Lubbock,41,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,4,2,2
-Lubbock,41,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,47,21,26
-Lubbock,41,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,41,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,40,20,20
-Lubbock,41,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,6,1,5
-Lubbock,41,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,49,23,26
-Lubbock,41,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,41,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,48,22,26
-Lubbock,41,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,1,1,0
-Lubbock,41,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,43,20,23
-Lubbock,41,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,4,2,2
-Lubbock,41,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,45,22,23
-Lubbock,41,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,3,0,3
-Lubbock,41,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,45,20,25
-Lubbock,41,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,3,3,0
-Lubbock,41,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,43,20,23
-Lubbock,41,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,5,3,2
-Lubbock,41,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,47,23,24
-Lubbock,41,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,2,0,2
+Lubbock,41,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,48,22,26
+Lubbock,41,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,41,"Democratic Proposition #2 Student Loan Debt",,DEM,For,41,17,24
+Lubbock,41,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,5,3,2
+Lubbock,41,"Democratic Proposition #3 Right to Healthcare",,DEM,For,43,19,24
+Lubbock,41,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,4,2,2
+Lubbock,41,"Democratic Proposition #4 Right to Economic Security",,DEM,For,47,21,26
+Lubbock,41,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,41,"Democratic Proposition #5 National Jobs Program",,DEM,For,40,20,20
+Lubbock,41,"Democratic Proposition #5 National Jobs Program",,DEM,Against,6,1,5
+Lubbock,41,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,49,23,26
+Lubbock,41,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,41,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,48,22,26
+Lubbock,41,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,1,1,0
+Lubbock,41,"Democratic Proposition #8 Right to Housing",,DEM,For,43,20,23
+Lubbock,41,"Democratic Proposition #8 Right to Housing",,DEM,Against,4,2,2
+Lubbock,41,"Democratic Proposition #9 Right to Vote",,DEM,For,45,22,23
+Lubbock,41,"Democratic Proposition #9 Right to Vote",,DEM,Against,3,0,3
+Lubbock,41,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,45,20,25
+Lubbock,41,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,3,3,0
+Lubbock,41,"Democratic Proposition #11 Immigrant Rights",,DEM,For,43,20,23
+Lubbock,41,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,5,3,2
+Lubbock,41,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,47,23,24
+Lubbock,41,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,2,0,2
 Lubbock,43,Registered Voters,,,,556,,
 Lubbock,43,U.S. Senate,,DEM,Beto O'Rourke,2,1,1
 Lubbock,43,U.S. Senate,,DEM,Sema Hernandez,3,0,3
@@ -13904,82 +11928,30 @@ Lubbock,43,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,6,1,
 Lubbock,43,State Representative,83,DEM,Drew Landry,7,1,6
 Lubbock,43,"Justice of the Peace, Precinct 3",,DEM,Aurora Chaides-Hernandez,6,1,5
 Lubbock,43,County Party Chair,,DEM,Stuart Williams,7,1,6
-Lubbock,43,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,5,1,4
-Lubbock,43,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,2,0,2
-Lubbock,43,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,5,1,4
-Lubbock,43,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,2,0,2
-Lubbock,43,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,6,1,5
-Lubbock,43,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,1,0,1
-Lubbock,43,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,6,1,5
-Lubbock,43,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,1,0,1
-Lubbock,43,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,6,1,5
-Lubbock,43,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,1,0,1
-Lubbock,43,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,7,1,6
-Lubbock,43,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,43,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,7,1,6
-Lubbock,43,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,43,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,5,0,5
-Lubbock,43,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,2,1,1
-Lubbock,43,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,6,1,5
-Lubbock,43,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,1,0,1
-Lubbock,43,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,5,1,4
-Lubbock,43,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,2,0,2
-Lubbock,43,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,4,1,3
-Lubbock,43,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,3,0,3
-Lubbock,43,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,7,1,6
-Lubbock,43,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,43,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,5,1,4
+Lubbock,43,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,2,0,2
+Lubbock,43,"Democratic Proposition #2 Student Loan Debt",,DEM,For,5,1,4
+Lubbock,43,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,2,0,2
+Lubbock,43,"Democratic Proposition #3 Right to Healthcare",,DEM,For,6,1,5
+Lubbock,43,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,1,0,1
+Lubbock,43,"Democratic Proposition #4 Right to Economic Security",,DEM,For,6,1,5
+Lubbock,43,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,1,0,1
+Lubbock,43,"Democratic Proposition #5 National Jobs Program",,DEM,For,6,1,5
+Lubbock,43,"Democratic Proposition #5 National Jobs Program",,DEM,Against,1,0,1
+Lubbock,43,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,7,1,6
+Lubbock,43,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,43,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,7,1,6
+Lubbock,43,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,43,"Democratic Proposition #8 Right to Housing",,DEM,For,5,0,5
+Lubbock,43,"Democratic Proposition #8 Right to Housing",,DEM,Against,2,1,1
+Lubbock,43,"Democratic Proposition #9 Right to Vote",,DEM,For,6,1,5
+Lubbock,43,"Democratic Proposition #9 Right to Vote",,DEM,Against,1,0,1
+Lubbock,43,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,5,1,4
+Lubbock,43,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,2,0,2
+Lubbock,43,"Democratic Proposition #11 Immigrant Rights",,DEM,For,4,1,3
+Lubbock,43,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,3,0,3
+Lubbock,43,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,7,1,6
+Lubbock,43,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,44,Registered Voters,,,,1363,,
 Lubbock,44,U.S. Senate,,DEM,Beto O'Rourke,20,11,9
 Lubbock,44,U.S. Senate,,DEM,Sema Hernandez,6,3,3
@@ -14012,82 +11984,30 @@ Lubbock,44,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,29,1
 Lubbock,44,State Representative,83,DEM,Drew Landry,30,16,14
 Lubbock,44,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,28,15,13
 Lubbock,44,County Party Chair,,DEM,Stuart Williams,30,16,14
-Lubbock,44,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,29,16,13
-Lubbock,44,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,1,0,1
-Lubbock,44,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,29,16,13
-Lubbock,44,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,1,0,1
-Lubbock,44,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,29,16,13
-Lubbock,44,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,44,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,29,16,13
-Lubbock,44,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,1,0,1
-Lubbock,44,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,27,15,12
-Lubbock,44,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,3,1,2
-Lubbock,44,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,30,16,14
-Lubbock,44,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,44,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,28,15,13
-Lubbock,44,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,2,1,1
-Lubbock,44,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,26,15,11
-Lubbock,44,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,3,1,2
-Lubbock,44,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,29,15,14
-Lubbock,44,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,2,1,1
-Lubbock,44,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,27,15,12
-Lubbock,44,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,2,1,1
-Lubbock,44,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,29,16,13
-Lubbock,44,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,1,0,1
-Lubbock,44,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,30,16,14
-Lubbock,44,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,44,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,29,16,13
+Lubbock,44,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,1,0,1
+Lubbock,44,"Democratic Proposition #2 Student Loan Debt",,DEM,For,29,16,13
+Lubbock,44,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,1,0,1
+Lubbock,44,"Democratic Proposition #3 Right to Healthcare",,DEM,For,29,16,13
+Lubbock,44,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,44,"Democratic Proposition #4 Right to Economic Security",,DEM,For,29,16,13
+Lubbock,44,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,1,0,1
+Lubbock,44,"Democratic Proposition #5 National Jobs Program",,DEM,For,27,15,12
+Lubbock,44,"Democratic Proposition #5 National Jobs Program",,DEM,Against,3,1,2
+Lubbock,44,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,30,16,14
+Lubbock,44,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,44,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,28,15,13
+Lubbock,44,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,2,1,1
+Lubbock,44,"Democratic Proposition #8 Right to Housing",,DEM,For,26,15,11
+Lubbock,44,"Democratic Proposition #8 Right to Housing",,DEM,Against,3,1,2
+Lubbock,44,"Democratic Proposition #9 Right to Vote",,DEM,For,29,15,14
+Lubbock,44,"Democratic Proposition #9 Right to Vote",,DEM,Against,2,1,1
+Lubbock,44,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,27,15,12
+Lubbock,44,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,2,1,1
+Lubbock,44,"Democratic Proposition #11 Immigrant Rights",,DEM,For,29,16,13
+Lubbock,44,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,1,0,1
+Lubbock,44,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,30,16,14
+Lubbock,44,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,45,Registered Voters,,,,426,,
 Lubbock,45,U.S. Senate,,DEM,Beto O'Rourke,4,1,3
 Lubbock,45,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -14120,82 +12040,30 @@ Lubbock,45,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,6,4,
 Lubbock,45,State Representative,83,DEM,Drew Landry,7,4,3
 Lubbock,45,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,6,4,2
 Lubbock,45,County Party Chair,,DEM,Stuart Williams,6,4,2
-Lubbock,45,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,9,4,5
-Lubbock,45,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,1,1,0
-Lubbock,45,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,9,4,5
-Lubbock,45,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,1,1,0
-Lubbock,45,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,8,3,5
-Lubbock,45,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,2,2,0
-Lubbock,45,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,8,4,4
-Lubbock,45,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,45,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,10,5,5
-Lubbock,45,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,45,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,10,5,5
-Lubbock,45,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,45,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,9,4,5
-Lubbock,45,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,1,1,0
-Lubbock,45,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,8,4,4
-Lubbock,45,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,2,1,1
-Lubbock,45,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,10,5,5
-Lubbock,45,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,45,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,10,5,5
-Lubbock,45,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,45,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,10,5,5
-Lubbock,45,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,45,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,10,5,5
-Lubbock,45,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,45,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,9,4,5
+Lubbock,45,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,1,1,0
+Lubbock,45,"Democratic Proposition #2 Student Loan Debt",,DEM,For,9,4,5
+Lubbock,45,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,1,1,0
+Lubbock,45,"Democratic Proposition #3 Right to Healthcare",,DEM,For,8,3,5
+Lubbock,45,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,2,2,0
+Lubbock,45,"Democratic Proposition #4 Right to Economic Security",,DEM,For,8,4,4
+Lubbock,45,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,45,"Democratic Proposition #5 National Jobs Program",,DEM,For,10,5,5
+Lubbock,45,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,45,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,10,5,5
+Lubbock,45,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,45,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,9,4,5
+Lubbock,45,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,1,1,0
+Lubbock,45,"Democratic Proposition #8 Right to Housing",,DEM,For,8,4,4
+Lubbock,45,"Democratic Proposition #8 Right to Housing",,DEM,Against,2,1,1
+Lubbock,45,"Democratic Proposition #9 Right to Vote",,DEM,For,10,5,5
+Lubbock,45,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,45,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,10,5,5
+Lubbock,45,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,45,"Democratic Proposition #11 Immigrant Rights",,DEM,For,10,5,5
+Lubbock,45,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,45,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,10,5,5
+Lubbock,45,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,46,Registered Voters,,,,2929,,
 Lubbock,46,U.S. Senate,,DEM,Beto O'Rourke,26,14,12
 Lubbock,46,U.S. Senate,,DEM,Sema Hernandez,2,2,0
@@ -14228,82 +12096,30 @@ Lubbock,46,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,34,1
 Lubbock,46,State Representative,83,DEM,Drew Landry,34,19,15
 Lubbock,46,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,33,17,16
 Lubbock,46,County Party Chair,,DEM,Stuart Williams,34,19,15
-Lubbock,46,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,38,21,17
-Lubbock,46,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,1,1,0
-Lubbock,46,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,37,20,17
-Lubbock,46,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,2,2,0
-Lubbock,46,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,33,18,15
-Lubbock,46,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,6,4,2
-Lubbock,46,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,33,18,15
-Lubbock,46,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,4,2,2
-Lubbock,46,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,37,21,16
-Lubbock,46,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,2,1,1
-Lubbock,46,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,38,22,16
-Lubbock,46,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,1,0,1
-Lubbock,46,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,34,19,15
-Lubbock,46,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,5,3,2
-Lubbock,46,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,31,17,14
-Lubbock,46,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,8,5,3
-Lubbock,46,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,36,21,15
-Lubbock,46,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,3,1,2
-Lubbock,46,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,33,18,15
-Lubbock,46,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,5,3,2
-Lubbock,46,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,29,14,15
-Lubbock,46,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,6,4,2
-Lubbock,46,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,34,18,16
-Lubbock,46,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,2,1,1
+Lubbock,46,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,38,21,17
+Lubbock,46,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,1,1,0
+Lubbock,46,"Democratic Proposition #2 Student Loan Debt",,DEM,For,37,20,17
+Lubbock,46,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,2,2,0
+Lubbock,46,"Democratic Proposition #3 Right to Healthcare",,DEM,For,33,18,15
+Lubbock,46,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,6,4,2
+Lubbock,46,"Democratic Proposition #4 Right to Economic Security",,DEM,For,33,18,15
+Lubbock,46,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,4,2,2
+Lubbock,46,"Democratic Proposition #5 National Jobs Program",,DEM,For,37,21,16
+Lubbock,46,"Democratic Proposition #5 National Jobs Program",,DEM,Against,2,1,1
+Lubbock,46,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,38,22,16
+Lubbock,46,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,1,0,1
+Lubbock,46,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,34,19,15
+Lubbock,46,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,5,3,2
+Lubbock,46,"Democratic Proposition #8 Right to Housing",,DEM,For,31,17,14
+Lubbock,46,"Democratic Proposition #8 Right to Housing",,DEM,Against,8,5,3
+Lubbock,46,"Democratic Proposition #9 Right to Vote",,DEM,For,36,21,15
+Lubbock,46,"Democratic Proposition #9 Right to Vote",,DEM,Against,3,1,2
+Lubbock,46,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,33,18,15
+Lubbock,46,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,5,3,2
+Lubbock,46,"Democratic Proposition #11 Immigrant Rights",,DEM,For,29,14,15
+Lubbock,46,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,6,4,2
+Lubbock,46,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,34,18,16
+Lubbock,46,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,2,1,1
 Lubbock,47,Registered Voters,,,,2555,,
 Lubbock,47,U.S. Senate,,DEM,Beto O'Rourke,83,52,31
 Lubbock,47,U.S. Senate,,DEM,Sema Hernandez,11,8,3
@@ -14337,82 +12153,30 @@ Lubbock,47,State Representative,84,DEM,Austin Michael Carrizales,43,31,12
 Lubbock,47,State Representative,84,DEM,Samantha Carrillo Fields,58,33,25
 Lubbock,47,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,99,63,36
 Lubbock,47,County Party Chair,,DEM,Stuart Williams,98,63,35
-Lubbock,47,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,105,66,39
-Lubbock,47,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,2,1,1
-Lubbock,47,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,100,63,37
-Lubbock,47,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,5,3,2
-Lubbock,47,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,103,66,37
-Lubbock,47,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,3,1,2
-Lubbock,47,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,105,66,39
-Lubbock,47,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,2,1,1
-Lubbock,47,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,101,65,36
-Lubbock,47,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,7,3,4
-Lubbock,47,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,106,66,40
-Lubbock,47,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,47,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,106,67,39
-Lubbock,47,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,1,1,0
-Lubbock,47,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,103,65,38
-Lubbock,47,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,3,2,1
-Lubbock,47,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,105,65,40
-Lubbock,47,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,3,3,0
-Lubbock,47,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,104,64,40
-Lubbock,47,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,3,3,0
-Lubbock,47,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,103,66,37
-Lubbock,47,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,1,0,1
-Lubbock,47,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,104,65,39
-Lubbock,47,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,1,0,1
+Lubbock,47,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,105,66,39
+Lubbock,47,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,2,1,1
+Lubbock,47,"Democratic Proposition #2 Student Loan Debt",,DEM,For,100,63,37
+Lubbock,47,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,5,3,2
+Lubbock,47,"Democratic Proposition #3 Right to Healthcare",,DEM,For,103,66,37
+Lubbock,47,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,3,1,2
+Lubbock,47,"Democratic Proposition #4 Right to Economic Security",,DEM,For,105,66,39
+Lubbock,47,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,2,1,1
+Lubbock,47,"Democratic Proposition #5 National Jobs Program",,DEM,For,101,65,36
+Lubbock,47,"Democratic Proposition #5 National Jobs Program",,DEM,Against,7,3,4
+Lubbock,47,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,106,66,40
+Lubbock,47,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,47,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,106,67,39
+Lubbock,47,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,1,1,0
+Lubbock,47,"Democratic Proposition #8 Right to Housing",,DEM,For,103,65,38
+Lubbock,47,"Democratic Proposition #8 Right to Housing",,DEM,Against,3,2,1
+Lubbock,47,"Democratic Proposition #9 Right to Vote",,DEM,For,105,65,40
+Lubbock,47,"Democratic Proposition #9 Right to Vote",,DEM,Against,3,3,0
+Lubbock,47,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,104,64,40
+Lubbock,47,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,3,3,0
+Lubbock,47,"Democratic Proposition #11 Immigrant Rights",,DEM,For,103,66,37
+Lubbock,47,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,1,0,1
+Lubbock,47,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,104,65,39
+Lubbock,47,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,1,0,1
 Lubbock,49,Registered Voters,,,,1072,,
 Lubbock,49,U.S. Senate,,DEM,Beto O'Rourke,19,6,13
 Lubbock,49,U.S. Senate,,DEM,Sema Hernandez,3,1,2
@@ -14446,82 +12210,30 @@ Lubbock,49,State Representative,84,DEM,Austin Michael Carrizales,8,1,7
 Lubbock,49,State Representative,84,DEM,Samantha Carrillo Fields,12,4,8
 Lubbock,49,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,19,5,14
 Lubbock,49,County Party Chair,,DEM,Stuart Williams,19,5,14
-Lubbock,49,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,22,6,16
-Lubbock,49,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,49,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,23,7,16
-Lubbock,49,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,49,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,22,7,15
-Lubbock,49,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,1,0,1
-Lubbock,49,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,22,7,15
-Lubbock,49,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,49,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,22,7,15
-Lubbock,49,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,1,0,1
-Lubbock,49,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,23,7,16
-Lubbock,49,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,49,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,23,7,16
-Lubbock,49,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,49,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,23,7,16
-Lubbock,49,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,49,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,22,7,15
-Lubbock,49,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,1,0,1
-Lubbock,49,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,23,7,16
-Lubbock,49,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,49,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,23,7,16
-Lubbock,49,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,49,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,23,7,16
-Lubbock,49,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,49,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,22,6,16
+Lubbock,49,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,49,"Democratic Proposition #2 Student Loan Debt",,DEM,For,23,7,16
+Lubbock,49,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,49,"Democratic Proposition #3 Right to Healthcare",,DEM,For,22,7,15
+Lubbock,49,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,1,0,1
+Lubbock,49,"Democratic Proposition #4 Right to Economic Security",,DEM,For,22,7,15
+Lubbock,49,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,49,"Democratic Proposition #5 National Jobs Program",,DEM,For,22,7,15
+Lubbock,49,"Democratic Proposition #5 National Jobs Program",,DEM,Against,1,0,1
+Lubbock,49,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,23,7,16
+Lubbock,49,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,49,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,23,7,16
+Lubbock,49,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,49,"Democratic Proposition #8 Right to Housing",,DEM,For,23,7,16
+Lubbock,49,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,49,"Democratic Proposition #9 Right to Vote",,DEM,For,22,7,15
+Lubbock,49,"Democratic Proposition #9 Right to Vote",,DEM,Against,1,0,1
+Lubbock,49,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,23,7,16
+Lubbock,49,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,49,"Democratic Proposition #11 Immigrant Rights",,DEM,For,23,7,16
+Lubbock,49,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,49,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,23,7,16
+Lubbock,49,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,50,Registered Voters,,,,1100,,
 Lubbock,50,U.S. Senate,,DEM,Beto O'Rourke,32,9,23
 Lubbock,50,U.S. Senate,,DEM,Sema Hernandez,1,1,0
@@ -14555,82 +12267,30 @@ Lubbock,50,State Representative,84,DEM,Austin Michael Carrizales,10,1,9
 Lubbock,50,State Representative,84,DEM,Samantha Carrillo Fields,21,9,12
 Lubbock,50,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,33,10,23
 Lubbock,50,County Party Chair,,DEM,Stuart Williams,33,10,23
-Lubbock,50,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,32,9,23
-Lubbock,50,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,1,1,0
-Lubbock,50,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,32,10,22
-Lubbock,50,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,1,0,1
-Lubbock,50,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,32,10,22
-Lubbock,50,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,1,0,1
-Lubbock,50,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,32,10,22
-Lubbock,50,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,1,0,1
-Lubbock,50,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,31,9,22
-Lubbock,50,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,2,1,1
-Lubbock,50,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,33,10,23
-Lubbock,50,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,50,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,33,10,23
-Lubbock,50,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,50,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,33,10,23
-Lubbock,50,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,50,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,33,10,23
-Lubbock,50,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,50,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,33,10,23
-Lubbock,50,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,50,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,33,10,23
-Lubbock,50,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,50,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,33,10,23
-Lubbock,50,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,50,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,32,9,23
+Lubbock,50,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,1,1,0
+Lubbock,50,"Democratic Proposition #2 Student Loan Debt",,DEM,For,32,10,22
+Lubbock,50,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,1,0,1
+Lubbock,50,"Democratic Proposition #3 Right to Healthcare",,DEM,For,32,10,22
+Lubbock,50,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,1,0,1
+Lubbock,50,"Democratic Proposition #4 Right to Economic Security",,DEM,For,32,10,22
+Lubbock,50,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,1,0,1
+Lubbock,50,"Democratic Proposition #5 National Jobs Program",,DEM,For,31,9,22
+Lubbock,50,"Democratic Proposition #5 National Jobs Program",,DEM,Against,2,1,1
+Lubbock,50,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,33,10,23
+Lubbock,50,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,50,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,33,10,23
+Lubbock,50,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,50,"Democratic Proposition #8 Right to Housing",,DEM,For,33,10,23
+Lubbock,50,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,50,"Democratic Proposition #9 Right to Vote",,DEM,For,33,10,23
+Lubbock,50,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,50,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,33,10,23
+Lubbock,50,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,50,"Democratic Proposition #11 Immigrant Rights",,DEM,For,33,10,23
+Lubbock,50,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,50,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,33,10,23
+Lubbock,50,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,51,Registered Voters,,,,179,,
 Lubbock,51,U.S. Senate,,DEM,Beto O'Rourke,2,1,1
 Lubbock,51,U.S. Senate,,DEM,Sema Hernandez,2,2,0
@@ -14664,82 +12324,30 @@ Lubbock,51,State Representative,83,DEM,Drew Landry,4,4,0
 Lubbock,51,"County Commissioner, Precinct 2",,DEM,Nick Harpster,4,4,0
 Lubbock,51,"Justice of the Peace, Precinct 2",,DEM,Daylan J. Flowers,4,4,0
 Lubbock,51,County Party Chair,,DEM,Stuart Williams,4,4,0
-Lubbock,51,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,5,4,1
-Lubbock,51,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,51,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,5,4,1
-Lubbock,51,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,51,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,5,4,1
-Lubbock,51,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,51,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,5,4,1
-Lubbock,51,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,51,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,4,3,1
-Lubbock,51,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,1,1,0
-Lubbock,51,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,5,4,1
-Lubbock,51,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,51,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,5,4,1
-Lubbock,51,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,51,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,5,4,1
-Lubbock,51,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,51,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,5,4,1
-Lubbock,51,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,51,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,5,4,1
-Lubbock,51,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,51,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,4,4,0
-Lubbock,51,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,51,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,5,4,1
-Lubbock,51,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,51,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,5,4,1
+Lubbock,51,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,51,"Democratic Proposition #2 Student Loan Debt",,DEM,For,5,4,1
+Lubbock,51,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,51,"Democratic Proposition #3 Right to Healthcare",,DEM,For,5,4,1
+Lubbock,51,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,51,"Democratic Proposition #4 Right to Economic Security",,DEM,For,5,4,1
+Lubbock,51,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,51,"Democratic Proposition #5 National Jobs Program",,DEM,For,4,3,1
+Lubbock,51,"Democratic Proposition #5 National Jobs Program",,DEM,Against,1,1,0
+Lubbock,51,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,5,4,1
+Lubbock,51,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,51,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,5,4,1
+Lubbock,51,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,51,"Democratic Proposition #8 Right to Housing",,DEM,For,5,4,1
+Lubbock,51,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,51,"Democratic Proposition #9 Right to Vote",,DEM,For,5,4,1
+Lubbock,51,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,51,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,5,4,1
+Lubbock,51,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,51,"Democratic Proposition #11 Immigrant Rights",,DEM,For,4,4,0
+Lubbock,51,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,51,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,5,4,1
+Lubbock,51,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,52,Registered Voters,,,,3000,,
 Lubbock,52,U.S. Senate,,DEM,Beto O'Rourke,59,30,29
 Lubbock,52,U.S. Senate,,DEM,Sema Hernandez,21,15,6
@@ -14771,82 +12379,30 @@ Lubbock,52,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Ja
 Lubbock,52,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,79,45,34
 Lubbock,52,State Representative,83,DEM,Drew Landry,83,47,36
 Lubbock,52,County Party Chair,,DEM,Stuart Williams,80,46,34
-Lubbock,52,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,84,50,34
-Lubbock,52,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,2,2,0
-Lubbock,52,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,90,53,37
-Lubbock,52,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,52,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,88,51,37
-Lubbock,52,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,1,1,0
-Lubbock,52,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,87,50,37
-Lubbock,52,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,1,1,0
-Lubbock,52,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,80,44,36
-Lubbock,52,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,7,6,1
-Lubbock,52,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,89,53,36
-Lubbock,52,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,52,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,89,53,36
-Lubbock,52,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,52,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,85,49,36
-Lubbock,52,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,4,3,1
-Lubbock,52,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,86,50,36
-Lubbock,52,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,4,3,1
-Lubbock,52,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,86,50,36
-Lubbock,52,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,3,2,1
-Lubbock,52,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,85,49,36
-Lubbock,52,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,4,3,1
-Lubbock,52,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,91,53,38
-Lubbock,52,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,52,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,84,50,34
+Lubbock,52,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,2,2,0
+Lubbock,52,"Democratic Proposition #2 Student Loan Debt",,DEM,For,90,53,37
+Lubbock,52,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,52,"Democratic Proposition #3 Right to Healthcare",,DEM,For,88,51,37
+Lubbock,52,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,1,1,0
+Lubbock,52,"Democratic Proposition #4 Right to Economic Security",,DEM,For,87,50,37
+Lubbock,52,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,1,1,0
+Lubbock,52,"Democratic Proposition #5 National Jobs Program",,DEM,For,80,44,36
+Lubbock,52,"Democratic Proposition #5 National Jobs Program",,DEM,Against,7,6,1
+Lubbock,52,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,89,53,36
+Lubbock,52,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,52,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,89,53,36
+Lubbock,52,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,52,"Democratic Proposition #8 Right to Housing",,DEM,For,85,49,36
+Lubbock,52,"Democratic Proposition #8 Right to Housing",,DEM,Against,4,3,1
+Lubbock,52,"Democratic Proposition #9 Right to Vote",,DEM,For,86,50,36
+Lubbock,52,"Democratic Proposition #9 Right to Vote",,DEM,Against,4,3,1
+Lubbock,52,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,86,50,36
+Lubbock,52,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,3,2,1
+Lubbock,52,"Democratic Proposition #11 Immigrant Rights",,DEM,For,85,49,36
+Lubbock,52,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,4,3,1
+Lubbock,52,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,91,53,38
+Lubbock,52,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,53,Registered Voters,,,,2928,,
 Lubbock,53,U.S. Senate,,DEM,Beto O'Rourke,54,22,32
 Lubbock,53,U.S. Senate,,DEM,Sema Hernandez,12,3,9
@@ -14880,82 +12436,30 @@ Lubbock,53,State Representative,84,DEM,Austin Michael Carrizales,22,11,11
 Lubbock,53,State Representative,84,DEM,Samantha Carrillo Fields,50,17,33
 Lubbock,53,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,71,29,42
 Lubbock,53,County Party Chair,,DEM,Stuart Williams,68,25,43
-Lubbock,53,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,74,30,44
-Lubbock,53,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,2,1,1
-Lubbock,53,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,73,30,43
-Lubbock,53,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,3,1,2
-Lubbock,53,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,68,31,37
-Lubbock,53,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,6,0,6
-Lubbock,53,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,74,31,43
-Lubbock,53,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,2,0,2
-Lubbock,53,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,71,29,42
-Lubbock,53,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,4,1,3
-Lubbock,53,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,75,31,44
-Lubbock,53,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,1,0,1
-Lubbock,53,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,71,27,44
-Lubbock,53,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,2,2,0
-Lubbock,53,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,73,30,43
-Lubbock,53,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,2,0,2
-Lubbock,53,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,75,31,44
-Lubbock,53,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,1,0,1
-Lubbock,53,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,73,31,42
-Lubbock,53,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,1,0,1
-Lubbock,53,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,71,30,41
-Lubbock,53,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,2,0,2
-Lubbock,53,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,72,28,44
-Lubbock,53,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,2,2,0
+Lubbock,53,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,74,30,44
+Lubbock,53,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,2,1,1
+Lubbock,53,"Democratic Proposition #2 Student Loan Debt",,DEM,For,73,30,43
+Lubbock,53,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,3,1,2
+Lubbock,53,"Democratic Proposition #3 Right to Healthcare",,DEM,For,68,31,37
+Lubbock,53,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,6,0,6
+Lubbock,53,"Democratic Proposition #4 Right to Economic Security",,DEM,For,74,31,43
+Lubbock,53,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,2,0,2
+Lubbock,53,"Democratic Proposition #5 National Jobs Program",,DEM,For,71,29,42
+Lubbock,53,"Democratic Proposition #5 National Jobs Program",,DEM,Against,4,1,3
+Lubbock,53,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,75,31,44
+Lubbock,53,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,1,0,1
+Lubbock,53,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,71,27,44
+Lubbock,53,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,2,2,0
+Lubbock,53,"Democratic Proposition #8 Right to Housing",,DEM,For,73,30,43
+Lubbock,53,"Democratic Proposition #8 Right to Housing",,DEM,Against,2,0,2
+Lubbock,53,"Democratic Proposition #9 Right to Vote",,DEM,For,75,31,44
+Lubbock,53,"Democratic Proposition #9 Right to Vote",,DEM,Against,1,0,1
+Lubbock,53,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,73,31,42
+Lubbock,53,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,1,0,1
+Lubbock,53,"Democratic Proposition #11 Immigrant Rights",,DEM,For,71,30,41
+Lubbock,53,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,2,0,2
+Lubbock,53,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,72,28,44
+Lubbock,53,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,2,2,0
 Lubbock,54,Registered Voters,,,,3061,,
 Lubbock,54,U.S. Senate,,DEM,Beto O'Rourke,73,50,23
 Lubbock,54,U.S. Senate,,DEM,Sema Hernandez,23,15,8
@@ -14987,82 +12491,30 @@ Lubbock,54,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Ja
 Lubbock,54,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,101,68,33
 Lubbock,54,State Representative,83,DEM,Drew Landry,101,68,33
 Lubbock,54,County Party Chair,,DEM,Stuart Williams,99,67,32
-Lubbock,54,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,103,68,35
-Lubbock,54,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,3,3,0
-Lubbock,54,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,98,64,34
-Lubbock,54,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,9,8,1
-Lubbock,54,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,101,67,34
-Lubbock,54,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,5,4,1
-Lubbock,54,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,101,68,33
-Lubbock,54,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,5,3,2
-Lubbock,54,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,100,67,33
-Lubbock,54,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,3,2,1
-Lubbock,54,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,104,70,34
-Lubbock,54,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,54,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,104,70,34
-Lubbock,54,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,54,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,100,66,34
-Lubbock,54,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,5,4,1
-Lubbock,54,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,103,68,35
-Lubbock,54,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,1,1,0
-Lubbock,54,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,103,70,33
-Lubbock,54,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,3,1,2
-Lubbock,54,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,103,69,34
-Lubbock,54,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,2,1,1
-Lubbock,54,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,102,68,34
-Lubbock,54,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,3,2,1
+Lubbock,54,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,103,68,35
+Lubbock,54,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,3,3,0
+Lubbock,54,"Democratic Proposition #2 Student Loan Debt",,DEM,For,98,64,34
+Lubbock,54,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,9,8,1
+Lubbock,54,"Democratic Proposition #3 Right to Healthcare",,DEM,For,101,67,34
+Lubbock,54,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,5,4,1
+Lubbock,54,"Democratic Proposition #4 Right to Economic Security",,DEM,For,101,68,33
+Lubbock,54,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,5,3,2
+Lubbock,54,"Democratic Proposition #5 National Jobs Program",,DEM,For,100,67,33
+Lubbock,54,"Democratic Proposition #5 National Jobs Program",,DEM,Against,3,2,1
+Lubbock,54,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,104,70,34
+Lubbock,54,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,54,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,104,70,34
+Lubbock,54,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,54,"Democratic Proposition #8 Right to Housing",,DEM,For,100,66,34
+Lubbock,54,"Democratic Proposition #8 Right to Housing",,DEM,Against,5,4,1
+Lubbock,54,"Democratic Proposition #9 Right to Vote",,DEM,For,103,68,35
+Lubbock,54,"Democratic Proposition #9 Right to Vote",,DEM,Against,1,1,0
+Lubbock,54,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,103,70,33
+Lubbock,54,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,3,1,2
+Lubbock,54,"Democratic Proposition #11 Immigrant Rights",,DEM,For,103,69,34
+Lubbock,54,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,2,1,1
+Lubbock,54,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,102,68,34
+Lubbock,54,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,3,2,1
 Lubbock,56,Registered Voters,,,,523,,
 Lubbock,56,U.S. Senate,,DEM,Beto O'Rourke,12,7,5
 Lubbock,56,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -15094,82 +12546,30 @@ Lubbock,56,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Ja
 Lubbock,56,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,13,8,5
 Lubbock,56,State Representative,83,DEM,Drew Landry,13,8,5
 Lubbock,56,County Party Chair,,DEM,Stuart Williams,13,8,5
-Lubbock,56,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,14,8,6
-Lubbock,56,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,56,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,14,8,6
-Lubbock,56,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,56,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,14,8,6
-Lubbock,56,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,56,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,13,7,6
-Lubbock,56,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,56,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,13,7,6
-Lubbock,56,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,1,1,0
-Lubbock,56,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,14,8,6
-Lubbock,56,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,56,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,13,7,6
-Lubbock,56,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,1,1,0
-Lubbock,56,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,12,6,6
-Lubbock,56,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,2,2,0
-Lubbock,56,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,12,6,6
-Lubbock,56,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,2,2,0
-Lubbock,56,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,13,7,6
-Lubbock,56,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
-Lubbock,56,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,14,8,6
-Lubbock,56,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,56,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,14,8,6
-Lubbock,56,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,56,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,14,8,6
+Lubbock,56,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,56,"Democratic Proposition #2 Student Loan Debt",,DEM,For,14,8,6
+Lubbock,56,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,56,"Democratic Proposition #3 Right to Healthcare",,DEM,For,14,8,6
+Lubbock,56,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,56,"Democratic Proposition #4 Right to Economic Security",,DEM,For,13,7,6
+Lubbock,56,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,56,"Democratic Proposition #5 National Jobs Program",,DEM,For,13,7,6
+Lubbock,56,"Democratic Proposition #5 National Jobs Program",,DEM,Against,1,1,0
+Lubbock,56,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,14,8,6
+Lubbock,56,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,56,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,13,7,6
+Lubbock,56,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,1,1,0
+Lubbock,56,"Democratic Proposition #8 Right to Housing",,DEM,For,12,6,6
+Lubbock,56,"Democratic Proposition #8 Right to Housing",,DEM,Against,2,2,0
+Lubbock,56,"Democratic Proposition #9 Right to Vote",,DEM,For,12,6,6
+Lubbock,56,"Democratic Proposition #9 Right to Vote",,DEM,Against,2,2,0
+Lubbock,56,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,13,7,6
+Lubbock,56,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
+Lubbock,56,"Democratic Proposition #11 Immigrant Rights",,DEM,For,14,8,6
+Lubbock,56,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,56,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,14,8,6
+Lubbock,56,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,57,Registered Voters,,,,2265,,
 Lubbock,57,U.S. Senate,,DEM,Beto O'Rourke,41,21,20
 Lubbock,57,U.S. Senate,,DEM,Sema Hernandez,26,16,10
@@ -15203,82 +12603,30 @@ Lubbock,57,State Representative,84,DEM,Austin Michael Carrizales,25,11,14
 Lubbock,57,State Representative,84,DEM,Samantha Carrillo Fields,44,25,19
 Lubbock,57,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,67,36,31
 Lubbock,57,County Party Chair,,DEM,Stuart Williams,67,36,31
-Lubbock,57,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,67,34,33
-Lubbock,57,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,2,1,1
-Lubbock,57,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,69,36,33
-Lubbock,57,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,4,2,2
-Lubbock,57,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,65,35,30
-Lubbock,57,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,7,3,4
-Lubbock,57,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,69,35,34
-Lubbock,57,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,2,1,1
-Lubbock,57,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,61,31,30
-Lubbock,57,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,9,5,4
-Lubbock,57,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,71,37,34
-Lubbock,57,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,57,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,72,37,35
-Lubbock,57,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,1,1,0
-Lubbock,57,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,68,36,32
-Lubbock,57,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,3,0,3
-Lubbock,57,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,70,37,33
-Lubbock,57,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,3,1,2
-Lubbock,57,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,69,34,35
-Lubbock,57,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,2,2,0
-Lubbock,57,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,67,32,35
-Lubbock,57,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,1,1,0
-Lubbock,57,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,69,34,35
-Lubbock,57,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,2,2,0
+Lubbock,57,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,67,34,33
+Lubbock,57,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,2,1,1
+Lubbock,57,"Democratic Proposition #2 Student Loan Debt",,DEM,For,69,36,33
+Lubbock,57,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,4,2,2
+Lubbock,57,"Democratic Proposition #3 Right to Healthcare",,DEM,For,65,35,30
+Lubbock,57,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,7,3,4
+Lubbock,57,"Democratic Proposition #4 Right to Economic Security",,DEM,For,69,35,34
+Lubbock,57,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,2,1,1
+Lubbock,57,"Democratic Proposition #5 National Jobs Program",,DEM,For,61,31,30
+Lubbock,57,"Democratic Proposition #5 National Jobs Program",,DEM,Against,9,5,4
+Lubbock,57,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,71,37,34
+Lubbock,57,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,57,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,72,37,35
+Lubbock,57,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,1,1,0
+Lubbock,57,"Democratic Proposition #8 Right to Housing",,DEM,For,68,36,32
+Lubbock,57,"Democratic Proposition #8 Right to Housing",,DEM,Against,3,0,3
+Lubbock,57,"Democratic Proposition #9 Right to Vote",,DEM,For,70,37,33
+Lubbock,57,"Democratic Proposition #9 Right to Vote",,DEM,Against,3,1,2
+Lubbock,57,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,69,34,35
+Lubbock,57,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,2,2,0
+Lubbock,57,"Democratic Proposition #11 Immigrant Rights",,DEM,For,67,32,35
+Lubbock,57,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,1,1,0
+Lubbock,57,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,69,34,35
+Lubbock,57,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,2,2,0
 Lubbock,58,Registered Voters,,,,1380,,
 Lubbock,58,U.S. Senate,,DEM,Beto O'Rourke,39,17,22
 Lubbock,58,U.S. Senate,,DEM,Sema Hernandez,9,5,4
@@ -15312,82 +12660,30 @@ Lubbock,58,State Representative,84,DEM,Austin Michael Carrizales,12,7,5
 Lubbock,58,State Representative,84,DEM,Samantha Carrillo Fields,33,16,17
 Lubbock,58,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,47,24,23
 Lubbock,58,County Party Chair,,DEM,Stuart Williams,47,24,23
-Lubbock,58,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,50,23,27
-Lubbock,58,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,2,2,0
-Lubbock,58,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,50,24,26
-Lubbock,58,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,2,1,1
-Lubbock,58,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,50,24,26
-Lubbock,58,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,3,2,1
-Lubbock,58,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,51,25,26
-Lubbock,58,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,2,1,1
-Lubbock,58,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,47,21,26
-Lubbock,58,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,5,4,1
-Lubbock,58,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,52,25,27
-Lubbock,58,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,1,1,0
-Lubbock,58,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,52,26,26
-Lubbock,58,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,1,0,1
-Lubbock,58,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,50,24,26
-Lubbock,58,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,2,1,1
-Lubbock,58,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,49,24,25
-Lubbock,58,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,3,1,2
-Lubbock,58,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,48,24,24
-Lubbock,58,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,3,0,3
-Lubbock,58,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,49,25,24
-Lubbock,58,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,3,0,3
-Lubbock,58,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,48,24,24
-Lubbock,58,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,4,1,3
+Lubbock,58,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,50,23,27
+Lubbock,58,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,2,2,0
+Lubbock,58,"Democratic Proposition #2 Student Loan Debt",,DEM,For,50,24,26
+Lubbock,58,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,2,1,1
+Lubbock,58,"Democratic Proposition #3 Right to Healthcare",,DEM,For,50,24,26
+Lubbock,58,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,3,2,1
+Lubbock,58,"Democratic Proposition #4 Right to Economic Security",,DEM,For,51,25,26
+Lubbock,58,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,2,1,1
+Lubbock,58,"Democratic Proposition #5 National Jobs Program",,DEM,For,47,21,26
+Lubbock,58,"Democratic Proposition #5 National Jobs Program",,DEM,Against,5,4,1
+Lubbock,58,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,52,25,27
+Lubbock,58,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,1,1,0
+Lubbock,58,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,52,26,26
+Lubbock,58,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,1,0,1
+Lubbock,58,"Democratic Proposition #8 Right to Housing",,DEM,For,50,24,26
+Lubbock,58,"Democratic Proposition #8 Right to Housing",,DEM,Against,2,1,1
+Lubbock,58,"Democratic Proposition #9 Right to Vote",,DEM,For,49,24,25
+Lubbock,58,"Democratic Proposition #9 Right to Vote",,DEM,Against,3,1,2
+Lubbock,58,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,48,24,24
+Lubbock,58,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,3,0,3
+Lubbock,58,"Democratic Proposition #11 Immigrant Rights",,DEM,For,49,25,24
+Lubbock,58,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,3,0,3
+Lubbock,58,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,48,24,24
+Lubbock,58,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,4,1,3
 Lubbock,59,Registered Voters,,,,2747,,
 Lubbock,59,U.S. Senate,,DEM,Beto O'Rourke,74,38,36
 Lubbock,59,U.S. Senate,,DEM,Sema Hernandez,23,12,11
@@ -15421,82 +12717,30 @@ Lubbock,59,State Representative,84,DEM,Austin Michael Carrizales,46,28,18
 Lubbock,59,State Representative,84,DEM,Samantha Carrillo Fields,57,26,31
 Lubbock,59,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,97,49,48
 Lubbock,59,County Party Chair,,DEM,Stuart Williams,99,50,49
-Lubbock,59,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,107,59,48
-Lubbock,59,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,59,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,103,56,47
-Lubbock,59,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,3,2,1
-Lubbock,59,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,106,58,48
-Lubbock,59,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,2,1,1
-Lubbock,59,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,106,58,48
-Lubbock,59,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,1,0,1
-Lubbock,59,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,98,54,44
-Lubbock,59,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,9,5,4
-Lubbock,59,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,107,59,48
-Lubbock,59,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,1,0,1
-Lubbock,59,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,107,58,49
-Lubbock,59,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,59,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,103,55,48
-Lubbock,59,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,3,2,1
-Lubbock,59,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,106,57,49
-Lubbock,59,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,2,2,0
-Lubbock,59,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,104,57,47
-Lubbock,59,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
-Lubbock,59,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,107,58,49
-Lubbock,59,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,1,1,0
-Lubbock,59,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,104,55,49
-Lubbock,59,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,2,2,0
+Lubbock,59,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,107,59,48
+Lubbock,59,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,59,"Democratic Proposition #2 Student Loan Debt",,DEM,For,103,56,47
+Lubbock,59,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,3,2,1
+Lubbock,59,"Democratic Proposition #3 Right to Healthcare",,DEM,For,106,58,48
+Lubbock,59,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,2,1,1
+Lubbock,59,"Democratic Proposition #4 Right to Economic Security",,DEM,For,106,58,48
+Lubbock,59,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,1,0,1
+Lubbock,59,"Democratic Proposition #5 National Jobs Program",,DEM,For,98,54,44
+Lubbock,59,"Democratic Proposition #5 National Jobs Program",,DEM,Against,9,5,4
+Lubbock,59,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,107,59,48
+Lubbock,59,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,1,0,1
+Lubbock,59,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,107,58,49
+Lubbock,59,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,59,"Democratic Proposition #8 Right to Housing",,DEM,For,103,55,48
+Lubbock,59,"Democratic Proposition #8 Right to Housing",,DEM,Against,3,2,1
+Lubbock,59,"Democratic Proposition #9 Right to Vote",,DEM,For,106,57,49
+Lubbock,59,"Democratic Proposition #9 Right to Vote",,DEM,Against,2,2,0
+Lubbock,59,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,104,57,47
+Lubbock,59,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
+Lubbock,59,"Democratic Proposition #11 Immigrant Rights",,DEM,For,107,58,49
+Lubbock,59,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,1,1,0
+Lubbock,59,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,104,55,49
+Lubbock,59,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,2,2,0
 Lubbock,60,Registered Voters,,,,1151,,
 Lubbock,60,U.S. Senate,,DEM,Beto O'Rourke,43,26,17
 Lubbock,60,U.S. Senate,,DEM,Sema Hernandez,4,2,2
@@ -15531,82 +12775,30 @@ Lubbock,60,State Representative,84,DEM,Samantha Carrillo Fields,29,17,12
 Lubbock,60,"County Commissioner, Precinct 2",,DEM,Nick Harpster,47,26,21
 Lubbock,60,"Justice of the Peace, Precinct 2",,DEM,Daylan J. Flowers,48,26,22
 Lubbock,60,County Party Chair,,DEM,Stuart Williams,49,27,22
-Lubbock,60,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,47,25,22
-Lubbock,60,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,2,2,0
-Lubbock,60,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,48,27,21
-Lubbock,60,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,2,2,0
-Lubbock,60,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,50,29,21
-Lubbock,60,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,1,0,1
-Lubbock,60,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,51,29,22
-Lubbock,60,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,60,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,49,28,21
-Lubbock,60,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,1,1,0
-Lubbock,60,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,52,29,23
-Lubbock,60,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,60,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,51,28,23
-Lubbock,60,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,60,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,50,27,23
-Lubbock,60,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,1,1,0
-Lubbock,60,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,52,29,23
-Lubbock,60,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,60,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,50,29,21
-Lubbock,60,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,60,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,51,28,23
-Lubbock,60,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,60,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,50,28,22
-Lubbock,60,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,60,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,47,25,22
+Lubbock,60,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,2,2,0
+Lubbock,60,"Democratic Proposition #2 Student Loan Debt",,DEM,For,48,27,21
+Lubbock,60,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,2,2,0
+Lubbock,60,"Democratic Proposition #3 Right to Healthcare",,DEM,For,50,29,21
+Lubbock,60,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,1,0,1
+Lubbock,60,"Democratic Proposition #4 Right to Economic Security",,DEM,For,51,29,22
+Lubbock,60,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,60,"Democratic Proposition #5 National Jobs Program",,DEM,For,49,28,21
+Lubbock,60,"Democratic Proposition #5 National Jobs Program",,DEM,Against,1,1,0
+Lubbock,60,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,52,29,23
+Lubbock,60,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,60,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,51,28,23
+Lubbock,60,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,60,"Democratic Proposition #8 Right to Housing",,DEM,For,50,27,23
+Lubbock,60,"Democratic Proposition #8 Right to Housing",,DEM,Against,1,1,0
+Lubbock,60,"Democratic Proposition #9 Right to Vote",,DEM,For,52,29,23
+Lubbock,60,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,60,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,50,29,21
+Lubbock,60,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,60,"Democratic Proposition #11 Immigrant Rights",,DEM,For,51,28,23
+Lubbock,60,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,60,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,50,28,22
+Lubbock,60,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,62,Registered Voters,,,,2378,,
 Lubbock,62,U.S. Senate,,DEM,Beto O'Rourke,50,32,18
 Lubbock,62,U.S. Senate,,DEM,Sema Hernandez,12,7,5
@@ -15639,82 +12831,30 @@ Lubbock,62,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,70,4
 Lubbock,62,State Representative,84,DEM,Austin Michael Carrizales,29,21,8
 Lubbock,62,State Representative,84,DEM,Samantha Carrillo Fields,41,24,17
 Lubbock,62,County Party Chair,,DEM,Stuart Williams,66,39,27
-Lubbock,62,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,76,48,28
-Lubbock,62,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,1,1,0
-Lubbock,62,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,72,45,27
-Lubbock,62,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,4,3,1
-Lubbock,62,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,73,46,27
-Lubbock,62,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,4,3,1
-Lubbock,62,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,72,45,27
-Lubbock,62,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,3,2,1
-Lubbock,62,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,67,44,23
-Lubbock,62,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,8,4,4
-Lubbock,62,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,77,49,28
-Lubbock,62,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,62,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,75,49,26
-Lubbock,62,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,3,1,2
-Lubbock,62,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,72,46,26
-Lubbock,62,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,6,4,2
-Lubbock,62,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,75,50,25
-Lubbock,62,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,2,0,2
-Lubbock,62,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,76,49,27
-Lubbock,62,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,62,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,74,48,26
-Lubbock,62,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,3,2,1
-Lubbock,62,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,75,48,27
-Lubbock,62,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,3,2,1
+Lubbock,62,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,76,48,28
+Lubbock,62,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,1,1,0
+Lubbock,62,"Democratic Proposition #2 Student Loan Debt",,DEM,For,72,45,27
+Lubbock,62,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,4,3,1
+Lubbock,62,"Democratic Proposition #3 Right to Healthcare",,DEM,For,73,46,27
+Lubbock,62,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,4,3,1
+Lubbock,62,"Democratic Proposition #4 Right to Economic Security",,DEM,For,72,45,27
+Lubbock,62,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,3,2,1
+Lubbock,62,"Democratic Proposition #5 National Jobs Program",,DEM,For,67,44,23
+Lubbock,62,"Democratic Proposition #5 National Jobs Program",,DEM,Against,8,4,4
+Lubbock,62,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,77,49,28
+Lubbock,62,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,62,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,75,49,26
+Lubbock,62,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,3,1,2
+Lubbock,62,"Democratic Proposition #8 Right to Housing",,DEM,For,72,46,26
+Lubbock,62,"Democratic Proposition #8 Right to Housing",,DEM,Against,6,4,2
+Lubbock,62,"Democratic Proposition #9 Right to Vote",,DEM,For,75,50,25
+Lubbock,62,"Democratic Proposition #9 Right to Vote",,DEM,Against,2,0,2
+Lubbock,62,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,76,49,27
+Lubbock,62,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,62,"Democratic Proposition #11 Immigrant Rights",,DEM,For,74,48,26
+Lubbock,62,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,3,2,1
+Lubbock,62,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,75,48,27
+Lubbock,62,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,3,2,1
 Lubbock,63,Registered Voters,,,,174,,
 Lubbock,63,U.S. Senate,,DEM,Beto O'Rourke,8,4,4
 Lubbock,63,U.S. Senate,,DEM,Sema Hernandez,2,1,1
@@ -15748,82 +12888,30 @@ Lubbock,63,State Representative,84,DEM,Austin Michael Carrizales,5,2,3
 Lubbock,63,State Representative,84,DEM,Samantha Carrillo Fields,4,3,1
 Lubbock,63,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,8,5,3
 Lubbock,63,County Party Chair,,DEM,Stuart Williams,8,4,4
-Lubbock,63,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,10,5,5
-Lubbock,63,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,63,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,10,5,5
-Lubbock,63,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,63,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,10,5,5
-Lubbock,63,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,63,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,9,5,4
-Lubbock,63,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,63,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,9,4,5
-Lubbock,63,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,1,1,0
-Lubbock,63,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,10,5,5
-Lubbock,63,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,63,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,10,5,5
-Lubbock,63,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,63,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,9,5,4
-Lubbock,63,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,63,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,10,5,5
-Lubbock,63,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,63,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,9,4,5
-Lubbock,63,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
-Lubbock,63,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,9,4,5
-Lubbock,63,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,1,1,0
-Lubbock,63,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,10,5,5
-Lubbock,63,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,63,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,10,5,5
+Lubbock,63,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,63,"Democratic Proposition #2 Student Loan Debt",,DEM,For,10,5,5
+Lubbock,63,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,63,"Democratic Proposition #3 Right to Healthcare",,DEM,For,10,5,5
+Lubbock,63,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,63,"Democratic Proposition #4 Right to Economic Security",,DEM,For,9,5,4
+Lubbock,63,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,63,"Democratic Proposition #5 National Jobs Program",,DEM,For,9,4,5
+Lubbock,63,"Democratic Proposition #5 National Jobs Program",,DEM,Against,1,1,0
+Lubbock,63,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,10,5,5
+Lubbock,63,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,63,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,10,5,5
+Lubbock,63,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,63,"Democratic Proposition #8 Right to Housing",,DEM,For,9,5,4
+Lubbock,63,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,63,"Democratic Proposition #9 Right to Vote",,DEM,For,10,5,5
+Lubbock,63,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,63,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,9,4,5
+Lubbock,63,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
+Lubbock,63,"Democratic Proposition #11 Immigrant Rights",,DEM,For,9,4,5
+Lubbock,63,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,1,1,0
+Lubbock,63,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,10,5,5
+Lubbock,63,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,64,Registered Voters,,,,0,,
 Lubbock,64,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
 Lubbock,64,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -15856,82 +12944,30 @@ Lubbock,64,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0,
 Lubbock,64,State Representative,83,DEM,Drew Landry,0,0,0
 Lubbock,64,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,0,0,0
 Lubbock,64,County Party Chair,,DEM,Stuart Williams,0,0,0
-Lubbock,64,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,0,0,0
-Lubbock,64,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,64,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,0,0,0
-Lubbock,64,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,64,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,0,0,0
-Lubbock,64,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,64,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,0,0,0
-Lubbock,64,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,64,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,0,0,0
-Lubbock,64,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,64,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,0,0,0
-Lubbock,64,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,64,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,0,0,0
-Lubbock,64,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,64,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,0,0,0
-Lubbock,64,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,64,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,0,0,0
-Lubbock,64,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,64,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,0,0,0
-Lubbock,64,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,64,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,0,0,0
-Lubbock,64,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,64,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,0,0,0
-Lubbock,64,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,64,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,0,0,0
+Lubbock,64,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,64,"Democratic Proposition #2 Student Loan Debt",,DEM,For,0,0,0
+Lubbock,64,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,64,"Democratic Proposition #3 Right to Healthcare",,DEM,For,0,0,0
+Lubbock,64,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,64,"Democratic Proposition #4 Right to Economic Security",,DEM,For,0,0,0
+Lubbock,64,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,64,"Democratic Proposition #5 National Jobs Program",,DEM,For,0,0,0
+Lubbock,64,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,64,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,0,0,0
+Lubbock,64,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,64,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,0,0,0
+Lubbock,64,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,64,"Democratic Proposition #8 Right to Housing",,DEM,For,0,0,0
+Lubbock,64,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,64,"Democratic Proposition #9 Right to Vote",,DEM,For,0,0,0
+Lubbock,64,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,64,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,0,0,0
+Lubbock,64,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,64,"Democratic Proposition #11 Immigrant Rights",,DEM,For,0,0,0
+Lubbock,64,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,64,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,0,0,0
+Lubbock,64,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,65,Registered Voters,,,,1161,,
 Lubbock,65,U.S. Senate,,DEM,Beto O'Rourke,6,5,1
 Lubbock,65,U.S. Senate,,DEM,Sema Hernandez,6,5,1
@@ -15964,82 +13000,30 @@ Lubbock,65,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,16,1
 Lubbock,65,State Representative,83,DEM,Drew Landry,16,13,3
 Lubbock,65,"Justice of the Peace, Precinct 3",,DEM,Aurora Chaides-Hernandez,15,12,3
 Lubbock,65,County Party Chair,,DEM,Stuart Williams,15,12,3
-Lubbock,65,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,14,11,3
-Lubbock,65,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,1,1,0
-Lubbock,65,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,14,11,3
-Lubbock,65,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,2,2,0
-Lubbock,65,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,16,13,3
-Lubbock,65,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,65,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,16,13,3
-Lubbock,65,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,65,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,16,13,3
-Lubbock,65,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,65,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,15,12,3
-Lubbock,65,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,1,1,0
-Lubbock,65,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,15,12,3
-Lubbock,65,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,1,1,0
-Lubbock,65,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,15,12,3
-Lubbock,65,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,1,1,0
-Lubbock,65,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,16,13,3
-Lubbock,65,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,65,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,16,13,3
-Lubbock,65,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,65,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,13,11,2
-Lubbock,65,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,2,1,1
-Lubbock,65,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,15,12,3
-Lubbock,65,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,1,1,0
+Lubbock,65,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,14,11,3
+Lubbock,65,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,1,1,0
+Lubbock,65,"Democratic Proposition #2 Student Loan Debt",,DEM,For,14,11,3
+Lubbock,65,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,2,2,0
+Lubbock,65,"Democratic Proposition #3 Right to Healthcare",,DEM,For,16,13,3
+Lubbock,65,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,65,"Democratic Proposition #4 Right to Economic Security",,DEM,For,16,13,3
+Lubbock,65,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,65,"Democratic Proposition #5 National Jobs Program",,DEM,For,16,13,3
+Lubbock,65,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,65,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,15,12,3
+Lubbock,65,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,1,1,0
+Lubbock,65,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,15,12,3
+Lubbock,65,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,1,1,0
+Lubbock,65,"Democratic Proposition #8 Right to Housing",,DEM,For,15,12,3
+Lubbock,65,"Democratic Proposition #8 Right to Housing",,DEM,Against,1,1,0
+Lubbock,65,"Democratic Proposition #9 Right to Vote",,DEM,For,16,13,3
+Lubbock,65,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,65,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,16,13,3
+Lubbock,65,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,65,"Democratic Proposition #11 Immigrant Rights",,DEM,For,13,11,2
+Lubbock,65,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,2,1,1
+Lubbock,65,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,15,12,3
+Lubbock,65,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,1,1,0
 Lubbock,66,Registered Voters,,,,2384,,
 Lubbock,66,U.S. Senate,,DEM,Beto O'Rourke,67,43,24
 Lubbock,66,U.S. Senate,,DEM,Sema Hernandez,8,6,2
@@ -16071,82 +13055,30 @@ Lubbock,66,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) Ja
 Lubbock,66,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,76,52,24
 Lubbock,66,State Representative,83,DEM,Drew Landry,81,54,27
 Lubbock,66,County Party Chair,,DEM,Stuart Williams,80,55,25
-Lubbock,66,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,85,56,29
-Lubbock,66,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,3,2,1
-Lubbock,66,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,77,48,29
-Lubbock,66,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,8,7,1
-Lubbock,66,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,83,54,29
-Lubbock,66,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,4,3,1
-Lubbock,66,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,82,54,28
-Lubbock,66,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,5,3,2
-Lubbock,66,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,80,53,27
-Lubbock,66,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,6,4,2
-Lubbock,66,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,88,58,30
-Lubbock,66,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,66,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,87,58,29
-Lubbock,66,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,66,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,81,55,26
-Lubbock,66,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,5,2,3
-Lubbock,66,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,84,57,27
-Lubbock,66,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,1,0,1
-Lubbock,66,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,87,57,30
-Lubbock,66,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
-Lubbock,66,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,85,57,28
-Lubbock,66,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,1,1,0
-Lubbock,66,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,83,55,28
-Lubbock,66,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,66,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,85,56,29
+Lubbock,66,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,3,2,1
+Lubbock,66,"Democratic Proposition #2 Student Loan Debt",,DEM,For,77,48,29
+Lubbock,66,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,8,7,1
+Lubbock,66,"Democratic Proposition #3 Right to Healthcare",,DEM,For,83,54,29
+Lubbock,66,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,4,3,1
+Lubbock,66,"Democratic Proposition #4 Right to Economic Security",,DEM,For,82,54,28
+Lubbock,66,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,5,3,2
+Lubbock,66,"Democratic Proposition #5 National Jobs Program",,DEM,For,80,53,27
+Lubbock,66,"Democratic Proposition #5 National Jobs Program",,DEM,Against,6,4,2
+Lubbock,66,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,88,58,30
+Lubbock,66,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,66,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,87,58,29
+Lubbock,66,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,66,"Democratic Proposition #8 Right to Housing",,DEM,For,81,55,26
+Lubbock,66,"Democratic Proposition #8 Right to Housing",,DEM,Against,5,2,3
+Lubbock,66,"Democratic Proposition #9 Right to Vote",,DEM,For,84,57,27
+Lubbock,66,"Democratic Proposition #9 Right to Vote",,DEM,Against,1,0,1
+Lubbock,66,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,87,57,30
+Lubbock,66,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
+Lubbock,66,"Democratic Proposition #11 Immigrant Rights",,DEM,For,85,57,28
+Lubbock,66,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,1,1,0
+Lubbock,66,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,83,55,28
+Lubbock,66,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,67,Registered Voters,,,,2100,,
 Lubbock,67,U.S. Senate,,DEM,Beto O'Rourke,46,29,17
 Lubbock,67,U.S. Senate,,DEM,Sema Hernandez,13,11,2
@@ -16180,82 +13112,30 @@ Lubbock,67,State Representative,83,DEM,Drew Landry,62,43,19
 Lubbock,67,"County Commissioner, Precinct 2",,DEM,Nick Harpster,58,39,19
 Lubbock,67,"Justice of the Peace, Precinct 2",,DEM,Daylan J. Flowers,60,40,20
 Lubbock,67,County Party Chair,,DEM,Stuart Williams,59,40,19
-Lubbock,67,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,66,45,21
-Lubbock,67,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,1,0,1
-Lubbock,67,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,62,42,20
-Lubbock,67,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,5,3,2
-Lubbock,67,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,62,40,22
-Lubbock,67,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,4,4,0
-Lubbock,67,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,65,44,21
-Lubbock,67,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,2,2,0
-Lubbock,67,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,60,43,17
-Lubbock,67,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,5,2,3
-Lubbock,67,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,68,46,22
-Lubbock,67,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,67,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,67,45,22
-Lubbock,67,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,67,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,60,42,18
-Lubbock,67,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,5,3,2
-Lubbock,67,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,66,44,22
-Lubbock,67,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,2,2,0
-Lubbock,67,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,66,45,21
-Lubbock,67,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,67,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,65,46,19
-Lubbock,67,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,2,0,2
-Lubbock,67,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,66,45,21
-Lubbock,67,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,2,1,1
+Lubbock,67,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,66,45,21
+Lubbock,67,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,1,0,1
+Lubbock,67,"Democratic Proposition #2 Student Loan Debt",,DEM,For,62,42,20
+Lubbock,67,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,5,3,2
+Lubbock,67,"Democratic Proposition #3 Right to Healthcare",,DEM,For,62,40,22
+Lubbock,67,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,4,4,0
+Lubbock,67,"Democratic Proposition #4 Right to Economic Security",,DEM,For,65,44,21
+Lubbock,67,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,2,2,0
+Lubbock,67,"Democratic Proposition #5 National Jobs Program",,DEM,For,60,43,17
+Lubbock,67,"Democratic Proposition #5 National Jobs Program",,DEM,Against,5,2,3
+Lubbock,67,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,68,46,22
+Lubbock,67,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,67,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,67,45,22
+Lubbock,67,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,67,"Democratic Proposition #8 Right to Housing",,DEM,For,60,42,18
+Lubbock,67,"Democratic Proposition #8 Right to Housing",,DEM,Against,5,3,2
+Lubbock,67,"Democratic Proposition #9 Right to Vote",,DEM,For,66,44,22
+Lubbock,67,"Democratic Proposition #9 Right to Vote",,DEM,Against,2,2,0
+Lubbock,67,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,66,45,21
+Lubbock,67,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,67,"Democratic Proposition #11 Immigrant Rights",,DEM,For,65,46,19
+Lubbock,67,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,2,0,2
+Lubbock,67,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,66,45,21
+Lubbock,67,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,2,1,1
 Lubbock,69,Registered Voters,,,,18,,
 Lubbock,69,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
 Lubbock,69,U.S. Senate,,DEM,Sema Hernandez,1,0,1
@@ -16288,82 +13168,30 @@ Lubbock,69,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0,
 Lubbock,69,State Representative,83,DEM,Drew Landry,0,0,0
 Lubbock,69,"Justice of the Peace, Precinct 3",,DEM,Aurora Chaides-Hernandez,0,0,0
 Lubbock,69,County Party Chair,,DEM,Stuart Williams,0,0,0
-Lubbock,69,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,1,0,1
-Lubbock,69,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,69,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,0,0,0
-Lubbock,69,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,1,0,1
-Lubbock,69,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,0,0,0
-Lubbock,69,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,1,0,1
-Lubbock,69,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,1,0,1
-Lubbock,69,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,69,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,1,0,1
-Lubbock,69,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,69,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,1,0,1
-Lubbock,69,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,69,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,1,0,1
-Lubbock,69,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,69,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,1,0,1
-Lubbock,69,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,69,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,1,0,1
-Lubbock,69,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,69,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,1,0,1
-Lubbock,69,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,69,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,1,0,1
-Lubbock,69,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,69,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,1,0,1
-Lubbock,69,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,69,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,1,0,1
+Lubbock,69,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,69,"Democratic Proposition #2 Student Loan Debt",,DEM,For,0,0,0
+Lubbock,69,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,1,0,1
+Lubbock,69,"Democratic Proposition #3 Right to Healthcare",,DEM,For,0,0,0
+Lubbock,69,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,1,0,1
+Lubbock,69,"Democratic Proposition #4 Right to Economic Security",,DEM,For,1,0,1
+Lubbock,69,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,69,"Democratic Proposition #5 National Jobs Program",,DEM,For,1,0,1
+Lubbock,69,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,69,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,1,0,1
+Lubbock,69,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,69,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,1,0,1
+Lubbock,69,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,69,"Democratic Proposition #8 Right to Housing",,DEM,For,1,0,1
+Lubbock,69,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,69,"Democratic Proposition #9 Right to Vote",,DEM,For,1,0,1
+Lubbock,69,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,69,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,1,0,1
+Lubbock,69,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,69,"Democratic Proposition #11 Immigrant Rights",,DEM,For,1,0,1
+Lubbock,69,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,69,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,1,0,1
+Lubbock,69,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,72,Registered Voters,,,,2809,,
 Lubbock,72,U.S. Senate,,DEM,Beto O'Rourke,54,29,25
 Lubbock,72,U.S. Senate,,DEM,Sema Hernandez,24,17,7
@@ -16397,82 +13225,30 @@ Lubbock,72,State Representative,84,DEM,Austin Michael Carrizales,24,16,8
 Lubbock,72,State Representative,84,DEM,Samantha Carrillo Fields,59,32,27
 Lubbock,72,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,82,48,34
 Lubbock,72,County Party Chair,,DEM,Stuart Williams,82,48,34
-Lubbock,72,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,87,51,36
-Lubbock,72,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,1,1,0
-Lubbock,72,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,81,47,34
-Lubbock,72,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,6,4,2
-Lubbock,72,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,83,49,34
-Lubbock,72,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,4,2,2
-Lubbock,72,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,82,47,35
-Lubbock,72,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,6,5,1
-Lubbock,72,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,83,47,36
-Lubbock,72,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,4,4,0
-Lubbock,72,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,86,51,35
-Lubbock,72,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,2,1,1
-Lubbock,72,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,83,48,35
-Lubbock,72,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,4,3,1
-Lubbock,72,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,81,47,34
-Lubbock,72,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,4,4,0
-Lubbock,72,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,83,48,35
-Lubbock,72,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,3,2,1
-Lubbock,72,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,84,48,36
-Lubbock,72,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,2,2,0
-Lubbock,72,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,86,50,36
-Lubbock,72,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,1,1,0
-Lubbock,72,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,84,49,35
-Lubbock,72,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,3,2,1
+Lubbock,72,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,87,51,36
+Lubbock,72,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,1,1,0
+Lubbock,72,"Democratic Proposition #2 Student Loan Debt",,DEM,For,81,47,34
+Lubbock,72,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,6,4,2
+Lubbock,72,"Democratic Proposition #3 Right to Healthcare",,DEM,For,83,49,34
+Lubbock,72,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,4,2,2
+Lubbock,72,"Democratic Proposition #4 Right to Economic Security",,DEM,For,82,47,35
+Lubbock,72,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,6,5,1
+Lubbock,72,"Democratic Proposition #5 National Jobs Program",,DEM,For,83,47,36
+Lubbock,72,"Democratic Proposition #5 National Jobs Program",,DEM,Against,4,4,0
+Lubbock,72,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,86,51,35
+Lubbock,72,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,2,1,1
+Lubbock,72,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,83,48,35
+Lubbock,72,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,4,3,1
+Lubbock,72,"Democratic Proposition #8 Right to Housing",,DEM,For,81,47,34
+Lubbock,72,"Democratic Proposition #8 Right to Housing",,DEM,Against,4,4,0
+Lubbock,72,"Democratic Proposition #9 Right to Vote",,DEM,For,83,48,35
+Lubbock,72,"Democratic Proposition #9 Right to Vote",,DEM,Against,3,2,1
+Lubbock,72,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,84,48,36
+Lubbock,72,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,2,2,0
+Lubbock,72,"Democratic Proposition #11 Immigrant Rights",,DEM,For,86,50,36
+Lubbock,72,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,1,1,0
+Lubbock,72,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,84,49,35
+Lubbock,72,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,3,2,1
 Lubbock,75,Registered Voters,,,,1100,,
 Lubbock,75,U.S. Senate,,DEM,Beto O'Rourke,28,17,11
 Lubbock,75,U.S. Senate,,DEM,Sema Hernandez,10,5,5
@@ -16507,82 +13283,30 @@ Lubbock,75,State Representative,84,DEM,Samantha Carrillo Fields,29,16,13
 Lubbock,75,"County Commissioner, Precinct 2",,DEM,Nick Harpster,43,25,18
 Lubbock,75,"Justice of the Peace, Precinct 2",,DEM,Daylan J. Flowers,40,24,16
 Lubbock,75,County Party Chair,,DEM,Stuart Williams,42,25,17
-Lubbock,75,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,42,25,17
-Lubbock,75,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,1,0,1
-Lubbock,75,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,41,24,17
-Lubbock,75,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,2,1,1
-Lubbock,75,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,42,25,17
-Lubbock,75,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,1,0,1
-Lubbock,75,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,41,25,16
-Lubbock,75,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,1,0,1
-Lubbock,75,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,41,24,17
-Lubbock,75,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,1,0,1
-Lubbock,75,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,43,26,17
-Lubbock,75,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,1,0,1
-Lubbock,75,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,40,23,17
-Lubbock,75,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,3,2,1
-Lubbock,75,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,42,25,17
-Lubbock,75,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,1,0,1
-Lubbock,75,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,43,26,17
-Lubbock,75,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,1,0,1
-Lubbock,75,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,43,26,17
-Lubbock,75,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,1,0,1
-Lubbock,75,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,43,26,17
-Lubbock,75,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,1,0,1
-Lubbock,75,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,42,25,17
-Lubbock,75,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,2,1,1
+Lubbock,75,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,42,25,17
+Lubbock,75,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,1,0,1
+Lubbock,75,"Democratic Proposition #2 Student Loan Debt",,DEM,For,41,24,17
+Lubbock,75,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,2,1,1
+Lubbock,75,"Democratic Proposition #3 Right to Healthcare",,DEM,For,42,25,17
+Lubbock,75,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,1,0,1
+Lubbock,75,"Democratic Proposition #4 Right to Economic Security",,DEM,For,41,25,16
+Lubbock,75,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,1,0,1
+Lubbock,75,"Democratic Proposition #5 National Jobs Program",,DEM,For,41,24,17
+Lubbock,75,"Democratic Proposition #5 National Jobs Program",,DEM,Against,1,0,1
+Lubbock,75,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,43,26,17
+Lubbock,75,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,1,0,1
+Lubbock,75,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,40,23,17
+Lubbock,75,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,3,2,1
+Lubbock,75,"Democratic Proposition #8 Right to Housing",,DEM,For,42,25,17
+Lubbock,75,"Democratic Proposition #8 Right to Housing",,DEM,Against,1,0,1
+Lubbock,75,"Democratic Proposition #9 Right to Vote",,DEM,For,43,26,17
+Lubbock,75,"Democratic Proposition #9 Right to Vote",,DEM,Against,1,0,1
+Lubbock,75,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,43,26,17
+Lubbock,75,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,1,0,1
+Lubbock,75,"Democratic Proposition #11 Immigrant Rights",,DEM,For,43,26,17
+Lubbock,75,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,1,0,1
+Lubbock,75,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,42,25,17
+Lubbock,75,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,2,1,1
 Lubbock,76,Registered Voters,,,,1700,,
 Lubbock,76,U.S. Senate,,DEM,Beto O'Rourke,28,19,9
 Lubbock,76,U.S. Senate,,DEM,Sema Hernandez,23,14,9
@@ -16616,82 +13340,30 @@ Lubbock,76,State Representative,84,DEM,Austin Michael Carrizales,13,8,5
 Lubbock,76,State Representative,84,DEM,Samantha Carrillo Fields,43,29,14
 Lubbock,76,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,53,35,18
 Lubbock,76,County Party Chair,,DEM,Stuart Williams,53,36,17
-Lubbock,76,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,57,38,19
-Lubbock,76,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,1,1,0
-Lubbock,76,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,57,38,19
-Lubbock,76,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,76,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,56,38,18
-Lubbock,76,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,2,1,1
-Lubbock,76,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,57,38,19
-Lubbock,76,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,76,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,53,36,17
-Lubbock,76,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,5,3,2
-Lubbock,76,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,57,38,19
-Lubbock,76,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,76,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,57,39,18
-Lubbock,76,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,76,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,53,37,16
-Lubbock,76,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,5,2,3
-Lubbock,76,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,58,39,19
-Lubbock,76,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,76,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,56,39,17
-Lubbock,76,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,76,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,54,36,18
-Lubbock,76,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,2,1,1
-Lubbock,76,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,58,39,19
-Lubbock,76,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,76,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,57,38,19
+Lubbock,76,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,1,1,0
+Lubbock,76,"Democratic Proposition #2 Student Loan Debt",,DEM,For,57,38,19
+Lubbock,76,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,76,"Democratic Proposition #3 Right to Healthcare",,DEM,For,56,38,18
+Lubbock,76,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,2,1,1
+Lubbock,76,"Democratic Proposition #4 Right to Economic Security",,DEM,For,57,38,19
+Lubbock,76,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,76,"Democratic Proposition #5 National Jobs Program",,DEM,For,53,36,17
+Lubbock,76,"Democratic Proposition #5 National Jobs Program",,DEM,Against,5,3,2
+Lubbock,76,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,57,38,19
+Lubbock,76,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,76,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,57,39,18
+Lubbock,76,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,76,"Democratic Proposition #8 Right to Housing",,DEM,For,53,37,16
+Lubbock,76,"Democratic Proposition #8 Right to Housing",,DEM,Against,5,2,3
+Lubbock,76,"Democratic Proposition #9 Right to Vote",,DEM,For,58,39,19
+Lubbock,76,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,76,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,56,39,17
+Lubbock,76,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,76,"Democratic Proposition #11 Immigrant Rights",,DEM,For,54,36,18
+Lubbock,76,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,2,1,1
+Lubbock,76,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,58,39,19
+Lubbock,76,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,78,Registered Voters,,,,2502,,
 Lubbock,78,U.S. Senate,,DEM,Beto O'Rourke,61,38,23
 Lubbock,78,U.S. Senate,,DEM,Sema Hernandez,5,3,2
@@ -16724,82 +13396,30 @@ Lubbock,78,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,74,4
 Lubbock,78,State Representative,84,DEM,Austin Michael Carrizales,32,22,10
 Lubbock,78,State Representative,84,DEM,Samantha Carrillo Fields,41,24,17
 Lubbock,78,County Party Chair,,DEM,Stuart Williams,75,48,27
-Lubbock,78,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,76,48,28
-Lubbock,78,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,1,1,0
-Lubbock,78,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,70,44,26
-Lubbock,78,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,7,4,3
-Lubbock,78,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,74,47,27
-Lubbock,78,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,3,2,1
-Lubbock,78,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,75,47,28
-Lubbock,78,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,1,1,0
-Lubbock,78,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,71,45,26
-Lubbock,78,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,4,3,1
-Lubbock,78,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,77,49,28
-Lubbock,78,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,1,1,0
-Lubbock,78,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,73,47,26
-Lubbock,78,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,3,2,1
-Lubbock,78,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,68,41,27
-Lubbock,78,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,10,9,1
-Lubbock,78,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,73,47,26
-Lubbock,78,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,2,1,1
-Lubbock,78,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,74,48,26
-Lubbock,78,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,4,2,2
-Lubbock,78,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,76,49,27
-Lubbock,78,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,78,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,76,49,27
-Lubbock,78,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,1,0,1
+Lubbock,78,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,76,48,28
+Lubbock,78,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,1,1,0
+Lubbock,78,"Democratic Proposition #2 Student Loan Debt",,DEM,For,70,44,26
+Lubbock,78,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,7,4,3
+Lubbock,78,"Democratic Proposition #3 Right to Healthcare",,DEM,For,74,47,27
+Lubbock,78,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,3,2,1
+Lubbock,78,"Democratic Proposition #4 Right to Economic Security",,DEM,For,75,47,28
+Lubbock,78,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,1,1,0
+Lubbock,78,"Democratic Proposition #5 National Jobs Program",,DEM,For,71,45,26
+Lubbock,78,"Democratic Proposition #5 National Jobs Program",,DEM,Against,4,3,1
+Lubbock,78,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,77,49,28
+Lubbock,78,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,1,1,0
+Lubbock,78,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,73,47,26
+Lubbock,78,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,3,2,1
+Lubbock,78,"Democratic Proposition #8 Right to Housing",,DEM,For,68,41,27
+Lubbock,78,"Democratic Proposition #8 Right to Housing",,DEM,Against,10,9,1
+Lubbock,78,"Democratic Proposition #9 Right to Vote",,DEM,For,73,47,26
+Lubbock,78,"Democratic Proposition #9 Right to Vote",,DEM,Against,2,1,1
+Lubbock,78,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,74,48,26
+Lubbock,78,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,4,2,2
+Lubbock,78,"Democratic Proposition #11 Immigrant Rights",,DEM,For,76,49,27
+Lubbock,78,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,78,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,76,49,27
+Lubbock,78,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,1,0,1
 Lubbock,92,Registered Voters,,,,377,,
 Lubbock,92,U.S. Senate,,DEM,Beto O'Rourke,3,2,1
 Lubbock,92,U.S. Senate,,DEM,Sema Hernandez,3,1,2
@@ -16833,82 +13453,30 @@ Lubbock,92,State Representative,84,DEM,Austin Michael Carrizales,5,3,2
 Lubbock,92,State Representative,84,DEM,Samantha Carrillo Fields,3,2,1
 Lubbock,92,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,8,5,3
 Lubbock,92,County Party Chair,,DEM,Stuart Williams,8,5,3
-Lubbock,92,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,10,7,3
-Lubbock,92,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,92,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,10,7,3
-Lubbock,92,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,92,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,8,5,3
-Lubbock,92,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,2,2,0
-Lubbock,92,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,10,7,3
-Lubbock,92,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,92,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,10,7,3
-Lubbock,92,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,92,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,10,7,3
-Lubbock,92,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,92,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,8,5,3
-Lubbock,92,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,2,2,0
-Lubbock,92,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,8,5,3
-Lubbock,92,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,2,2,0
-Lubbock,92,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,10,7,3
-Lubbock,92,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,92,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,10,7,3
-Lubbock,92,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,92,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,8,5,3
-Lubbock,92,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,92,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,6,3,3
-Lubbock,92,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,2,2,0
+Lubbock,92,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,10,7,3
+Lubbock,92,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,92,"Democratic Proposition #2 Student Loan Debt",,DEM,For,10,7,3
+Lubbock,92,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,92,"Democratic Proposition #3 Right to Healthcare",,DEM,For,8,5,3
+Lubbock,92,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,2,2,0
+Lubbock,92,"Democratic Proposition #4 Right to Economic Security",,DEM,For,10,7,3
+Lubbock,92,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,92,"Democratic Proposition #5 National Jobs Program",,DEM,For,10,7,3
+Lubbock,92,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,92,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,10,7,3
+Lubbock,92,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,92,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,8,5,3
+Lubbock,92,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,2,2,0
+Lubbock,92,"Democratic Proposition #8 Right to Housing",,DEM,For,8,5,3
+Lubbock,92,"Democratic Proposition #8 Right to Housing",,DEM,Against,2,2,0
+Lubbock,92,"Democratic Proposition #9 Right to Vote",,DEM,For,10,7,3
+Lubbock,92,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,92,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,10,7,3
+Lubbock,92,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,92,"Democratic Proposition #11 Immigrant Rights",,DEM,For,8,5,3
+Lubbock,92,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,92,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,6,3,3
+Lubbock,92,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,2,2,0
 Lubbock,96,Registered Voters,,,,121,,
 Lubbock,96,U.S. Senate,,DEM,Beto O'Rourke,7,5,2
 Lubbock,96,U.S. Senate,,DEM,Sema Hernandez,2,0,2
@@ -16942,82 +13510,30 @@ Lubbock,96,State Representative,84,DEM,Austin Michael Carrizales,3,1,2
 Lubbock,96,State Representative,84,DEM,Samantha Carrillo Fields,5,3,2
 Lubbock,96,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,9,5,4
 Lubbock,96,County Party Chair,,DEM,Stuart Williams,9,5,4
-Lubbock,96,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,8,5,3
-Lubbock,96,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,1,0,1
-Lubbock,96,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,8,5,3
-Lubbock,96,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,1,0,1
-Lubbock,96,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,8,4,4
-Lubbock,96,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,1,1,0
-Lubbock,96,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,9,5,4
-Lubbock,96,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,96,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,9,5,4
-Lubbock,96,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,96,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,9,5,4
-Lubbock,96,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,96,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,9,5,4
-Lubbock,96,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,96,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,7,4,3
-Lubbock,96,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,2,1,1
-Lubbock,96,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,9,5,4
-Lubbock,96,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,96,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,9,5,4
-Lubbock,96,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,96,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,9,5,4
-Lubbock,96,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,96,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,9,5,4
-Lubbock,96,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,96,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,8,5,3
+Lubbock,96,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,1,0,1
+Lubbock,96,"Democratic Proposition #2 Student Loan Debt",,DEM,For,8,5,3
+Lubbock,96,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,1,0,1
+Lubbock,96,"Democratic Proposition #3 Right to Healthcare",,DEM,For,8,4,4
+Lubbock,96,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,1,1,0
+Lubbock,96,"Democratic Proposition #4 Right to Economic Security",,DEM,For,9,5,4
+Lubbock,96,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,96,"Democratic Proposition #5 National Jobs Program",,DEM,For,9,5,4
+Lubbock,96,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,96,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,9,5,4
+Lubbock,96,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,96,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,9,5,4
+Lubbock,96,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,96,"Democratic Proposition #8 Right to Housing",,DEM,For,7,4,3
+Lubbock,96,"Democratic Proposition #8 Right to Housing",,DEM,Against,2,1,1
+Lubbock,96,"Democratic Proposition #9 Right to Vote",,DEM,For,9,5,4
+Lubbock,96,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,96,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,9,5,4
+Lubbock,96,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,96,"Democratic Proposition #11 Immigrant Rights",,DEM,For,9,5,4
+Lubbock,96,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,96,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,9,5,4
+Lubbock,96,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,102,Registered Voters,,,,499,,
 Lubbock,102,U.S. Senate,,DEM,Beto O'Rourke,3,2,1
 Lubbock,102,U.S. Senate,,DEM,Sema Hernandez,2,2,0
@@ -17050,82 +13566,30 @@ Lubbock,102,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,5,4
 Lubbock,102,State Representative,83,DEM,Drew Landry,5,4,1
 Lubbock,102,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,5,4,1
 Lubbock,102,County Party Chair,,DEM,Stuart Williams,5,4,1
-Lubbock,102,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,4,3,1
-Lubbock,102,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,1,1,0
-Lubbock,102,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,4,3,1
-Lubbock,102,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,1,1,0
-Lubbock,102,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,4,3,1
-Lubbock,102,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,1,1,0
-Lubbock,102,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,4,3,1
-Lubbock,102,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,1,1,0
-Lubbock,102,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,5,4,1
-Lubbock,102,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,102,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,5,4,1
-Lubbock,102,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,102,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,4,3,1
-Lubbock,102,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,1,1,0
-Lubbock,102,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,4,3,1
-Lubbock,102,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,1,1,0
-Lubbock,102,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,4,3,1
-Lubbock,102,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,1,1,0
-Lubbock,102,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,4,3,1
-Lubbock,102,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
-Lubbock,102,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,4,3,1
-Lubbock,102,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,1,1,0
-Lubbock,102,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,5,4,1
-Lubbock,102,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,102,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,4,3,1
+Lubbock,102,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,1,1,0
+Lubbock,102,"Democratic Proposition #2 Student Loan Debt",,DEM,For,4,3,1
+Lubbock,102,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,1,1,0
+Lubbock,102,"Democratic Proposition #3 Right to Healthcare",,DEM,For,4,3,1
+Lubbock,102,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,1,1,0
+Lubbock,102,"Democratic Proposition #4 Right to Economic Security",,DEM,For,4,3,1
+Lubbock,102,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,1,1,0
+Lubbock,102,"Democratic Proposition #5 National Jobs Program",,DEM,For,5,4,1
+Lubbock,102,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,102,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,5,4,1
+Lubbock,102,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,102,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,4,3,1
+Lubbock,102,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,1,1,0
+Lubbock,102,"Democratic Proposition #8 Right to Housing",,DEM,For,4,3,1
+Lubbock,102,"Democratic Proposition #8 Right to Housing",,DEM,Against,1,1,0
+Lubbock,102,"Democratic Proposition #9 Right to Vote",,DEM,For,4,3,1
+Lubbock,102,"Democratic Proposition #9 Right to Vote",,DEM,Against,1,1,0
+Lubbock,102,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,4,3,1
+Lubbock,102,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
+Lubbock,102,"Democratic Proposition #11 Immigrant Rights",,DEM,For,4,3,1
+Lubbock,102,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,1,1,0
+Lubbock,102,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,5,4,1
+Lubbock,102,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,104,Registered Voters,,,,859,,
 Lubbock,104,U.S. Senate,,DEM,Beto O'Rourke,11,8,3
 Lubbock,104,U.S. Senate,,DEM,Sema Hernandez,5,4,1
@@ -17157,82 +13621,30 @@ Lubbock,104,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) J
 Lubbock,104,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,17,13,4
 Lubbock,104,State Representative,83,DEM,Drew Landry,17,13,4
 Lubbock,104,County Party Chair,,DEM,Stuart Williams,17,13,4
-Lubbock,104,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,18,13,5
-Lubbock,104,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,2,0,2
-Lubbock,104,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,19,13,6
-Lubbock,104,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,1,0,1
-Lubbock,104,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,18,13,5
-Lubbock,104,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,2,0,2
-Lubbock,104,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,18,13,5
-Lubbock,104,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,2,0,2
-Lubbock,104,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,16,12,4
-Lubbock,104,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,4,1,3
-Lubbock,104,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,20,13,7
-Lubbock,104,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,104,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,18,13,5
-Lubbock,104,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,2,0,2
-Lubbock,104,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,18,12,6
-Lubbock,104,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,2,1,1
-Lubbock,104,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,17,13,4
-Lubbock,104,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,3,0,3
-Lubbock,104,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,19,13,6
-Lubbock,104,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,1,0,1
-Lubbock,104,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,19,13,6
-Lubbock,104,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,1,0,1
-Lubbock,104,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,20,13,7
-Lubbock,104,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,104,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,18,13,5
+Lubbock,104,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,2,0,2
+Lubbock,104,"Democratic Proposition #2 Student Loan Debt",,DEM,For,19,13,6
+Lubbock,104,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,1,0,1
+Lubbock,104,"Democratic Proposition #3 Right to Healthcare",,DEM,For,18,13,5
+Lubbock,104,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,2,0,2
+Lubbock,104,"Democratic Proposition #4 Right to Economic Security",,DEM,For,18,13,5
+Lubbock,104,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,2,0,2
+Lubbock,104,"Democratic Proposition #5 National Jobs Program",,DEM,For,16,12,4
+Lubbock,104,"Democratic Proposition #5 National Jobs Program",,DEM,Against,4,1,3
+Lubbock,104,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,20,13,7
+Lubbock,104,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,104,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,18,13,5
+Lubbock,104,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,2,0,2
+Lubbock,104,"Democratic Proposition #8 Right to Housing",,DEM,For,18,12,6
+Lubbock,104,"Democratic Proposition #8 Right to Housing",,DEM,Against,2,1,1
+Lubbock,104,"Democratic Proposition #9 Right to Vote",,DEM,For,17,13,4
+Lubbock,104,"Democratic Proposition #9 Right to Vote",,DEM,Against,3,0,3
+Lubbock,104,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,19,13,6
+Lubbock,104,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,1,0,1
+Lubbock,104,"Democratic Proposition #11 Immigrant Rights",,DEM,For,19,13,6
+Lubbock,104,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,1,0,1
+Lubbock,104,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,20,13,7
+Lubbock,104,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,109,Registered Voters,,,,2761,,
 Lubbock,109,U.S. Senate,,DEM,Beto O'Rourke,56,33,23
 Lubbock,109,U.S. Senate,,DEM,Sema Hernandez,20,16,4
@@ -17264,82 +13676,30 @@ Lubbock,109,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) J
 Lubbock,109,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,78,50,28
 Lubbock,109,State Representative,83,DEM,Drew Landry,81,53,28
 Lubbock,109,County Party Chair,,DEM,Stuart Williams,81,52,29
-Lubbock,109,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,82,52,30
-Lubbock,109,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,2,1,1
-Lubbock,109,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,77,50,27
-Lubbock,109,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,9,4,5
-Lubbock,109,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,81,50,31
-Lubbock,109,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,5,4,1
-Lubbock,109,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,83,53,30
-Lubbock,109,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,3,1,2
-Lubbock,109,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,83,52,31
-Lubbock,109,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,3,2,1
-Lubbock,109,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,85,53,32
-Lubbock,109,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,1,1,0
-Lubbock,109,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,85,54,31
-Lubbock,109,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,1,0,1
-Lubbock,109,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,76,48,28
-Lubbock,109,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,8,5,3
-Lubbock,109,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,84,53,31
-Lubbock,109,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,2,1,1
-Lubbock,109,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,84,53,31
-Lubbock,109,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,2,1,1
-Lubbock,109,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,84,54,30
-Lubbock,109,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,1,0,1
-Lubbock,109,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,85,53,32
-Lubbock,109,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,1,1,0
+Lubbock,109,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,82,52,30
+Lubbock,109,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,2,1,1
+Lubbock,109,"Democratic Proposition #2 Student Loan Debt",,DEM,For,77,50,27
+Lubbock,109,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,9,4,5
+Lubbock,109,"Democratic Proposition #3 Right to Healthcare",,DEM,For,81,50,31
+Lubbock,109,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,5,4,1
+Lubbock,109,"Democratic Proposition #4 Right to Economic Security",,DEM,For,83,53,30
+Lubbock,109,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,3,1,2
+Lubbock,109,"Democratic Proposition #5 National Jobs Program",,DEM,For,83,52,31
+Lubbock,109,"Democratic Proposition #5 National Jobs Program",,DEM,Against,3,2,1
+Lubbock,109,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,85,53,32
+Lubbock,109,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,1,1,0
+Lubbock,109,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,85,54,31
+Lubbock,109,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,1,0,1
+Lubbock,109,"Democratic Proposition #8 Right to Housing",,DEM,For,76,48,28
+Lubbock,109,"Democratic Proposition #8 Right to Housing",,DEM,Against,8,5,3
+Lubbock,109,"Democratic Proposition #9 Right to Vote",,DEM,For,84,53,31
+Lubbock,109,"Democratic Proposition #9 Right to Vote",,DEM,Against,2,1,1
+Lubbock,109,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,84,53,31
+Lubbock,109,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,2,1,1
+Lubbock,109,"Democratic Proposition #11 Immigrant Rights",,DEM,For,84,54,30
+Lubbock,109,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,1,0,1
+Lubbock,109,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,85,53,32
+Lubbock,109,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,1,1,0
 Lubbock,110,Registered Voters,,,,2997,,
 Lubbock,110,U.S. Senate,,DEM,Beto O'Rourke,75,46,29
 Lubbock,110,U.S. Senate,,DEM,Sema Hernandez,5,2,3
@@ -17371,82 +13731,30 @@ Lubbock,110,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) J
 Lubbock,110,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,81,51,30
 Lubbock,110,State Representative,83,DEM,Drew Landry,83,52,31
 Lubbock,110,County Party Chair,,DEM,Stuart Williams,83,52,31
-Lubbock,110,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,88,54,34
-Lubbock,110,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,1,1,0
-Lubbock,110,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,82,51,31
-Lubbock,110,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,8,5,3
-Lubbock,110,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,83,51,32
-Lubbock,110,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,5,4,1
-Lubbock,110,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,83,51,32
-Lubbock,110,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,5,3,2
-Lubbock,110,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,86,54,32
-Lubbock,110,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,3,1,2
-Lubbock,110,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,89,55,34
-Lubbock,110,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,110,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,90,56,34
-Lubbock,110,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,110,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,84,52,32
-Lubbock,110,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,6,4,2
-Lubbock,110,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,85,52,33
-Lubbock,110,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,5,4,1
-Lubbock,110,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,85,53,32
-Lubbock,110,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,2,1,1
-Lubbock,110,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,89,55,34
-Lubbock,110,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,1,1,0
-Lubbock,110,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,87,55,32
-Lubbock,110,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,3,1,2
+Lubbock,110,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,88,54,34
+Lubbock,110,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,1,1,0
+Lubbock,110,"Democratic Proposition #2 Student Loan Debt",,DEM,For,82,51,31
+Lubbock,110,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,8,5,3
+Lubbock,110,"Democratic Proposition #3 Right to Healthcare",,DEM,For,83,51,32
+Lubbock,110,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,5,4,1
+Lubbock,110,"Democratic Proposition #4 Right to Economic Security",,DEM,For,83,51,32
+Lubbock,110,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,5,3,2
+Lubbock,110,"Democratic Proposition #5 National Jobs Program",,DEM,For,86,54,32
+Lubbock,110,"Democratic Proposition #5 National Jobs Program",,DEM,Against,3,1,2
+Lubbock,110,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,89,55,34
+Lubbock,110,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,110,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,90,56,34
+Lubbock,110,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,110,"Democratic Proposition #8 Right to Housing",,DEM,For,84,52,32
+Lubbock,110,"Democratic Proposition #8 Right to Housing",,DEM,Against,6,4,2
+Lubbock,110,"Democratic Proposition #9 Right to Vote",,DEM,For,85,52,33
+Lubbock,110,"Democratic Proposition #9 Right to Vote",,DEM,Against,5,4,1
+Lubbock,110,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,85,53,32
+Lubbock,110,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,2,1,1
+Lubbock,110,"Democratic Proposition #11 Immigrant Rights",,DEM,For,89,55,34
+Lubbock,110,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,1,1,0
+Lubbock,110,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,87,55,32
+Lubbock,110,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,3,1,2
 Lubbock,111,Registered Voters,,,,1053,,
 Lubbock,111,U.S. Senate,,DEM,Beto O'Rourke,13,7,6
 Lubbock,111,U.S. Senate,,DEM,Sema Hernandez,2,1,1
@@ -17478,82 +13786,30 @@ Lubbock,111,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) J
 Lubbock,111,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,15,8,7
 Lubbock,111,State Representative,83,DEM,Drew Landry,15,8,7
 Lubbock,111,County Party Chair,,DEM,Stuart Williams,15,8,7
-Lubbock,111,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,16,8,8
-Lubbock,111,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,1,1,0
-Lubbock,111,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,16,8,8
-Lubbock,111,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,1,1,0
-Lubbock,111,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,17,9,8
-Lubbock,111,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,111,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,17,9,8
-Lubbock,111,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,111,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,16,8,8
-Lubbock,111,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,1,1,0
-Lubbock,111,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,17,9,8
-Lubbock,111,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,111,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,16,9,7
-Lubbock,111,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,1,0,1
-Lubbock,111,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,17,9,8
-Lubbock,111,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,111,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,16,8,8
-Lubbock,111,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,1,1,0
-Lubbock,111,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,15,8,7
-Lubbock,111,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,2,1,1
-Lubbock,111,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,16,9,7
-Lubbock,111,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,1,0,1
-Lubbock,111,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,16,9,7
-Lubbock,111,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,1,0,1
+Lubbock,111,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,16,8,8
+Lubbock,111,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,1,1,0
+Lubbock,111,"Democratic Proposition #2 Student Loan Debt",,DEM,For,16,8,8
+Lubbock,111,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,1,1,0
+Lubbock,111,"Democratic Proposition #3 Right to Healthcare",,DEM,For,17,9,8
+Lubbock,111,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,111,"Democratic Proposition #4 Right to Economic Security",,DEM,For,17,9,8
+Lubbock,111,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,111,"Democratic Proposition #5 National Jobs Program",,DEM,For,16,8,8
+Lubbock,111,"Democratic Proposition #5 National Jobs Program",,DEM,Against,1,1,0
+Lubbock,111,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,17,9,8
+Lubbock,111,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,111,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,16,9,7
+Lubbock,111,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,1,0,1
+Lubbock,111,"Democratic Proposition #8 Right to Housing",,DEM,For,17,9,8
+Lubbock,111,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,111,"Democratic Proposition #9 Right to Vote",,DEM,For,16,8,8
+Lubbock,111,"Democratic Proposition #9 Right to Vote",,DEM,Against,1,1,0
+Lubbock,111,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,15,8,7
+Lubbock,111,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,2,1,1
+Lubbock,111,"Democratic Proposition #11 Immigrant Rights",,DEM,For,16,9,7
+Lubbock,111,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,1,0,1
+Lubbock,111,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,16,9,7
+Lubbock,111,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,1,0,1
 Lubbock,112,Registered Voters,,,,237,,
 Lubbock,112,U.S. Senate,,DEM,Beto O'Rourke,5,1,4
 Lubbock,112,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -17586,82 +13842,30 @@ Lubbock,112,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,5,1
 Lubbock,112,State Representative,83,DEM,Drew Landry,5,1,4
 Lubbock,112,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,3,0,3
 Lubbock,112,County Party Chair,,DEM,Stuart Williams,5,1,4
-Lubbock,112,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,4,0,4
-Lubbock,112,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,1,1,0
-Lubbock,112,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,5,1,4
-Lubbock,112,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,112,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,4,0,4
-Lubbock,112,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,1,1,0
-Lubbock,112,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,4,0,4
-Lubbock,112,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,1,1,0
-Lubbock,112,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,4,1,3
-Lubbock,112,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,1,0,1
-Lubbock,112,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,5,1,4
-Lubbock,112,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,112,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,5,1,4
-Lubbock,112,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,112,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,4,0,4
-Lubbock,112,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,1,1,0
-Lubbock,112,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,5,1,4
-Lubbock,112,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,112,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,5,1,4
-Lubbock,112,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,112,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,5,1,4
-Lubbock,112,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,112,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,5,1,4
-Lubbock,112,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,112,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,4,0,4
+Lubbock,112,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,1,1,0
+Lubbock,112,"Democratic Proposition #2 Student Loan Debt",,DEM,For,5,1,4
+Lubbock,112,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,112,"Democratic Proposition #3 Right to Healthcare",,DEM,For,4,0,4
+Lubbock,112,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,1,1,0
+Lubbock,112,"Democratic Proposition #4 Right to Economic Security",,DEM,For,4,0,4
+Lubbock,112,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,1,1,0
+Lubbock,112,"Democratic Proposition #5 National Jobs Program",,DEM,For,4,1,3
+Lubbock,112,"Democratic Proposition #5 National Jobs Program",,DEM,Against,1,0,1
+Lubbock,112,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,5,1,4
+Lubbock,112,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,112,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,5,1,4
+Lubbock,112,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,112,"Democratic Proposition #8 Right to Housing",,DEM,For,4,0,4
+Lubbock,112,"Democratic Proposition #8 Right to Housing",,DEM,Against,1,1,0
+Lubbock,112,"Democratic Proposition #9 Right to Vote",,DEM,For,5,1,4
+Lubbock,112,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,112,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,5,1,4
+Lubbock,112,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,112,"Democratic Proposition #11 Immigrant Rights",,DEM,For,5,1,4
+Lubbock,112,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,112,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,5,1,4
+Lubbock,112,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,113,Registered Voters,,,,1841,,
 Lubbock,113,U.S. Senate,,DEM,Beto O'Rourke,64,32,32
 Lubbock,113,U.S. Senate,,DEM,Sema Hernandez,18,10,8
@@ -17695,82 +13899,30 @@ Lubbock,113,State Representative,84,DEM,Austin Michael Carrizales,38,19,19
 Lubbock,113,State Representative,84,DEM,Samantha Carrillo Fields,44,21,23
 Lubbock,113,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,81,39,42
 Lubbock,113,County Party Chair,,DEM,Stuart Williams,80,38,42
-Lubbock,113,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,83,43,40
-Lubbock,113,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,3,1,2
-Lubbock,113,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,83,42,41
-Lubbock,113,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,2,1,1
-Lubbock,113,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,80,41,39
-Lubbock,113,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,4,2,2
-Lubbock,113,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,80,41,39
-Lubbock,113,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,5,2,3
-Lubbock,113,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,77,40,37
-Lubbock,113,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,9,4,5
-Lubbock,113,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,83,43,40
-Lubbock,113,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,2,0,2
-Lubbock,113,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,83,43,40
-Lubbock,113,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,3,1,2
-Lubbock,113,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,78,40,38
-Lubbock,113,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,8,4,4
-Lubbock,113,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,81,42,39
-Lubbock,113,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,5,2,3
-Lubbock,113,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,84,42,42
-Lubbock,113,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,2,2,0
-Lubbock,113,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,84,42,42
-Lubbock,113,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,2,2,0
-Lubbock,113,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,81,40,41
-Lubbock,113,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,3,2,1
+Lubbock,113,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,83,43,40
+Lubbock,113,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,3,1,2
+Lubbock,113,"Democratic Proposition #2 Student Loan Debt",,DEM,For,83,42,41
+Lubbock,113,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,2,1,1
+Lubbock,113,"Democratic Proposition #3 Right to Healthcare",,DEM,For,80,41,39
+Lubbock,113,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,4,2,2
+Lubbock,113,"Democratic Proposition #4 Right to Economic Security",,DEM,For,80,41,39
+Lubbock,113,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,5,2,3
+Lubbock,113,"Democratic Proposition #5 National Jobs Program",,DEM,For,77,40,37
+Lubbock,113,"Democratic Proposition #5 National Jobs Program",,DEM,Against,9,4,5
+Lubbock,113,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,83,43,40
+Lubbock,113,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,2,0,2
+Lubbock,113,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,83,43,40
+Lubbock,113,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,3,1,2
+Lubbock,113,"Democratic Proposition #8 Right to Housing",,DEM,For,78,40,38
+Lubbock,113,"Democratic Proposition #8 Right to Housing",,DEM,Against,8,4,4
+Lubbock,113,"Democratic Proposition #9 Right to Vote",,DEM,For,81,42,39
+Lubbock,113,"Democratic Proposition #9 Right to Vote",,DEM,Against,5,2,3
+Lubbock,113,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,84,42,42
+Lubbock,113,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,2,2,0
+Lubbock,113,"Democratic Proposition #11 Immigrant Rights",,DEM,For,84,42,42
+Lubbock,113,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,2,2,0
+Lubbock,113,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,81,40,41
+Lubbock,113,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,3,2,1
 Lubbock,114,Registered Voters,,,,789,,
 Lubbock,114,U.S. Senate,,DEM,Beto O'Rourke,20,7,13
 Lubbock,114,U.S. Senate,,DEM,Sema Hernandez,16,10,6
@@ -17804,82 +13956,30 @@ Lubbock,114,State Representative,84,DEM,Austin Michael Carrizales,21,11,10
 Lubbock,114,State Representative,84,DEM,Samantha Carrillo Fields,21,8,13
 Lubbock,114,"Justice of the Peace, Precinct 3",,DEM,Aurora Chaides-Hernandez,41,19,22
 Lubbock,114,County Party Chair,,DEM,Stuart Williams,40,17,23
-Lubbock,114,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,44,19,25
-Lubbock,114,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,114,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,42,18,24
-Lubbock,114,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,2,1,1
-Lubbock,114,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,43,18,25
-Lubbock,114,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,1,1,0
-Lubbock,114,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,43,19,24
-Lubbock,114,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,114,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,40,17,23
-Lubbock,114,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,3,2,1
-Lubbock,114,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,44,19,25
-Lubbock,114,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,114,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,44,19,25
-Lubbock,114,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,114,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,40,16,24
-Lubbock,114,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,4,3,1
-Lubbock,114,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,42,18,24
-Lubbock,114,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,114,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,42,17,25
-Lubbock,114,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,2,2,0
-Lubbock,114,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,43,19,24
-Lubbock,114,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,1,0,1
-Lubbock,114,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,43,18,25
-Lubbock,114,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,1,1,0
+Lubbock,114,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,44,19,25
+Lubbock,114,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,114,"Democratic Proposition #2 Student Loan Debt",,DEM,For,42,18,24
+Lubbock,114,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,2,1,1
+Lubbock,114,"Democratic Proposition #3 Right to Healthcare",,DEM,For,43,18,25
+Lubbock,114,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,1,1,0
+Lubbock,114,"Democratic Proposition #4 Right to Economic Security",,DEM,For,43,19,24
+Lubbock,114,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,114,"Democratic Proposition #5 National Jobs Program",,DEM,For,40,17,23
+Lubbock,114,"Democratic Proposition #5 National Jobs Program",,DEM,Against,3,2,1
+Lubbock,114,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,44,19,25
+Lubbock,114,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,114,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,44,19,25
+Lubbock,114,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,114,"Democratic Proposition #8 Right to Housing",,DEM,For,40,16,24
+Lubbock,114,"Democratic Proposition #8 Right to Housing",,DEM,Against,4,3,1
+Lubbock,114,"Democratic Proposition #9 Right to Vote",,DEM,For,42,18,24
+Lubbock,114,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,114,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,42,17,25
+Lubbock,114,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,2,2,0
+Lubbock,114,"Democratic Proposition #11 Immigrant Rights",,DEM,For,43,19,24
+Lubbock,114,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,1,0,1
+Lubbock,114,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,43,18,25
+Lubbock,114,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,1,1,0
 Lubbock,117,Registered Voters,,,,45,,
 Lubbock,117,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
 Lubbock,117,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -17913,82 +14013,30 @@ Lubbock,117,State Representative,84,DEM,Austin Michael Carrizales,0,0,0
 Lubbock,117,State Representative,84,DEM,Samantha Carrillo Fields,0,0,0
 Lubbock,117,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,0,0,0
 Lubbock,117,County Party Chair,,DEM,Stuart Williams,0,0,0
-Lubbock,117,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,0,0,0
-Lubbock,117,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,117,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,0,0,0
-Lubbock,117,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,117,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,0,0,0
-Lubbock,117,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,117,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,0,0,0
-Lubbock,117,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,117,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,0,0,0
-Lubbock,117,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,117,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,0,0,0
-Lubbock,117,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,117,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,0,0,0
-Lubbock,117,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,117,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,0,0,0
-Lubbock,117,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,117,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,0,0,0
-Lubbock,117,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,117,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,0,0,0
-Lubbock,117,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,117,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,0,0,0
-Lubbock,117,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,117,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,0,0,0
-Lubbock,117,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,117,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,0,0,0
+Lubbock,117,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,117,"Democratic Proposition #2 Student Loan Debt",,DEM,For,0,0,0
+Lubbock,117,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,117,"Democratic Proposition #3 Right to Healthcare",,DEM,For,0,0,0
+Lubbock,117,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,117,"Democratic Proposition #4 Right to Economic Security",,DEM,For,0,0,0
+Lubbock,117,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,117,"Democratic Proposition #5 National Jobs Program",,DEM,For,0,0,0
+Lubbock,117,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,117,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,0,0,0
+Lubbock,117,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,117,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,0,0,0
+Lubbock,117,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,117,"Democratic Proposition #8 Right to Housing",,DEM,For,0,0,0
+Lubbock,117,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,117,"Democratic Proposition #9 Right to Vote",,DEM,For,0,0,0
+Lubbock,117,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,117,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,0,0,0
+Lubbock,117,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,117,"Democratic Proposition #11 Immigrant Rights",,DEM,For,0,0,0
+Lubbock,117,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,117,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,0,0,0
+Lubbock,117,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,118,Registered Voters,,,,1737,,
 Lubbock,118,U.S. Senate,,DEM,Beto O'Rourke,38,22,16
 Lubbock,118,U.S. Senate,,DEM,Sema Hernandez,15,6,9
@@ -18022,82 +14070,30 @@ Lubbock,118,State Representative,83,DEM,Drew Landry,55,32,23
 Lubbock,118,"County Commissioner, Precinct 2",,DEM,Nick Harpster,54,32,22
 Lubbock,118,"Justice of the Peace, Precinct 2",,DEM,Daylan J. Flowers,55,32,23
 Lubbock,118,County Party Chair,,DEM,Stuart Williams,54,33,21
-Lubbock,118,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,58,33,25
-Lubbock,118,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,2,2,0
-Lubbock,118,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,56,31,25
-Lubbock,118,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,3,3,0
-Lubbock,118,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,57,33,24
-Lubbock,118,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,3,2,1
-Lubbock,118,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,55,31,24
-Lubbock,118,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,3,3,0
-Lubbock,118,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,57,33,24
-Lubbock,118,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,3,2,1
-Lubbock,118,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,58,33,25
-Lubbock,118,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,2,2,0
-Lubbock,118,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,57,33,24
-Lubbock,118,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,1,1,0
-Lubbock,118,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,53,30,23
-Lubbock,118,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,3,2,1
-Lubbock,118,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,55,32,23
-Lubbock,118,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,4,2,2
-Lubbock,118,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,58,33,25
-Lubbock,118,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
-Lubbock,118,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,57,32,25
-Lubbock,118,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,2,2,0
-Lubbock,118,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,55,32,23
-Lubbock,118,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,3,1,2
+Lubbock,118,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,58,33,25
+Lubbock,118,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,2,2,0
+Lubbock,118,"Democratic Proposition #2 Student Loan Debt",,DEM,For,56,31,25
+Lubbock,118,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,3,3,0
+Lubbock,118,"Democratic Proposition #3 Right to Healthcare",,DEM,For,57,33,24
+Lubbock,118,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,3,2,1
+Lubbock,118,"Democratic Proposition #4 Right to Economic Security",,DEM,For,55,31,24
+Lubbock,118,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,3,3,0
+Lubbock,118,"Democratic Proposition #5 National Jobs Program",,DEM,For,57,33,24
+Lubbock,118,"Democratic Proposition #5 National Jobs Program",,DEM,Against,3,2,1
+Lubbock,118,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,58,33,25
+Lubbock,118,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,2,2,0
+Lubbock,118,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,57,33,24
+Lubbock,118,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,1,1,0
+Lubbock,118,"Democratic Proposition #8 Right to Housing",,DEM,For,53,30,23
+Lubbock,118,"Democratic Proposition #8 Right to Housing",,DEM,Against,3,2,1
+Lubbock,118,"Democratic Proposition #9 Right to Vote",,DEM,For,55,32,23
+Lubbock,118,"Democratic Proposition #9 Right to Vote",,DEM,Against,4,2,2
+Lubbock,118,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,58,33,25
+Lubbock,118,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
+Lubbock,118,"Democratic Proposition #11 Immigrant Rights",,DEM,For,57,32,25
+Lubbock,118,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,2,2,0
+Lubbock,118,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,55,32,23
+Lubbock,118,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,3,1,2
 Lubbock,119,Registered Voters,,,,2810,,
 Lubbock,119,U.S. Senate,,DEM,Beto O'Rourke,74,32,42
 Lubbock,119,U.S. Senate,,DEM,Sema Hernandez,20,12,8
@@ -18131,82 +14127,30 @@ Lubbock,119,State Representative,83,DEM,Drew Landry,95,46,49
 Lubbock,119,"County Commissioner, Precinct 2",,DEM,Nick Harpster,97,47,50
 Lubbock,119,"Justice of the Peace, Precinct 2",,DEM,Daylan J. Flowers,97,47,50
 Lubbock,119,County Party Chair,,DEM,Stuart Williams,98,47,51
-Lubbock,119,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,100,48,52
-Lubbock,119,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,2,1,1
-Lubbock,119,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,98,48,50
-Lubbock,119,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,5,1,4
-Lubbock,119,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,100,49,51
-Lubbock,119,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,2,0,2
-Lubbock,119,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,99,47,52
-Lubbock,119,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,5,3,2
-Lubbock,119,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,96,46,50
-Lubbock,119,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,4,3,1
-Lubbock,119,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,102,49,53
-Lubbock,119,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,1,0,1
-Lubbock,119,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,102,49,53
-Lubbock,119,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,1,0,1
-Lubbock,119,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,99,47,52
-Lubbock,119,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,3,2,1
-Lubbock,119,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,98,47,51
-Lubbock,119,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,5,3,2
-Lubbock,119,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,99,48,51
-Lubbock,119,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,2,1,1
-Lubbock,119,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,100,47,53
-Lubbock,119,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,4,3,1
-Lubbock,119,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,100,48,52
-Lubbock,119,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,2,1,1
+Lubbock,119,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,100,48,52
+Lubbock,119,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,2,1,1
+Lubbock,119,"Democratic Proposition #2 Student Loan Debt",,DEM,For,98,48,50
+Lubbock,119,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,5,1,4
+Lubbock,119,"Democratic Proposition #3 Right to Healthcare",,DEM,For,100,49,51
+Lubbock,119,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,2,0,2
+Lubbock,119,"Democratic Proposition #4 Right to Economic Security",,DEM,For,99,47,52
+Lubbock,119,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,5,3,2
+Lubbock,119,"Democratic Proposition #5 National Jobs Program",,DEM,For,96,46,50
+Lubbock,119,"Democratic Proposition #5 National Jobs Program",,DEM,Against,4,3,1
+Lubbock,119,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,102,49,53
+Lubbock,119,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,1,0,1
+Lubbock,119,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,102,49,53
+Lubbock,119,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,1,0,1
+Lubbock,119,"Democratic Proposition #8 Right to Housing",,DEM,For,99,47,52
+Lubbock,119,"Democratic Proposition #8 Right to Housing",,DEM,Against,3,2,1
+Lubbock,119,"Democratic Proposition #9 Right to Vote",,DEM,For,98,47,51
+Lubbock,119,"Democratic Proposition #9 Right to Vote",,DEM,Against,5,3,2
+Lubbock,119,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,99,48,51
+Lubbock,119,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,2,1,1
+Lubbock,119,"Democratic Proposition #11 Immigrant Rights",,DEM,For,100,47,53
+Lubbock,119,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,4,3,1
+Lubbock,119,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,100,48,52
+Lubbock,119,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,2,1,1
 Lubbock,120,Registered Voters,,,,3144,,
 Lubbock,120,U.S. Senate,,DEM,Beto O'Rourke,28,12,16
 Lubbock,120,U.S. Senate,,DEM,Sema Hernandez,8,4,4
@@ -18238,82 +14182,30 @@ Lubbock,120,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) J
 Lubbock,120,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,36,16,20
 Lubbock,120,State Representative,83,DEM,Drew Landry,37,17,20
 Lubbock,120,County Party Chair,,DEM,Stuart Williams,36,16,20
-Lubbock,120,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,39,18,21
-Lubbock,120,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,120,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,35,13,22
-Lubbock,120,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,3,3,0
-Lubbock,120,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,37,17,20
-Lubbock,120,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,3,1,2
-Lubbock,120,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,39,18,21
-Lubbock,120,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,1,0,1
-Lubbock,120,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,34,17,17
-Lubbock,120,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,5,1,4
-Lubbock,120,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,39,18,21
-Lubbock,120,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,120,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,39,17,22
-Lubbock,120,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,1,1,0
-Lubbock,120,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,34,16,18
-Lubbock,120,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,5,2,3
-Lubbock,120,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,37,17,20
-Lubbock,120,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,2,1,1
-Lubbock,120,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,39,17,22
-Lubbock,120,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
-Lubbock,120,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,38,16,22
-Lubbock,120,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,2,2,0
-Lubbock,120,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,39,18,21
-Lubbock,120,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,1,0,1
+Lubbock,120,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,39,18,21
+Lubbock,120,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,120,"Democratic Proposition #2 Student Loan Debt",,DEM,For,35,13,22
+Lubbock,120,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,3,3,0
+Lubbock,120,"Democratic Proposition #3 Right to Healthcare",,DEM,For,37,17,20
+Lubbock,120,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,3,1,2
+Lubbock,120,"Democratic Proposition #4 Right to Economic Security",,DEM,For,39,18,21
+Lubbock,120,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,1,0,1
+Lubbock,120,"Democratic Proposition #5 National Jobs Program",,DEM,For,34,17,17
+Lubbock,120,"Democratic Proposition #5 National Jobs Program",,DEM,Against,5,1,4
+Lubbock,120,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,39,18,21
+Lubbock,120,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,120,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,39,17,22
+Lubbock,120,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,1,1,0
+Lubbock,120,"Democratic Proposition #8 Right to Housing",,DEM,For,34,16,18
+Lubbock,120,"Democratic Proposition #8 Right to Housing",,DEM,Against,5,2,3
+Lubbock,120,"Democratic Proposition #9 Right to Vote",,DEM,For,37,17,20
+Lubbock,120,"Democratic Proposition #9 Right to Vote",,DEM,Against,2,1,1
+Lubbock,120,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,39,17,22
+Lubbock,120,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
+Lubbock,120,"Democratic Proposition #11 Immigrant Rights",,DEM,For,38,16,22
+Lubbock,120,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,2,2,0
+Lubbock,120,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,39,18,21
+Lubbock,120,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,1,0,1
 Lubbock,121,Registered Voters,,,,2623,,
 Lubbock,121,U.S. Senate,,DEM,Beto O'Rourke,26,10,16
 Lubbock,121,U.S. Senate,,DEM,Sema Hernandez,9,7,2
@@ -18345,82 +14237,30 @@ Lubbock,121,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) J
 Lubbock,121,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,37,16,21
 Lubbock,121,State Representative,83,DEM,Drew Landry,37,17,20
 Lubbock,121,County Party Chair,,DEM,Stuart Williams,38,17,21
-Lubbock,121,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,37,16,21
-Lubbock,121,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,1,1,0
-Lubbock,121,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,34,14,20
-Lubbock,121,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,4,3,1
-Lubbock,121,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,38,17,21
-Lubbock,121,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,121,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,37,17,20
-Lubbock,121,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,1,0,1
-Lubbock,121,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,37,17,20
-Lubbock,121,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,1,0,1
-Lubbock,121,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,38,17,21
-Lubbock,121,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,121,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,38,17,21
-Lubbock,121,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,121,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,34,15,19
-Lubbock,121,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,3,2,1
-Lubbock,121,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,36,15,21
-Lubbock,121,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,2,2,0
-Lubbock,121,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,36,17,19
-Lubbock,121,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,121,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,37,17,20
-Lubbock,121,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,1,0,1
-Lubbock,121,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,38,17,21
-Lubbock,121,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,121,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,37,16,21
+Lubbock,121,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,1,1,0
+Lubbock,121,"Democratic Proposition #2 Student Loan Debt",,DEM,For,34,14,20
+Lubbock,121,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,4,3,1
+Lubbock,121,"Democratic Proposition #3 Right to Healthcare",,DEM,For,38,17,21
+Lubbock,121,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,121,"Democratic Proposition #4 Right to Economic Security",,DEM,For,37,17,20
+Lubbock,121,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,1,0,1
+Lubbock,121,"Democratic Proposition #5 National Jobs Program",,DEM,For,37,17,20
+Lubbock,121,"Democratic Proposition #5 National Jobs Program",,DEM,Against,1,0,1
+Lubbock,121,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,38,17,21
+Lubbock,121,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,121,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,38,17,21
+Lubbock,121,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,121,"Democratic Proposition #8 Right to Housing",,DEM,For,34,15,19
+Lubbock,121,"Democratic Proposition #8 Right to Housing",,DEM,Against,3,2,1
+Lubbock,121,"Democratic Proposition #9 Right to Vote",,DEM,For,36,15,21
+Lubbock,121,"Democratic Proposition #9 Right to Vote",,DEM,Against,2,2,0
+Lubbock,121,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,36,17,19
+Lubbock,121,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,121,"Democratic Proposition #11 Immigrant Rights",,DEM,For,37,17,20
+Lubbock,121,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,1,0,1
+Lubbock,121,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,38,17,21
+Lubbock,121,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,122,Registered Voters,,,,1151,,
 Lubbock,122,U.S. Senate,,DEM,Beto O'Rourke,36,23,13
 Lubbock,122,U.S. Senate,,DEM,Sema Hernandez,11,5,6
@@ -18454,82 +14294,30 @@ Lubbock,122,State Representative,83,DEM,Drew Landry,53,34,19
 Lubbock,122,"County Commissioner, Precinct 2",,DEM,Nick Harpster,52,33,19
 Lubbock,122,"Justice of the Peace, Precinct 2",,DEM,Daylan J. Flowers,51,32,19
 Lubbock,122,County Party Chair,,DEM,Stuart Williams,52,32,20
-Lubbock,122,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,51,30,21
-Lubbock,122,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,2,1,1
-Lubbock,122,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,51,30,21
-Lubbock,122,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,5,4,1
-Lubbock,122,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,52,31,21
-Lubbock,122,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,3,2,1
-Lubbock,122,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,55,33,22
-Lubbock,122,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,1,1,0
-Lubbock,122,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,54,33,21
-Lubbock,122,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,2,1,1
-Lubbock,122,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,56,34,22
-Lubbock,122,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,122,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,53,32,21
-Lubbock,122,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,2,1,1
-Lubbock,122,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,53,32,21
-Lubbock,122,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,3,2,1
-Lubbock,122,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,55,34,21
-Lubbock,122,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,1,0,1
-Lubbock,122,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,55,33,22
-Lubbock,122,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
-Lubbock,122,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,54,33,21
-Lubbock,122,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,2,1,1
-Lubbock,122,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,54,33,21
-Lubbock,122,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,1,1,0
+Lubbock,122,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,51,30,21
+Lubbock,122,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,2,1,1
+Lubbock,122,"Democratic Proposition #2 Student Loan Debt",,DEM,For,51,30,21
+Lubbock,122,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,5,4,1
+Lubbock,122,"Democratic Proposition #3 Right to Healthcare",,DEM,For,52,31,21
+Lubbock,122,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,3,2,1
+Lubbock,122,"Democratic Proposition #4 Right to Economic Security",,DEM,For,55,33,22
+Lubbock,122,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,1,1,0
+Lubbock,122,"Democratic Proposition #5 National Jobs Program",,DEM,For,54,33,21
+Lubbock,122,"Democratic Proposition #5 National Jobs Program",,DEM,Against,2,1,1
+Lubbock,122,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,56,34,22
+Lubbock,122,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,122,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,53,32,21
+Lubbock,122,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,2,1,1
+Lubbock,122,"Democratic Proposition #8 Right to Housing",,DEM,For,53,32,21
+Lubbock,122,"Democratic Proposition #8 Right to Housing",,DEM,Against,3,2,1
+Lubbock,122,"Democratic Proposition #9 Right to Vote",,DEM,For,55,34,21
+Lubbock,122,"Democratic Proposition #9 Right to Vote",,DEM,Against,1,0,1
+Lubbock,122,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,55,33,22
+Lubbock,122,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
+Lubbock,122,"Democratic Proposition #11 Immigrant Rights",,DEM,For,54,33,21
+Lubbock,122,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,2,1,1
+Lubbock,122,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,54,33,21
+Lubbock,122,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,1,1,0
 Lubbock,123,Registered Voters,,,,1787,,
 Lubbock,123,U.S. Senate,,DEM,Beto O'Rourke,44,24,20
 Lubbock,123,U.S. Senate,,DEM,Sema Hernandez,10,7,3
@@ -18563,82 +14351,30 @@ Lubbock,123,State Representative,83,DEM,Drew Landry,57,34,23
 Lubbock,123,"County Commissioner, Precinct 2",,DEM,Nick Harpster,55,33,22
 Lubbock,123,"Justice of the Peace, Precinct 2",,DEM,Daylan J. Flowers,54,32,22
 Lubbock,123,County Party Chair,,DEM,Stuart Williams,53,31,22
-Lubbock,123,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,59,33,26
-Lubbock,123,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,1,1,0
-Lubbock,123,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,58,34,24
-Lubbock,123,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,3,1,2
-Lubbock,123,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,58,34,24
-Lubbock,123,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,3,1,2
-Lubbock,123,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,60,35,25
-Lubbock,123,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,1,0,1
-Lubbock,123,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,58,34,24
-Lubbock,123,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,2,1,1
-Lubbock,123,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,61,35,26
-Lubbock,123,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,123,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,59,33,26
-Lubbock,123,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,1,1,0
-Lubbock,123,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,58,34,24
-Lubbock,123,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,1,0,1
-Lubbock,123,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,58,32,26
-Lubbock,123,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,2,2,0
-Lubbock,123,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,59,33,26
-Lubbock,123,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
-Lubbock,123,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,57,32,25
-Lubbock,123,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,1,1,0
-Lubbock,123,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,58,32,26
-Lubbock,123,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,123,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,59,33,26
+Lubbock,123,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,1,1,0
+Lubbock,123,"Democratic Proposition #2 Student Loan Debt",,DEM,For,58,34,24
+Lubbock,123,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,3,1,2
+Lubbock,123,"Democratic Proposition #3 Right to Healthcare",,DEM,For,58,34,24
+Lubbock,123,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,3,1,2
+Lubbock,123,"Democratic Proposition #4 Right to Economic Security",,DEM,For,60,35,25
+Lubbock,123,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,1,0,1
+Lubbock,123,"Democratic Proposition #5 National Jobs Program",,DEM,For,58,34,24
+Lubbock,123,"Democratic Proposition #5 National Jobs Program",,DEM,Against,2,1,1
+Lubbock,123,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,61,35,26
+Lubbock,123,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,123,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,59,33,26
+Lubbock,123,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,1,1,0
+Lubbock,123,"Democratic Proposition #8 Right to Housing",,DEM,For,58,34,24
+Lubbock,123,"Democratic Proposition #8 Right to Housing",,DEM,Against,1,0,1
+Lubbock,123,"Democratic Proposition #9 Right to Vote",,DEM,For,58,32,26
+Lubbock,123,"Democratic Proposition #9 Right to Vote",,DEM,Against,2,2,0
+Lubbock,123,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,59,33,26
+Lubbock,123,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
+Lubbock,123,"Democratic Proposition #11 Immigrant Rights",,DEM,For,57,32,25
+Lubbock,123,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,1,1,0
+Lubbock,123,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,58,32,26
+Lubbock,123,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,124,Registered Voters,,,,1872,,
 Lubbock,124,U.S. Senate,,DEM,Beto O'Rourke,47,25,22
 Lubbock,124,U.S. Senate,,DEM,Sema Hernandez,12,10,2
@@ -18671,82 +14407,30 @@ Lubbock,124,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,64,
 Lubbock,124,State Representative,84,DEM,Austin Michael Carrizales,21,13,8
 Lubbock,124,State Representative,84,DEM,Samantha Carrillo Fields,42,27,15
 Lubbock,124,County Party Chair,,DEM,Stuart Williams,62,37,25
-Lubbock,124,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,67,42,25
-Lubbock,124,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,1,1,0
-Lubbock,124,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,66,42,24
-Lubbock,124,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,2,1,1
-Lubbock,124,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,64,39,25
-Lubbock,124,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,5,5,0
-Lubbock,124,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,64,41,23
-Lubbock,124,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,2,2,0
-Lubbock,124,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,64,40,24
-Lubbock,124,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,3,3,0
-Lubbock,124,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,67,42,25
-Lubbock,124,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,1,1,0
-Lubbock,124,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,68,43,25
-Lubbock,124,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,1,1,0
-Lubbock,124,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,62,38,24
-Lubbock,124,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,3,3,0
-Lubbock,124,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,65,40,25
-Lubbock,124,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,3,3,0
-Lubbock,124,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,65,42,23
-Lubbock,124,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,2,1,1
-Lubbock,124,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,66,41,25
-Lubbock,124,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,2,2,0
-Lubbock,124,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,65,41,24
-Lubbock,124,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,2,1,1
+Lubbock,124,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,67,42,25
+Lubbock,124,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,1,1,0
+Lubbock,124,"Democratic Proposition #2 Student Loan Debt",,DEM,For,66,42,24
+Lubbock,124,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,2,1,1
+Lubbock,124,"Democratic Proposition #3 Right to Healthcare",,DEM,For,64,39,25
+Lubbock,124,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,5,5,0
+Lubbock,124,"Democratic Proposition #4 Right to Economic Security",,DEM,For,64,41,23
+Lubbock,124,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,2,2,0
+Lubbock,124,"Democratic Proposition #5 National Jobs Program",,DEM,For,64,40,24
+Lubbock,124,"Democratic Proposition #5 National Jobs Program",,DEM,Against,3,3,0
+Lubbock,124,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,67,42,25
+Lubbock,124,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,1,1,0
+Lubbock,124,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,68,43,25
+Lubbock,124,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,1,1,0
+Lubbock,124,"Democratic Proposition #8 Right to Housing",,DEM,For,62,38,24
+Lubbock,124,"Democratic Proposition #8 Right to Housing",,DEM,Against,3,3,0
+Lubbock,124,"Democratic Proposition #9 Right to Vote",,DEM,For,65,40,25
+Lubbock,124,"Democratic Proposition #9 Right to Vote",,DEM,Against,3,3,0
+Lubbock,124,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,65,42,23
+Lubbock,124,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,2,1,1
+Lubbock,124,"Democratic Proposition #11 Immigrant Rights",,DEM,For,66,41,25
+Lubbock,124,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,2,2,0
+Lubbock,124,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,65,41,24
+Lubbock,124,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,2,1,1
 Lubbock,125,Registered Voters,,,,2130,,
 Lubbock,125,U.S. Senate,,DEM,Beto O'Rourke,51,34,17
 Lubbock,125,U.S. Senate,,DEM,Sema Hernandez,13,11,2
@@ -18779,82 +14463,30 @@ Lubbock,125,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,68,
 Lubbock,125,State Representative,84,DEM,Austin Michael Carrizales,31,23,8
 Lubbock,125,State Representative,84,DEM,Samantha Carrillo Fields,39,29,10
 Lubbock,125,County Party Chair,,DEM,Stuart Williams,66,48,18
-Lubbock,125,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,73,54,19
-Lubbock,125,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,1,1,0
-Lubbock,125,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,73,54,19
-Lubbock,125,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,125,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,72,53,19
-Lubbock,125,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,2,1,1
-Lubbock,125,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,73,53,20
-Lubbock,125,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,125,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,72,54,18
-Lubbock,125,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,1,0,1
-Lubbock,125,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,74,55,19
-Lubbock,125,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,125,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,74,54,20
-Lubbock,125,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,125,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,72,53,19
-Lubbock,125,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,2,1,1
-Lubbock,125,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,74,54,20
-Lubbock,125,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,125,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,74,54,20
-Lubbock,125,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,125,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,74,54,20
-Lubbock,125,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,2,2,0
-Lubbock,125,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,73,54,19
-Lubbock,125,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,1,1,0
+Lubbock,125,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,73,54,19
+Lubbock,125,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,1,1,0
+Lubbock,125,"Democratic Proposition #2 Student Loan Debt",,DEM,For,73,54,19
+Lubbock,125,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,125,"Democratic Proposition #3 Right to Healthcare",,DEM,For,72,53,19
+Lubbock,125,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,2,1,1
+Lubbock,125,"Democratic Proposition #4 Right to Economic Security",,DEM,For,73,53,20
+Lubbock,125,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,125,"Democratic Proposition #5 National Jobs Program",,DEM,For,72,54,18
+Lubbock,125,"Democratic Proposition #5 National Jobs Program",,DEM,Against,1,0,1
+Lubbock,125,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,74,55,19
+Lubbock,125,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,125,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,74,54,20
+Lubbock,125,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,125,"Democratic Proposition #8 Right to Housing",,DEM,For,72,53,19
+Lubbock,125,"Democratic Proposition #8 Right to Housing",,DEM,Against,2,1,1
+Lubbock,125,"Democratic Proposition #9 Right to Vote",,DEM,For,74,54,20
+Lubbock,125,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,125,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,74,54,20
+Lubbock,125,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,125,"Democratic Proposition #11 Immigrant Rights",,DEM,For,74,54,20
+Lubbock,125,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,2,2,0
+Lubbock,125,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,73,54,19
+Lubbock,125,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,1,1,0
 Lubbock,126,Registered Voters,,,,1567,,
 Lubbock,126,U.S. Senate,,DEM,Beto O'Rourke,28,20,8
 Lubbock,126,U.S. Senate,,DEM,Sema Hernandez,15,13,2
@@ -18889,82 +14521,30 @@ Lubbock,126,State Representative,84,DEM,Samantha Carrillo Fields,19,13,6
 Lubbock,126,"County Commissioner, Precinct 2",,DEM,Nick Harpster,47,36,11
 Lubbock,126,"Justice of the Peace, Precinct 2",,DEM,Daylan J. Flowers,46,35,11
 Lubbock,126,County Party Chair,,DEM,Stuart Williams,45,35,10
-Lubbock,126,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,47,37,10
-Lubbock,126,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,126,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,49,38,11
-Lubbock,126,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,126,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,48,37,11
-Lubbock,126,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,1,1,0
-Lubbock,126,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,47,36,11
-Lubbock,126,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,126,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,47,36,11
-Lubbock,126,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,2,2,0
-Lubbock,126,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,49,38,11
-Lubbock,126,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,126,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,47,36,11
-Lubbock,126,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,1,1,0
-Lubbock,126,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,47,36,11
-Lubbock,126,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,1,1,0
-Lubbock,126,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,46,36,10
-Lubbock,126,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,2,1,1
-Lubbock,126,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,47,36,11
-Lubbock,126,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
-Lubbock,126,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,48,37,11
-Lubbock,126,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,126,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,48,37,11
-Lubbock,126,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,1,1,0
+Lubbock,126,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,47,37,10
+Lubbock,126,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,126,"Democratic Proposition #2 Student Loan Debt",,DEM,For,49,38,11
+Lubbock,126,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,126,"Democratic Proposition #3 Right to Healthcare",,DEM,For,48,37,11
+Lubbock,126,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,1,1,0
+Lubbock,126,"Democratic Proposition #4 Right to Economic Security",,DEM,For,47,36,11
+Lubbock,126,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,126,"Democratic Proposition #5 National Jobs Program",,DEM,For,47,36,11
+Lubbock,126,"Democratic Proposition #5 National Jobs Program",,DEM,Against,2,2,0
+Lubbock,126,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,49,38,11
+Lubbock,126,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,126,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,47,36,11
+Lubbock,126,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,1,1,0
+Lubbock,126,"Democratic Proposition #8 Right to Housing",,DEM,For,47,36,11
+Lubbock,126,"Democratic Proposition #8 Right to Housing",,DEM,Against,1,1,0
+Lubbock,126,"Democratic Proposition #9 Right to Vote",,DEM,For,46,36,10
+Lubbock,126,"Democratic Proposition #9 Right to Vote",,DEM,Against,2,1,1
+Lubbock,126,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,47,36,11
+Lubbock,126,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
+Lubbock,126,"Democratic Proposition #11 Immigrant Rights",,DEM,For,48,37,11
+Lubbock,126,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,126,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,48,37,11
+Lubbock,126,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,1,1,0
 Lubbock,127,Registered Voters,,,,2506,,
 Lubbock,127,U.S. Senate,,DEM,Beto O'Rourke,58,39,19
 Lubbock,127,U.S. Senate,,DEM,Sema Hernandez,14,9,5
@@ -18999,82 +14579,30 @@ Lubbock,127,State Representative,84,DEM,Samantha Carrillo Fields,52,33,19
 Lubbock,127,"County Commissioner, Precinct 2",,DEM,Nick Harpster,78,55,23
 Lubbock,127,"Justice of the Peace, Precinct 2",,DEM,Daylan J. Flowers,77,55,22
 Lubbock,127,County Party Chair,,DEM,Stuart Williams,80,56,24
-Lubbock,127,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,87,61,26
-Lubbock,127,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,127,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,84,60,24
-Lubbock,127,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,5,3,2
-Lubbock,127,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,84,60,24
-Lubbock,127,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,2,1,1
-Lubbock,127,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,83,58,25
-Lubbock,127,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,2,1,1
-Lubbock,127,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,84,59,25
-Lubbock,127,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,3,2,1
-Lubbock,127,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,88,62,26
-Lubbock,127,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,127,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,88,62,26
-Lubbock,127,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,127,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,85,61,24
-Lubbock,127,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,4,2,2
-Lubbock,127,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,84,59,25
-Lubbock,127,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,4,3,1
-Lubbock,127,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,86,61,25
-Lubbock,127,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
-Lubbock,127,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,86,61,25
-Lubbock,127,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,1,1,0
-Lubbock,127,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,87,61,26
-Lubbock,127,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,1,1,0
+Lubbock,127,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,87,61,26
+Lubbock,127,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,127,"Democratic Proposition #2 Student Loan Debt",,DEM,For,84,60,24
+Lubbock,127,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,5,3,2
+Lubbock,127,"Democratic Proposition #3 Right to Healthcare",,DEM,For,84,60,24
+Lubbock,127,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,2,1,1
+Lubbock,127,"Democratic Proposition #4 Right to Economic Security",,DEM,For,83,58,25
+Lubbock,127,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,2,1,1
+Lubbock,127,"Democratic Proposition #5 National Jobs Program",,DEM,For,84,59,25
+Lubbock,127,"Democratic Proposition #5 National Jobs Program",,DEM,Against,3,2,1
+Lubbock,127,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,88,62,26
+Lubbock,127,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,127,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,88,62,26
+Lubbock,127,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,127,"Democratic Proposition #8 Right to Housing",,DEM,For,85,61,24
+Lubbock,127,"Democratic Proposition #8 Right to Housing",,DEM,Against,4,2,2
+Lubbock,127,"Democratic Proposition #9 Right to Vote",,DEM,For,84,59,25
+Lubbock,127,"Democratic Proposition #9 Right to Vote",,DEM,Against,4,3,1
+Lubbock,127,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,86,61,25
+Lubbock,127,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
+Lubbock,127,"Democratic Proposition #11 Immigrant Rights",,DEM,For,86,61,25
+Lubbock,127,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,1,1,0
+Lubbock,127,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,87,61,26
+Lubbock,127,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,1,1,0
 Lubbock,128,Registered Voters,,,,1834,,
 Lubbock,128,U.S. Senate,,DEM,Beto O'Rourke,47,35,12
 Lubbock,128,U.S. Senate,,DEM,Sema Hernandez,8,5,3
@@ -19107,82 +14635,30 @@ Lubbock,128,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,59,
 Lubbock,128,State Representative,84,DEM,Austin Michael Carrizales,26,18,8
 Lubbock,128,State Representative,84,DEM,Samantha Carrillo Fields,36,26,10
 Lubbock,128,County Party Chair,,DEM,Stuart Williams,60,42,18
-Lubbock,128,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,64,45,19
-Lubbock,128,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,2,2,0
-Lubbock,128,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,60,44,16
-Lubbock,128,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,5,3,2
-Lubbock,128,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,62,45,17
-Lubbock,128,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,3,2,1
-Lubbock,128,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,64,46,18
-Lubbock,128,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,2,1,1
-Lubbock,128,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,58,43,15
-Lubbock,128,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,6,3,3
-Lubbock,128,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,64,47,17
-Lubbock,128,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,128,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,65,47,18
-Lubbock,128,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,128,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,60,43,17
-Lubbock,128,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,5,4,1
-Lubbock,128,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,62,45,17
-Lubbock,128,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,4,2,2
-Lubbock,128,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,63,45,18
-Lubbock,128,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
-Lubbock,128,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,65,47,18
-Lubbock,128,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,1,0,1
-Lubbock,128,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,62,45,17
-Lubbock,128,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,4,2,2
+Lubbock,128,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,64,45,19
+Lubbock,128,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,2,2,0
+Lubbock,128,"Democratic Proposition #2 Student Loan Debt",,DEM,For,60,44,16
+Lubbock,128,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,5,3,2
+Lubbock,128,"Democratic Proposition #3 Right to Healthcare",,DEM,For,62,45,17
+Lubbock,128,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,3,2,1
+Lubbock,128,"Democratic Proposition #4 Right to Economic Security",,DEM,For,64,46,18
+Lubbock,128,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,2,1,1
+Lubbock,128,"Democratic Proposition #5 National Jobs Program",,DEM,For,58,43,15
+Lubbock,128,"Democratic Proposition #5 National Jobs Program",,DEM,Against,6,3,3
+Lubbock,128,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,64,47,17
+Lubbock,128,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,128,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,65,47,18
+Lubbock,128,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,128,"Democratic Proposition #8 Right to Housing",,DEM,For,60,43,17
+Lubbock,128,"Democratic Proposition #8 Right to Housing",,DEM,Against,5,4,1
+Lubbock,128,"Democratic Proposition #9 Right to Vote",,DEM,For,62,45,17
+Lubbock,128,"Democratic Proposition #9 Right to Vote",,DEM,Against,4,2,2
+Lubbock,128,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,63,45,18
+Lubbock,128,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
+Lubbock,128,"Democratic Proposition #11 Immigrant Rights",,DEM,For,65,47,18
+Lubbock,128,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,1,0,1
+Lubbock,128,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,62,45,17
+Lubbock,128,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,4,2,2
 Lubbock,129,Registered Voters,,,,3138,,
 Lubbock,129,U.S. Senate,,DEM,Beto O'Rourke,55,37,18
 Lubbock,129,U.S. Senate,,DEM,Sema Hernandez,12,5,7
@@ -19215,82 +14691,30 @@ Lubbock,129,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,73,
 Lubbock,129,State Representative,84,DEM,Austin Michael Carrizales,22,16,6
 Lubbock,129,State Representative,84,DEM,Samantha Carrillo Fields,53,29,24
 Lubbock,129,County Party Chair,,DEM,Stuart Williams,74,45,29
-Lubbock,129,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,77,47,30
-Lubbock,129,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,2,2,0
-Lubbock,129,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,72,45,27
-Lubbock,129,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,7,4,3
-Lubbock,129,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,77,48,29
-Lubbock,129,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,3,2,1
-Lubbock,129,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,80,50,30
-Lubbock,129,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,129,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,74,47,27
-Lubbock,129,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,6,3,3
-Lubbock,129,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,80,50,30
-Lubbock,129,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,129,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,79,50,29
-Lubbock,129,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,129,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,76,50,26
-Lubbock,129,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,3,0,3
-Lubbock,129,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,74,46,28
-Lubbock,129,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,6,4,2
-Lubbock,129,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,80,50,30
-Lubbock,129,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,129,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,70,42,28
-Lubbock,129,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,6,5,1
-Lubbock,129,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,76,48,28
-Lubbock,129,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,1,0,1
+Lubbock,129,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,77,47,30
+Lubbock,129,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,2,2,0
+Lubbock,129,"Democratic Proposition #2 Student Loan Debt",,DEM,For,72,45,27
+Lubbock,129,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,7,4,3
+Lubbock,129,"Democratic Proposition #3 Right to Healthcare",,DEM,For,77,48,29
+Lubbock,129,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,3,2,1
+Lubbock,129,"Democratic Proposition #4 Right to Economic Security",,DEM,For,80,50,30
+Lubbock,129,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,129,"Democratic Proposition #5 National Jobs Program",,DEM,For,74,47,27
+Lubbock,129,"Democratic Proposition #5 National Jobs Program",,DEM,Against,6,3,3
+Lubbock,129,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,80,50,30
+Lubbock,129,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,129,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,79,50,29
+Lubbock,129,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,129,"Democratic Proposition #8 Right to Housing",,DEM,For,76,50,26
+Lubbock,129,"Democratic Proposition #8 Right to Housing",,DEM,Against,3,0,3
+Lubbock,129,"Democratic Proposition #9 Right to Vote",,DEM,For,74,46,28
+Lubbock,129,"Democratic Proposition #9 Right to Vote",,DEM,Against,6,4,2
+Lubbock,129,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,80,50,30
+Lubbock,129,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,129,"Democratic Proposition #11 Immigrant Rights",,DEM,For,70,42,28
+Lubbock,129,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,6,5,1
+Lubbock,129,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,76,48,28
+Lubbock,129,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,1,0,1
 Lubbock,131,Registered Voters,,,,2,,
 Lubbock,131,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
 Lubbock,131,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -19323,82 +14747,30 @@ Lubbock,131,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0
 Lubbock,131,State Representative,83,DEM,Drew Landry,0,0,0
 Lubbock,131,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,0,0,0
 Lubbock,131,County Party Chair,,DEM,Stuart Williams,0,0,0
-Lubbock,131,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,0,0,0
-Lubbock,131,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,131,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,0,0,0
-Lubbock,131,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,131,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,0,0,0
-Lubbock,131,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,131,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,0,0,0
-Lubbock,131,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,131,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,0,0,0
-Lubbock,131,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,131,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,0,0,0
-Lubbock,131,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,131,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,0,0,0
-Lubbock,131,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,131,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,0,0,0
-Lubbock,131,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,131,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,0,0,0
-Lubbock,131,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,131,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,0,0,0
-Lubbock,131,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,131,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,0,0,0
-Lubbock,131,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,131,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,0,0,0
-Lubbock,131,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,131,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,0,0,0
+Lubbock,131,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,131,"Democratic Proposition #2 Student Loan Debt",,DEM,For,0,0,0
+Lubbock,131,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,131,"Democratic Proposition #3 Right to Healthcare",,DEM,For,0,0,0
+Lubbock,131,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,131,"Democratic Proposition #4 Right to Economic Security",,DEM,For,0,0,0
+Lubbock,131,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,131,"Democratic Proposition #5 National Jobs Program",,DEM,For,0,0,0
+Lubbock,131,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,131,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,0,0,0
+Lubbock,131,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,131,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,0,0,0
+Lubbock,131,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,131,"Democratic Proposition #8 Right to Housing",,DEM,For,0,0,0
+Lubbock,131,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,131,"Democratic Proposition #9 Right to Vote",,DEM,For,0,0,0
+Lubbock,131,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,131,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,0,0,0
+Lubbock,131,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,131,"Democratic Proposition #11 Immigrant Rights",,DEM,For,0,0,0
+Lubbock,131,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,131,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,0,0,0
+Lubbock,131,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,132,Registered Voters,,,,12,,
 Lubbock,132,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
 Lubbock,132,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -19431,82 +14803,30 @@ Lubbock,132,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0
 Lubbock,132,State Representative,83,DEM,Drew Landry,0,0,0
 Lubbock,132,"Justice of the Peace, Precinct 3",,DEM,Aurora Chaides-Hernandez,0,0,0
 Lubbock,132,County Party Chair,,DEM,Stuart Williams,0,0,0
-Lubbock,132,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,0,0,0
-Lubbock,132,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,132,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,0,0,0
-Lubbock,132,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,132,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,0,0,0
-Lubbock,132,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,132,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,0,0,0
-Lubbock,132,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,132,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,0,0,0
-Lubbock,132,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,132,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,0,0,0
-Lubbock,132,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,132,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,0,0,0
-Lubbock,132,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,132,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,0,0,0
-Lubbock,132,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,132,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,0,0,0
-Lubbock,132,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,132,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,0,0,0
-Lubbock,132,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,132,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,0,0,0
-Lubbock,132,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,132,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,0,0,0
-Lubbock,132,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,132,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,0,0,0
+Lubbock,132,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,132,"Democratic Proposition #2 Student Loan Debt",,DEM,For,0,0,0
+Lubbock,132,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,132,"Democratic Proposition #3 Right to Healthcare",,DEM,For,0,0,0
+Lubbock,132,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,132,"Democratic Proposition #4 Right to Economic Security",,DEM,For,0,0,0
+Lubbock,132,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,132,"Democratic Proposition #5 National Jobs Program",,DEM,For,0,0,0
+Lubbock,132,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,132,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,0,0,0
+Lubbock,132,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,132,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,0,0,0
+Lubbock,132,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,132,"Democratic Proposition #8 Right to Housing",,DEM,For,0,0,0
+Lubbock,132,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,132,"Democratic Proposition #9 Right to Vote",,DEM,For,0,0,0
+Lubbock,132,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,132,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,0,0,0
+Lubbock,132,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,132,"Democratic Proposition #11 Immigrant Rights",,DEM,For,0,0,0
+Lubbock,132,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,132,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,0,0,0
+Lubbock,132,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,135,Registered Voters,,,,211,,
 Lubbock,135,U.S. Senate,,DEM,Beto O'Rourke,2,2,0
 Lubbock,135,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -19539,82 +14859,30 @@ Lubbock,135,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,2,2
 Lubbock,135,State Representative,83,DEM,Drew Landry,2,2,0
 Lubbock,135,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,2,2,0
 Lubbock,135,County Party Chair,,DEM,Stuart Williams,2,2,0
-Lubbock,135,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,2,2,0
-Lubbock,135,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,135,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,2,2,0
-Lubbock,135,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,135,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,1,1,0
-Lubbock,135,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,1,1,0
-Lubbock,135,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,2,2,0
-Lubbock,135,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,135,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,2,2,0
-Lubbock,135,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,135,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,2,2,0
-Lubbock,135,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,135,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,2,2,0
-Lubbock,135,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,135,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,2,2,0
-Lubbock,135,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,135,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,2,2,0
-Lubbock,135,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,135,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,2,2,0
-Lubbock,135,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,135,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,2,2,0
-Lubbock,135,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,135,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,2,2,0
-Lubbock,135,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,135,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,2,2,0
+Lubbock,135,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,135,"Democratic Proposition #2 Student Loan Debt",,DEM,For,2,2,0
+Lubbock,135,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,135,"Democratic Proposition #3 Right to Healthcare",,DEM,For,1,1,0
+Lubbock,135,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,1,1,0
+Lubbock,135,"Democratic Proposition #4 Right to Economic Security",,DEM,For,2,2,0
+Lubbock,135,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,135,"Democratic Proposition #5 National Jobs Program",,DEM,For,2,2,0
+Lubbock,135,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,135,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,2,2,0
+Lubbock,135,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,135,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,2,2,0
+Lubbock,135,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,135,"Democratic Proposition #8 Right to Housing",,DEM,For,2,2,0
+Lubbock,135,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,135,"Democratic Proposition #9 Right to Vote",,DEM,For,2,2,0
+Lubbock,135,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,135,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,2,2,0
+Lubbock,135,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,135,"Democratic Proposition #11 Immigrant Rights",,DEM,For,2,2,0
+Lubbock,135,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,135,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,2,2,0
+Lubbock,135,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,138,Registered Voters,,,,256,,
 Lubbock,138,U.S. Senate,,DEM,Beto O'Rourke,6,2,4
 Lubbock,138,U.S. Senate,,DEM,Sema Hernandez,2,2,0
@@ -19646,82 +14914,30 @@ Lubbock,138,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) J
 Lubbock,138,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,7,4,3
 Lubbock,138,State Representative,83,DEM,Drew Landry,7,4,3
 Lubbock,138,County Party Chair,,DEM,Stuart Williams,7,4,3
-Lubbock,138,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,9,5,4
-Lubbock,138,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,138,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,9,5,4
-Lubbock,138,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,138,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,8,5,3
-Lubbock,138,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,1,0,1
-Lubbock,138,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,8,5,3
-Lubbock,138,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,1,0,1
-Lubbock,138,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,9,5,4
-Lubbock,138,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,138,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,9,5,4
-Lubbock,138,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,138,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,9,5,4
-Lubbock,138,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,138,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,9,5,4
-Lubbock,138,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,138,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,8,5,3
-Lubbock,138,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,138,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,9,5,4
-Lubbock,138,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,138,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,9,5,4
-Lubbock,138,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,138,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,9,5,4
-Lubbock,138,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,138,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,9,5,4
+Lubbock,138,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,138,"Democratic Proposition #2 Student Loan Debt",,DEM,For,9,5,4
+Lubbock,138,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,138,"Democratic Proposition #3 Right to Healthcare",,DEM,For,8,5,3
+Lubbock,138,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,1,0,1
+Lubbock,138,"Democratic Proposition #4 Right to Economic Security",,DEM,For,8,5,3
+Lubbock,138,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,1,0,1
+Lubbock,138,"Democratic Proposition #5 National Jobs Program",,DEM,For,9,5,4
+Lubbock,138,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,138,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,9,5,4
+Lubbock,138,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,138,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,9,5,4
+Lubbock,138,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,138,"Democratic Proposition #8 Right to Housing",,DEM,For,9,5,4
+Lubbock,138,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,138,"Democratic Proposition #9 Right to Vote",,DEM,For,8,5,3
+Lubbock,138,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,138,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,9,5,4
+Lubbock,138,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,138,"Democratic Proposition #11 Immigrant Rights",,DEM,For,9,5,4
+Lubbock,138,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,138,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,9,5,4
+Lubbock,138,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,140,Registered Voters,,,,3259,,
 Lubbock,140,U.S. Senate,,DEM,Beto O'Rourke,57,33,24
 Lubbock,140,U.S. Senate,,DEM,Sema Hernandez,9,9,0
@@ -19753,82 +14969,30 @@ Lubbock,140,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) J
 Lubbock,140,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,70,46,24
 Lubbock,140,State Representative,83,DEM,Drew Landry,72,47,25
 Lubbock,140,County Party Chair,,DEM,Stuart Williams,73,48,25
-Lubbock,140,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,75,48,27
-Lubbock,140,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,1,1,0
-Lubbock,140,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,73,47,26
-Lubbock,140,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,4,3,1
-Lubbock,140,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,75,48,27
-Lubbock,140,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,3,3,0
-Lubbock,140,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,76,49,27
-Lubbock,140,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,1,1,0
-Lubbock,140,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,69,44,25
-Lubbock,140,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,7,6,1
-Lubbock,140,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,76,50,26
-Lubbock,140,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,140,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,75,48,27
-Lubbock,140,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,1,1,0
-Lubbock,140,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,72,46,26
-Lubbock,140,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,3,3,0
-Lubbock,140,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,75,49,26
-Lubbock,140,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,3,2,1
-Lubbock,140,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,73,47,26
-Lubbock,140,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,3,3,0
-Lubbock,140,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,74,49,25
-Lubbock,140,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,2,1,1
-Lubbock,140,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,74,49,25
-Lubbock,140,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,1,0,1
+Lubbock,140,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,75,48,27
+Lubbock,140,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,1,1,0
+Lubbock,140,"Democratic Proposition #2 Student Loan Debt",,DEM,For,73,47,26
+Lubbock,140,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,4,3,1
+Lubbock,140,"Democratic Proposition #3 Right to Healthcare",,DEM,For,75,48,27
+Lubbock,140,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,3,3,0
+Lubbock,140,"Democratic Proposition #4 Right to Economic Security",,DEM,For,76,49,27
+Lubbock,140,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,1,1,0
+Lubbock,140,"Democratic Proposition #5 National Jobs Program",,DEM,For,69,44,25
+Lubbock,140,"Democratic Proposition #5 National Jobs Program",,DEM,Against,7,6,1
+Lubbock,140,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,76,50,26
+Lubbock,140,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,140,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,75,48,27
+Lubbock,140,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,1,1,0
+Lubbock,140,"Democratic Proposition #8 Right to Housing",,DEM,For,72,46,26
+Lubbock,140,"Democratic Proposition #8 Right to Housing",,DEM,Against,3,3,0
+Lubbock,140,"Democratic Proposition #9 Right to Vote",,DEM,For,75,49,26
+Lubbock,140,"Democratic Proposition #9 Right to Vote",,DEM,Against,3,2,1
+Lubbock,140,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,73,47,26
+Lubbock,140,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,3,3,0
+Lubbock,140,"Democratic Proposition #11 Immigrant Rights",,DEM,For,74,49,25
+Lubbock,140,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,2,1,1
+Lubbock,140,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,74,49,25
+Lubbock,140,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,1,0,1
 Lubbock,141,Registered Voters,,,,2628,,
 Lubbock,141,U.S. Senate,,DEM,Beto O'Rourke,58,36,22
 Lubbock,141,U.S. Senate,,DEM,Sema Hernandez,27,22,5
@@ -19860,82 +15024,30 @@ Lubbock,141,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) J
 Lubbock,141,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,93,67,26
 Lubbock,141,State Representative,83,DEM,Drew Landry,95,67,28
 Lubbock,141,County Party Chair,,DEM,Stuart Williams,95,67,28
-Lubbock,141,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,97,68,29
-Lubbock,141,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,1,1,0
-Lubbock,141,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,92,64,28
-Lubbock,141,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,5,5,0
-Lubbock,141,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,96,68,28
-Lubbock,141,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,1,1,0
-Lubbock,141,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,94,65,29
-Lubbock,141,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,4,4,0
-Lubbock,141,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,92,65,27
-Lubbock,141,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,5,4,1
-Lubbock,141,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,98,69,29
-Lubbock,141,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,141,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,95,67,28
-Lubbock,141,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,2,2,0
-Lubbock,141,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,92,65,27
-Lubbock,141,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,5,3,2
-Lubbock,141,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,94,67,27
-Lubbock,141,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,5,3,2
-Lubbock,141,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,97,69,28
-Lubbock,141,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,2,1,1
-Lubbock,141,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,93,66,27
-Lubbock,141,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,4,2,2
-Lubbock,141,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,97,69,28
-Lubbock,141,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,1,1,0
+Lubbock,141,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,97,68,29
+Lubbock,141,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,1,1,0
+Lubbock,141,"Democratic Proposition #2 Student Loan Debt",,DEM,For,92,64,28
+Lubbock,141,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,5,5,0
+Lubbock,141,"Democratic Proposition #3 Right to Healthcare",,DEM,For,96,68,28
+Lubbock,141,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,1,1,0
+Lubbock,141,"Democratic Proposition #4 Right to Economic Security",,DEM,For,94,65,29
+Lubbock,141,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,4,4,0
+Lubbock,141,"Democratic Proposition #5 National Jobs Program",,DEM,For,92,65,27
+Lubbock,141,"Democratic Proposition #5 National Jobs Program",,DEM,Against,5,4,1
+Lubbock,141,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,98,69,29
+Lubbock,141,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,141,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,95,67,28
+Lubbock,141,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,2,2,0
+Lubbock,141,"Democratic Proposition #8 Right to Housing",,DEM,For,92,65,27
+Lubbock,141,"Democratic Proposition #8 Right to Housing",,DEM,Against,5,3,2
+Lubbock,141,"Democratic Proposition #9 Right to Vote",,DEM,For,94,67,27
+Lubbock,141,"Democratic Proposition #9 Right to Vote",,DEM,Against,5,3,2
+Lubbock,141,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,97,69,28
+Lubbock,141,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,2,1,1
+Lubbock,141,"Democratic Proposition #11 Immigrant Rights",,DEM,For,93,66,27
+Lubbock,141,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,4,2,2
+Lubbock,141,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,97,69,28
+Lubbock,141,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,1,1,0
 Lubbock,142,Registered Voters,,,,131,,
 Lubbock,142,U.S. Senate,,DEM,Beto O'Rourke,1,0,1
 Lubbock,142,U.S. Senate,,DEM,Sema Hernandez,2,1,1
@@ -19969,82 +15081,30 @@ Lubbock,142,State Representative,83,DEM,Drew Landry,4,2,2
 Lubbock,142,"County Commissioner, Precinct 2",,DEM,Nick Harpster,4,2,2
 Lubbock,142,"Justice of the Peace, Precinct 2",,DEM,Daylan J. Flowers,4,2,2
 Lubbock,142,County Party Chair,,DEM,Stuart Williams,4,2,2
-Lubbock,142,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,2,1,1
-Lubbock,142,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,2,1,1
-Lubbock,142,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,1,1,0
-Lubbock,142,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,2,1,1
-Lubbock,142,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,3,1,2
-Lubbock,142,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,1,1,0
-Lubbock,142,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,4,2,2
-Lubbock,142,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,142,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,4,2,2
-Lubbock,142,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,142,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,4,2,2
-Lubbock,142,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,142,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,4,2,2
-Lubbock,142,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,142,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,3,1,2
-Lubbock,142,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,1,1,0
-Lubbock,142,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,4,2,2
-Lubbock,142,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,142,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,3,1,2
-Lubbock,142,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
-Lubbock,142,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,4,2,2
-Lubbock,142,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,142,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,4,2,2
-Lubbock,142,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,142,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,2,1,1
+Lubbock,142,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,2,1,1
+Lubbock,142,"Democratic Proposition #2 Student Loan Debt",,DEM,For,1,1,0
+Lubbock,142,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,2,1,1
+Lubbock,142,"Democratic Proposition #3 Right to Healthcare",,DEM,For,3,1,2
+Lubbock,142,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,1,1,0
+Lubbock,142,"Democratic Proposition #4 Right to Economic Security",,DEM,For,4,2,2
+Lubbock,142,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,142,"Democratic Proposition #5 National Jobs Program",,DEM,For,4,2,2
+Lubbock,142,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,142,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,4,2,2
+Lubbock,142,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,142,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,4,2,2
+Lubbock,142,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,142,"Democratic Proposition #8 Right to Housing",,DEM,For,3,1,2
+Lubbock,142,"Democratic Proposition #8 Right to Housing",,DEM,Against,1,1,0
+Lubbock,142,"Democratic Proposition #9 Right to Vote",,DEM,For,4,2,2
+Lubbock,142,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,142,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,3,1,2
+Lubbock,142,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
+Lubbock,142,"Democratic Proposition #11 Immigrant Rights",,DEM,For,4,2,2
+Lubbock,142,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,142,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,4,2,2
+Lubbock,142,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,143,Registered Voters,,,,10,,
 Lubbock,143,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
 Lubbock,143,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -20077,82 +15137,30 @@ Lubbock,143,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0
 Lubbock,143,State Representative,83,DEM,Drew Landry,0,0,0
 Lubbock,143,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,0,0,0
 Lubbock,143,County Party Chair,,DEM,Stuart Williams,0,0,0
-Lubbock,143,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,0,0,0
-Lubbock,143,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,143,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,0,0,0
-Lubbock,143,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,143,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,0,0,0
-Lubbock,143,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,143,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,0,0,0
-Lubbock,143,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,143,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,0,0,0
-Lubbock,143,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,143,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,0,0,0
-Lubbock,143,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,143,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,0,0,0
-Lubbock,143,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,143,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,0,0,0
-Lubbock,143,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,143,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,0,0,0
-Lubbock,143,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,143,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,0,0,0
-Lubbock,143,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,143,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,0,0,0
-Lubbock,143,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,143,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,0,0,0
-Lubbock,143,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,143,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,0,0,0
+Lubbock,143,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,143,"Democratic Proposition #2 Student Loan Debt",,DEM,For,0,0,0
+Lubbock,143,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,143,"Democratic Proposition #3 Right to Healthcare",,DEM,For,0,0,0
+Lubbock,143,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,143,"Democratic Proposition #4 Right to Economic Security",,DEM,For,0,0,0
+Lubbock,143,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,143,"Democratic Proposition #5 National Jobs Program",,DEM,For,0,0,0
+Lubbock,143,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,143,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,0,0,0
+Lubbock,143,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,143,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,0,0,0
+Lubbock,143,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,143,"Democratic Proposition #8 Right to Housing",,DEM,For,0,0,0
+Lubbock,143,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,143,"Democratic Proposition #9 Right to Vote",,DEM,For,0,0,0
+Lubbock,143,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,143,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,0,0,0
+Lubbock,143,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,143,"Democratic Proposition #11 Immigrant Rights",,DEM,For,0,0,0
+Lubbock,143,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,143,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,0,0,0
+Lubbock,143,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,144,Registered Voters,,,,0,,
 Lubbock,144,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
 Lubbock,144,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -20184,82 +15192,30 @@ Lubbock,144,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) J
 Lubbock,144,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0,0
 Lubbock,144,State Representative,83,DEM,Drew Landry,0,0,0
 Lubbock,144,County Party Chair,,DEM,Stuart Williams,0,0,0
-Lubbock,144,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,0,0,0
-Lubbock,144,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,144,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,0,0,0
-Lubbock,144,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,144,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,0,0,0
-Lubbock,144,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,144,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,0,0,0
-Lubbock,144,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,144,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,0,0,0
-Lubbock,144,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,144,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,0,0,0
-Lubbock,144,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,144,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,0,0,0
-Lubbock,144,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,144,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,0,0,0
-Lubbock,144,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,144,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,0,0,0
-Lubbock,144,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,144,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,0,0,0
-Lubbock,144,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,144,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,0,0,0
-Lubbock,144,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,144,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,0,0,0
-Lubbock,144,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,144,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,0,0,0
+Lubbock,144,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,144,"Democratic Proposition #2 Student Loan Debt",,DEM,For,0,0,0
+Lubbock,144,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,144,"Democratic Proposition #3 Right to Healthcare",,DEM,For,0,0,0
+Lubbock,144,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,144,"Democratic Proposition #4 Right to Economic Security",,DEM,For,0,0,0
+Lubbock,144,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,144,"Democratic Proposition #5 National Jobs Program",,DEM,For,0,0,0
+Lubbock,144,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,144,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,0,0,0
+Lubbock,144,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,144,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,0,0,0
+Lubbock,144,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,144,"Democratic Proposition #8 Right to Housing",,DEM,For,0,0,0
+Lubbock,144,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,144,"Democratic Proposition #9 Right to Vote",,DEM,For,0,0,0
+Lubbock,144,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,144,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,0,0,0
+Lubbock,144,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,144,"Democratic Proposition #11 Immigrant Rights",,DEM,For,0,0,0
+Lubbock,144,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,144,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,0,0,0
+Lubbock,144,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,145,Registered Voters,,,,0,,
 Lubbock,145,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
 Lubbock,145,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -20291,82 +15247,30 @@ Lubbock,145,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) J
 Lubbock,145,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0,0
 Lubbock,145,State Representative,83,DEM,Drew Landry,0,0,0
 Lubbock,145,County Party Chair,,DEM,Stuart Williams,0,0,0
-Lubbock,145,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,0,0,0
-Lubbock,145,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,145,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,0,0,0
-Lubbock,145,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,145,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,0,0,0
-Lubbock,145,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,145,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,0,0,0
-Lubbock,145,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,145,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,0,0,0
-Lubbock,145,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,145,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,0,0,0
-Lubbock,145,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,145,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,0,0,0
-Lubbock,145,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,145,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,0,0,0
-Lubbock,145,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,145,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,0,0,0
-Lubbock,145,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,145,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,0,0,0
-Lubbock,145,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,145,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,0,0,0
-Lubbock,145,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,145,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,0,0,0
-Lubbock,145,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,145,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,0,0,0
+Lubbock,145,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,145,"Democratic Proposition #2 Student Loan Debt",,DEM,For,0,0,0
+Lubbock,145,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,145,"Democratic Proposition #3 Right to Healthcare",,DEM,For,0,0,0
+Lubbock,145,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,145,"Democratic Proposition #4 Right to Economic Security",,DEM,For,0,0,0
+Lubbock,145,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,145,"Democratic Proposition #5 National Jobs Program",,DEM,For,0,0,0
+Lubbock,145,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,145,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,0,0,0
+Lubbock,145,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,145,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,0,0,0
+Lubbock,145,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,145,"Democratic Proposition #8 Right to Housing",,DEM,For,0,0,0
+Lubbock,145,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,145,"Democratic Proposition #9 Right to Vote",,DEM,For,0,0,0
+Lubbock,145,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,145,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,0,0,0
+Lubbock,145,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,145,"Democratic Proposition #11 Immigrant Rights",,DEM,For,0,0,0
+Lubbock,145,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,145,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,0,0,0
+Lubbock,145,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,146,Registered Voters,,,,0,,
 Lubbock,146,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
 Lubbock,146,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -20400,82 +15304,30 @@ Lubbock,146,State Representative,84,DEM,Austin Michael Carrizales,0,0,0
 Lubbock,146,State Representative,84,DEM,Samantha Carrillo Fields,0,0,0
 Lubbock,146,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,0,0,0
 Lubbock,146,County Party Chair,,DEM,Stuart Williams,0,0,0
-Lubbock,146,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,0,0,0
-Lubbock,146,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,146,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,0,0,0
-Lubbock,146,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,146,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,0,0,0
-Lubbock,146,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,146,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,0,0,0
-Lubbock,146,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,146,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,0,0,0
-Lubbock,146,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,146,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,0,0,0
-Lubbock,146,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,146,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,0,0,0
-Lubbock,146,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,146,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,0,0,0
-Lubbock,146,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,146,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,0,0,0
-Lubbock,146,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,146,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,0,0,0
-Lubbock,146,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,146,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,0,0,0
-Lubbock,146,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,146,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,0,0,0
-Lubbock,146,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,146,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,0,0,0
+Lubbock,146,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,146,"Democratic Proposition #2 Student Loan Debt",,DEM,For,0,0,0
+Lubbock,146,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,146,"Democratic Proposition #3 Right to Healthcare",,DEM,For,0,0,0
+Lubbock,146,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,146,"Democratic Proposition #4 Right to Economic Security",,DEM,For,0,0,0
+Lubbock,146,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,146,"Democratic Proposition #5 National Jobs Program",,DEM,For,0,0,0
+Lubbock,146,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,146,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,0,0,0
+Lubbock,146,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,146,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,0,0,0
+Lubbock,146,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,146,"Democratic Proposition #8 Right to Housing",,DEM,For,0,0,0
+Lubbock,146,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,146,"Democratic Proposition #9 Right to Vote",,DEM,For,0,0,0
+Lubbock,146,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,146,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,0,0,0
+Lubbock,146,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,146,"Democratic Proposition #11 Immigrant Rights",,DEM,For,0,0,0
+Lubbock,146,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,146,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,0,0,0
+Lubbock,146,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,147,Registered Voters,,,,0,,
 Lubbock,147,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
 Lubbock,147,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -20509,82 +15361,30 @@ Lubbock,147,State Representative,84,DEM,Austin Michael Carrizales,0,0,0
 Lubbock,147,State Representative,84,DEM,Samantha Carrillo Fields,0,0,0
 Lubbock,147,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,0,0,0
 Lubbock,147,County Party Chair,,DEM,Stuart Williams,0,0,0
-Lubbock,147,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,0,0,0
-Lubbock,147,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,147,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,0,0,0
-Lubbock,147,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,147,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,0,0,0
-Lubbock,147,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,147,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,0,0,0
-Lubbock,147,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,147,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,0,0,0
-Lubbock,147,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,147,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,0,0,0
-Lubbock,147,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,147,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,0,0,0
-Lubbock,147,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,147,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,0,0,0
-Lubbock,147,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,147,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,0,0,0
-Lubbock,147,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,147,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,0,0,0
-Lubbock,147,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,147,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,0,0,0
-Lubbock,147,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,147,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,0,0,0
-Lubbock,147,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,147,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,0,0,0
+Lubbock,147,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,147,"Democratic Proposition #2 Student Loan Debt",,DEM,For,0,0,0
+Lubbock,147,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,147,"Democratic Proposition #3 Right to Healthcare",,DEM,For,0,0,0
+Lubbock,147,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,147,"Democratic Proposition #4 Right to Economic Security",,DEM,For,0,0,0
+Lubbock,147,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,147,"Democratic Proposition #5 National Jobs Program",,DEM,For,0,0,0
+Lubbock,147,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,147,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,0,0,0
+Lubbock,147,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,147,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,0,0,0
+Lubbock,147,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,147,"Democratic Proposition #8 Right to Housing",,DEM,For,0,0,0
+Lubbock,147,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,147,"Democratic Proposition #9 Right to Vote",,DEM,For,0,0,0
+Lubbock,147,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,147,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,0,0,0
+Lubbock,147,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,147,"Democratic Proposition #11 Immigrant Rights",,DEM,For,0,0,0
+Lubbock,147,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,147,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,0,0,0
+Lubbock,147,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,148,Registered Voters,,,,0,,
 Lubbock,148,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
 Lubbock,148,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -20618,82 +15418,30 @@ Lubbock,148,State Representative,84,DEM,Austin Michael Carrizales,0,0,0
 Lubbock,148,State Representative,84,DEM,Samantha Carrillo Fields,0,0,0
 Lubbock,148,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,0,0,0
 Lubbock,148,County Party Chair,,DEM,Stuart Williams,0,0,0
-Lubbock,148,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,0,0,0
-Lubbock,148,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,148,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,0,0,0
-Lubbock,148,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,148,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,0,0,0
-Lubbock,148,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,148,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,0,0,0
-Lubbock,148,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,148,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,0,0,0
-Lubbock,148,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,148,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,0,0,0
-Lubbock,148,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,148,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,0,0,0
-Lubbock,148,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,148,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,0,0,0
-Lubbock,148,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,148,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,0,0,0
-Lubbock,148,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,148,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,0,0,0
-Lubbock,148,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,148,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,0,0,0
-Lubbock,148,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,148,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,0,0,0
-Lubbock,148,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,148,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,0,0,0
+Lubbock,148,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,148,"Democratic Proposition #2 Student Loan Debt",,DEM,For,0,0,0
+Lubbock,148,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,148,"Democratic Proposition #3 Right to Healthcare",,DEM,For,0,0,0
+Lubbock,148,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,148,"Democratic Proposition #4 Right to Economic Security",,DEM,For,0,0,0
+Lubbock,148,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,148,"Democratic Proposition #5 National Jobs Program",,DEM,For,0,0,0
+Lubbock,148,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,148,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,0,0,0
+Lubbock,148,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,148,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,0,0,0
+Lubbock,148,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,148,"Democratic Proposition #8 Right to Housing",,DEM,For,0,0,0
+Lubbock,148,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,148,"Democratic Proposition #9 Right to Vote",,DEM,For,0,0,0
+Lubbock,148,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,148,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,0,0,0
+Lubbock,148,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,148,"Democratic Proposition #11 Immigrant Rights",,DEM,For,0,0,0
+Lubbock,148,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,148,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,0,0,0
+Lubbock,148,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,149,Registered Voters,,,,0,,
 Lubbock,149,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
 Lubbock,149,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -20726,82 +15474,30 @@ Lubbock,149,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0
 Lubbock,149,State Representative,83,DEM,Drew Landry,0,0,0
 Lubbock,149,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,0,0,0
 Lubbock,149,County Party Chair,,DEM,Stuart Williams,0,0,0
-Lubbock,149,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,0,0,0
-Lubbock,149,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,149,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,0,0,0
-Lubbock,149,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,149,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,0,0,0
-Lubbock,149,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,149,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,0,0,0
-Lubbock,149,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,149,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,0,0,0
-Lubbock,149,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,149,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,0,0,0
-Lubbock,149,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,149,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,0,0,0
-Lubbock,149,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,149,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,0,0,0
-Lubbock,149,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,149,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,0,0,0
-Lubbock,149,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,149,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,0,0,0
-Lubbock,149,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,149,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,0,0,0
-Lubbock,149,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,149,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,0,0,0
-Lubbock,149,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,149,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,0,0,0
+Lubbock,149,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,149,"Democratic Proposition #2 Student Loan Debt",,DEM,For,0,0,0
+Lubbock,149,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,149,"Democratic Proposition #3 Right to Healthcare",,DEM,For,0,0,0
+Lubbock,149,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,149,"Democratic Proposition #4 Right to Economic Security",,DEM,For,0,0,0
+Lubbock,149,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,149,"Democratic Proposition #5 National Jobs Program",,DEM,For,0,0,0
+Lubbock,149,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,149,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,0,0,0
+Lubbock,149,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,149,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,0,0,0
+Lubbock,149,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,149,"Democratic Proposition #8 Right to Housing",,DEM,For,0,0,0
+Lubbock,149,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,149,"Democratic Proposition #9 Right to Vote",,DEM,For,0,0,0
+Lubbock,149,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,149,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,0,0,0
+Lubbock,149,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,149,"Democratic Proposition #11 Immigrant Rights",,DEM,For,0,0,0
+Lubbock,149,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,149,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,0,0,0
+Lubbock,149,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,150,Registered Voters,,,,0,,
 Lubbock,150,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
 Lubbock,150,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -20835,82 +15531,30 @@ Lubbock,150,State Representative,84,DEM,Austin Michael Carrizales,0,0,0
 Lubbock,150,State Representative,84,DEM,Samantha Carrillo Fields,0,0,0
 Lubbock,150,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,0,0,0
 Lubbock,150,County Party Chair,,DEM,Stuart Williams,0,0,0
-Lubbock,150,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,0,0,0
-Lubbock,150,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,150,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,0,0,0
-Lubbock,150,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,150,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,0,0,0
-Lubbock,150,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,150,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,0,0,0
-Lubbock,150,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,150,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,0,0,0
-Lubbock,150,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,150,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,0,0,0
-Lubbock,150,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,150,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,0,0,0
-Lubbock,150,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,150,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,0,0,0
-Lubbock,150,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,150,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,0,0,0
-Lubbock,150,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,150,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,0,0,0
-Lubbock,150,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,150,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,0,0,0
-Lubbock,150,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,150,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,0,0,0
-Lubbock,150,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,150,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,0,0,0
+Lubbock,150,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,150,"Democratic Proposition #2 Student Loan Debt",,DEM,For,0,0,0
+Lubbock,150,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,150,"Democratic Proposition #3 Right to Healthcare",,DEM,For,0,0,0
+Lubbock,150,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,150,"Democratic Proposition #4 Right to Economic Security",,DEM,For,0,0,0
+Lubbock,150,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,150,"Democratic Proposition #5 National Jobs Program",,DEM,For,0,0,0
+Lubbock,150,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,150,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,0,0,0
+Lubbock,150,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,150,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,0,0,0
+Lubbock,150,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,150,"Democratic Proposition #8 Right to Housing",,DEM,For,0,0,0
+Lubbock,150,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,150,"Democratic Proposition #9 Right to Vote",,DEM,For,0,0,0
+Lubbock,150,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,150,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,0,0,0
+Lubbock,150,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,150,"Democratic Proposition #11 Immigrant Rights",,DEM,For,0,0,0
+Lubbock,150,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,150,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,0,0,0
+Lubbock,150,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,151,Registered Voters,,,,1057,,
 Lubbock,151,U.S. Senate,,DEM,Beto O'Rourke,13,6,7
 Lubbock,151,U.S. Senate,,DEM,Sema Hernandez,6,5,1
@@ -20943,82 +15587,30 @@ Lubbock,151,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,22,
 Lubbock,151,State Representative,83,DEM,Drew Landry,20,11,9
 Lubbock,151,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,21,12,9
 Lubbock,151,County Party Chair,,DEM,Stuart Williams,21,12,9
-Lubbock,151,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,22,13,9
-Lubbock,151,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,151,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,22,13,9
-Lubbock,151,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,151,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,22,13,9
-Lubbock,151,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,151,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,21,12,9
-Lubbock,151,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,151,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,21,12,9
-Lubbock,151,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,151,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,22,13,9
-Lubbock,151,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,151,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,22,13,9
-Lubbock,151,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,151,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,20,12,8
-Lubbock,151,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,2,1,1
-Lubbock,151,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,20,11,9
-Lubbock,151,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,1,1,0
-Lubbock,151,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,22,13,9
-Lubbock,151,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,151,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,21,13,8
-Lubbock,151,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,1,0,1
-Lubbock,151,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,21,12,9
-Lubbock,151,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,151,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,22,13,9
+Lubbock,151,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,151,"Democratic Proposition #2 Student Loan Debt",,DEM,For,22,13,9
+Lubbock,151,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,151,"Democratic Proposition #3 Right to Healthcare",,DEM,For,22,13,9
+Lubbock,151,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,151,"Democratic Proposition #4 Right to Economic Security",,DEM,For,21,12,9
+Lubbock,151,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,151,"Democratic Proposition #5 National Jobs Program",,DEM,For,21,12,9
+Lubbock,151,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,151,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,22,13,9
+Lubbock,151,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,151,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,22,13,9
+Lubbock,151,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,151,"Democratic Proposition #8 Right to Housing",,DEM,For,20,12,8
+Lubbock,151,"Democratic Proposition #8 Right to Housing",,DEM,Against,2,1,1
+Lubbock,151,"Democratic Proposition #9 Right to Vote",,DEM,For,20,11,9
+Lubbock,151,"Democratic Proposition #9 Right to Vote",,DEM,Against,1,1,0
+Lubbock,151,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,22,13,9
+Lubbock,151,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,151,"Democratic Proposition #11 Immigrant Rights",,DEM,For,21,13,8
+Lubbock,151,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,1,0,1
+Lubbock,151,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,21,12,9
+Lubbock,151,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,152,Registered Voters,,,,1327,,
 Lubbock,152,U.S. Senate,,DEM,Beto O'Rourke,40,24,16
 Lubbock,152,U.S. Senate,,DEM,Sema Hernandez,11,6,5
@@ -21052,82 +15644,30 @@ Lubbock,152,State Representative,84,DEM,Austin Michael Carrizales,26,16,10
 Lubbock,152,State Representative,84,DEM,Samantha Carrillo Fields,24,16,8
 Lubbock,152,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,50,32,18
 Lubbock,152,County Party Chair,,DEM,Stuart Williams,48,32,16
-Lubbock,152,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,54,32,22
-Lubbock,152,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,152,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,52,30,22
-Lubbock,152,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,2,2,0
-Lubbock,152,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,52,31,21
-Lubbock,152,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,2,1,1
-Lubbock,152,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,50,29,21
-Lubbock,152,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,4,3,1
-Lubbock,152,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,51,30,21
-Lubbock,152,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,3,2,1
-Lubbock,152,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,55,33,22
-Lubbock,152,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,152,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,54,33,21
-Lubbock,152,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,1,0,1
-Lubbock,152,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,51,29,22
-Lubbock,152,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,3,3,0
-Lubbock,152,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,53,31,22
-Lubbock,152,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,152,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,54,32,22
-Lubbock,152,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
-Lubbock,152,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,54,33,21
-Lubbock,152,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,1,0,1
-Lubbock,152,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,52,31,21
-Lubbock,152,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,2,1,1
+Lubbock,152,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,54,32,22
+Lubbock,152,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,152,"Democratic Proposition #2 Student Loan Debt",,DEM,For,52,30,22
+Lubbock,152,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,2,2,0
+Lubbock,152,"Democratic Proposition #3 Right to Healthcare",,DEM,For,52,31,21
+Lubbock,152,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,2,1,1
+Lubbock,152,"Democratic Proposition #4 Right to Economic Security",,DEM,For,50,29,21
+Lubbock,152,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,4,3,1
+Lubbock,152,"Democratic Proposition #5 National Jobs Program",,DEM,For,51,30,21
+Lubbock,152,"Democratic Proposition #5 National Jobs Program",,DEM,Against,3,2,1
+Lubbock,152,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,55,33,22
+Lubbock,152,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,152,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,54,33,21
+Lubbock,152,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,1,0,1
+Lubbock,152,"Democratic Proposition #8 Right to Housing",,DEM,For,51,29,22
+Lubbock,152,"Democratic Proposition #8 Right to Housing",,DEM,Against,3,3,0
+Lubbock,152,"Democratic Proposition #9 Right to Vote",,DEM,For,53,31,22
+Lubbock,152,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,152,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,54,32,22
+Lubbock,152,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
+Lubbock,152,"Democratic Proposition #11 Immigrant Rights",,DEM,For,54,33,21
+Lubbock,152,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,1,0,1
+Lubbock,152,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,52,31,21
+Lubbock,152,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,2,1,1
 Lubbock,153,Registered Voters,,,,1675,,
 Lubbock,153,U.S. Senate,,DEM,Beto O'Rourke,20,18,2
 Lubbock,153,U.S. Senate,,DEM,Sema Hernandez,31,23,8
@@ -21161,82 +15701,30 @@ Lubbock,153,State Representative,84,DEM,Austin Michael Carrizales,36,27,9
 Lubbock,153,State Representative,84,DEM,Samantha Carrillo Fields,31,26,5
 Lubbock,153,"Justice of the Peace, Precinct 3",,DEM,Aurora Chaides-Hernandez,62,50,12
 Lubbock,153,County Party Chair,,DEM,Stuart Williams,60,46,14
-Lubbock,153,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,71,56,15
-Lubbock,153,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,2,2,0
-Lubbock,153,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,71,56,15
-Lubbock,153,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,3,3,0
-Lubbock,153,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,70,56,14
-Lubbock,153,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,4,3,1
-Lubbock,153,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,70,56,14
-Lubbock,153,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,2,2,0
-Lubbock,153,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,66,52,14
-Lubbock,153,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,5,5,0
-Lubbock,153,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,72,58,14
-Lubbock,153,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,1,1,0
-Lubbock,153,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,68,54,14
-Lubbock,153,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,4,4,0
-Lubbock,153,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,66,53,13
-Lubbock,153,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,6,4,2
-Lubbock,153,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,70,56,14
-Lubbock,153,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,3,2,1
-Lubbock,153,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,72,57,15
-Lubbock,153,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
-Lubbock,153,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,68,55,13
-Lubbock,153,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,4,3,1
-Lubbock,153,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,68,54,14
-Lubbock,153,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,4,4,0
+Lubbock,153,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,71,56,15
+Lubbock,153,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,2,2,0
+Lubbock,153,"Democratic Proposition #2 Student Loan Debt",,DEM,For,71,56,15
+Lubbock,153,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,3,3,0
+Lubbock,153,"Democratic Proposition #3 Right to Healthcare",,DEM,For,70,56,14
+Lubbock,153,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,4,3,1
+Lubbock,153,"Democratic Proposition #4 Right to Economic Security",,DEM,For,70,56,14
+Lubbock,153,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,2,2,0
+Lubbock,153,"Democratic Proposition #5 National Jobs Program",,DEM,For,66,52,14
+Lubbock,153,"Democratic Proposition #5 National Jobs Program",,DEM,Against,5,5,0
+Lubbock,153,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,72,58,14
+Lubbock,153,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,1,1,0
+Lubbock,153,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,68,54,14
+Lubbock,153,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,4,4,0
+Lubbock,153,"Democratic Proposition #8 Right to Housing",,DEM,For,66,53,13
+Lubbock,153,"Democratic Proposition #8 Right to Housing",,DEM,Against,6,4,2
+Lubbock,153,"Democratic Proposition #9 Right to Vote",,DEM,For,70,56,14
+Lubbock,153,"Democratic Proposition #9 Right to Vote",,DEM,Against,3,2,1
+Lubbock,153,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,72,57,15
+Lubbock,153,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,1,1,0
+Lubbock,153,"Democratic Proposition #11 Immigrant Rights",,DEM,For,68,55,13
+Lubbock,153,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,4,3,1
+Lubbock,153,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,68,54,14
+Lubbock,153,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,4,4,0
 Lubbock,154,Registered Voters,,,,3003,,
 Lubbock,154,U.S. Senate,,DEM,Beto O'Rourke,50,32,18
 Lubbock,154,U.S. Senate,,DEM,Sema Hernandez,11,9,2
@@ -21268,82 +15756,30 @@ Lubbock,154,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) J
 Lubbock,154,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,63,40,23
 Lubbock,154,State Representative,83,DEM,Drew Landry,64,41,23
 Lubbock,154,County Party Chair,,DEM,Stuart Williams,63,40,23
-Lubbock,154,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,68,46,22
-Lubbock,154,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,4,3,1
-Lubbock,154,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,64,44,20
-Lubbock,154,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,7,5,2
-Lubbock,154,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,66,45,21
-Lubbock,154,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,6,4,2
-Lubbock,154,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,66,46,20
-Lubbock,154,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,7,4,3
-Lubbock,154,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,63,41,22
-Lubbock,154,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,9,8,1
-Lubbock,154,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,71,48,23
-Lubbock,154,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,2,2,0
-Lubbock,154,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,65,44,21
-Lubbock,154,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,6,5,1
-Lubbock,154,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,64,43,21
-Lubbock,154,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,9,7,2
-Lubbock,154,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,67,45,22
-Lubbock,154,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,5,4,1
-Lubbock,154,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,67,46,21
-Lubbock,154,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,5,3,2
-Lubbock,154,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,69,47,22
-Lubbock,154,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,3,3,0
-Lubbock,154,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,68,45,23
-Lubbock,154,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,3,3,0
+Lubbock,154,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,68,46,22
+Lubbock,154,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,4,3,1
+Lubbock,154,"Democratic Proposition #2 Student Loan Debt",,DEM,For,64,44,20
+Lubbock,154,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,7,5,2
+Lubbock,154,"Democratic Proposition #3 Right to Healthcare",,DEM,For,66,45,21
+Lubbock,154,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,6,4,2
+Lubbock,154,"Democratic Proposition #4 Right to Economic Security",,DEM,For,66,46,20
+Lubbock,154,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,7,4,3
+Lubbock,154,"Democratic Proposition #5 National Jobs Program",,DEM,For,63,41,22
+Lubbock,154,"Democratic Proposition #5 National Jobs Program",,DEM,Against,9,8,1
+Lubbock,154,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,71,48,23
+Lubbock,154,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,2,2,0
+Lubbock,154,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,65,44,21
+Lubbock,154,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,6,5,1
+Lubbock,154,"Democratic Proposition #8 Right to Housing",,DEM,For,64,43,21
+Lubbock,154,"Democratic Proposition #8 Right to Housing",,DEM,Against,9,7,2
+Lubbock,154,"Democratic Proposition #9 Right to Vote",,DEM,For,67,45,22
+Lubbock,154,"Democratic Proposition #9 Right to Vote",,DEM,Against,5,4,1
+Lubbock,154,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,67,46,21
+Lubbock,154,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,5,3,2
+Lubbock,154,"Democratic Proposition #11 Immigrant Rights",,DEM,For,69,47,22
+Lubbock,154,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,3,3,0
+Lubbock,154,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,68,45,23
+Lubbock,154,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,3,3,0
 Lubbock,155,Registered Voters,,,,2044,,
 Lubbock,155,U.S. Senate,,DEM,Beto O'Rourke,26,20,6
 Lubbock,155,U.S. Senate,,DEM,Sema Hernandez,6,5,1
@@ -21375,82 +15811,30 @@ Lubbock,155,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) J
 Lubbock,155,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,35,28,7
 Lubbock,155,State Representative,83,DEM,Drew Landry,34,27,7
 Lubbock,155,County Party Chair,,DEM,Stuart Williams,35,28,7
-Lubbock,155,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,35,28,7
-Lubbock,155,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,155,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,33,26,7
-Lubbock,155,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,1,1,0
-Lubbock,155,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,34,27,7
-Lubbock,155,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,1,1,0
-Lubbock,155,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,34,27,7
-Lubbock,155,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,1,1,0
-Lubbock,155,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,34,27,7
-Lubbock,155,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,1,1,0
-Lubbock,155,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,35,28,7
-Lubbock,155,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,155,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,35,28,7
-Lubbock,155,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,155,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,32,26,6
-Lubbock,155,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,2,1,1
-Lubbock,155,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,35,28,7
-Lubbock,155,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,155,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,34,28,6
-Lubbock,155,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,1,0,1
-Lubbock,155,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,33,28,5
-Lubbock,155,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,2,0,2
-Lubbock,155,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,35,28,7
-Lubbock,155,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,155,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,35,28,7
+Lubbock,155,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,155,"Democratic Proposition #2 Student Loan Debt",,DEM,For,33,26,7
+Lubbock,155,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,1,1,0
+Lubbock,155,"Democratic Proposition #3 Right to Healthcare",,DEM,For,34,27,7
+Lubbock,155,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,1,1,0
+Lubbock,155,"Democratic Proposition #4 Right to Economic Security",,DEM,For,34,27,7
+Lubbock,155,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,1,1,0
+Lubbock,155,"Democratic Proposition #5 National Jobs Program",,DEM,For,34,27,7
+Lubbock,155,"Democratic Proposition #5 National Jobs Program",,DEM,Against,1,1,0
+Lubbock,155,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,35,28,7
+Lubbock,155,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,155,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,35,28,7
+Lubbock,155,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,155,"Democratic Proposition #8 Right to Housing",,DEM,For,32,26,6
+Lubbock,155,"Democratic Proposition #8 Right to Housing",,DEM,Against,2,1,1
+Lubbock,155,"Democratic Proposition #9 Right to Vote",,DEM,For,35,28,7
+Lubbock,155,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,155,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,34,28,6
+Lubbock,155,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,1,0,1
+Lubbock,155,"Democratic Proposition #11 Immigrant Rights",,DEM,For,33,28,5
+Lubbock,155,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,2,0,2
+Lubbock,155,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,35,28,7
+Lubbock,155,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,157,Registered Voters,,,,0,,
 Lubbock,157,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
 Lubbock,157,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -21484,82 +15868,30 @@ Lubbock,157,State Representative,83,DEM,Drew Landry,0,0,0
 Lubbock,157,"County Commissioner, Precinct 2",,DEM,Nick Harpster,0,0,0
 Lubbock,157,"Justice of the Peace, Precinct 2",,DEM,Daylan J. Flowers,0,0,0
 Lubbock,157,County Party Chair,,DEM,Stuart Williams,0,0,0
-Lubbock,157,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,0,0,0
-Lubbock,157,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,157,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,0,0,0
-Lubbock,157,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,157,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,0,0,0
-Lubbock,157,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,157,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,0,0,0
-Lubbock,157,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,157,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,0,0,0
-Lubbock,157,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,157,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,0,0,0
-Lubbock,157,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,157,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,0,0,0
-Lubbock,157,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,157,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,0,0,0
-Lubbock,157,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,157,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,0,0,0
-Lubbock,157,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,157,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,0,0,0
-Lubbock,157,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,157,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,0,0,0
-Lubbock,157,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,157,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,0,0,0
-Lubbock,157,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,157,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,0,0,0
+Lubbock,157,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,157,"Democratic Proposition #2 Student Loan Debt",,DEM,For,0,0,0
+Lubbock,157,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,157,"Democratic Proposition #3 Right to Healthcare",,DEM,For,0,0,0
+Lubbock,157,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,157,"Democratic Proposition #4 Right to Economic Security",,DEM,For,0,0,0
+Lubbock,157,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,157,"Democratic Proposition #5 National Jobs Program",,DEM,For,0,0,0
+Lubbock,157,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,157,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,0,0,0
+Lubbock,157,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,157,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,0,0,0
+Lubbock,157,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,157,"Democratic Proposition #8 Right to Housing",,DEM,For,0,0,0
+Lubbock,157,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,157,"Democratic Proposition #9 Right to Vote",,DEM,For,0,0,0
+Lubbock,157,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,157,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,0,0,0
+Lubbock,157,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,157,"Democratic Proposition #11 Immigrant Rights",,DEM,For,0,0,0
+Lubbock,157,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,157,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,0,0,0
+Lubbock,157,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,158,Registered Voters,,,,0,,
 Lubbock,158,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
 Lubbock,158,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -21592,82 +15924,30 @@ Lubbock,158,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0
 Lubbock,158,State Representative,83,DEM,Drew Landry,0,0,0
 Lubbock,158,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,0,0,0
 Lubbock,158,County Party Chair,,DEM,Stuart Williams,0,0,0
-Lubbock,158,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,0,0,0
-Lubbock,158,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,158,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,0,0,0
-Lubbock,158,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,158,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,0,0,0
-Lubbock,158,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,158,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,0,0,0
-Lubbock,158,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,158,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,0,0,0
-Lubbock,158,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,158,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,0,0,0
-Lubbock,158,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,158,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,0,0,0
-Lubbock,158,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,158,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,0,0,0
-Lubbock,158,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,158,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,0,0,0
-Lubbock,158,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,158,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,0,0,0
-Lubbock,158,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,158,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,0,0,0
-Lubbock,158,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,158,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,0,0,0
-Lubbock,158,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,158,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,0,0,0
+Lubbock,158,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,158,"Democratic Proposition #2 Student Loan Debt",,DEM,For,0,0,0
+Lubbock,158,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,158,"Democratic Proposition #3 Right to Healthcare",,DEM,For,0,0,0
+Lubbock,158,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,158,"Democratic Proposition #4 Right to Economic Security",,DEM,For,0,0,0
+Lubbock,158,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,158,"Democratic Proposition #5 National Jobs Program",,DEM,For,0,0,0
+Lubbock,158,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,158,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,0,0,0
+Lubbock,158,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,158,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,0,0,0
+Lubbock,158,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,158,"Democratic Proposition #8 Right to Housing",,DEM,For,0,0,0
+Lubbock,158,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,158,"Democratic Proposition #9 Right to Vote",,DEM,For,0,0,0
+Lubbock,158,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,158,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,0,0,0
+Lubbock,158,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,158,"Democratic Proposition #11 Immigrant Rights",,DEM,For,0,0,0
+Lubbock,158,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,158,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,0,0,0
+Lubbock,158,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,159,Registered Voters,,,,0,,
 Lubbock,159,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
 Lubbock,159,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -21700,82 +15980,30 @@ Lubbock,159,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0
 Lubbock,159,State Representative,83,DEM,Drew Landry,0,0,0
 Lubbock,159,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,0,0,0
 Lubbock,159,County Party Chair,,DEM,Stuart Williams,0,0,0
-Lubbock,159,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,0,0,0
-Lubbock,159,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,159,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,0,0,0
-Lubbock,159,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,159,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,0,0,0
-Lubbock,159,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,159,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,0,0,0
-Lubbock,159,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,159,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,0,0,0
-Lubbock,159,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,159,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,0,0,0
-Lubbock,159,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,159,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,0,0,0
-Lubbock,159,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,159,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,0,0,0
-Lubbock,159,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,159,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,0,0,0
-Lubbock,159,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,159,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,0,0,0
-Lubbock,159,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,159,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,0,0,0
-Lubbock,159,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,159,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,0,0,0
-Lubbock,159,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,159,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,0,0,0
+Lubbock,159,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,159,"Democratic Proposition #2 Student Loan Debt",,DEM,For,0,0,0
+Lubbock,159,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,159,"Democratic Proposition #3 Right to Healthcare",,DEM,For,0,0,0
+Lubbock,159,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,159,"Democratic Proposition #4 Right to Economic Security",,DEM,For,0,0,0
+Lubbock,159,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,159,"Democratic Proposition #5 National Jobs Program",,DEM,For,0,0,0
+Lubbock,159,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,159,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,0,0,0
+Lubbock,159,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,159,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,0,0,0
+Lubbock,159,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,159,"Democratic Proposition #8 Right to Housing",,DEM,For,0,0,0
+Lubbock,159,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,159,"Democratic Proposition #9 Right to Vote",,DEM,For,0,0,0
+Lubbock,159,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,159,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,0,0,0
+Lubbock,159,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,159,"Democratic Proposition #11 Immigrant Rights",,DEM,For,0,0,0
+Lubbock,159,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,159,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,0,0,0
+Lubbock,159,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,160,Registered Voters,,,,5,,
 Lubbock,160,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
 Lubbock,160,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -21808,82 +16036,30 @@ Lubbock,160,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0
 Lubbock,160,State Representative,83,DEM,Drew Landry,0,0,0
 Lubbock,160,"Justice of the Peace, Precinct 3",,DEM,Aurora Chaides-Hernandez,0,0,0
 Lubbock,160,County Party Chair,,DEM,Stuart Williams,0,0,0
-Lubbock,160,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,0,0,0
-Lubbock,160,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,160,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,0,0,0
-Lubbock,160,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,160,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,0,0,0
-Lubbock,160,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,160,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,0,0,0
-Lubbock,160,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,160,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,0,0,0
-Lubbock,160,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,160,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,0,0,0
-Lubbock,160,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,160,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,0,0,0
-Lubbock,160,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,160,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,0,0,0
-Lubbock,160,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,160,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,0,0,0
-Lubbock,160,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,160,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,0,0,0
-Lubbock,160,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,160,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,0,0,0
-Lubbock,160,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,160,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,0,0,0
-Lubbock,160,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,160,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,0,0,0
+Lubbock,160,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,160,"Democratic Proposition #2 Student Loan Debt",,DEM,For,0,0,0
+Lubbock,160,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,160,"Democratic Proposition #3 Right to Healthcare",,DEM,For,0,0,0
+Lubbock,160,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,160,"Democratic Proposition #4 Right to Economic Security",,DEM,For,0,0,0
+Lubbock,160,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,160,"Democratic Proposition #5 National Jobs Program",,DEM,For,0,0,0
+Lubbock,160,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,160,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,0,0,0
+Lubbock,160,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,160,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,0,0,0
+Lubbock,160,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,160,"Democratic Proposition #8 Right to Housing",,DEM,For,0,0,0
+Lubbock,160,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,160,"Democratic Proposition #9 Right to Vote",,DEM,For,0,0,0
+Lubbock,160,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,160,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,0,0,0
+Lubbock,160,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,160,"Democratic Proposition #11 Immigrant Rights",,DEM,For,0,0,0
+Lubbock,160,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,160,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,0,0,0
+Lubbock,160,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,161,Registered Voters,,,,6,,
 Lubbock,161,U.S. Senate,,DEM,Beto O'Rourke,1,0,1
 Lubbock,161,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -21915,82 +16091,30 @@ Lubbock,161,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) J
 Lubbock,161,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,1,0,1
 Lubbock,161,State Representative,83,DEM,Drew Landry,0,0,0
 Lubbock,161,County Party Chair,,DEM,Stuart Williams,1,0,1
-Lubbock,161,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,1,0,1
-Lubbock,161,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,161,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,1,0,1
-Lubbock,161,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,161,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,1,0,1
-Lubbock,161,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,161,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,1,0,1
-Lubbock,161,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,161,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,1,0,1
-Lubbock,161,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,161,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,1,0,1
-Lubbock,161,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,161,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,1,0,1
-Lubbock,161,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,161,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,1,0,1
-Lubbock,161,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,161,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,1,0,1
-Lubbock,161,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,161,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,1,0,1
-Lubbock,161,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,161,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,1,0,1
-Lubbock,161,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,161,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,1,0,1
-Lubbock,161,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,161,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,1,0,1
+Lubbock,161,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,161,"Democratic Proposition #2 Student Loan Debt",,DEM,For,1,0,1
+Lubbock,161,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,161,"Democratic Proposition #3 Right to Healthcare",,DEM,For,1,0,1
+Lubbock,161,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,161,"Democratic Proposition #4 Right to Economic Security",,DEM,For,1,0,1
+Lubbock,161,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,161,"Democratic Proposition #5 National Jobs Program",,DEM,For,1,0,1
+Lubbock,161,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,161,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,1,0,1
+Lubbock,161,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,161,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,1,0,1
+Lubbock,161,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,161,"Democratic Proposition #8 Right to Housing",,DEM,For,1,0,1
+Lubbock,161,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,161,"Democratic Proposition #9 Right to Vote",,DEM,For,1,0,1
+Lubbock,161,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,161,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,1,0,1
+Lubbock,161,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,161,"Democratic Proposition #11 Immigrant Rights",,DEM,For,1,0,1
+Lubbock,161,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,161,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,1,0,1
+Lubbock,161,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,162,Registered Voters,,,,0,,
 Lubbock,162,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
 Lubbock,162,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -22022,82 +16146,30 @@ Lubbock,162,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) J
 Lubbock,162,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0,0
 Lubbock,162,State Representative,83,DEM,Drew Landry,0,0,0
 Lubbock,162,County Party Chair,,DEM,Stuart Williams,0,0,0
-Lubbock,162,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,0,0,0
-Lubbock,162,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,162,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,0,0,0
-Lubbock,162,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,162,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,0,0,0
-Lubbock,162,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,162,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,0,0,0
-Lubbock,162,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,162,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,0,0,0
-Lubbock,162,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,162,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,0,0,0
-Lubbock,162,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,162,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,0,0,0
-Lubbock,162,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,162,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,0,0,0
-Lubbock,162,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,162,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,0,0,0
-Lubbock,162,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,162,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,0,0,0
-Lubbock,162,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,162,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,0,0,0
-Lubbock,162,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,162,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,0,0,0
-Lubbock,162,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,162,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,0,0,0
+Lubbock,162,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,162,"Democratic Proposition #2 Student Loan Debt",,DEM,For,0,0,0
+Lubbock,162,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,162,"Democratic Proposition #3 Right to Healthcare",,DEM,For,0,0,0
+Lubbock,162,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,162,"Democratic Proposition #4 Right to Economic Security",,DEM,For,0,0,0
+Lubbock,162,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,162,"Democratic Proposition #5 National Jobs Program",,DEM,For,0,0,0
+Lubbock,162,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,162,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,0,0,0
+Lubbock,162,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,162,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,0,0,0
+Lubbock,162,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,162,"Democratic Proposition #8 Right to Housing",,DEM,For,0,0,0
+Lubbock,162,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,162,"Democratic Proposition #9 Right to Vote",,DEM,For,0,0,0
+Lubbock,162,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,162,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,0,0,0
+Lubbock,162,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,162,"Democratic Proposition #11 Immigrant Rights",,DEM,For,0,0,0
+Lubbock,162,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,162,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,0,0,0
+Lubbock,162,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,163,Registered Voters,,,,11,,
 Lubbock,163,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
 Lubbock,163,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -22129,82 +16201,30 @@ Lubbock,163,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) J
 Lubbock,163,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0,0
 Lubbock,163,State Representative,83,DEM,Drew Landry,0,0,0
 Lubbock,163,County Party Chair,,DEM,Stuart Williams,0,0,0
-Lubbock,163,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,0,0,0
-Lubbock,163,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,163,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,0,0,0
-Lubbock,163,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,163,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,0,0,0
-Lubbock,163,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,163,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,0,0,0
-Lubbock,163,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,163,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,0,0,0
-Lubbock,163,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,163,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,0,0,0
-Lubbock,163,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,163,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,0,0,0
-Lubbock,163,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,163,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,0,0,0
-Lubbock,163,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,163,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,0,0,0
-Lubbock,163,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,163,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,0,0,0
-Lubbock,163,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,163,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,0,0,0
-Lubbock,163,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,163,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,0,0,0
-Lubbock,163,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,163,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,0,0,0
+Lubbock,163,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,163,"Democratic Proposition #2 Student Loan Debt",,DEM,For,0,0,0
+Lubbock,163,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,163,"Democratic Proposition #3 Right to Healthcare",,DEM,For,0,0,0
+Lubbock,163,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,163,"Democratic Proposition #4 Right to Economic Security",,DEM,For,0,0,0
+Lubbock,163,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,163,"Democratic Proposition #5 National Jobs Program",,DEM,For,0,0,0
+Lubbock,163,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,163,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,0,0,0
+Lubbock,163,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,163,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,0,0,0
+Lubbock,163,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,163,"Democratic Proposition #8 Right to Housing",,DEM,For,0,0,0
+Lubbock,163,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,163,"Democratic Proposition #9 Right to Vote",,DEM,For,0,0,0
+Lubbock,163,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,163,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,0,0,0
+Lubbock,163,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,163,"Democratic Proposition #11 Immigrant Rights",,DEM,For,0,0,0
+Lubbock,163,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,163,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,0,0,0
+Lubbock,163,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,164,Registered Voters,,,,2,,
 Lubbock,164,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
 Lubbock,164,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -22236,82 +16256,30 @@ Lubbock,164,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) J
 Lubbock,164,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0,0
 Lubbock,164,State Representative,83,DEM,Drew Landry,0,0,0
 Lubbock,164,County Party Chair,,DEM,Stuart Williams,0,0,0
-Lubbock,164,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,0,0,0
-Lubbock,164,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,164,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,0,0,0
-Lubbock,164,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,164,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,0,0,0
-Lubbock,164,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,164,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,0,0,0
-Lubbock,164,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,164,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,0,0,0
-Lubbock,164,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,164,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,0,0,0
-Lubbock,164,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,164,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,0,0,0
-Lubbock,164,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,164,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,0,0,0
-Lubbock,164,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,164,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,0,0,0
-Lubbock,164,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,164,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,0,0,0
-Lubbock,164,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,164,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,0,0,0
-Lubbock,164,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,164,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,0,0,0
-Lubbock,164,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,164,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,0,0,0
+Lubbock,164,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,164,"Democratic Proposition #2 Student Loan Debt",,DEM,For,0,0,0
+Lubbock,164,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,164,"Democratic Proposition #3 Right to Healthcare",,DEM,For,0,0,0
+Lubbock,164,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,164,"Democratic Proposition #4 Right to Economic Security",,DEM,For,0,0,0
+Lubbock,164,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,164,"Democratic Proposition #5 National Jobs Program",,DEM,For,0,0,0
+Lubbock,164,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,164,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,0,0,0
+Lubbock,164,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,164,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,0,0,0
+Lubbock,164,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,164,"Democratic Proposition #8 Right to Housing",,DEM,For,0,0,0
+Lubbock,164,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,164,"Democratic Proposition #9 Right to Vote",,DEM,For,0,0,0
+Lubbock,164,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,164,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,0,0,0
+Lubbock,164,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,164,"Democratic Proposition #11 Immigrant Rights",,DEM,For,0,0,0
+Lubbock,164,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,164,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,0,0,0
+Lubbock,164,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,165,Registered Voters,,,,4,,
 Lubbock,165,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
 Lubbock,165,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -22343,82 +16311,30 @@ Lubbock,165,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) J
 Lubbock,165,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0,0
 Lubbock,165,State Representative,83,DEM,Drew Landry,0,0,0
 Lubbock,165,County Party Chair,,DEM,Stuart Williams,0,0,0
-Lubbock,165,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,0,0,0
-Lubbock,165,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,165,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,0,0,0
-Lubbock,165,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,165,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,0,0,0
-Lubbock,165,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,165,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,0,0,0
-Lubbock,165,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,165,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,0,0,0
-Lubbock,165,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,165,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,0,0,0
-Lubbock,165,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,165,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,0,0,0
-Lubbock,165,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,165,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,0,0,0
-Lubbock,165,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,165,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,0,0,0
-Lubbock,165,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,165,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,0,0,0
-Lubbock,165,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,165,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,0,0,0
-Lubbock,165,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,165,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,0,0,0
-Lubbock,165,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,165,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,0,0,0
+Lubbock,165,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,165,"Democratic Proposition #2 Student Loan Debt",,DEM,For,0,0,0
+Lubbock,165,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,165,"Democratic Proposition #3 Right to Healthcare",,DEM,For,0,0,0
+Lubbock,165,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,165,"Democratic Proposition #4 Right to Economic Security",,DEM,For,0,0,0
+Lubbock,165,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,165,"Democratic Proposition #5 National Jobs Program",,DEM,For,0,0,0
+Lubbock,165,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,165,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,0,0,0
+Lubbock,165,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,165,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,0,0,0
+Lubbock,165,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,165,"Democratic Proposition #8 Right to Housing",,DEM,For,0,0,0
+Lubbock,165,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,165,"Democratic Proposition #9 Right to Vote",,DEM,For,0,0,0
+Lubbock,165,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,165,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,0,0,0
+Lubbock,165,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,165,"Democratic Proposition #11 Immigrant Rights",,DEM,For,0,0,0
+Lubbock,165,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,165,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,0,0,0
+Lubbock,165,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,166,Registered Voters,,,,1,,
 Lubbock,166,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
 Lubbock,166,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -22450,82 +16366,30 @@ Lubbock,166,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) J
 Lubbock,166,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0,0
 Lubbock,166,State Representative,83,DEM,Drew Landry,0,0,0
 Lubbock,166,County Party Chair,,DEM,Stuart Williams,0,0,0
-Lubbock,166,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,0,0,0
-Lubbock,166,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,166,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,0,0,0
-Lubbock,166,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,166,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,0,0,0
-Lubbock,166,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,166,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,0,0,0
-Lubbock,166,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,166,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,0,0,0
-Lubbock,166,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,166,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,0,0,0
-Lubbock,166,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,166,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,0,0,0
-Lubbock,166,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,166,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,0,0,0
-Lubbock,166,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,166,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,0,0,0
-Lubbock,166,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,166,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,0,0,0
-Lubbock,166,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,166,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,0,0,0
-Lubbock,166,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,166,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,0,0,0
-Lubbock,166,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,166,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,0,0,0
+Lubbock,166,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,166,"Democratic Proposition #2 Student Loan Debt",,DEM,For,0,0,0
+Lubbock,166,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,166,"Democratic Proposition #3 Right to Healthcare",,DEM,For,0,0,0
+Lubbock,166,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,166,"Democratic Proposition #4 Right to Economic Security",,DEM,For,0,0,0
+Lubbock,166,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,166,"Democratic Proposition #5 National Jobs Program",,DEM,For,0,0,0
+Lubbock,166,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,166,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,0,0,0
+Lubbock,166,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,166,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,0,0,0
+Lubbock,166,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,166,"Democratic Proposition #8 Right to Housing",,DEM,For,0,0,0
+Lubbock,166,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,166,"Democratic Proposition #9 Right to Vote",,DEM,For,0,0,0
+Lubbock,166,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,166,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,0,0,0
+Lubbock,166,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,166,"Democratic Proposition #11 Immigrant Rights",,DEM,For,0,0,0
+Lubbock,166,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,166,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,0,0,0
+Lubbock,166,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,167,Registered Voters,,,,3,,
 Lubbock,167,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
 Lubbock,167,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -22557,82 +16421,30 @@ Lubbock,167,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) J
 Lubbock,167,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0,0
 Lubbock,167,State Representative,83,DEM,Drew Landry,0,0,0
 Lubbock,167,County Party Chair,,DEM,Stuart Williams,0,0,0
-Lubbock,167,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,0,0,0
-Lubbock,167,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,167,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,0,0,0
-Lubbock,167,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,167,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,0,0,0
-Lubbock,167,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,167,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,0,0,0
-Lubbock,167,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,167,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,0,0,0
-Lubbock,167,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,167,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,0,0,0
-Lubbock,167,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,167,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,0,0,0
-Lubbock,167,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,167,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,0,0,0
-Lubbock,167,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,167,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,0,0,0
-Lubbock,167,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,167,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,0,0,0
-Lubbock,167,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,167,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,0,0,0
-Lubbock,167,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,167,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,0,0,0
-Lubbock,167,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,167,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,0,0,0
+Lubbock,167,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,167,"Democratic Proposition #2 Student Loan Debt",,DEM,For,0,0,0
+Lubbock,167,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,167,"Democratic Proposition #3 Right to Healthcare",,DEM,For,0,0,0
+Lubbock,167,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,167,"Democratic Proposition #4 Right to Economic Security",,DEM,For,0,0,0
+Lubbock,167,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,167,"Democratic Proposition #5 National Jobs Program",,DEM,For,0,0,0
+Lubbock,167,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,167,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,0,0,0
+Lubbock,167,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,167,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,0,0,0
+Lubbock,167,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,167,"Democratic Proposition #8 Right to Housing",,DEM,For,0,0,0
+Lubbock,167,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,167,"Democratic Proposition #9 Right to Vote",,DEM,For,0,0,0
+Lubbock,167,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,167,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,0,0,0
+Lubbock,167,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,167,"Democratic Proposition #11 Immigrant Rights",,DEM,For,0,0,0
+Lubbock,167,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,167,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,0,0,0
+Lubbock,167,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,168,Registered Voters,,,,6,,
 Lubbock,168,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
 Lubbock,168,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -22664,82 +16476,30 @@ Lubbock,168,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) J
 Lubbock,168,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0,0
 Lubbock,168,State Representative,83,DEM,Drew Landry,0,0,0
 Lubbock,168,County Party Chair,,DEM,Stuart Williams,0,0,0
-Lubbock,168,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,0,0,0
-Lubbock,168,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,168,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,0,0,0
-Lubbock,168,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,168,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,0,0,0
-Lubbock,168,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,168,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,0,0,0
-Lubbock,168,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,168,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,0,0,0
-Lubbock,168,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,168,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,0,0,0
-Lubbock,168,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,168,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,0,0,0
-Lubbock,168,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,168,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,0,0,0
-Lubbock,168,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,168,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,0,0,0
-Lubbock,168,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,168,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,0,0,0
-Lubbock,168,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,168,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,0,0,0
-Lubbock,168,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,168,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,0,0,0
-Lubbock,168,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,168,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,0,0,0
+Lubbock,168,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,168,"Democratic Proposition #2 Student Loan Debt",,DEM,For,0,0,0
+Lubbock,168,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,168,"Democratic Proposition #3 Right to Healthcare",,DEM,For,0,0,0
+Lubbock,168,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,168,"Democratic Proposition #4 Right to Economic Security",,DEM,For,0,0,0
+Lubbock,168,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,168,"Democratic Proposition #5 National Jobs Program",,DEM,For,0,0,0
+Lubbock,168,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,168,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,0,0,0
+Lubbock,168,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,168,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,0,0,0
+Lubbock,168,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,168,"Democratic Proposition #8 Right to Housing",,DEM,For,0,0,0
+Lubbock,168,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,168,"Democratic Proposition #9 Right to Vote",,DEM,For,0,0,0
+Lubbock,168,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,168,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,0,0,0
+Lubbock,168,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,168,"Democratic Proposition #11 Immigrant Rights",,DEM,For,0,0,0
+Lubbock,168,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,168,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,0,0,0
+Lubbock,168,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,169,Registered Voters,,,,0,,
 Lubbock,169,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
 Lubbock,169,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -22771,82 +16531,30 @@ Lubbock,169,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) J
 Lubbock,169,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0,0
 Lubbock,169,State Representative,83,DEM,Drew Landry,0,0,0
 Lubbock,169,County Party Chair,,DEM,Stuart Williams,0,0,0
-Lubbock,169,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,0,0,0
-Lubbock,169,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,169,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,0,0,0
-Lubbock,169,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,169,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,0,0,0
-Lubbock,169,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,169,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,0,0,0
-Lubbock,169,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,169,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,0,0,0
-Lubbock,169,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,169,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,0,0,0
-Lubbock,169,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,169,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,0,0,0
-Lubbock,169,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,169,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,0,0,0
-Lubbock,169,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,169,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,0,0,0
-Lubbock,169,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,169,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,0,0,0
-Lubbock,169,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,169,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,0,0,0
-Lubbock,169,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,169,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,0,0,0
-Lubbock,169,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,169,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,0,0,0
+Lubbock,169,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,169,"Democratic Proposition #2 Student Loan Debt",,DEM,For,0,0,0
+Lubbock,169,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,169,"Democratic Proposition #3 Right to Healthcare",,DEM,For,0,0,0
+Lubbock,169,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,169,"Democratic Proposition #4 Right to Economic Security",,DEM,For,0,0,0
+Lubbock,169,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,169,"Democratic Proposition #5 National Jobs Program",,DEM,For,0,0,0
+Lubbock,169,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,169,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,0,0,0
+Lubbock,169,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,169,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,0,0,0
+Lubbock,169,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,169,"Democratic Proposition #8 Right to Housing",,DEM,For,0,0,0
+Lubbock,169,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,169,"Democratic Proposition #9 Right to Vote",,DEM,For,0,0,0
+Lubbock,169,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,169,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,0,0,0
+Lubbock,169,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,169,"Democratic Proposition #11 Immigrant Rights",,DEM,For,0,0,0
+Lubbock,169,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,169,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,0,0,0
+Lubbock,169,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,170,Registered Voters,,,,0,,
 Lubbock,170,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
 Lubbock,170,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -22878,82 +16586,30 @@ Lubbock,170,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) J
 Lubbock,170,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0,0
 Lubbock,170,State Representative,83,DEM,Drew Landry,0,0,0
 Lubbock,170,County Party Chair,,DEM,Stuart Williams,0,0,0
-Lubbock,170,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,0,0,0
-Lubbock,170,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,170,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,0,0,0
-Lubbock,170,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,170,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,0,0,0
-Lubbock,170,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,170,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,0,0,0
-Lubbock,170,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,170,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,0,0,0
-Lubbock,170,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,170,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,0,0,0
-Lubbock,170,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,170,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,0,0,0
-Lubbock,170,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,170,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,0,0,0
-Lubbock,170,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,170,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,0,0,0
-Lubbock,170,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,170,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,0,0,0
-Lubbock,170,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,170,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,0,0,0
-Lubbock,170,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,170,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,0,0,0
-Lubbock,170,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,170,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,0,0,0
+Lubbock,170,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,170,"Democratic Proposition #2 Student Loan Debt",,DEM,For,0,0,0
+Lubbock,170,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,170,"Democratic Proposition #3 Right to Healthcare",,DEM,For,0,0,0
+Lubbock,170,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,170,"Democratic Proposition #4 Right to Economic Security",,DEM,For,0,0,0
+Lubbock,170,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,170,"Democratic Proposition #5 National Jobs Program",,DEM,For,0,0,0
+Lubbock,170,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,170,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,0,0,0
+Lubbock,170,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,170,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,0,0,0
+Lubbock,170,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,170,"Democratic Proposition #8 Right to Housing",,DEM,For,0,0,0
+Lubbock,170,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,170,"Democratic Proposition #9 Right to Vote",,DEM,For,0,0,0
+Lubbock,170,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,170,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,0,0,0
+Lubbock,170,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,170,"Democratic Proposition #11 Immigrant Rights",,DEM,For,0,0,0
+Lubbock,170,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,170,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,0,0,0
+Lubbock,170,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,171,Registered Voters,,,,0,,
 Lubbock,171,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
 Lubbock,171,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -22985,82 +16641,30 @@ Lubbock,171,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) J
 Lubbock,171,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0,0
 Lubbock,171,State Representative,83,DEM,Drew Landry,0,0,0
 Lubbock,171,County Party Chair,,DEM,Stuart Williams,0,0,0
-Lubbock,171,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,0,0,0
-Lubbock,171,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,171,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,0,0,0
-Lubbock,171,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,171,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,0,0,0
-Lubbock,171,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,171,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,0,0,0
-Lubbock,171,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,171,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,0,0,0
-Lubbock,171,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,171,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,0,0,0
-Lubbock,171,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,171,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,0,0,0
-Lubbock,171,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,171,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,0,0,0
-Lubbock,171,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,171,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,0,0,0
-Lubbock,171,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,171,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,0,0,0
-Lubbock,171,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,171,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,0,0,0
-Lubbock,171,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,171,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,0,0,0
-Lubbock,171,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,171,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,0,0,0
+Lubbock,171,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,171,"Democratic Proposition #2 Student Loan Debt",,DEM,For,0,0,0
+Lubbock,171,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,171,"Democratic Proposition #3 Right to Healthcare",,DEM,For,0,0,0
+Lubbock,171,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,171,"Democratic Proposition #4 Right to Economic Security",,DEM,For,0,0,0
+Lubbock,171,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,171,"Democratic Proposition #5 National Jobs Program",,DEM,For,0,0,0
+Lubbock,171,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,171,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,0,0,0
+Lubbock,171,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,171,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,0,0,0
+Lubbock,171,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,171,"Democratic Proposition #8 Right to Housing",,DEM,For,0,0,0
+Lubbock,171,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,171,"Democratic Proposition #9 Right to Vote",,DEM,For,0,0,0
+Lubbock,171,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,171,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,0,0,0
+Lubbock,171,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,171,"Democratic Proposition #11 Immigrant Rights",,DEM,For,0,0,0
+Lubbock,171,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,171,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,0,0,0
+Lubbock,171,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,172,Registered Voters,,,,3,,
 Lubbock,172,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
 Lubbock,172,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -23092,82 +16696,30 @@ Lubbock,172,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) J
 Lubbock,172,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0,0
 Lubbock,172,State Representative,83,DEM,Drew Landry,0,0,0
 Lubbock,172,County Party Chair,,DEM,Stuart Williams,0,0,0
-Lubbock,172,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,0,0,0
-Lubbock,172,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,172,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,0,0,0
-Lubbock,172,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,172,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,0,0,0
-Lubbock,172,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,172,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,0,0,0
-Lubbock,172,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,172,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,0,0,0
-Lubbock,172,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,172,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,0,0,0
-Lubbock,172,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,172,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,0,0,0
-Lubbock,172,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,172,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,0,0,0
-Lubbock,172,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,172,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,0,0,0
-Lubbock,172,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,172,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,0,0,0
-Lubbock,172,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,172,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,0,0,0
-Lubbock,172,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,172,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,0,0,0
-Lubbock,172,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,172,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,0,0,0
+Lubbock,172,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,172,"Democratic Proposition #2 Student Loan Debt",,DEM,For,0,0,0
+Lubbock,172,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,172,"Democratic Proposition #3 Right to Healthcare",,DEM,For,0,0,0
+Lubbock,172,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,172,"Democratic Proposition #4 Right to Economic Security",,DEM,For,0,0,0
+Lubbock,172,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,172,"Democratic Proposition #5 National Jobs Program",,DEM,For,0,0,0
+Lubbock,172,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,172,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,0,0,0
+Lubbock,172,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,172,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,0,0,0
+Lubbock,172,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,172,"Democratic Proposition #8 Right to Housing",,DEM,For,0,0,0
+Lubbock,172,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,172,"Democratic Proposition #9 Right to Vote",,DEM,For,0,0,0
+Lubbock,172,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,172,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,0,0,0
+Lubbock,172,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,172,"Democratic Proposition #11 Immigrant Rights",,DEM,For,0,0,0
+Lubbock,172,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,172,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,0,0,0
+Lubbock,172,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,173,Registered Voters,,,,1,,
 Lubbock,173,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
 Lubbock,173,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -23199,82 +16751,30 @@ Lubbock,173,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) J
 Lubbock,173,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0,0
 Lubbock,173,State Representative,83,DEM,Drew Landry,0,0,0
 Lubbock,173,County Party Chair,,DEM,Stuart Williams,0,0,0
-Lubbock,173,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,0,0,0
-Lubbock,173,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,173,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,0,0,0
-Lubbock,173,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,173,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,0,0,0
-Lubbock,173,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,173,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,0,0,0
-Lubbock,173,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,173,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,0,0,0
-Lubbock,173,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,173,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,0,0,0
-Lubbock,173,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,173,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,0,0,0
-Lubbock,173,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,173,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,0,0,0
-Lubbock,173,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,173,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,0,0,0
-Lubbock,173,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,173,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,0,0,0
-Lubbock,173,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,173,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,0,0,0
-Lubbock,173,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,173,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,0,0,0
-Lubbock,173,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,173,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,0,0,0
+Lubbock,173,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,173,"Democratic Proposition #2 Student Loan Debt",,DEM,For,0,0,0
+Lubbock,173,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,173,"Democratic Proposition #3 Right to Healthcare",,DEM,For,0,0,0
+Lubbock,173,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,173,"Democratic Proposition #4 Right to Economic Security",,DEM,For,0,0,0
+Lubbock,173,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,173,"Democratic Proposition #5 National Jobs Program",,DEM,For,0,0,0
+Lubbock,173,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,173,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,0,0,0
+Lubbock,173,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,173,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,0,0,0
+Lubbock,173,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,173,"Democratic Proposition #8 Right to Housing",,DEM,For,0,0,0
+Lubbock,173,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,173,"Democratic Proposition #9 Right to Vote",,DEM,For,0,0,0
+Lubbock,173,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,173,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,0,0,0
+Lubbock,173,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,173,"Democratic Proposition #11 Immigrant Rights",,DEM,For,0,0,0
+Lubbock,173,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,173,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,0,0,0
+Lubbock,173,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,174,Registered Voters,,,,22,,
 Lubbock,174,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
 Lubbock,174,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -23306,82 +16806,30 @@ Lubbock,174,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) J
 Lubbock,174,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0,0
 Lubbock,174,State Representative,83,DEM,Drew Landry,0,0,0
 Lubbock,174,County Party Chair,,DEM,Stuart Williams,0,0,0
-Lubbock,174,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,0,0,0
-Lubbock,174,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,174,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,0,0,0
-Lubbock,174,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,174,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,0,0,0
-Lubbock,174,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,174,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,0,0,0
-Lubbock,174,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,174,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,0,0,0
-Lubbock,174,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,174,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,0,0,0
-Lubbock,174,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,174,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,0,0,0
-Lubbock,174,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,174,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,0,0,0
-Lubbock,174,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,174,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,0,0,0
-Lubbock,174,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,174,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,0,0,0
-Lubbock,174,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,174,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,0,0,0
-Lubbock,174,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,174,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,0,0,0
-Lubbock,174,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,174,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,0,0,0
+Lubbock,174,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,174,"Democratic Proposition #2 Student Loan Debt",,DEM,For,0,0,0
+Lubbock,174,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,174,"Democratic Proposition #3 Right to Healthcare",,DEM,For,0,0,0
+Lubbock,174,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,174,"Democratic Proposition #4 Right to Economic Security",,DEM,For,0,0,0
+Lubbock,174,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,174,"Democratic Proposition #5 National Jobs Program",,DEM,For,0,0,0
+Lubbock,174,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,174,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,0,0,0
+Lubbock,174,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,174,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,0,0,0
+Lubbock,174,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,174,"Democratic Proposition #8 Right to Housing",,DEM,For,0,0,0
+Lubbock,174,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,174,"Democratic Proposition #9 Right to Vote",,DEM,For,0,0,0
+Lubbock,174,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,174,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,0,0,0
+Lubbock,174,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,174,"Democratic Proposition #11 Immigrant Rights",,DEM,For,0,0,0
+Lubbock,174,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,174,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,0,0,0
+Lubbock,174,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,175,Registered Voters,,,,25,,
 Lubbock,175,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
 Lubbock,175,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -23413,82 +16861,30 @@ Lubbock,175,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) J
 Lubbock,175,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0,0
 Lubbock,175,State Representative,83,DEM,Drew Landry,0,0,0
 Lubbock,175,County Party Chair,,DEM,Stuart Williams,0,0,0
-Lubbock,175,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,0,0,0
-Lubbock,175,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,175,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,0,0,0
-Lubbock,175,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,175,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,0,0,0
-Lubbock,175,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,175,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,0,0,0
-Lubbock,175,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,175,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,0,0,0
-Lubbock,175,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,175,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,0,0,0
-Lubbock,175,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,175,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,0,0,0
-Lubbock,175,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,175,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,0,0,0
-Lubbock,175,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,175,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,0,0,0
-Lubbock,175,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,175,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,0,0,0
-Lubbock,175,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,175,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,0,0,0
-Lubbock,175,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,175,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,0,0,0
-Lubbock,175,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,175,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,0,0,0
+Lubbock,175,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,175,"Democratic Proposition #2 Student Loan Debt",,DEM,For,0,0,0
+Lubbock,175,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,175,"Democratic Proposition #3 Right to Healthcare",,DEM,For,0,0,0
+Lubbock,175,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,175,"Democratic Proposition #4 Right to Economic Security",,DEM,For,0,0,0
+Lubbock,175,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,175,"Democratic Proposition #5 National Jobs Program",,DEM,For,0,0,0
+Lubbock,175,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,175,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,0,0,0
+Lubbock,175,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,175,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,0,0,0
+Lubbock,175,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,175,"Democratic Proposition #8 Right to Housing",,DEM,For,0,0,0
+Lubbock,175,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,175,"Democratic Proposition #9 Right to Vote",,DEM,For,0,0,0
+Lubbock,175,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,175,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,0,0,0
+Lubbock,175,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,175,"Democratic Proposition #11 Immigrant Rights",,DEM,For,0,0,0
+Lubbock,175,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,175,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,0,0,0
+Lubbock,175,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,176,Registered Voters,,,,1,,
 Lubbock,176,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
 Lubbock,176,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -23520,82 +16916,30 @@ Lubbock,176,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) J
 Lubbock,176,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0,0
 Lubbock,176,State Representative,83,DEM,Drew Landry,0,0,0
 Lubbock,176,County Party Chair,,DEM,Stuart Williams,0,0,0
-Lubbock,176,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,0,0,0
-Lubbock,176,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,176,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,0,0,0
-Lubbock,176,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,176,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,0,0,0
-Lubbock,176,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,176,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,0,0,0
-Lubbock,176,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,176,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,0,0,0
-Lubbock,176,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,176,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,0,0,0
-Lubbock,176,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,176,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,0,0,0
-Lubbock,176,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,176,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,0,0,0
-Lubbock,176,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,176,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,0,0,0
-Lubbock,176,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,176,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,0,0,0
-Lubbock,176,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,176,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,0,0,0
-Lubbock,176,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,176,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,0,0,0
-Lubbock,176,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,176,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,0,0,0
+Lubbock,176,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,176,"Democratic Proposition #2 Student Loan Debt",,DEM,For,0,0,0
+Lubbock,176,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,176,"Democratic Proposition #3 Right to Healthcare",,DEM,For,0,0,0
+Lubbock,176,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,176,"Democratic Proposition #4 Right to Economic Security",,DEM,For,0,0,0
+Lubbock,176,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,176,"Democratic Proposition #5 National Jobs Program",,DEM,For,0,0,0
+Lubbock,176,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,176,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,0,0,0
+Lubbock,176,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,176,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,0,0,0
+Lubbock,176,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,176,"Democratic Proposition #8 Right to Housing",,DEM,For,0,0,0
+Lubbock,176,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,176,"Democratic Proposition #9 Right to Vote",,DEM,For,0,0,0
+Lubbock,176,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,176,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,0,0,0
+Lubbock,176,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,176,"Democratic Proposition #11 Immigrant Rights",,DEM,For,0,0,0
+Lubbock,176,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,176,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,0,0,0
+Lubbock,176,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,177,Registered Voters,,,,2,,
 Lubbock,177,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
 Lubbock,177,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -23627,82 +16971,30 @@ Lubbock,177,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) J
 Lubbock,177,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0,0
 Lubbock,177,State Representative,83,DEM,Drew Landry,0,0,0
 Lubbock,177,County Party Chair,,DEM,Stuart Williams,0,0,0
-Lubbock,177,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,0,0,0
-Lubbock,177,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,177,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,0,0,0
-Lubbock,177,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,177,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,0,0,0
-Lubbock,177,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,177,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,0,0,0
-Lubbock,177,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,177,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,0,0,0
-Lubbock,177,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,177,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,0,0,0
-Lubbock,177,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,177,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,0,0,0
-Lubbock,177,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,177,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,0,0,0
-Lubbock,177,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,177,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,0,0,0
-Lubbock,177,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,177,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,0,0,0
-Lubbock,177,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,177,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,0,0,0
-Lubbock,177,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,177,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,0,0,0
-Lubbock,177,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,177,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,0,0,0
+Lubbock,177,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,177,"Democratic Proposition #2 Student Loan Debt",,DEM,For,0,0,0
+Lubbock,177,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,177,"Democratic Proposition #3 Right to Healthcare",,DEM,For,0,0,0
+Lubbock,177,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,177,"Democratic Proposition #4 Right to Economic Security",,DEM,For,0,0,0
+Lubbock,177,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,177,"Democratic Proposition #5 National Jobs Program",,DEM,For,0,0,0
+Lubbock,177,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,177,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,0,0,0
+Lubbock,177,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,177,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,0,0,0
+Lubbock,177,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,177,"Democratic Proposition #8 Right to Housing",,DEM,For,0,0,0
+Lubbock,177,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,177,"Democratic Proposition #9 Right to Vote",,DEM,For,0,0,0
+Lubbock,177,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,177,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,0,0,0
+Lubbock,177,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,177,"Democratic Proposition #11 Immigrant Rights",,DEM,For,0,0,0
+Lubbock,177,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,177,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,0,0,0
+Lubbock,177,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,178,Registered Voters,,,,283,,
 Lubbock,178,U.S. Senate,,DEM,Beto O'Rourke,4,3,1
 Lubbock,178,U.S. Senate,,DEM,Sema Hernandez,1,1,0
@@ -23734,82 +17026,30 @@ Lubbock,178,"Presiding Judge, Court of Criminal Appeals",,DEM,Maria T. (Terri) J
 Lubbock,178,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,5,4,1
 Lubbock,178,State Representative,83,DEM,Drew Landry,5,4,1
 Lubbock,178,County Party Chair,,DEM,Stuart Williams,5,4,1
-Lubbock,178,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,5,4,1
-Lubbock,178,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,178,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,5,4,1
-Lubbock,178,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,178,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,5,4,1
-Lubbock,178,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,178,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,5,4,1
-Lubbock,178,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,178,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,5,4,1
-Lubbock,178,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,178,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,5,4,1
-Lubbock,178,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,178,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,5,4,1
-Lubbock,178,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,178,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,5,4,1
-Lubbock,178,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,178,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,5,4,1
-Lubbock,178,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,178,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,5,4,1
-Lubbock,178,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,178,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,5,4,1
-Lubbock,178,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,178,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,5,4,1
-Lubbock,178,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,178,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,5,4,1
+Lubbock,178,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,178,"Democratic Proposition #2 Student Loan Debt",,DEM,For,5,4,1
+Lubbock,178,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,178,"Democratic Proposition #3 Right to Healthcare",,DEM,For,5,4,1
+Lubbock,178,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,178,"Democratic Proposition #4 Right to Economic Security",,DEM,For,5,4,1
+Lubbock,178,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,178,"Democratic Proposition #5 National Jobs Program",,DEM,For,5,4,1
+Lubbock,178,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,178,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,5,4,1
+Lubbock,178,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,178,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,5,4,1
+Lubbock,178,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,178,"Democratic Proposition #8 Right to Housing",,DEM,For,5,4,1
+Lubbock,178,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,178,"Democratic Proposition #9 Right to Vote",,DEM,For,5,4,1
+Lubbock,178,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,178,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,5,4,1
+Lubbock,178,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,178,"Democratic Proposition #11 Immigrant Rights",,DEM,For,5,4,1
+Lubbock,178,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,178,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,5,4,1
+Lubbock,178,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,180,Registered Voters,,,,0,,
 Lubbock,180,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
 Lubbock,180,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -23842,82 +17082,30 @@ Lubbock,180,"Judge, Court of Criminal Appeals, Place 7",,DEM,Ramona Franklin,0,0
 Lubbock,180,State Representative,83,DEM,Drew Landry,0,0,0
 Lubbock,180,"County Commissioner, Precinct 4",,DEM,T.G. Caraway,0,0,0
 Lubbock,180,County Party Chair,,DEM,Stuart Williams,0,0,0
-Lubbock,180,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,0,0,0
-Lubbock,180,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,180,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,0,0,0
-Lubbock,180,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,180,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,0,0,0
-Lubbock,180,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,180,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,0,0,0
-Lubbock,180,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,180,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,0,0,0
-Lubbock,180,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,180,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,0,0,0
-Lubbock,180,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,180,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,0,0,0
-Lubbock,180,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,180,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,0,0,0
-Lubbock,180,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,180,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,0,0,0
-Lubbock,180,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,180,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,0,0,0
-Lubbock,180,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,180,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,0,0,0
-Lubbock,180,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,180,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,0,0,0
-Lubbock,180,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,180,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,0,0,0
+Lubbock,180,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,180,"Democratic Proposition #2 Student Loan Debt",,DEM,For,0,0,0
+Lubbock,180,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,180,"Democratic Proposition #3 Right to Healthcare",,DEM,For,0,0,0
+Lubbock,180,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,180,"Democratic Proposition #4 Right to Economic Security",,DEM,For,0,0,0
+Lubbock,180,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,180,"Democratic Proposition #5 National Jobs Program",,DEM,For,0,0,0
+Lubbock,180,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,180,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,0,0,0
+Lubbock,180,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,180,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,0,0,0
+Lubbock,180,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,180,"Democratic Proposition #8 Right to Housing",,DEM,For,0,0,0
+Lubbock,180,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,180,"Democratic Proposition #9 Right to Vote",,DEM,For,0,0,0
+Lubbock,180,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,180,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,0,0,0
+Lubbock,180,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,180,"Democratic Proposition #11 Immigrant Rights",,DEM,For,0,0,0
+Lubbock,180,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,180,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,0,0,0
+Lubbock,180,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,181,Registered Voters,,,,0,,
 Lubbock,181,U.S. Senate,,DEM,Beto O'Rourke,0,0,0
 Lubbock,181,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -23951,82 +17139,30 @@ Lubbock,181,State Representative,84,DEM,Austin Michael Carrizales,0,0,0
 Lubbock,181,State Representative,84,DEM,Samantha Carrillo Fields,0,0,0
 Lubbock,181,"Justice of the Peace, Precinct 3",,DEM,Aurora Chaides-Hernandez,0,0,0
 Lubbock,181,County Party Chair,,DEM,Stuart Williams,0,0,0
-Lubbock,181,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,0,0,0
-Lubbock,181,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,181,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,0,0,0
-Lubbock,181,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,181,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,0,0,0
-Lubbock,181,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,181,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,0,0,0
-Lubbock,181,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,181,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,0,0,0
-Lubbock,181,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,181,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,0,0,0
-Lubbock,181,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,181,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,0,0,0
-Lubbock,181,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,181,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,0,0,0
-Lubbock,181,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,181,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,0,0,0
-Lubbock,181,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,181,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,0,0,0
-Lubbock,181,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,181,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,0,0,0
-Lubbock,181,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,181,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,0,0,0
-Lubbock,181,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,181,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,0,0,0
+Lubbock,181,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,181,"Democratic Proposition #2 Student Loan Debt",,DEM,For,0,0,0
+Lubbock,181,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,181,"Democratic Proposition #3 Right to Healthcare",,DEM,For,0,0,0
+Lubbock,181,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,181,"Democratic Proposition #4 Right to Economic Security",,DEM,For,0,0,0
+Lubbock,181,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,181,"Democratic Proposition #5 National Jobs Program",,DEM,For,0,0,0
+Lubbock,181,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,181,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,0,0,0
+Lubbock,181,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,181,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,0,0,0
+Lubbock,181,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,181,"Democratic Proposition #8 Right to Housing",,DEM,For,0,0,0
+Lubbock,181,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,181,"Democratic Proposition #9 Right to Vote",,DEM,For,0,0,0
+Lubbock,181,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,181,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,0,0,0
+Lubbock,181,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,181,"Democratic Proposition #11 Immigrant Rights",,DEM,For,0,0,0
+Lubbock,181,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,181,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,0,0,0
+Lubbock,181,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0
 Lubbock,182,Registered Voters,,,,27,,
 Lubbock,182,U.S. Senate,,DEM,Beto O'Rourke,1,1,0
 Lubbock,182,U.S. Senate,,DEM,Sema Hernandez,0,0,0
@@ -24060,79 +17196,27 @@ Lubbock,182,State Representative,84,DEM,Austin Michael Carrizales,1,1,0
 Lubbock,182,State Representative,84,DEM,Samantha Carrillo Fields,0,0,0
 Lubbock,182,"Justice of the Peace, Precinct 3",,DEM,Aurora Chaides-Hernandez,0,0,0
 Lubbock,182,County Party Chair,,DEM,Stuart Williams,1,1,0
-Lubbock,182,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,For,1,1,0
-Lubbock,182,"Democratic Proposition #1
-
-Right to a 21st Century Public Education",,DEM,Against,0,0,0
-Lubbock,182,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,For,1,1,0
-Lubbock,182,"Democratic Proposition #2
-
-Student Loan Debt",,DEM,Against,0,0,0
-Lubbock,182,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,For,1,1,0
-Lubbock,182,"Democratic Proposition #3
-
-Right to Healthcare",,DEM,Against,0,0,0
-Lubbock,182,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,For,1,1,0
-Lubbock,182,"Democratic Proposition #4
-
-Right to Economic Security",,DEM,Against,0,0,0
-Lubbock,182,"Democratic Proposition #5
-
-National Jobs Program",,DEM,For,1,1,0
-Lubbock,182,"Democratic Proposition #5
-
-National Jobs Program",,DEM,Against,0,0,0
-Lubbock,182,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,For,1,1,0
-Lubbock,182,"Democratic Proposition #6
-
-Right to Clean Air, Safe Water, 
-
-and a Healthy Environment",,DEM,Against,0,0,0
-Lubbock,182,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,For,1,1,0
-Lubbock,182,"Democratic Proposition #7
-
-Right to Dignity & Respect",,DEM,Against,0,0,0
-Lubbock,182,"Democratic Proposition #8
-
-Right to Housing",,DEM,For,1,1,0
-Lubbock,182,"Democratic Proposition #8
-
-Right to Housing",,DEM,Against,0,0,0
-Lubbock,182,"Democratic Proposition #9
-
-Right to Vote",,DEM,For,1,1,0
-Lubbock,182,"Democratic Proposition #9
-
-Right to Vote",,DEM,Against,0,0,0
-Lubbock,182,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,For,1,1,0
-Lubbock,182,"Democratic Proposition #10
-
-Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
-Lubbock,182,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,For,1,1,0
-Lubbock,182,"Democratic Proposition #11
-
-Immigrant Rights",,DEM,Against,0,0,0
-Lubbock,182,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,For,0,0,0
-Lubbock,182,"Democratic Proposition #12
-
-Right to Fair Taxation",,DEM,Against,0,0,0
+Lubbock,182,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,For,1,1,0
+Lubbock,182,"Democratic Proposition #1 Right to a 21st Century Public Education",,DEM,Against,0,0,0
+Lubbock,182,"Democratic Proposition #2 Student Loan Debt",,DEM,For,1,1,0
+Lubbock,182,"Democratic Proposition #2 Student Loan Debt",,DEM,Against,0,0,0
+Lubbock,182,"Democratic Proposition #3 Right to Healthcare",,DEM,For,1,1,0
+Lubbock,182,"Democratic Proposition #3 Right to Healthcare",,DEM,Against,0,0,0
+Lubbock,182,"Democratic Proposition #4 Right to Economic Security",,DEM,For,1,1,0
+Lubbock,182,"Democratic Proposition #4 Right to Economic Security",,DEM,Against,0,0,0
+Lubbock,182,"Democratic Proposition #5 National Jobs Program",,DEM,For,1,1,0
+Lubbock,182,"Democratic Proposition #5 National Jobs Program",,DEM,Against,0,0,0
+Lubbock,182,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,For,1,1,0
+Lubbock,182,"Democratic Proposition #6 Right to Clean Air, Safe Water,  and a Healthy Environment",,DEM,Against,0,0,0
+Lubbock,182,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,For,1,1,0
+Lubbock,182,"Democratic Proposition #7 Right to Dignity & Respect",,DEM,Against,0,0,0
+Lubbock,182,"Democratic Proposition #8 Right to Housing",,DEM,For,1,1,0
+Lubbock,182,"Democratic Proposition #8 Right to Housing",,DEM,Against,0,0,0
+Lubbock,182,"Democratic Proposition #9 Right to Vote",,DEM,For,1,1,0
+Lubbock,182,"Democratic Proposition #9 Right to Vote",,DEM,Against,0,0,0
+Lubbock,182,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,For,1,1,0
+Lubbock,182,"Democratic Proposition #10 Right to a Fair Criminal Justice System",,DEM,Against,0,0,0
+Lubbock,182,"Democratic Proposition #11 Immigrant Rights",,DEM,For,1,1,0
+Lubbock,182,"Democratic Proposition #11 Immigrant Rights",,DEM,Against,0,0,0
+Lubbock,182,"Democratic Proposition #12 Right to Fair Taxation",,DEM,For,0,0,0
+Lubbock,182,"Democratic Proposition #12 Right to Fair Taxation",,DEM,Against,0,0,0

--- a/2018/20180306__tx__primary__young__precinct.csv
+++ b/2018/20180306__tx__primary__young__precinct.csv
@@ -43,13 +43,13 @@ Young,5,County Judge,,REP,Paul M. Hemphill,97,19,126,242
 Young,5,District Clerk,,REP,Jamie Freeze Land,248,88,311,647
 Young,5,County Clerk,,REP,Kay Jennings Hardin,250,88,318,656
 Young,5,County Treasurer,,REP,Ann B. Daily,246,86,312,644
-Young,5,"County Commissioner,Precinct No. 2",,REP,Matt Pruitt,119,52,195,366
-Young,5,"County Commissioner,Precinct No. 2",,REP,Larry Pratt,97,28,111,236
-Young,5,"County Commissioner,Precinct No. 2",,REP,Les Remington,63,14,45,122
-Young,5,"Justice of the Peace,Precinct No. 1",,REP,Jason Hearne,93,25,167,285
-Young,5,"Justice of the Peace,Precinct No. 1",,REP,Randy Saylor,72,21,78,171
-Young,5,"Justice of the Peace,Precinct No. 1",,REP,Norman B. Carpenter,54,19,60,133
-Young,5,"Justice of the Peace,Precinct No. 1",,REP,Jabe Underwood,60,17,49,126
+Young,5,"County Commissioner, Precinct No. 2",,REP,Matt Pruitt,119,52,195,366
+Young,5,"County Commissioner, Precinct No. 2",,REP,Larry Pratt,97,28,111,236
+Young,5,"County Commissioner, Precinct No. 2",,REP,Les Remington,63,14,45,122
+Young,5,"Justice of the Peace, Precinct No. 1",,REP,Jason Hearne,93,25,167,285
+Young,5,"Justice of the Peace, Precinct No. 1",,REP,Randy Saylor,72,21,78,171
+Young,5,"Justice of the Peace, Precinct No. 1",,REP,Norman B. Carpenter,54,19,60,133
+Young,5,"Justice of the Peace, Precinct No. 1",,REP,Jabe Underwood,60,17,49,126
 Young,5,County Chairman,,REP,Kyle Zohn Milam,245,84,326,655
 Young,5,U.S. Senate,,DEM,Edward Kimbrough,6,4,3,13
 Young,5,U.S. Senate,,DEM,Beto O'Rourke,7,4,11,22
@@ -172,13 +172,13 @@ Young,6,County Judge,,REP,Paul M. Hemphill,12,3,13,28
 Young,6,District Clerk,,REP,Jamie Freeze Land,29,8,23,60
 Young,6,County Clerk,,REP,Kay Jennings Hardin,29,8,22,59
 Young,6,County Treasurer,,REP,Ann B. Daily,29,8,23,60
-Young,6,"County Commissioner,Precinct No. 2",,REP,Matt Pruitt,13,1,8,22
-Young,6,"County Commissioner,Precinct No. 2",,REP,Larry Pratt,16,5,14,35
-Young,6,"County Commissioner,Precinct No. 2",,REP,Les Remington,7,2,5,14
-Young,6,"Justice of the Peace,Precinct No. 1",,REP,Jason Hearne,10,1,7,18
-Young,6,"Justice of the Peace,Precinct No. 1",,REP,Randy Saylor,10,1,5,16
-Young,6,"Justice of the Peace,Precinct No. 1",,REP,Norman B. Carpenter,5,3,11,19
-Young,6,"Justice of the Peace,Precinct No. 1",,REP,Jabe Underwood,11,3,3,17
+Young,6,"County Commissioner, Precinct No. 2",,REP,Matt Pruitt,13,1,8,22
+Young,6,"County Commissioner, Precinct No. 2",,REP,Larry Pratt,16,5,14,35
+Young,6,"County Commissioner, Precinct No. 2",,REP,Les Remington,7,2,5,14
+Young,6,"Justice of the Peace, Precinct No. 1",,REP,Jason Hearne,10,1,7,18
+Young,6,"Justice of the Peace, Precinct No. 1",,REP,Randy Saylor,10,1,5,16
+Young,6,"Justice of the Peace, Precinct No. 1",,REP,Norman B. Carpenter,5,3,11,19
+Young,6,"Justice of the Peace, Precinct No. 1",,REP,Jabe Underwood,11,3,3,17
 Young,6,County Chairman,,REP,Kyle Zohn Milam,31,8,22,61
 Young,6,U.S. Senate,,DEM,Edward Kimbrough,0,1,0,1
 Young,6,U.S. Senate,,DEM,Beto O'Rourke,0,0,0,0
@@ -301,13 +301,13 @@ Young,7,County Judge,,REP,Paul M. Hemphill,6,2,7,15
 Young,7,District Clerk,,REP,Jamie Freeze Land,26,3,17,46
 Young,7,County Clerk,,REP,Kay Jennings Hardin,27,2,16,45
 Young,7,County Treasurer,,REP,Ann B. Daily,26,3,17,46
-Young,7,"County Commissioner,Precinct No. 2",,REP,Matt Pruitt,16,1,13,30
-Young,7,"County Commissioner,Precinct No. 2",,REP,Larry Pratt,15,2,8,25
-Young,7,"County Commissioner,Precinct No. 2",,REP,Les Remington,2,1,1,4
-Young,7,"Justice of the Peace,Precinct No. 3",,REP,Stan G. Mahler,13,2,7,22
-Young,7,"Justice of the Peace,Precinct No. 3",,REP,Becky Perez,17,3,15,35
-Young,7,"Constable, Precinct No. 3Unexpired Term",,REP,Cliff Blackstock,18,2,16,36
-Young,7,"Constable, Precinct No. 3Unexpired Term",,REP,Larry Thacker,14,2,3,19
+Young,7,"County Commissioner, Precinct No. 2",,REP,Matt Pruitt,16,1,13,30
+Young,7,"County Commissioner, Precinct No. 2",,REP,Larry Pratt,15,2,8,25
+Young,7,"County Commissioner, Precinct No. 2",,REP,Les Remington,2,1,1,4
+Young,7,"Justice of the Peace, Precinct No. 3",,REP,Stan G. Mahler,13,2,7,22
+Young,7,"Justice of the Peace, Precinct No. 3",,REP,Becky Perez,17,3,15,35
+Young,7,"Constable, Precinct No. 3 Unexpired Term",,REP,Cliff Blackstock,18,2,16,36
+Young,7,"Constable, Precinct No. 3 Unexpired Term",,REP,Larry Thacker,14,2,3,19
 Young,7,County Chairman,,REP,Kyle Zohn Milam,24,2,18,44
 Young,7,U.S. Senate,,DEM,Edward Kimbrough,1,0,0,1
 Young,7,U.S. Senate,,DEM,Beto O'Rourke,1,0,2,3
@@ -430,10 +430,10 @@ Young,10,County Judge,,REP,Paul M. Hemphill,20,3,4,27
 Young,10,District Clerk,,REP,Jamie Freeze Land,62,13,10,85
 Young,10,County Clerk,,REP,Kay Jennings Hardin,62,13,10,85
 Young,10,County Treasurer,,REP,Ann B. Daily,63,13,10,86
-Young,10,"Justice of the Peace,Precinct No. 3",,REP,Stan G. Mahler,31,7,4,42
-Young,10,"Justice of the Peace,Precinct No. 3",,REP,Becky Perez,49,12,9,70
-Young,10,"Constable, Precinct No. 3Unexpired Term",,REP,Cliff Blackstock,44,10,6,60
-Young,10,"Constable, Precinct No. 3Unexpired Term",,REP,Larry Thacker,24,8,5,37
+Young,10,"Justice of the Peace, Precinct No. 3",,REP,Stan G. Mahler,31,7,4,42
+Young,10,"Justice of the Peace, Precinct No. 3",,REP,Becky Perez,49,12,9,70
+Young,10,"Constable, Precinct No. 3 Unexpired Term",,REP,Cliff Blackstock,44,10,6,60
+Young,10,"Constable, Precinct No. 3 Unexpired Term",,REP,Larry Thacker,24,8,5,37
 Young,10,County Chairman,,REP,Kyle Zohn Milam,59,12,10,81
 Young,10,U.S. Senate,,REP,Edward Kimbrough,2,0,0,2
 Young,10,U.S. Senate,,REP,Beto O'Rourke,2,0,0,2
@@ -556,11 +556,11 @@ Young,16,County Judge,,REP,Paul M. Hemphill,22,0,4,26
 Young,16,District Clerk,,REP,Jamie Freeze Land,50,3,10,63
 Young,16,County Clerk,,REP,Kay Jennings Hardin,54,3,12,69
 Young,16,County Treasurer,,REP,Ann B. Daily,55,3,10,68
-Young,16,"County Commissioner,Precinct No. 4",,REP,Jimmy Ray Wiley,56,3,14,73
-Young,16,"Justice of the Peace,Precinct No. 3",,REP,Stan G. Mahler,42,3,12,57
-Young,16,"Justice of the Peace,Precinct No. 3",,REP,Becky Perez,15,0,2,17
-Young,16,"Constable, Precinct No. 3Unexpired Term",,REP,Cliff Blackstock,34,2,11,47
-Young,16,"Constable, Precinct No. 3Unexpired Term",,REP,Larry Thacker,20,1,2,23
+Young,16,"County Commissioner, Precinct No. 4",,REP,Jimmy Ray Wiley,56,3,14,73
+Young,16,"Justice of the Peace, Precinct No. 3",,REP,Stan G. Mahler,42,3,12,57
+Young,16,"Justice of the Peace, Precinct No. 3",,REP,Becky Perez,15,0,2,17
+Young,16,"Constable, Precinct No. 3 Unexpired Term",,REP,Cliff Blackstock,34,2,11,47
+Young,16,"Constable, Precinct No. 3 Unexpired Term",,REP,Larry Thacker,20,1,2,23
 Young,16,County Chairman,,REP,Kyle Zohn Milam,55,2,12,69
 Young,16,U.S. Senate,,DEM,Edward Kimbrough,0,0,0,0
 Young,16,U.S. Senate,,DEM,Beto O'Rourke,0,0,0,0
@@ -683,11 +683,11 @@ Young,20,County Judge,,REP,Paul M. Hemphill,9,0,5,14
 Young,20,District Clerk,,REP,Jamie Freeze Land,13,2,14,29
 Young,20,County Clerk,,REP,Kay Jennings Hardin,14,2,14,30
 Young,20,County Treasurer,,REP,Ann B. Daily,13,2,14,29
-Young,20,"County Commissioner,Precinct No. 4",,REP,Jimmy Ray Wiley,12,2,17,31
-Young,20,"Justice of the Peace,Precinct No. 3",,REP,Stan G. Mahler,13,0,11,24
-Young,20,"Justice of the Peace,Precinct No. 3",,REP,Becky Perez,2,3,8,13
-Young,20,"Constable, Precinct No. 3Unexpired Term",,REP,Cliff Blackstock,6,2,8,16
-Young,20,"Constable, Precinct No. 3Unexpired Term",,REP,Larry Thacker,6,1,6,13
+Young,20,"County Commissioner, Precinct No. 4",,REP,Jimmy Ray Wiley,12,2,17,31
+Young,20,"Justice of the Peace, Precinct No. 3",,REP,Stan G. Mahler,13,0,11,24
+Young,20,"Justice of the Peace, Precinct No. 3",,REP,Becky Perez,2,3,8,13
+Young,20,"Constable, Precinct No. 3 Unexpired Term",,REP,Cliff Blackstock,6,2,8,16
+Young,20,"Constable, Precinct No. 3 Unexpired Term",,REP,Larry Thacker,6,1,6,13
 Young,20,County Chairman,,REP,Kyle Zohn Milam,13,2,15,30
 Young,20,U.S. Senate,,DEM,Edward Kimbrough,0,2,0,2
 Young,20,U.S. Senate,,DEM,Beto O'Rourke,2,1,0,3
@@ -810,10 +810,10 @@ Young,22,County Judge,,REP,Paul M. Hemphill,114,39,125,278
 Young,22,District Clerk,,REP,Jamie Freeze Land,296,112,304,712
 Young,22,County Clerk,,REP,Kay Jennings Hardin,291,114,308,713
 Young,22,County Treasurer,,REP,Ann B. Daily,292,115,310,717
-Young,22,"Justice of the Peace,Precinct No. 1",,REP,Jason Hearne,116,36,150,302
-Young,22,"Justice of the Peace,Precinct No. 1",,REP,Randy Saylor,94,32,77,203
-Young,22,"Justice of the Peace,Precinct No. 1",,REP,Norman B. Carpenter,66,37,82,185
-Young,22,"Justice of the Peace,Precinct No. 1",,REP,Jabe Underwood,62,24,60,146
+Young,22,"Justice of the Peace, Precinct No. 1",,REP,Jason Hearne,116,36,150,302
+Young,22,"Justice of the Peace, Precinct No. 1",,REP,Randy Saylor,94,32,77,203
+Young,22,"Justice of the Peace, Precinct No. 1",,REP,Norman B. Carpenter,66,37,82,185
+Young,22,"Justice of the Peace, Precinct No. 1",,REP,Jabe Underwood,62,24,60,146
 Young,22,County Chairman,,REP,Kyle Zohn Milam,297,113,315,725
 Young,22,U.S. Senate,,DEM,Edward Kimbrough,2,7,2,11
 Young,22,U.S. Senate,,DEM,Beto O'Rourke,6,6,12,24
@@ -936,10 +936,10 @@ Young,23,County Judge,,REP,Paul M. Hemphill,47,13,67,127
 Young,23,District Clerk,,REP,Jamie Freeze Land,188,49,201,438
 Young,23,County Clerk,,REP,Kay Jennings Hardin,191,49,208,448
 Young,23,County Treasurer,,REP,Ann B. Daily,191,52,202,445
-Young,23,"Justice of the Peace,Precinct No. 3",,REP,Stan G. Mahler,149,47,174,370
-Young,23,"Justice of the Peace,Precinct No. 3",,REP,Becky Perez,81,20,76,177
-Young,23,"Constable, Precinct No. 3Unexpired Term",,REP,Cliff Blackstock,141,38,154,333
-Young,23,"Constable, Precinct No. 3Unexpired Term",,REP,Larry Thacker,79,22,80,181
+Young,23,"Justice of the Peace, Precinct No. 3",,REP,Stan G. Mahler,149,47,174,370
+Young,23,"Justice of the Peace, Precinct No. 3",,REP,Becky Perez,81,20,76,177
+Young,23,"Constable, Precinct No. 3 Unexpired Term",,REP,Cliff Blackstock,141,38,154,333
+Young,23,"Constable, Precinct No. 3 Unexpired Term",,REP,Larry Thacker,79,22,80,181
 Young,23,County Chairman,,REP,Kyle Zohn Milam,184,47,197,428
 Young,23,U.S. Senate,,DEM,Edward Kimbrough,2,8,5,15
 Young,23,U.S. Senate,,DEM,Beto O'Rourke,11,4,5,20
@@ -1062,11 +1062,11 @@ Young,24,County Judge,,REP,Paul M. Hemphill,39,9,37,85
 Young,24,District Clerk,,REP,Jamie Freeze Land,90,40,107,237
 Young,24,County Clerk,,REP,Kay Jennings Hardin,89,40,112,241
 Young,24,County Treasurer,,REP,Ann B. Daily,87,41,112,240
-Young,24,"County Commissioner,Precinct No. 4",,REP,Jimmy Ray Wiley,92,41,110,243
-Young,24,"Justice of the Peace,Precinct No. 1",,REP,Jason Hearne,44,15,42,101
-Young,24,"Justice of the Peace,Precinct No. 1",,REP,Randy Saylor,14,12,33,59
-Young,24,"Justice of the Peace,Precinct No. 1",,REP,Norman B. Carpenter,21,6,24,51
-Young,24,"Justice of the Peace,Precinct No. 1",,REP,Jabe Underwood,23,12,25,60
+Young,24,"County Commissioner, Precinct No. 4",,REP,Jimmy Ray Wiley,92,41,110,243
+Young,24,"Justice of the Peace, Precinct No. 1",,REP,Jason Hearne,44,15,42,101
+Young,24,"Justice of the Peace, Precinct No. 1",,REP,Randy Saylor,14,12,33,59
+Young,24,"Justice of the Peace, Precinct No. 1",,REP,Norman B. Carpenter,21,6,24,51
+Young,24,"Justice of the Peace, Precinct No. 1",,REP,Jabe Underwood,23,12,25,60
 Young,24,County Chairman,,REP,Kyle Zohn Milam,88,40,111,239
 Young,24,U.S. Senate,,DEM,Edward Kimbrough,4,3,2,9
 Young,24,U.S. Senate,,DEM,Beto O'Rourke,6,6,16,28


### PR DESCRIPTION
The file `2018/20180306__tx__primary__lubbock__precinct.csv` has records where the office has `\n` character, but it should really be a space.  Or are we okay with multiline values in records?