### PR TITLE
Add precinct-level results for the 2020 primary election in Burleson County

### DIFF
--- a/2020/20200303__tx__primary__burleson__precinct.csv
+++ b/2020/20200303__tx__primary__burleson__precinct.csv
@@ -1,0 +1,1943 @@
+county,precinct,office,district,party,candidate,votes,early_voting,election_day
+Burleson,113,Registered Voters,,,Registered Voters,664,,
+Burleson,113,President,,REP,Joe Walsh,4,2,2
+Burleson,113,President,,REP,Donald J. Trump,291,140,151
+Burleson,113,President,,REP,Matthew John Matern,0,0,0
+Burleson,113,President,,REP,"Roque ""Rocky"" De La Fuente Guerra",0,0,0
+Burleson,113,President,,REP,Bill Weld,0,0,0
+Burleson,113,President,,REP,Bob Ely,0,0,0
+Burleson,113,President,,REP,Zoltan G. Istvan,0,0,0
+Burleson,113,President,,REP,Uncommitted,5,4,1
+Burleson,113,U.S. Senate,,REP,John Cornyn,221,109,112
+Burleson,113,U.S. Senate,,REP,Virgil Bierschwale,4,2,2
+Burleson,113,U.S. Senate,,REP,Mark Yancey,14,7,7
+Burleson,113,U.S. Senate,,REP,John Anthony Castro,4,3,1
+Burleson,113,U.S. Senate,,REP,Dwayne Stovall,33,16,17
+Burleson,113,U.S. House,17,REP,George W. Hindman,55,27,28
+Burleson,113,U.S. House,17,REP,Jeff Oppenheim,5,3,2
+Burleson,113,U.S. House,17,REP,Todd Kent,22,9,13
+Burleson,113,U.S. House,17,REP,Trent Sutton,17,10,7
+Burleson,113,U.S. House,17,REP,Laurie Godfrey McReynolds,3,1,2
+Burleson,113,U.S. House,17,REP,Elianor Vessali,24,4,20
+Burleson,113,U.S. House,17,REP,Renée Swann,100,55,45
+Burleson,113,U.S. House,17,REP,Kristen Alamo Rowin,3,2,1
+Burleson,113,U.S. House,17,REP,David Saucedo,3,1,2
+Burleson,113,U.S. House,17,REP,Ahmad Adnan,0,0,0
+Burleson,113,U.S. House,17,REP,Scott Bland,0,0,0
+Burleson,113,U.S. House,17,REP,Pete Sessions,43,25,18
+Burleson,113,Railroad Commissioner,,REP,"James ""Jim"" Wright",171,79,92
+Burleson,113,Railroad Commissioner,,REP,Ryan Sitton,85,43,42
+Burleson,113,"Chief Justice, Supreme Court",,REP,Nathan Hecht,241,114,127
+Burleson,113,"Justice, Supreme Court, Place 6",,REP,Jane Bland,243,116,127
+Burleson,113,"Justice, Supreme Court, Place 7",,REP,Jeff Boyd,242,116,126
+Burleson,113,"Justice, Supreme Court, Place 8",,REP,Brett Busby,242,114,128
+Burleson,113,"Judge, Court of Criminal Appeals, Place 3",,REP,Bert Richardson,161,76,85
+Burleson,113,"Judge, Court of Criminal Appeals, Place 3",,REP,Gina Parker,85,41,44
+Burleson,113,"Judge, Court of Criminal Appeals, Place 4",,REP,Kevin Patrick Yeary,235,113,122
+Burleson,113,"Judge, Court of Criminal Appeals, Place 9",,REP,David Newell,233,109,124
+Burleson,113,"Member, State Board of Education, District 10",,REP,Tom Maynard,233,110,123
+Burleson,113,State Senator,18,REP,Lois W. Kolkhorst,254,123,131
+Burleson,113,State Representative,13,REP,Ben Leman,239,118,121
+Burleson,113,"Justice, 10th Court of Appeals District, Place 2",,REP,Matt Johnson,233,111,122
+Burleson,113,"Justice, 10th Court of Appeals District, Place 3",,REP,John E. Neill,235,111,124
+Burleson,113,"District Judge, 21st Judicial District",,REP,Carson Campbell,241,117,124
+Burleson,113,"District Judge, 335th Judicial District",,REP,Charles W. Carver,58,19,39
+Burleson,113,"District Judge, 335th Judicial District",,REP,Reva L. Towslee Corbett,226,121,105
+Burleson,113,County Judge,,REP,Keith Schroeder,260,126,134
+Burleson,113,County Attorney,,REP,Susan Deski,240,119,121
+Burleson,113,Sheriff,,REP,Jayson Lyday,90,29,61
+Burleson,113,Sheriff,,REP,Gene Hermes,204,114,90
+Burleson,113,County Tax Assessor-Collector,,REP,Jessica Lucero,92,43,49
+Burleson,113,County Tax Assessor-Collector,,REP,Cheryl Story Castaneda,190,97,93
+Burleson,113,"County Commissioner, Precinct No. 1",,REP,Dwayne Faust,213,109,104
+Burleson,113,"County Commissioner, Precinct No. 1",,REP,Mike Weichert,28,15,13
+Burleson,113,"County Commissioner, Precinct No. 1",,REP,Larry Nichols,10,5,5
+Burleson,113,"County Commissioner, Precinct No. 1",,REP,Joe Baldwin Jr.,46,17,29
+Burleson,113,"Constable, Precinct No. 1",,REP,Jason Muzny,211,97,114
+Burleson,113,"Constable, Precinct No. 1",,REP,Peter Glidewell,85,48,37
+Burleson,113,County Chairman,,REP,Tyler Groce,262,131,131
+Burleson,113,Proposition 1,,REP,Yes,249,126,123
+Burleson,113,Proposition 1,,REP,No,43,17,26
+Burleson,113,Proposition 2,,REP,Yes,250,123,127
+Burleson,113,Proposition 2,,REP,No,41,18,23
+Burleson,113,Proposition 3,,REP,Yes,258,125,133
+Burleson,113,Proposition 3,,REP,No,27,13,14
+Burleson,113,Proposition 4,,REP,Yes,278,136,142
+Burleson,113,Proposition 4,,REP,No,9,3,6
+Burleson,113,Proposition 5,,REP,Yes,255,118,137
+Burleson,113,Proposition 5,,REP,No,29,20,9
+Burleson,113,Proposition 6,,REP,Yes,267,136,131
+Burleson,113,Proposition 6,,REP,No,20,2,18
+Burleson,113,Proposition 7,,REP,Yes,277,137,140
+Burleson,113,Proposition 7,,REP,No,10,3,7
+Burleson,113,Proposition 8,,REP,Yes,285,139,146
+Burleson,113,Proposition 8,,REP,No,3,0,3
+Burleson,113,Proposition 9,,REP,Yes,275,132,143
+Burleson,113,Proposition 9,,REP,No,16,8,8
+Burleson,113,Proposition 10,,REP,Yes,260,127,133
+Burleson,113,Proposition 10,,REP,No,28,12,16
+Burleson,114,Registered Voters,,,Registered Voters,1842,,
+Burleson,114,President,,REP,Joe Walsh,5,3,2
+Burleson,114,President,,REP,Donald J. Trump,503,345,158
+Burleson,114,President,,REP,Matthew John Matern,2,1,1
+Burleson,114,President,,REP,"Roque ""Rocky"" De La Fuente Guerra",2,0,2
+Burleson,114,President,,REP,Bill Weld,2,1,1
+Burleson,114,President,,REP,Bob Ely,1,1,0
+Burleson,114,President,,REP,Zoltan G. Istvan,0,0,0
+Burleson,114,President,,REP,Uncommitted,21,15,6
+Burleson,114,U.S. Senate,,REP,John Cornyn,375,253,122
+Burleson,114,U.S. Senate,,REP,Virgil Bierschwale,4,3,1
+Burleson,114,U.S. Senate,,REP,Mark Yancey,40,27,13
+Burleson,114,U.S. Senate,,REP,John Anthony Castro,26,12,14
+Burleson,114,U.S. Senate,,REP,Dwayne Stovall,48,34,14
+Burleson,114,U.S. House,17,REP,George W. Hindman,84,55,29
+Burleson,114,U.S. House,17,REP,Jeff Oppenheim,9,3,6
+Burleson,114,U.S. House,17,REP,Todd Kent,35,24,11
+Burleson,114,U.S. House,17,REP,Trent Sutton,31,25,6
+Burleson,114,U.S. House,17,REP,Laurie Godfrey McReynolds,5,1,4
+Burleson,114,U.S. House,17,REP,Elianor Vessali,48,29,19
+Burleson,114,U.S. House,17,REP,Renée Swann,164,118,46
+Burleson,114,U.S. House,17,REP,Kristen Alamo Rowin,5,4,1
+Burleson,114,U.S. House,17,REP,David Saucedo,6,1,5
+Burleson,114,U.S. House,17,REP,Ahmad Adnan,4,2,2
+Burleson,114,U.S. House,17,REP,Scott Bland,8,4,4
+Burleson,114,U.S. House,17,REP,Pete Sessions,99,68,31
+Burleson,114,Railroad Commissioner,,REP,"James ""Jim"" Wright",310,195,115
+Burleson,114,Railroad Commissioner,,REP,Ryan Sitton,140,103,37
+Burleson,114,"Chief Justice, Supreme Court",,REP,Nathan Hecht,418,277,141
+Burleson,114,"Justice, Supreme Court, Place 6",,REP,Jane Bland,416,277,139
+Burleson,114,"Justice, Supreme Court, Place 7",,REP,Jeff Boyd,423,284,139
+Burleson,114,"Justice, Supreme Court, Place 8",,REP,Brett Busby,421,281,140
+Burleson,114,"Judge, Court of Criminal Appeals, Place 3",,REP,Bert Richardson,268,176,92
+Burleson,114,"Judge, Court of Criminal Appeals, Place 3",,REP,Gina Parker,156,102,54
+Burleson,114,"Judge, Court of Criminal Appeals, Place 4",,REP,Kevin Patrick Yeary,408,277,131
+Burleson,114,"Judge, Court of Criminal Appeals, Place 9",,REP,David Newell,408,278,130
+Burleson,114,"Member, State Board of Education, District 10",,REP,Tom Maynard,406,275,131
+Burleson,114,State Senator,18,REP,Lois W. Kolkhorst,443,302,141
+Burleson,114,State Representative,13,REP,Ben Leman,441,305,136
+Burleson,114,"Justice, 10th Court of Appeals District, Place 2",,REP,Matt Johnson,408,279,129
+Burleson,114,"Justice, 10th Court of Appeals District, Place 3",,REP,John E. Neill,407,280,127
+Burleson,114,"District Judge, 21st Judicial District",,REP,Carson Campbell,424,293,131
+Burleson,114,"District Judge, 335th Judicial District",,REP,Charles W. Carver,102,56,46
+Burleson,114,"District Judge, 335th Judicial District",,REP,Reva L. Towslee Corbett,409,285,124
+Burleson,114,County Judge,,REP,Keith Schroeder,453,309,144
+Burleson,114,County Attorney,,REP,Susan Deski,418,287,131
+Burleson,114,Sheriff,,REP,Jayson Lyday,177,122,55
+Burleson,114,Sheriff,,REP,Gene Hermes,360,242,118
+Burleson,114,County Tax Assessor-Collector,,REP,Jessica Lucero,192,131,61
+Burleson,114,County Tax Assessor-Collector,,REP,Cheryl Story Castaneda,319,216,103
+Burleson,114,"County Commissioner, Precinct No. 1",,REP,Dwayne Faust,309,211,98
+Burleson,114,"County Commissioner, Precinct No. 1",,REP,Mike Weichert,70,44,26
+Burleson,114,"County Commissioner, Precinct No. 1",,REP,Larry Nichols,27,18,9
+Burleson,114,"County Commissioner, Precinct No. 1",,REP,Joe Baldwin Jr.,120,82,38
+Burleson,114,"Constable, Precinct No. 1",,REP,Jason Muzny,248,155,93
+Burleson,114,"Constable, Precinct No. 1",,REP,Peter Glidewell,280,201,79
+Burleson,114,County Chairman,,REP,Tyler Groce,461,312,149
+Burleson,114,Proposition 1,,REP,Yes,461,313,148
+Burleson,114,Proposition 1,,REP,No,59,37,22
+Burleson,114,Proposition 2,,REP,Yes,440,310,130
+Burleson,114,Proposition 2,,REP,No,78,44,34
+Burleson,114,Proposition 3,,REP,Yes,463,322,141
+Burleson,114,Proposition 3,,REP,No,36,18,18
+Burleson,114,Proposition 4,,REP,Yes,471,324,147
+Burleson,114,Proposition 4,,REP,No,34,19,15
+Burleson,114,Proposition 5,,REP,Yes,464,316,148
+Burleson,114,Proposition 5,,REP,No,43,31,12
+Burleson,114,Proposition 6,,REP,Yes,460,317,143
+Burleson,114,Proposition 6,,REP,No,38,23,15
+Burleson,114,Proposition 7,,REP,Yes,497,338,159
+Burleson,114,Proposition 7,,REP,No,7,4,3
+Burleson,114,Proposition 8,,REP,Yes,498,341,157
+Burleson,114,Proposition 8,,REP,No,8,5,3
+Burleson,114,Proposition 9,,REP,Yes,485,329,156
+Burleson,114,Proposition 9,,REP,No,19,15,4
+Burleson,114,Proposition 10,,REP,Yes,454,311,143
+Burleson,114,Proposition 10,,REP,No,55,32,23
+Burleson,203,Registered Voters,,,Registered Voters,411,,
+Burleson,203,President,,REP,Joe Walsh,1,1,0
+Burleson,203,President,,REP,Donald J. Trump,123,56,67
+Burleson,203,President,,REP,Matthew John Matern,1,0,1
+Burleson,203,President,,REP,"Roque ""Rocky"" De La Fuente Guerra",2,0,2
+Burleson,203,President,,REP,Bill Weld,2,0,2
+Burleson,203,President,,REP,Bob Ely,0,0,0
+Burleson,203,President,,REP,Zoltan G. Istvan,0,0,0
+Burleson,203,President,,REP,Uncommitted,2,0,2
+Burleson,203,U.S. Senate,,REP,John Cornyn,96,46,50
+Burleson,203,U.S. Senate,,REP,Virgil Bierschwale,0,0,0
+Burleson,203,U.S. Senate,,REP,Mark Yancey,9,2,7
+Burleson,203,U.S. Senate,,REP,John Anthony Castro,2,0,2
+Burleson,203,U.S. Senate,,REP,Dwayne Stovall,19,6,13
+Burleson,203,U.S. House,17,REP,George W. Hindman,20,8,12
+Burleson,203,U.S. House,17,REP,Jeff Oppenheim,1,0,1
+Burleson,203,U.S. House,17,REP,Todd Kent,13,4,9
+Burleson,203,U.S. House,17,REP,Trent Sutton,3,2,1
+Burleson,203,U.S. House,17,REP,Laurie Godfrey McReynolds,1,0,1
+Burleson,203,U.S. House,17,REP,Elianor Vessali,20,6,14
+Burleson,203,U.S. House,17,REP,Renée Swann,43,22,21
+Burleson,203,U.S. House,17,REP,Kristen Alamo Rowin,1,0,1
+Burleson,203,U.S. House,17,REP,David Saucedo,2,1,1
+Burleson,203,U.S. House,17,REP,Ahmad Adnan,1,0,1
+Burleson,203,U.S. House,17,REP,Scott Bland,3,1,2
+Burleson,203,U.S. House,17,REP,Pete Sessions,20,12,8
+Burleson,203,Railroad Commissioner,,REP,"James ""Jim"" Wright",72,33,39
+Burleson,203,Railroad Commissioner,,REP,Ryan Sitton,46,19,27
+Burleson,203,"Chief Justice, Supreme Court",,REP,Nathan Hecht,111,45,66
+Burleson,203,"Justice, Supreme Court, Place 6",,REP,Jane Bland,112,46,66
+Burleson,203,"Justice, Supreme Court, Place 7",,REP,Jeff Boyd,113,47,66
+Burleson,203,"Justice, Supreme Court, Place 8",,REP,Brett Busby,113,47,66
+Burleson,203,"Judge, Court of Criminal Appeals, Place 3",,REP,Bert Richardson,75,36,39
+Burleson,203,"Judge, Court of Criminal Appeals, Place 3",,REP,Gina Parker,37,11,26
+Burleson,203,"Judge, Court of Criminal Appeals, Place 4",,REP,Kevin Patrick Yeary,106,46,60
+Burleson,203,"Judge, Court of Criminal Appeals, Place 9",,REP,David Newell,106,46,60
+Burleson,203,"Member, State Board of Education, District 10",,REP,Tom Maynard,104,46,58
+Burleson,203,State Senator,18,REP,Lois W. Kolkhorst,116,54,62
+Burleson,203,State Representative,13,REP,Ben Leman,113,53,60
+Burleson,203,"Justice, 10th Court of Appeals District, Place 2",,REP,Matt Johnson,105,48,57
+Burleson,203,"Justice, 10th Court of Appeals District, Place 3",,REP,John E. Neill,103,48,55
+Burleson,203,"District Judge, 21st Judicial District",,REP,Carson Campbell,105,48,57
+Burleson,203,"District Judge, 335th Judicial District",,REP,Charles W. Carver,26,12,14
+Burleson,203,"District Judge, 335th Judicial District",,REP,Reva L. Towslee Corbett,100,45,55
+Burleson,203,County Judge,,REP,Keith Schroeder,111,51,60
+Burleson,203,County Attorney,,REP,Susan Deski,106,51,55
+Burleson,203,Sheriff,,REP,Jayson Lyday,40,12,28
+Burleson,203,Sheriff,,REP,Gene Hermes,89,46,43
+Burleson,203,County Tax Assessor-Collector,,REP,Jessica Lucero,42,16,26
+Burleson,203,County Tax Assessor-Collector,,REP,Cheryl Story Castaneda,83,41,42
+Burleson,203,"Constable, Precinct No. 2",,REP,Dennis Gaas,114,54,60
+Burleson,203,County Chairman,,REP,Tyler Groce,110,49,61
+Burleson,203,Proposition 1,,REP,Yes,116,47,69
+Burleson,203,Proposition 1,,REP,No,16,11,5
+Burleson,203,Proposition 2,,REP,Yes,109,47,62
+Burleson,203,Proposition 2,,REP,No,22,11,11
+Burleson,203,Proposition 3,,REP,Yes,119,53,66
+Burleson,203,Proposition 3,,REP,No,6,3,3
+Burleson,203,Proposition 4,,REP,Yes,121,56,65
+Burleson,203,Proposition 4,,REP,No,8,1,7
+Burleson,203,Proposition 5,,REP,Yes,121,54,67
+Burleson,203,Proposition 5,,REP,No,11,5,6
+Burleson,203,Proposition 6,,REP,Yes,121,53,68
+Burleson,203,Proposition 6,,REP,No,7,4,3
+Burleson,203,Proposition 7,,REP,Yes,130,58,72
+Burleson,203,Proposition 7,,REP,No,1,0,1
+Burleson,203,Proposition 8,,REP,Yes,123,57,66
+Burleson,203,Proposition 8,,REP,No,5,1,4
+Burleson,203,Proposition 9,,REP,Yes,126,57,69
+Burleson,203,Proposition 9,,REP,No,4,1,3
+Burleson,203,Proposition 10,,REP,Yes,121,55,66
+Burleson,203,Proposition 10,,REP,No,7,3,4
+Burleson,204,Registered Voters,,,Registered Voters,670,,
+Burleson,204,President,,REP,Joe Walsh,2,0,2
+Burleson,204,President,,REP,Donald J. Trump,228,157,71
+Burleson,204,President,,REP,Matthew John Matern,0,0,0
+Burleson,204,President,,REP,"Roque ""Rocky"" De La Fuente Guerra",0,0,0
+Burleson,204,President,,REP,Bill Weld,2,1,1
+Burleson,204,President,,REP,Bob Ely,1,1,0
+Burleson,204,President,,REP,Zoltan G. Istvan,0,0,0
+Burleson,204,President,,REP,Uncommitted,8,3,5
+Burleson,204,U.S. Senate,,REP,John Cornyn,193,135,58
+Burleson,204,U.S. Senate,,REP,Virgil Bierschwale,2,0,2
+Burleson,204,U.S. Senate,,REP,Mark Yancey,9,6,3
+Burleson,204,U.S. Senate,,REP,John Anthony Castro,6,3,3
+Burleson,204,U.S. Senate,,REP,Dwayne Stovall,17,8,9
+Burleson,204,U.S. House,17,REP,George W. Hindman,33,26,7
+Burleson,204,U.S. House,17,REP,Jeff Oppenheim,3,2,1
+Burleson,204,U.S. House,17,REP,Todd Kent,11,8,3
+Burleson,204,U.S. House,17,REP,Trent Sutton,7,6,1
+Burleson,204,U.S. House,17,REP,Laurie Godfrey McReynolds,1,0,1
+Burleson,204,U.S. House,17,REP,Elianor Vessali,28,11,17
+Burleson,204,U.S. House,17,REP,Renée Swann,74,56,18
+Burleson,204,U.S. House,17,REP,Kristen Alamo Rowin,4,3,1
+Burleson,204,U.S. House,17,REP,David Saucedo,2,2,0
+Burleson,204,U.S. House,17,REP,Ahmad Adnan,1,1,0
+Burleson,204,U.S. House,17,REP,Scott Bland,3,2,1
+Burleson,204,U.S. House,17,REP,Pete Sessions,59,41,18
+Burleson,204,Railroad Commissioner,,REP,"James ""Jim"" Wright",133,96,37
+Burleson,204,Railroad Commissioner,,REP,Ryan Sitton,75,50,25
+Burleson,204,"Chief Justice, Supreme Court",,REP,Nathan Hecht,197,135,62
+Burleson,204,"Justice, Supreme Court, Place 6",,REP,Jane Bland,192,132,60
+Burleson,204,"Justice, Supreme Court, Place 7",,REP,Jeff Boyd,194,132,62
+Burleson,204,"Justice, Supreme Court, Place 8",,REP,Brett Busby,194,133,61
+Burleson,204,"Judge, Court of Criminal Appeals, Place 3",,REP,Bert Richardson,131,92,39
+Burleson,204,"Judge, Court of Criminal Appeals, Place 3",,REP,Gina Parker,69,47,22
+Burleson,204,"Judge, Court of Criminal Appeals, Place 4",,REP,Kevin Patrick Yeary,191,132,59
+Burleson,204,"Judge, Court of Criminal Appeals, Place 9",,REP,David Newell,189,131,58
+Burleson,204,"Member, State Board of Education, District 10",,REP,Tom Maynard,188,131,57
+Burleson,204,State Senator,18,REP,Lois W. Kolkhorst,207,143,64
+Burleson,204,State Representative,13,REP,Ben Leman,205,139,66
+Burleson,204,"Justice, 10th Court of Appeals District, Place 2",,REP,Matt Johnson,189,129,60
+Burleson,204,"Justice, 10th Court of Appeals District, Place 3",,REP,John E. Neill,190,129,61
+Burleson,204,"District Judge, 21st Judicial District",,REP,Carson Campbell,195,135,60
+Burleson,204,"District Judge, 335th Judicial District",,REP,Charles W. Carver,39,21,18
+Burleson,204,"District Judge, 335th Judicial District",,REP,Reva L. Towslee Corbett,196,139,57
+Burleson,204,County Judge,,REP,Keith Schroeder,203,141,62
+Burleson,204,County Attorney,,REP,Susan Deski,192,131,61
+Burleson,204,Sheriff,,REP,Jayson Lyday,73,54,19
+Burleson,204,Sheriff,,REP,Gene Hermes,166,111,55
+Burleson,204,County Tax Assessor-Collector,,REP,Jessica Lucero,72,49,23
+Burleson,204,County Tax Assessor-Collector,,REP,Cheryl Story Castaneda,164,114,50
+Burleson,204,"Constable, Precinct No. 2",,REP,Dennis Gaas,213,144,69
+Burleson,204,County Chairman,,REP,Tyler Groce,198,137,61
+Burleson,204,Proposition 1,,REP,Yes,212,144,68
+Burleson,204,Proposition 1,,REP,No,27,19,8
+Burleson,204,Proposition 2,,REP,Yes,206,145,61
+Burleson,204,Proposition 2,,REP,No,32,20,12
+Burleson,204,Proposition 3,,REP,Yes,217,152,65
+Burleson,204,Proposition 3,,REP,No,18,10,8
+Burleson,204,Proposition 4,,REP,Yes,221,154,67
+Burleson,204,Proposition 4,,REP,No,15,9,6
+Burleson,204,Proposition 5,,REP,Yes,208,144,64
+Burleson,204,Proposition 5,,REP,No,26,17,9
+Burleson,204,Proposition 6,,REP,Yes,217,149,68
+Burleson,204,Proposition 6,,REP,No,17,12,5
+Burleson,204,Proposition 7,,REP,Yes,230,158,72
+Burleson,204,Proposition 7,,REP,No,5,4,1
+Burleson,204,Proposition 8,,REP,Yes,230,159,71
+Burleson,204,Proposition 8,,REP,No,4,3,1
+Burleson,204,Proposition 9,,REP,Yes,224,154,70
+Burleson,204,Proposition 9,,REP,No,10,8,2
+Burleson,204,Proposition 10,,REP,Yes,202,142,60
+Burleson,204,Proposition 10,,REP,No,25,16,9
+Burleson,207,Registered Voters,,,Registered Voters,479,,
+Burleson,207,President,,REP,Joe Walsh,1,1,0
+Burleson,207,President,,REP,Donald J. Trump,104,53,51
+Burleson,207,President,,REP,Matthew John Matern,1,0,1
+Burleson,207,President,,REP,"Roque ""Rocky"" De La Fuente Guerra",0,0,0
+Burleson,207,President,,REP,Bill Weld,0,0,0
+Burleson,207,President,,REP,Bob Ely,0,0,0
+Burleson,207,President,,REP,Zoltan G. Istvan,0,0,0
+Burleson,207,President,,REP,Uncommitted,1,0,1
+Burleson,207,U.S. Senate,,REP,John Cornyn,79,41,38
+Burleson,207,U.S. Senate,,REP,Virgil Bierschwale,1,0,1
+Burleson,207,U.S. Senate,,REP,Mark Yancey,8,2,6
+Burleson,207,U.S. Senate,,REP,John Anthony Castro,1,1,0
+Burleson,207,U.S. Senate,,REP,Dwayne Stovall,10,6,4
+Burleson,207,U.S. House,17,REP,George W. Hindman,23,11,12
+Burleson,207,U.S. House,17,REP,Jeff Oppenheim,1,0,1
+Burleson,207,U.S. House,17,REP,Todd Kent,1,0,1
+Burleson,207,U.S. House,17,REP,Trent Sutton,6,3,3
+Burleson,207,U.S. House,17,REP,Laurie Godfrey McReynolds,2,2,0
+Burleson,207,U.S. House,17,REP,Elianor Vessali,9,5,4
+Burleson,207,U.S. House,17,REP,Renée Swann,33,16,17
+Burleson,207,U.S. House,17,REP,Kristen Alamo Rowin,1,1,0
+Burleson,207,U.S. House,17,REP,David Saucedo,0,0,0
+Burleson,207,U.S. House,17,REP,Ahmad Adnan,0,0,0
+Burleson,207,U.S. House,17,REP,Scott Bland,1,0,1
+Burleson,207,U.S. House,17,REP,Pete Sessions,24,13,11
+Burleson,207,Railroad Commissioner,,REP,"James ""Jim"" Wright",42,15,27
+Burleson,207,Railroad Commissioner,,REP,Ryan Sitton,46,30,16
+Burleson,207,"Chief Justice, Supreme Court",,REP,Nathan Hecht,78,40,38
+Burleson,207,"Justice, Supreme Court, Place 6",,REP,Jane Bland,77,41,36
+Burleson,207,"Justice, Supreme Court, Place 7",,REP,Jeff Boyd,72,38,34
+Burleson,207,"Justice, Supreme Court, Place 8",,REP,Brett Busby,76,39,37
+Burleson,207,"Judge, Court of Criminal Appeals, Place 3",,REP,Bert Richardson,48,22,26
+Burleson,207,"Judge, Court of Criminal Appeals, Place 3",,REP,Gina Parker,30,16,14
+Burleson,207,"Judge, Court of Criminal Appeals, Place 4",,REP,Kevin Patrick Yeary,71,37,34
+Burleson,207,"Judge, Court of Criminal Appeals, Place 9",,REP,David Newell,72,37,35
+Burleson,207,"Member, State Board of Education, District 10",,REP,Tom Maynard,75,38,37
+Burleson,207,State Senator,18,REP,Lois W. Kolkhorst,90,43,47
+Burleson,207,State Representative,13,REP,Ben Leman,87,44,43
+Burleson,207,"Justice, 10th Court of Appeals District, Place 2",,REP,Matt Johnson,71,36,35
+Burleson,207,"Justice, 10th Court of Appeals District, Place 3",,REP,John E. Neill,71,36,35
+Burleson,207,"District Judge, 21st Judicial District",,REP,Carson Campbell,76,40,36
+Burleson,207,"District Judge, 335th Judicial District",,REP,Charles W. Carver,24,11,13
+Burleson,207,"District Judge, 335th Judicial District",,REP,Reva L. Towslee Corbett,74,39,35
+Burleson,207,County Judge,,REP,Keith Schroeder,87,41,46
+Burleson,207,County Attorney,,REP,Susan Deski,75,38,37
+Burleson,207,Sheriff,,REP,Jayson Lyday,41,23,18
+Burleson,207,Sheriff,,REP,Gene Hermes,61,27,34
+Burleson,207,County Tax Assessor-Collector,,REP,Jessica Lucero,38,22,16
+Burleson,207,County Tax Assessor-Collector,,REP,Cheryl Story Castaneda,60,27,33
+Burleson,207,"Constable, Precinct No. 2",,REP,Dennis Gaas,91,45,46
+Burleson,207,County Chairman,,REP,Tyler Groce,85,44,41
+Burleson,207,Proposition 1,,REP,Yes,90,43,47
+Burleson,207,Proposition 1,,REP,No,11,7,4
+Burleson,207,Proposition 2,,REP,Yes,89,44,45
+Burleson,207,Proposition 2,,REP,No,12,6,6
+Burleson,207,Proposition 3,,REP,Yes,88,48,40
+Burleson,207,Proposition 3,,REP,No,6,1,5
+Burleson,207,Proposition 4,,REP,Yes,96,49,47
+Burleson,207,Proposition 4,,REP,No,3,1,2
+Burleson,207,Proposition 5,,REP,Yes,91,46,45
+Burleson,207,Proposition 5,,REP,No,6,3,3
+Burleson,207,Proposition 6,,REP,Yes,90,47,43
+Burleson,207,Proposition 6,,REP,No,6,2,4
+Burleson,207,Proposition 7,,REP,Yes,99,50,49
+Burleson,207,Proposition 7,,REP,No,0,0,0
+Burleson,207,Proposition 8,,REP,Yes,96,49,47
+Burleson,207,Proposition 8,,REP,No,2,1,1
+Burleson,207,Proposition 9,,REP,Yes,95,47,48
+Burleson,207,Proposition 9,,REP,No,2,2,0
+Burleson,207,Proposition 10,,REP,Yes,91,50,41
+Burleson,207,Proposition 10,,REP,No,5,1,4
+Burleson,211,Registered Voters,,,Registered Voters,996,,
+Burleson,211,President,,REP,Joe Walsh,3,1,2
+Burleson,211,President,,REP,Donald J. Trump,286,64,222
+Burleson,211,President,,REP,Matthew John Matern,0,0,0
+Burleson,211,President,,REP,"Roque ""Rocky"" De La Fuente Guerra",0,0,0
+Burleson,211,President,,REP,Bill Weld,1,1,0
+Burleson,211,President,,REP,Bob Ely,1,1,0
+Burleson,211,President,,REP,Zoltan G. Istvan,0,0,0
+Burleson,211,President,,REP,Uncommitted,5,2,3
+Burleson,211,U.S. Senate,,REP,John Cornyn,238,61,177
+Burleson,211,U.S. Senate,,REP,Virgil Bierschwale,3,0,3
+Burleson,211,U.S. Senate,,REP,Mark Yancey,12,1,11
+Burleson,211,U.S. Senate,,REP,John Anthony Castro,5,0,5
+Burleson,211,U.S. Senate,,REP,Dwayne Stovall,27,4,23
+Burleson,211,U.S. House,17,REP,George W. Hindman,52,8,44
+Burleson,211,U.S. House,17,REP,Jeff Oppenheim,4,0,4
+Burleson,211,U.S. House,17,REP,Todd Kent,15,4,11
+Burleson,211,U.S. House,17,REP,Trent Sutton,34,8,26
+Burleson,211,U.S. House,17,REP,Laurie Godfrey McReynolds,3,0,3
+Burleson,211,U.S. House,17,REP,Elianor Vessali,50,9,41
+Burleson,211,U.S. House,17,REP,Renée Swann,90,26,64
+Burleson,211,U.S. House,17,REP,Kristen Alamo Rowin,0,0,0
+Burleson,211,U.S. House,17,REP,David Saucedo,1,1,0
+Burleson,211,U.S. House,17,REP,Ahmad Adnan,0,0,0
+Burleson,211,U.S. House,17,REP,Scott Bland,0,0,0
+Burleson,211,U.S. House,17,REP,Pete Sessions,39,14,25
+Burleson,211,Railroad Commissioner,,REP,"James ""Jim"" Wright",152,29,123
+Burleson,211,Railroad Commissioner,,REP,Ryan Sitton,110,31,79
+Burleson,211,"Chief Justice, Supreme Court",,REP,Nathan Hecht,246,58,188
+Burleson,211,"Justice, Supreme Court, Place 6",,REP,Jane Bland,246,59,187
+Burleson,211,"Justice, Supreme Court, Place 7",,REP,Jeff Boyd,249,57,192
+Burleson,211,"Justice, Supreme Court, Place 8",,REP,Brett Busby,251,58,193
+Burleson,211,"Judge, Court of Criminal Appeals, Place 3",,REP,Bert Richardson,154,36,118
+Burleson,211,"Judge, Court of Criminal Appeals, Place 3",,REP,Gina Parker,101,23,78
+Burleson,211,"Judge, Court of Criminal Appeals, Place 4",,REP,Kevin Patrick Yeary,246,58,188
+Burleson,211,"Judge, Court of Criminal Appeals, Place 9",,REP,David Newell,247,57,190
+Burleson,211,"Member, State Board of Education, District 10",,REP,Tom Maynard,247,59,188
+Burleson,211,State Senator,18,REP,Lois W. Kolkhorst,269,67,202
+Burleson,211,State Representative,13,REP,Ben Leman,270,65,205
+Burleson,211,"Justice, 10th Court of Appeals District, Place 2",,REP,Matt Johnson,246,60,186
+Burleson,211,"Justice, 10th Court of Appeals District, Place 3",,REP,John E. Neill,250,60,190
+Burleson,211,"District Judge, 21st Judicial District",,REP,Carson Campbell,252,60,192
+Burleson,211,"District Judge, 335th Judicial District",,REP,Charles W. Carver,97,20,77
+Burleson,211,"District Judge, 335th Judicial District",,REP,Reva L. Towslee Corbett,183,48,135
+Burleson,211,County Judge,,REP,Keith Schroeder,267,65,202
+Burleson,211,County Attorney,,REP,Susan Deski,255,63,192
+Burleson,211,Sheriff,,REP,Jayson Lyday,121,26,95
+Burleson,211,Sheriff,,REP,Gene Hermes,166,42,124
+Burleson,211,County Tax Assessor-Collector,,REP,Jessica Lucero,145,35,110
+Burleson,211,County Tax Assessor-Collector,,REP,Cheryl Story Castaneda,133,32,101
+Burleson,211,"Constable, Precinct No. 2",,REP,Dennis Gaas,279,67,212
+Burleson,211,County Chairman,,REP,Tyler Groce,259,64,195
+Burleson,211,Proposition 1,,REP,Yes,251,54,197
+Burleson,211,Proposition 1,,REP,No,43,15,28
+Burleson,211,Proposition 2,,REP,Yes,257,54,203
+Burleson,211,Proposition 2,,REP,No,35,14,21
+Burleson,211,Proposition 3,,REP,Yes,266,60,206
+Burleson,211,Proposition 3,,REP,No,19,6,13
+Burleson,211,Proposition 4,,REP,Yes,272,61,211
+Burleson,211,Proposition 4,,REP,No,17,7,10
+Burleson,211,Proposition 5,,REP,Yes,259,61,198
+Burleson,211,Proposition 5,,REP,No,29,6,23
+Burleson,211,Proposition 6,,REP,Yes,273,64,209
+Burleson,211,Proposition 6,,REP,No,17,4,13
+Burleson,211,Proposition 7,,REP,Yes,286,65,221
+Burleson,211,Proposition 7,,REP,No,5,3,2
+Burleson,211,Proposition 8,,REP,Yes,285,67,218
+Burleson,211,Proposition 8,,REP,No,6,2,4
+Burleson,211,Proposition 9,,REP,Yes,276,64,212
+Burleson,211,Proposition 9,,REP,No,15,3,12
+Burleson,211,Proposition 10,,REP,Yes,273,61,212
+Burleson,211,Proposition 10,,REP,No,20,6,14
+Burleson,215,Registered Voters,,,Registered Voters,467,,
+Burleson,215,President,,REP,Joe Walsh,2,0,2
+Burleson,215,President,,REP,Donald J. Trump,112,38,74
+Burleson,215,President,,REP,Matthew John Matern,0,0,0
+Burleson,215,President,,REP,"Roque ""Rocky"" De La Fuente Guerra",0,0,0
+Burleson,215,President,,REP,Bill Weld,0,0,0
+Burleson,215,President,,REP,Bob Ely,0,0,0
+Burleson,215,President,,REP,Zoltan G. Istvan,1,0,1
+Burleson,215,President,,REP,Uncommitted,2,2,0
+Burleson,215,U.S. Senate,,REP,John Cornyn,76,24,52
+Burleson,215,U.S. Senate,,REP,Virgil Bierschwale,3,1,2
+Burleson,215,U.S. Senate,,REP,Mark Yancey,10,4,6
+Burleson,215,U.S. Senate,,REP,John Anthony Castro,5,3,2
+Burleson,215,U.S. Senate,,REP,Dwayne Stovall,14,4,10
+Burleson,215,U.S. House,17,REP,George W. Hindman,15,6,9
+Burleson,215,U.S. House,17,REP,Jeff Oppenheim,4,0,4
+Burleson,215,U.S. House,17,REP,Todd Kent,2,1,1
+Burleson,215,U.S. House,17,REP,Trent Sutton,4,0,4
+Burleson,215,U.S. House,17,REP,Laurie Godfrey McReynolds,1,0,1
+Burleson,215,U.S. House,17,REP,Elianor Vessali,14,3,11
+Burleson,215,U.S. House,17,REP,Renée Swann,42,15,27
+Burleson,215,U.S. House,17,REP,Kristen Alamo Rowin,3,1,2
+Burleson,215,U.S. House,17,REP,David Saucedo,0,0,0
+Burleson,215,U.S. House,17,REP,Ahmad Adnan,0,0,0
+Burleson,215,U.S. House,17,REP,Scott Bland,1,1,0
+Burleson,215,U.S. House,17,REP,Pete Sessions,25,11,14
+Burleson,215,Railroad Commissioner,,REP,"James ""Jim"" Wright",72,21,51
+Burleson,215,Railroad Commissioner,,REP,Ryan Sitton,26,11,15
+Burleson,215,"Chief Justice, Supreme Court",,REP,Nathan Hecht,98,31,67
+Burleson,215,"Justice, Supreme Court, Place 6",,REP,Jane Bland,95,31,64
+Burleson,215,"Justice, Supreme Court, Place 7",,REP,Jeff Boyd,100,31,69
+Burleson,215,"Justice, Supreme Court, Place 8",,REP,Brett Busby,97,31,66
+Burleson,215,"Judge, Court of Criminal Appeals, Place 3",,REP,Bert Richardson,63,23,40
+Burleson,215,"Judge, Court of Criminal Appeals, Place 3",,REP,Gina Parker,35,10,25
+Burleson,215,"Judge, Court of Criminal Appeals, Place 4",,REP,Kevin Patrick Yeary,96,32,64
+Burleson,215,"Judge, Court of Criminal Appeals, Place 9",,REP,David Newell,96,32,64
+Burleson,215,"Member, State Board of Education, District 10",,REP,Tom Maynard,97,31,66
+Burleson,215,State Senator,18,REP,Lois W. Kolkhorst,97,33,64
+Burleson,215,State Representative,13,REP,Ben Leman,97,33,64
+Burleson,215,"Justice, 10th Court of Appeals District, Place 2",,REP,Matt Johnson,95,32,63
+Burleson,215,"Justice, 10th Court of Appeals District, Place 3",,REP,John E. Neill,96,32,64
+Burleson,215,"District Judge, 21st Judicial District",,REP,Carson Campbell,97,32,65
+Burleson,215,"District Judge, 335th Judicial District",,REP,Charles W. Carver,54,15,39
+Burleson,215,"District Judge, 335th Judicial District",,REP,Reva L. Towslee Corbett,47,21,26
+Burleson,215,County Judge,,REP,Keith Schroeder,96,32,64
+Burleson,215,County Attorney,,REP,Susan Deski,91,30,61
+Burleson,215,Sheriff,,REP,Jayson Lyday,40,12,28
+Burleson,215,Sheriff,,REP,Gene Hermes,70,27,43
+Burleson,215,County Tax Assessor-Collector,,REP,Jessica Lucero,30,13,17
+Burleson,215,County Tax Assessor-Collector,,REP,Cheryl Story Castaneda,70,21,49
+Burleson,215,"Constable, Precinct No. 2",,REP,Dennis Gaas,98,33,65
+Burleson,215,County Chairman,,REP,Tyler Groce,97,33,64
+Burleson,215,Proposition 1,,REP,Yes,97,34,63
+Burleson,215,Proposition 1,,REP,No,16,6,10
+Burleson,215,Proposition 2,,REP,Yes,95,34,61
+Burleson,215,Proposition 2,,REP,No,19,6,13
+Burleson,215,Proposition 3,,REP,Yes,106,39,67
+Burleson,215,Proposition 3,,REP,No,7,1,6
+Burleson,215,Proposition 4,,REP,Yes,108,38,70
+Burleson,215,Proposition 4,,REP,No,4,2,2
+Burleson,215,Proposition 5,,REP,Yes,107,38,69
+Burleson,215,Proposition 5,,REP,No,7,2,5
+Burleson,215,Proposition 6,,REP,Yes,106,39,67
+Burleson,215,Proposition 6,,REP,No,9,1,8
+Burleson,215,Proposition 7,,REP,Yes,111,39,72
+Burleson,215,Proposition 7,,REP,No,4,1,3
+Burleson,215,Proposition 8,,REP,Yes,110,39,71
+Burleson,215,Proposition 8,,REP,No,3,1,2
+Burleson,215,Proposition 9,,REP,Yes,106,37,69
+Burleson,215,Proposition 9,,REP,No,5,2,3
+Burleson,215,Proposition 10,,REP,Yes,105,39,66
+Burleson,215,Proposition 10,,REP,No,10,1,9
+Burleson,301,Registered Voters,,,Registered Voters,1329,,
+Burleson,301,President,,REP,Joe Walsh,7,5,2
+Burleson,301,President,,REP,Donald J. Trump,428,298,130
+Burleson,301,President,,REP,Matthew John Matern,0,0,0
+Burleson,301,President,,REP,"Roque ""Rocky"" De La Fuente Guerra",2,2,0
+Burleson,301,President,,REP,Bill Weld,1,1,0
+Burleson,301,President,,REP,Bob Ely,1,0,1
+Burleson,301,President,,REP,Zoltan G. Istvan,1,0,1
+Burleson,301,President,,REP,Uncommitted,34,21,13
+Burleson,301,U.S. Senate,,REP,John Cornyn,370,266,104
+Burleson,301,U.S. Senate,,REP,Virgil Bierschwale,5,3,2
+Burleson,301,U.S. Senate,,REP,Mark Yancey,19,13,6
+Burleson,301,U.S. Senate,,REP,John Anthony Castro,14,7,7
+Burleson,301,U.S. Senate,,REP,Dwayne Stovall,35,14,21
+Burleson,301,U.S. House,17,REP,George W. Hindman,78,49,29
+Burleson,301,U.S. House,17,REP,Jeff Oppenheim,7,5,2
+Burleson,301,U.S. House,17,REP,Todd Kent,23,12,11
+Burleson,301,U.S. House,17,REP,Trent Sutton,22,15,7
+Burleson,301,U.S. House,17,REP,Laurie Godfrey McReynolds,3,2,1
+Burleson,301,U.S. House,17,REP,Elianor Vessali,43,25,18
+Burleson,301,U.S. House,17,REP,Renée Swann,171,130,41
+Burleson,301,U.S. House,17,REP,Kristen Alamo Rowin,7,6,1
+Burleson,301,U.S. House,17,REP,David Saucedo,8,3,5
+Burleson,301,U.S. House,17,REP,Ahmad Adnan,2,1,1
+Burleson,301,U.S. House,17,REP,Scott Bland,8,7,1
+Burleson,301,U.S. House,17,REP,Pete Sessions,79,54,25
+Burleson,301,Railroad Commissioner,,REP,"James ""Jim"" Wright",246,151,95
+Burleson,301,Railroad Commissioner,,REP,Ryan Sitton,157,123,34
+Burleson,301,"Chief Justice, Supreme Court",,REP,Nathan Hecht,357,242,115
+Burleson,301,"Justice, Supreme Court, Place 6",,REP,Jane Bland,349,239,110
+Burleson,301,"Justice, Supreme Court, Place 7",,REP,Jeff Boyd,360,246,114
+Burleson,301,"Justice, Supreme Court, Place 8",,REP,Brett Busby,357,244,113
+Burleson,301,"Judge, Court of Criminal Appeals, Place 3",,REP,Bert Richardson,247,168,79
+Burleson,301,"Judge, Court of Criminal Appeals, Place 3",,REP,Gina Parker,115,78,37
+Burleson,301,"Judge, Court of Criminal Appeals, Place 4",,REP,Kevin Patrick Yeary,339,231,108
+Burleson,301,"Judge, Court of Criminal Appeals, Place 9",,REP,David Newell,336,232,104
+Burleson,301,"Member, State Board of Education, District 10",,REP,Tom Maynard,344,236,108
+Burleson,301,State Senator,18,REP,Lois W. Kolkhorst,376,262,114
+Burleson,301,State Representative,13,REP,Ben Leman,374,260,114
+Burleson,301,"Justice, 10th Court of Appeals District, Place 2",,REP,Matt Johnson,347,238,109
+Burleson,301,"Justice, 10th Court of Appeals District, Place 3",,REP,John E. Neill,345,236,109
+Burleson,301,"District Judge, 21st Judicial District",,REP,Carson Campbell,362,253,109
+Burleson,301,"District Judge, 335th Judicial District",,REP,Charles W. Carver,73,47,26
+Burleson,301,"District Judge, 335th Judicial District",,REP,Reva L. Towslee Corbett,378,260,118
+Burleson,301,County Judge,,REP,Keith Schroeder,390,273,117
+Burleson,301,County Attorney,,REP,Susan Deski,351,240,111
+Burleson,301,Sheriff,,REP,Jayson Lyday,161,100,61
+Burleson,301,Sheriff,,REP,Gene Hermes,310,223,87
+Burleson,301,County Tax Assessor-Collector,,REP,Jessica Lucero,181,129,52
+Burleson,301,County Tax Assessor-Collector,,REP,Cheryl Story Castaneda,263,175,88
+Burleson,301,"County Commissioner, Precinct No. 3",,REP,Curtis Barnett,107,61,46
+Burleson,301,"County Commissioner, Precinct No. 3",,REP,David Hildebrand,349,249,100
+Burleson,301,"Constable, Precinct No. 3",,REP,Jay Boykin,383,262,121
+Burleson,301,County Chairman,,REP,Tyler Groce,389,269,120
+Burleson,301,Proposition 1,,REP,Yes,408,286,122
+Burleson,301,Proposition 1,,REP,No,54,33,21
+Burleson,301,Proposition 2,,REP,Yes,395,275,120
+Burleson,301,Proposition 2,,REP,No,65,42,23
+Burleson,301,Proposition 3,,REP,Yes,426,295,131
+Burleson,301,Proposition 3,,REP,No,27,17,10
+Burleson,301,Proposition 4,,REP,Yes,414,289,125
+Burleson,301,Proposition 4,,REP,No,38,21,17
+Burleson,301,Proposition 5,,REP,Yes,393,274,119
+Burleson,301,Proposition 5,,REP,No,49,31,18
+Burleson,301,Proposition 6,,REP,Yes,413,289,124
+Burleson,301,Proposition 6,,REP,No,30,16,14
+Burleson,301,Proposition 7,,REP,Yes,442,305,137
+Burleson,301,Proposition 7,,REP,No,8,7,1
+Burleson,301,Proposition 8,,REP,Yes,438,301,137
+Burleson,301,Proposition 8,,REP,No,7,6,1
+Burleson,301,Proposition 9,,REP,Yes,432,300,132
+Burleson,301,Proposition 9,,REP,No,18,10,8
+Burleson,301,Proposition 10,,REP,Yes,418,292,126
+Burleson,301,Proposition 10,,REP,No,34,22,12
+Burleson,305,Registered Voters,,,Registered Voters,557,,
+Burleson,305,President,,REP,Joe Walsh,1,1,0
+Burleson,305,President,,REP,Donald J. Trump,184,127,57
+Burleson,305,President,,REP,Matthew John Matern,0,0,0
+Burleson,305,President,,REP,"Roque ""Rocky"" De La Fuente Guerra",0,0,0
+Burleson,305,President,,REP,Bill Weld,1,0,1
+Burleson,305,President,,REP,Bob Ely,0,0,0
+Burleson,305,President,,REP,Zoltan G. Istvan,1,0,1
+Burleson,305,President,,REP,Uncommitted,2,2,0
+Burleson,305,U.S. Senate,,REP,John Cornyn,141,98,43
+Burleson,305,U.S. Senate,,REP,Virgil Bierschwale,4,3,1
+Burleson,305,U.S. Senate,,REP,Mark Yancey,8,4,4
+Burleson,305,U.S. Senate,,REP,John Anthony Castro,2,1,1
+Burleson,305,U.S. Senate,,REP,Dwayne Stovall,28,19,9
+Burleson,305,U.S. House,17,REP,George W. Hindman,35,26,9
+Burleson,305,U.S. House,17,REP,Jeff Oppenheim,4,2,2
+Burleson,305,U.S. House,17,REP,Todd Kent,6,4,2
+Burleson,305,U.S. House,17,REP,Trent Sutton,8,7,1
+Burleson,305,U.S. House,17,REP,Laurie Godfrey McReynolds,0,0,0
+Burleson,305,U.S. House,17,REP,Elianor Vessali,19,13,6
+Burleson,305,U.S. House,17,REP,Renée Swann,69,47,22
+Burleson,305,U.S. House,17,REP,Kristen Alamo Rowin,0,0,0
+Burleson,305,U.S. House,17,REP,David Saucedo,0,0,0
+Burleson,305,U.S. House,17,REP,Ahmad Adnan,0,0,0
+Burleson,305,U.S. House,17,REP,Scott Bland,1,0,1
+Burleson,305,U.S. House,17,REP,Pete Sessions,38,23,15
+Burleson,305,Railroad Commissioner,,REP,"James ""Jim"" Wright",116,78,38
+Burleson,305,Railroad Commissioner,,REP,Ryan Sitton,50,36,14
+Burleson,305,"Chief Justice, Supreme Court",,REP,Nathan Hecht,155,111,44
+Burleson,305,"Justice, Supreme Court, Place 6",,REP,Jane Bland,153,108,45
+Burleson,305,"Justice, Supreme Court, Place 7",,REP,Jeff Boyd,155,109,46
+Burleson,305,"Justice, Supreme Court, Place 8",,REP,Brett Busby,154,109,45
+Burleson,305,"Judge, Court of Criminal Appeals, Place 3",,REP,Bert Richardson,102,75,27
+Burleson,305,"Judge, Court of Criminal Appeals, Place 3",,REP,Gina Parker,52,33,19
+Burleson,305,"Judge, Court of Criminal Appeals, Place 4",,REP,Kevin Patrick Yeary,154,110,44
+Burleson,305,"Judge, Court of Criminal Appeals, Place 9",,REP,David Newell,153,109,44
+Burleson,305,"Member, State Board of Education, District 10",,REP,Tom Maynard,153,108,45
+Burleson,305,State Senator,18,REP,Lois W. Kolkhorst,157,112,45
+Burleson,305,State Representative,13,REP,Ben Leman,154,110,44
+Burleson,305,"Justice, 10th Court of Appeals District, Place 2",,REP,Matt Johnson,153,110,43
+Burleson,305,"Justice, 10th Court of Appeals District, Place 3",,REP,John E. Neill,153,110,43
+Burleson,305,"District Judge, 21st Judicial District",,REP,Carson Campbell,155,112,43
+Burleson,305,"District Judge, 335th Judicial District",,REP,Charles W. Carver,45,32,13
+Burleson,305,"District Judge, 335th Judicial District",,REP,Reva L. Towslee Corbett,132,89,43
+Burleson,305,County Judge,,REP,Keith Schroeder,157,112,45
+Burleson,305,County Attorney,,REP,Susan Deski,151,107,44
+Burleson,305,Sheriff,,REP,Jayson Lyday,75,52,23
+Burleson,305,Sheriff,,REP,Gene Hermes,112,76,36
+Burleson,305,County Tax Assessor-Collector,,REP,Jessica Lucero,66,49,17
+Burleson,305,County Tax Assessor-Collector,,REP,Cheryl Story Castaneda,107,71,36
+Burleson,305,"County Commissioner, Precinct No. 3",,REP,Curtis Barnett,41,21,20
+Burleson,305,"County Commissioner, Precinct No. 3",,REP,David Hildebrand,141,103,38
+Burleson,305,"Constable, Precinct No. 3",,REP,Jay Boykin,155,111,44
+Burleson,305,County Chairman,,REP,Tyler Groce,156,111,45
+Burleson,305,Proposition 1,,REP,Yes,169,118,51
+Burleson,305,Proposition 1,,REP,No,20,12,8
+Burleson,305,Proposition 2,,REP,Yes,164,112,52
+Burleson,305,Proposition 2,,REP,No,22,15,7
+Burleson,305,Proposition 3,,REP,Yes,178,123,55
+Burleson,305,Proposition 3,,REP,No,7,3,4
+Burleson,305,Proposition 4,,REP,Yes,178,122,56
+Burleson,305,Proposition 4,,REP,No,7,4,3
+Burleson,305,Proposition 5,,REP,Yes,175,119,56
+Burleson,305,Proposition 5,,REP,No,7,5,2
+Burleson,305,Proposition 6,,REP,Yes,176,122,54
+Burleson,305,Proposition 6,,REP,No,10,6,4
+Burleson,305,Proposition 7,,REP,Yes,184,128,56
+Burleson,305,Proposition 7,,REP,No,2,0,2
+Burleson,305,Proposition 8,,REP,Yes,181,125,56
+Burleson,305,Proposition 8,,REP,No,4,1,3
+Burleson,305,Proposition 9,,REP,Yes,180,124,56
+Burleson,305,Proposition 9,,REP,No,5,3,2
+Burleson,305,Proposition 10,,REP,Yes,175,120,55
+Burleson,305,Proposition 10,,REP,No,11,8,3
+Burleson,308,Registered Voters,,,Registered Voters,440,,
+Burleson,308,President,,REP,Joe Walsh,1,1,0
+Burleson,308,President,,REP,Donald J. Trump,150,70,80
+Burleson,308,President,,REP,Matthew John Matern,0,0,0
+Burleson,308,President,,REP,"Roque ""Rocky"" De La Fuente Guerra",0,0,0
+Burleson,308,President,,REP,Bill Weld,0,0,0
+Burleson,308,President,,REP,Bob Ely,0,0,0
+Burleson,308,President,,REP,Zoltan G. Istvan,0,0,0
+Burleson,308,President,,REP,Uncommitted,7,1,6
+Burleson,308,U.S. Senate,,REP,John Cornyn,120,54,66
+Burleson,308,U.S. Senate,,REP,Virgil Bierschwale,2,1,1
+Burleson,308,U.S. Senate,,REP,Mark Yancey,8,5,3
+Burleson,308,U.S. Senate,,REP,John Anthony Castro,5,2,3
+Burleson,308,U.S. Senate,,REP,Dwayne Stovall,16,6,10
+Burleson,308,U.S. House,17,REP,George W. Hindman,34,12,22
+Burleson,308,U.S. House,17,REP,Jeff Oppenheim,2,1,1
+Burleson,308,U.S. House,17,REP,Todd Kent,6,3,3
+Burleson,308,U.S. House,17,REP,Trent Sutton,6,4,2
+Burleson,308,U.S. House,17,REP,Laurie Godfrey McReynolds,1,0,1
+Burleson,308,U.S. House,17,REP,Elianor Vessali,21,6,15
+Burleson,308,U.S. House,17,REP,Renée Swann,52,31,21
+Burleson,308,U.S. House,17,REP,Kristen Alamo Rowin,3,2,1
+Burleson,308,U.S. House,17,REP,David Saucedo,1,0,1
+Burleson,308,U.S. House,17,REP,Ahmad Adnan,0,0,0
+Burleson,308,U.S. House,17,REP,Scott Bland,1,1,0
+Burleson,308,U.S. House,17,REP,Pete Sessions,27,11,16
+Burleson,308,Railroad Commissioner,,REP,"James ""Jim"" Wright",91,40,51
+Burleson,308,Railroad Commissioner,,REP,Ryan Sitton,55,28,27
+Burleson,308,"Chief Justice, Supreme Court",,REP,Nathan Hecht,135,61,74
+Burleson,308,"Justice, Supreme Court, Place 6",,REP,Jane Bland,135,61,74
+Burleson,308,"Justice, Supreme Court, Place 7",,REP,Jeff Boyd,138,62,76
+Burleson,308,"Justice, Supreme Court, Place 8",,REP,Brett Busby,137,61,76
+Burleson,308,"Judge, Court of Criminal Appeals, Place 3",,REP,Bert Richardson,79,41,38
+Burleson,308,"Judge, Court of Criminal Appeals, Place 3",,REP,Gina Parker,59,23,36
+Burleson,308,"Judge, Court of Criminal Appeals, Place 4",,REP,Kevin Patrick Yeary,132,60,72
+Burleson,308,"Judge, Court of Criminal Appeals, Place 9",,REP,David Newell,137,62,75
+Burleson,308,"Member, State Board of Education, District 10",,REP,Tom Maynard,135,63,72
+Burleson,308,State Senator,18,REP,Lois W. Kolkhorst,139,65,74
+Burleson,308,State Representative,13,REP,Ben Leman,143,66,77
+Burleson,308,"Justice, 10th Court of Appeals District, Place 2",,REP,Matt Johnson,134,61,73
+Burleson,308,"Justice, 10th Court of Appeals District, Place 3",,REP,John E. Neill,137,62,75
+Burleson,308,"District Judge, 21st Judicial District",,REP,Carson Campbell,144,66,78
+Burleson,308,"District Judge, 335th Judicial District",,REP,Charles W. Carver,44,26,18
+Burleson,308,"District Judge, 335th Judicial District",,REP,Reva L. Towslee Corbett,113,46,67
+Burleson,308,County Judge,,REP,Keith Schroeder,143,65,78
+Burleson,308,County Attorney,,REP,Susan Deski,138,64,74
+Burleson,308,Sheriff,,REP,Jayson Lyday,61,24,37
+Burleson,308,Sheriff,,REP,Gene Hermes,94,48,46
+Burleson,308,County Tax Assessor-Collector,,REP,Jessica Lucero,70,37,33
+Burleson,308,County Tax Assessor-Collector,,REP,Cheryl Story Castaneda,79,33,46
+Burleson,308,"County Commissioner, Precinct No. 3",,REP,Curtis Barnett,56,21,35
+Burleson,308,"County Commissioner, Precinct No. 3",,REP,David Hildebrand,99,50,49
+Burleson,308,"Constable, Precinct No. 3",,REP,Jay Boykin,147,69,78
+Burleson,308,County Chairman,,REP,Tyler Groce,141,64,77
+Burleson,308,Proposition 1,,REP,Yes,140,65,75
+Burleson,308,Proposition 1,,REP,No,13,6,7
+Burleson,308,Proposition 2,,REP,Yes,132,64,68
+Burleson,308,Proposition 2,,REP,No,18,6,12
+Burleson,308,Proposition 3,,REP,Yes,134,63,71
+Burleson,308,Proposition 3,,REP,No,17,8,9
+Burleson,308,Proposition 4,,REP,Yes,145,67,78
+Burleson,308,Proposition 4,,REP,No,5,3,2
+Burleson,308,Proposition 5,,REP,Yes,141,66,75
+Burleson,308,Proposition 5,,REP,No,8,4,4
+Burleson,308,Proposition 6,,REP,Yes,138,66,72
+Burleson,308,Proposition 6,,REP,No,9,4,5
+Burleson,308,Proposition 7,,REP,Yes,150,72,78
+Burleson,308,Proposition 7,,REP,No,1,0,1
+Burleson,308,Proposition 8,,REP,Yes,149,71,78
+Burleson,308,Proposition 8,,REP,No,2,1,1
+Burleson,308,Proposition 9,,REP,Yes,145,70,75
+Burleson,308,Proposition 9,,REP,No,5,1,4
+Burleson,308,Proposition 10,,REP,Yes,143,68,75
+Burleson,308,Proposition 10,,REP,No,9,3,6
+Burleson,309,Registered Voters,,,Registered Voters,752,,
+Burleson,309,President,,REP,Joe Walsh,2,0,2
+Burleson,309,President,,REP,Donald J. Trump,267,160,107
+Burleson,309,President,,REP,Matthew John Matern,0,0,0
+Burleson,309,President,,REP,"Roque ""Rocky"" De La Fuente Guerra",0,0,0
+Burleson,309,President,,REP,Bill Weld,2,1,1
+Burleson,309,President,,REP,Bob Ely,0,0,0
+Burleson,309,President,,REP,Zoltan G. Istvan,0,0,0
+Burleson,309,President,,REP,Uncommitted,8,5,3
+Burleson,309,U.S. Senate,,REP,John Cornyn,201,122,79
+Burleson,309,U.S. Senate,,REP,Virgil Bierschwale,5,0,5
+Burleson,309,U.S. Senate,,REP,Mark Yancey,17,11,6
+Burleson,309,U.S. Senate,,REP,John Anthony Castro,12,4,8
+Burleson,309,U.S. Senate,,REP,Dwayne Stovall,27,17,10
+Burleson,309,U.S. House,17,REP,George W. Hindman,51,34,17
+Burleson,309,U.S. House,17,REP,Jeff Oppenheim,5,2,3
+Burleson,309,U.S. House,17,REP,Todd Kent,10,5,5
+Burleson,309,U.S. House,17,REP,Trent Sutton,21,12,9
+Burleson,309,U.S. House,17,REP,Laurie Godfrey McReynolds,0,0,0
+Burleson,309,U.S. House,17,REP,Elianor Vessali,22,13,9
+Burleson,309,U.S. House,17,REP,Renée Swann,83,51,32
+Burleson,309,U.S. House,17,REP,Kristen Alamo Rowin,12,8,4
+Burleson,309,U.S. House,17,REP,David Saucedo,5,3,2
+Burleson,309,U.S. House,17,REP,Ahmad Adnan,0,0,0
+Burleson,309,U.S. House,17,REP,Scott Bland,0,0,0
+Burleson,309,U.S. House,17,REP,Pete Sessions,51,29,22
+Burleson,309,Railroad Commissioner,,REP,"James ""Jim"" Wright",148,83,65
+Burleson,309,Railroad Commissioner,,REP,Ryan Sitton,92,57,35
+Burleson,309,"Chief Justice, Supreme Court",,REP,Nathan Hecht,232,135,97
+Burleson,309,"Justice, Supreme Court, Place 6",,REP,Jane Bland,232,137,95
+Burleson,309,"Justice, Supreme Court, Place 7",,REP,Jeff Boyd,234,136,98
+Burleson,309,"Justice, Supreme Court, Place 8",,REP,Brett Busby,231,135,96
+Burleson,309,"Judge, Court of Criminal Appeals, Place 3",,REP,Bert Richardson,157,86,71
+Burleson,309,"Judge, Court of Criminal Appeals, Place 3",,REP,Gina Parker,78,52,26
+Burleson,309,"Judge, Court of Criminal Appeals, Place 4",,REP,Kevin Patrick Yeary,229,135,94
+Burleson,309,"Judge, Court of Criminal Appeals, Place 9",,REP,David Newell,230,136,94
+Burleson,309,"Member, State Board of Education, District 10",,REP,Tom Maynard,232,136,96
+Burleson,309,State Senator,18,REP,Lois W. Kolkhorst,239,145,94
+Burleson,309,State Representative,13,REP,Ben Leman,238,139,99
+Burleson,309,"Justice, 10th Court of Appeals District, Place 2",,REP,Matt Johnson,228,134,94
+Burleson,309,"Justice, 10th Court of Appeals District, Place 3",,REP,John E. Neill,229,135,94
+Burleson,309,"District Judge, 21st Judicial District",,REP,Carson Campbell,234,139,95
+Burleson,309,"District Judge, 335th Judicial District",,REP,Charles W. Carver,62,33,29
+Burleson,309,"District Judge, 335th Judicial District",,REP,Reva L. Towslee Corbett,199,122,77
+Burleson,309,County Judge,,REP,Keith Schroeder,240,144,96
+Burleson,309,County Attorney,,REP,Susan Deski,232,138,94
+Burleson,309,Sheriff,,REP,Jayson Lyday,132,76,56
+Burleson,309,Sheriff,,REP,Gene Hermes,145,91,54
+Burleson,309,County Tax Assessor-Collector,,REP,Jessica Lucero,108,68,40
+Burleson,309,County Tax Assessor-Collector,,REP,Cheryl Story Castaneda,148,84,64
+Burleson,309,"County Commissioner, Precinct No. 3",,REP,Curtis Barnett,79,46,33
+Burleson,309,"County Commissioner, Precinct No. 3",,REP,David Hildebrand,192,114,78
+Burleson,309,"Constable, Precinct No. 3",,REP,Jay Boykin,246,146,100
+Burleson,309,County Chairman,,REP,Tyler Groce,245,144,101
+Burleson,309,Proposition 1,,REP,Yes,247,147,100
+Burleson,309,Proposition 1,,REP,No,29,18,11
+Burleson,309,Proposition 2,,REP,Yes,243,147,96
+Burleson,309,Proposition 2,,REP,No,33,19,14
+Burleson,309,Proposition 3,,REP,Yes,257,155,102
+Burleson,309,Proposition 3,,REP,No,17,8,9
+Burleson,309,Proposition 4,,REP,Yes,261,158,103
+Burleson,309,Proposition 4,,REP,No,11,4,7
+Burleson,309,Proposition 5,,REP,Yes,246,149,97
+Burleson,309,Proposition 5,,REP,No,25,13,12
+Burleson,309,Proposition 6,,REP,Yes,261,159,102
+Burleson,309,Proposition 6,,REP,No,7,1,6
+Burleson,309,Proposition 7,,REP,Yes,264,159,105
+Burleson,309,Proposition 7,,REP,No,3,1,2
+Burleson,309,Proposition 8,,REP,Yes,266,163,103
+Burleson,309,Proposition 8,,REP,No,4,0,4
+Burleson,309,Proposition 9,,REP,Yes,259,158,101
+Burleson,309,Proposition 9,,REP,No,10,3,7
+Burleson,309,Proposition 10,,REP,Yes,244,143,101
+Burleson,309,Proposition 10,,REP,No,21,15,6
+Burleson,406,Registered Voters,,,Registered Voters,1273,,
+Burleson,406,President,,REP,Joe Walsh,3,3,0
+Burleson,406,President,,REP,Donald J. Trump,189,50,139
+Burleson,406,President,,REP,Matthew John Matern,1,1,0
+Burleson,406,President,,REP,"Roque ""Rocky"" De La Fuente Guerra",1,0,1
+Burleson,406,President,,REP,Bill Weld,1,1,0
+Burleson,406,President,,REP,Bob Ely,0,0,0
+Burleson,406,President,,REP,Zoltan G. Istvan,0,0,0
+Burleson,406,President,,REP,Uncommitted,5,2,3
+Burleson,406,U.S. Senate,,REP,John Cornyn,154,47,107
+Burleson,406,U.S. Senate,,REP,Virgil Bierschwale,2,1,1
+Burleson,406,U.S. Senate,,REP,Mark Yancey,10,2,8
+Burleson,406,U.S. Senate,,REP,John Anthony Castro,4,2,2
+Burleson,406,U.S. Senate,,REP,Dwayne Stovall,24,5,19
+Burleson,406,U.S. House,17,REP,George W. Hindman,20,0,20
+Burleson,406,U.S. House,17,REP,Jeff Oppenheim,4,0,4
+Burleson,406,U.S. House,17,REP,Todd Kent,10,3,7
+Burleson,406,U.S. House,17,REP,Trent Sutton,6,2,4
+Burleson,406,U.S. House,17,REP,Laurie Godfrey McReynolds,2,0,2
+Burleson,406,U.S. House,17,REP,Elianor Vessali,24,3,21
+Burleson,406,U.S. House,17,REP,Renée Swann,69,33,36
+Burleson,406,U.S. House,17,REP,Kristen Alamo Rowin,6,4,2
+Burleson,406,U.S. House,17,REP,David Saucedo,0,0,0
+Burleson,406,U.S. House,17,REP,Ahmad Adnan,1,1,0
+Burleson,406,U.S. House,17,REP,Scott Bland,6,0,6
+Burleson,406,U.S. House,17,REP,Pete Sessions,41,10,31
+Burleson,406,Railroad Commissioner,,REP,"James ""Jim"" Wright",114,33,81
+Burleson,406,Railroad Commissioner,,REP,Ryan Sitton,65,20,45
+Burleson,406,"Chief Justice, Supreme Court",,REP,Nathan Hecht,168,51,117
+Burleson,406,"Justice, Supreme Court, Place 6",,REP,Jane Bland,165,52,113
+Burleson,406,"Justice, Supreme Court, Place 7",,REP,Jeff Boyd,169,52,117
+Burleson,406,"Justice, Supreme Court, Place 8",,REP,Brett Busby,166,52,114
+Burleson,406,"Judge, Court of Criminal Appeals, Place 3",,REP,Bert Richardson,108,27,81
+Burleson,406,"Judge, Court of Criminal Appeals, Place 3",,REP,Gina Parker,59,21,38
+Burleson,406,"Judge, Court of Criminal Appeals, Place 4",,REP,Kevin Patrick Yeary,167,51,116
+Burleson,406,"Judge, Court of Criminal Appeals, Place 9",,REP,David Newell,165,51,114
+Burleson,406,"Member, State Board of Education, District 10",,REP,Tom Maynard,161,50,111
+Burleson,406,State Senator,18,REP,Lois W. Kolkhorst,180,52,128
+Burleson,406,State Representative,13,REP,Ben Leman,174,53,121
+Burleson,406,"Justice, 10th Court of Appeals District, Place 2",,REP,Matt Johnson,167,51,116
+Burleson,406,"Justice, 10th Court of Appeals District, Place 3",,REP,John E. Neill,166,51,115
+Burleson,406,"District Judge, 21st Judicial District",,REP,Carson Campbell,167,52,115
+Burleson,406,"District Judge, 335th Judicial District",,REP,Charles W. Carver,64,13,51
+Burleson,406,"District Judge, 335th Judicial District",,REP,Reva L. Towslee Corbett,121,42,79
+Burleson,406,County Judge,,REP,Keith Schroeder,176,55,121
+Burleson,406,County Attorney,,REP,Susan Deski,164,51,113
+Burleson,406,Sheriff,,REP,Jayson Lyday,90,17,73
+Burleson,406,Sheriff,,REP,Gene Hermes,108,40,68
+Burleson,406,County Tax Assessor-Collector,,REP,Jessica Lucero,88,31,57
+Burleson,406,County Tax Assessor-Collector,,REP,Cheryl Story Castaneda,100,25,75
+Burleson,406,"Constable, Precinct No. 4",,REP,Paul Muzny,170,52,118
+Burleson,406,County Chairman,,REP,Tyler Groce,173,52,121
+Burleson,406,Proposition 1,,REP,Yes,176,49,127
+Burleson,406,Proposition 1,,REP,No,20,6,14
+Burleson,406,Proposition 2,,REP,Yes,165,43,122
+Burleson,406,Proposition 2,,REP,No,31,12,19
+Burleson,406,Proposition 3,,REP,Yes,181,49,132
+Burleson,406,Proposition 3,,REP,No,14,6,8
+Burleson,406,Proposition 4,,REP,Yes,185,47,138
+Burleson,406,Proposition 4,,REP,No,10,8,2
+Burleson,406,Proposition 5,,REP,Yes,180,47,133
+Burleson,406,Proposition 5,,REP,No,17,7,10
+Burleson,406,Proposition 6,,REP,Yes,187,53,134
+Burleson,406,Proposition 6,,REP,No,10,2,8
+Burleson,406,Proposition 7,,REP,Yes,193,53,140
+Burleson,406,Proposition 7,,REP,No,6,2,4
+Burleson,406,Proposition 8,,REP,Yes,192,52,140
+Burleson,406,Proposition 8,,REP,No,5,3,2
+Burleson,406,Proposition 9,,REP,Yes,193,55,138
+Burleson,406,Proposition 9,,REP,No,4,0,4
+Burleson,406,Proposition 10,,REP,Yes,179,50,129
+Burleson,406,Proposition 10,,REP,No,18,5,13
+Burleson,410,Registered Voters,,,Registered Voters,1939,,
+Burleson,410,President,,REP,Joe Walsh,5,1,4
+Burleson,410,President,,REP,Donald J. Trump,481,232,249
+Burleson,410,President,,REP,Matthew John Matern,1,1,0
+Burleson,410,President,,REP,"Roque ""Rocky"" De La Fuente Guerra",0,0,0
+Burleson,410,President,,REP,Bill Weld,1,1,0
+Burleson,410,President,,REP,Bob Ely,1,0,1
+Burleson,410,President,,REP,Zoltan G. Istvan,0,0,0
+Burleson,410,President,,REP,Uncommitted,10,3,7
+Burleson,410,U.S. Senate,,REP,John Cornyn,378,192,186
+Burleson,410,U.S. Senate,,REP,Virgil Bierschwale,4,1,3
+Burleson,410,U.S. Senate,,REP,Mark Yancey,18,7,11
+Burleson,410,U.S. Senate,,REP,John Anthony Castro,11,5,6
+Burleson,410,U.S. Senate,,REP,Dwayne Stovall,66,24,42
+Burleson,410,U.S. House,17,REP,George W. Hindman,89,35,54
+Burleson,410,U.S. House,17,REP,Jeff Oppenheim,7,2,5
+Burleson,410,U.S. House,17,REP,Todd Kent,22,8,14
+Burleson,410,U.S. House,17,REP,Trent Sutton,19,11,8
+Burleson,410,U.S. House,17,REP,Laurie Godfrey McReynolds,6,2,4
+Burleson,410,U.S. House,17,REP,Elianor Vessali,60,22,38
+Burleson,410,U.S. House,17,REP,Renée Swann,175,94,81
+Burleson,410,U.S. House,17,REP,Kristen Alamo Rowin,3,2,1
+Burleson,410,U.S. House,17,REP,David Saucedo,1,1,0
+Burleson,410,U.S. House,17,REP,Ahmad Adnan,0,0,0
+Burleson,410,U.S. House,17,REP,Scott Bland,9,5,4
+Burleson,410,U.S. House,17,REP,Pete Sessions,92,48,44
+Burleson,410,Railroad Commissioner,,REP,"James ""Jim"" Wright",282,138,144
+Burleson,410,Railroad Commissioner,,REP,Ryan Sitton,163,78,85
+Burleson,410,"Chief Justice, Supreme Court",,REP,Nathan Hecht,417,197,220
+Burleson,410,"Justice, Supreme Court, Place 6",,REP,Jane Bland,425,201,224
+Burleson,410,"Justice, Supreme Court, Place 7",,REP,Jeff Boyd,421,201,220
+Burleson,410,"Justice, Supreme Court, Place 8",,REP,Brett Busby,425,203,222
+Burleson,410,"Judge, Court of Criminal Appeals, Place 3",,REP,Bert Richardson,266,129,137
+Burleson,410,"Judge, Court of Criminal Appeals, Place 3",,REP,Gina Parker,166,78,88
+Burleson,410,"Judge, Court of Criminal Appeals, Place 4",,REP,Kevin Patrick Yeary,422,199,223
+Burleson,410,"Judge, Court of Criminal Appeals, Place 9",,REP,David Newell,423,201,222
+Burleson,410,"Member, State Board of Education, District 10",,REP,Tom Maynard,422,201,221
+Burleson,410,State Senator,18,REP,Lois W. Kolkhorst,454,221,233
+Burleson,410,State Representative,13,REP,Ben Leman,447,215,232
+Burleson,410,"Justice, 10th Court of Appeals District, Place 2",,REP,Matt Johnson,425,202,223
+Burleson,410,"Justice, 10th Court of Appeals District, Place 3",,REP,John E. Neill,426,202,224
+Burleson,410,"District Judge, 21st Judicial District",,REP,Carson Campbell,427,202,225
+Burleson,410,"District Judge, 335th Judicial District",,REP,Charles W. Carver,169,79,90
+Burleson,410,"District Judge, 335th Judicial District",,REP,Reva L. Towslee Corbett,297,147,150
+Burleson,410,County Judge,,REP,Keith Schroeder,430,209,221
+Burleson,410,County Attorney,,REP,Susan Deski,418,199,219
+Burleson,410,Sheriff,,REP,Jayson Lyday,220,103,117
+Burleson,410,Sheriff,,REP,Gene Hermes,265,130,135
+Burleson,410,County Tax Assessor-Collector,,REP,Jessica Lucero,203,88,115
+Burleson,410,County Tax Assessor-Collector,,REP,Cheryl Story Castaneda,255,134,121
+Burleson,410,"Constable, Precinct No. 4",,REP,Paul Muzny,437,212,225
+Burleson,410,County Chairman,,REP,Tyler Groce,418,202,216
+Burleson,410,Proposition 1,,REP,Yes,437,205,232
+Burleson,410,Proposition 1,,REP,No,50,27,23
+Burleson,410,Proposition 2,,REP,Yes,427,209,218
+Burleson,410,Proposition 2,,REP,No,58,22,36
+Burleson,410,Proposition 3,,REP,Yes,457,218,239
+Burleson,410,Proposition 3,,REP,No,25,11,14
+Burleson,410,Proposition 4,,REP,Yes,460,220,240
+Burleson,410,Proposition 4,,REP,No,21,9,12
+Burleson,410,Proposition 5,,REP,Yes,449,212,237
+Burleson,410,Proposition 5,,REP,No,29,16,13
+Burleson,410,Proposition 6,,REP,Yes,456,219,237
+Burleson,410,Proposition 6,,REP,No,22,10,12
+Burleson,410,Proposition 7,,REP,Yes,475,229,246
+Burleson,410,Proposition 7,,REP,No,7,2,5
+Burleson,410,Proposition 8,,REP,Yes,475,227,248
+Burleson,410,Proposition 8,,REP,No,6,3,3
+Burleson,410,Proposition 9,,REP,Yes,465,224,241
+Burleson,410,Proposition 9,,REP,No,18,8,10
+Burleson,410,Proposition 10,,REP,Yes,442,209,233
+Burleson,410,Proposition 10,,REP,No,36,21,15
+Burleson,113,President,,DEM,Michael R. Bloomberg,8,5,3
+Burleson,113,President,,DEM,Tulsi Gabbard,0,0,0
+Burleson,113,President,,DEM,Deval Patrick,0,0,0
+Burleson,113,President,,DEM,John K. Delaney,0,0,0
+Burleson,113,President,,DEM,Joseph R. Biden,16,4,12
+Burleson,113,President,,DEM,Robby Wells,0,0,0
+Burleson,113,President,,DEM,Amy Klobuchar,0,0,0
+Burleson,113,President,,DEM,Michael Bennet,0,0,0
+Burleson,113,President,,DEM,Elizabeth Warren,0,0,0
+Burleson,113,President,,DEM,Pete Buttigieg,1,1,0
+Burleson,113,President,,DEM,Bernie Sanders,4,1,3
+Burleson,113,President,,DEM,Cory Booker,0,0,0
+Burleson,113,President,,DEM,"Roque ""Rocky"" De La Fuente",0,0,0
+Burleson,113,President,,DEM,Andrew Yang,0,0,0
+Burleson,113,President,,DEM,Julián Castro,0,0,0
+Burleson,113,President,,DEM,Tom Steyer,0,0,0
+Burleson,113,President,,DEM,Marianne Williamson,0,0,0
+Burleson,113,U.S. Senate,,DEM,Royce West,3,1,2
+Burleson,113,U.S. Senate,,DEM,Michael Cooper,4,2,2
+Burleson,113,U.S. Senate,,DEM,"Annie ""Mamá"" Garcia",5,3,2
+Burleson,113,U.S. Senate,,DEM,Cristina Tzintzun Ramirez,1,1,0
+Burleson,113,U.S. Senate,,DEM,Adrian Ocegueda,0,0,0
+Burleson,113,U.S. Senate,,DEM,Victor Hugo Harris,0,0,0
+Burleson,113,U.S. Senate,,DEM,D.R. Hunter,0,0,0
+Burleson,113,U.S. Senate,,DEM,Jack Daniel Foster Jr,1,1,0
+Burleson,113,U.S. Senate,,DEM,"Mary ""MJ"" Hegar",5,1,4
+Burleson,113,U.S. Senate,,DEM,Chris Bell,2,1,1
+Burleson,113,U.S. Senate,,DEM,Amanda K. Edwards,0,0,0
+Burleson,113,U.S. Senate,,DEM,Sema Hernandez,2,1,1
+Burleson,113,U.S. House,17,DEM,Rick Kennedy,9,4,5
+Burleson,113,U.S. House,17,DEM,William Foster III,11,6,5
+Burleson,113,U.S. House,17,DEM,David Anthony Jaramillo,1,1,0
+Burleson,113,Railroad Commissioner,,DEM,Kelly Stone,7,3,4
+Burleson,113,Railroad Commissioner,,DEM,"Roberto R. ""Beto"" Alonzo",2,0,2
+Burleson,113,Railroad Commissioner,,DEM,Mark Watson,7,5,2
+Burleson,113,Railroad Commissioner,,DEM,Chrysta Castañeda,4,3,1
+Burleson,113,"Chief Justice, Supreme Court",,DEM,Jerry Zimmerer,12,6,6
+Burleson,113,"Chief Justice, Supreme Court",,DEM,Amy Clark Meachum,8,5,3
+Burleson,113,"Justice, Supreme Court, Place 6",,DEM,Larry Praeger,10,5,5
+Burleson,113,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,9,6,3
+Burleson,113,"Justice, Supreme Court, Place 7",,DEM,Brandy Voss,8,4,4
+Burleson,113,"Justice, Supreme Court, Place 7",,DEM,Staci Williams,11,7,4
+Burleson,113,"Justice, Supreme Court, Place 8",,DEM,Peter Kelly,15,8,7
+Burleson,113,"Justice, Supreme Court, Place 8",,DEM,Gisela D. Triana,6,3,3
+Burleson,113,"Judge, Court of Criminal Appeals, Place 3",,DEM,Dan Wood,6,4,2
+Burleson,113,"Judge, Court of Criminal Appeals, Place 3",,DEM,William Pieratt Demond,3,2,1
+Burleson,113,"Judge, Court of Criminal Appeals, Place 3",,DEM,Elizabeth Davis Frizell,9,5,4
+Burleson,113,"Judge, Court of Criminal Appeals, Place 4",,DEM,Tina Clinton,12,7,5
+Burleson,113,"Judge, Court of Criminal Appeals, Place 4",,DEM,Steven Miears,6,4,2
+Burleson,113,"Judge, Court of Criminal Appeals, Place 9",,DEM,Brandon Birmingham,19,11,8
+Burleson,113,"Member, State Board of Education, District 10",,DEM,Stephen Wyman,9,3,6
+Burleson,113,"Member, State Board of Education, District 10",,DEM,Marsha Burnett-Webster,12,8,4
+Burleson,113,State Senator,18,DEM,Michael Antalan,20,11,9
+Burleson,113,County Chairman,,DEM,Linda Arbuckle,19,10,9
+Burleson,113,Proposition 1,,DEM,Yes,22,11,11
+Burleson,113,Proposition 1,,DEM,No,2,0,2
+Burleson,113,Proposition 2,,DEM,Yes,22,11,11
+Burleson,113,Proposition 2,,DEM,No,1,0,1
+Burleson,113,Proposition 3,,DEM,Yes,22,11,11
+Burleson,113,Proposition 3,,DEM,No,2,0,2
+Burleson,113,Proposition 4,,DEM,Yes,22,11,11
+Burleson,113,Proposition 4,,DEM,No,2,0,2
+Burleson,113,Proposition 5,,DEM,Yes,21,11,10
+Burleson,113,Proposition 5,,DEM,No,2,0,2
+Burleson,113,Proposition 6,,DEM,Yes,23,11,12
+Burleson,113,Proposition 6,,DEM,No,1,0,1
+Burleson,113,Proposition 7,,DEM,Yes,24,11,13
+Burleson,113,Proposition 7,,DEM,No,0,0,0
+Burleson,113,Proposition 8,,DEM,Yes,22,11,11
+Burleson,113,Proposition 8,,DEM,No,1,0,1
+Burleson,113,Proposition 9,,DEM,Yes,22,11,11
+Burleson,113,Proposition 9,,DEM,No,2,0,2
+Burleson,113,Proposition 10,,DEM,Yes,19,10,9
+Burleson,113,Proposition 10,,DEM,No,3,1,2
+Burleson,113,Proposition 11,,DEM,Yes,21,10,11
+Burleson,113,Proposition 11,,DEM,No,1,1,0
+Burleson,114,President,,DEM,Michael R. Bloomberg,29,22,7
+Burleson,114,President,,DEM,Tulsi Gabbard,0,0,0
+Burleson,114,President,,DEM,Deval Patrick,0,0,0
+Burleson,114,President,,DEM,John K. Delaney,0,0,0
+Burleson,114,President,,DEM,Joseph R. Biden,42,25,17
+Burleson,114,President,,DEM,Robby Wells,0,0,0
+Burleson,114,President,,DEM,Amy Klobuchar,0,0,0
+Burleson,114,President,,DEM,Michael Bennet,1,1,0
+Burleson,114,President,,DEM,Elizabeth Warren,8,4,4
+Burleson,114,President,,DEM,Pete Buttigieg,0,0,0
+Burleson,114,President,,DEM,Bernie Sanders,21,8,13
+Burleson,114,President,,DEM,Cory Booker,1,1,0
+Burleson,114,President,,DEM,"Roque ""Rocky"" De La Fuente",1,1,0
+Burleson,114,President,,DEM,Andrew Yang,0,0,0
+Burleson,114,President,,DEM,Julián Castro,1,0,1
+Burleson,114,President,,DEM,Tom Steyer,0,0,0
+Burleson,114,President,,DEM,Marianne Williamson,1,0,1
+Burleson,114,U.S. Senate,,DEM,Royce West,11,8,3
+Burleson,114,U.S. Senate,,DEM,Michael Cooper,15,11,4
+Burleson,114,U.S. Senate,,DEM,"Annie ""Mamá"" Garcia",10,6,4
+Burleson,114,U.S. Senate,,DEM,Cristina Tzintzun Ramirez,8,2,6
+Burleson,114,U.S. Senate,,DEM,Adrian Ocegueda,3,2,1
+Burleson,114,U.S. Senate,,DEM,Victor Hugo Harris,3,1,2
+Burleson,114,U.S. Senate,,DEM,D.R. Hunter,2,2,0
+Burleson,114,U.S. Senate,,DEM,Jack Daniel Foster Jr,5,3,2
+Burleson,114,U.S. Senate,,DEM,"Mary ""MJ"" Hegar",21,13,8
+Burleson,114,U.S. Senate,,DEM,Chris Bell,8,5,3
+Burleson,114,U.S. Senate,,DEM,Amanda K. Edwards,4,1,3
+Burleson,114,U.S. Senate,,DEM,Sema Hernandez,7,5,2
+Burleson,114,U.S. House,17,DEM,Rick Kennedy,46,30,16
+Burleson,114,U.S. House,17,DEM,William Foster III,22,10,12
+Burleson,114,U.S. House,17,DEM,David Anthony Jaramillo,31,21,10
+Burleson,114,Railroad Commissioner,,DEM,Kelly Stone,19,12,7
+Burleson,114,Railroad Commissioner,,DEM,"Roberto R. ""Beto"" Alonzo",35,23,12
+Burleson,114,Railroad Commissioner,,DEM,Mark Watson,21,9,12
+Burleson,114,Railroad Commissioner,,DEM,Chrysta Castañeda,23,14,9
+Burleson,114,"Chief Justice, Supreme Court",,DEM,Jerry Zimmerer,37,23,14
+Burleson,114,"Chief Justice, Supreme Court",,DEM,Amy Clark Meachum,59,36,23
+Burleson,114,"Justice, Supreme Court, Place 6",,DEM,Larry Praeger,45,22,23
+Burleson,114,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,48,34,14
+Burleson,114,"Justice, Supreme Court, Place 7",,DEM,Brandy Voss,32,20,12
+Burleson,114,"Justice, Supreme Court, Place 7",,DEM,Staci Williams,63,36,27
+Burleson,114,"Justice, Supreme Court, Place 8",,DEM,Peter Kelly,52,30,22
+Burleson,114,"Justice, Supreme Court, Place 8",,DEM,Gisela D. Triana,43,26,17
+Burleson,114,"Judge, Court of Criminal Appeals, Place 3",,DEM,Dan Wood,23,15,8
+Burleson,114,"Judge, Court of Criminal Appeals, Place 3",,DEM,William Pieratt Demond,16,8,8
+Burleson,114,"Judge, Court of Criminal Appeals, Place 3",,DEM,Elizabeth Davis Frizell,56,33,23
+Burleson,114,"Judge, Court of Criminal Appeals, Place 4",,DEM,Tina Clinton,69,42,27
+Burleson,114,"Judge, Court of Criminal Appeals, Place 4",,DEM,Steven Miears,26,14,12
+Burleson,114,"Judge, Court of Criminal Appeals, Place 9",,DEM,Brandon Birmingham,90,54,36
+Burleson,114,"Member, State Board of Education, District 10",,DEM,Stephen Wyman,27,21,6
+Burleson,114,"Member, State Board of Education, District 10",,DEM,Marsha Burnett-Webster,67,34,33
+Burleson,114,State Senator,18,DEM,Michael Antalan,87,50,37
+Burleson,114,County Chairman,,DEM,Linda Arbuckle,90,54,36
+Burleson,114,Proposition 1,,DEM,Yes,101,61,40
+Burleson,114,Proposition 1,,DEM,No,3,2,1
+Burleson,114,Proposition 2,,DEM,Yes,100,60,40
+Burleson,114,Proposition 2,,DEM,No,3,2,1
+Burleson,114,Proposition 3,,DEM,Yes,102,61,41
+Burleson,114,Proposition 3,,DEM,No,1,1,0
+Burleson,114,Proposition 4,,DEM,Yes,100,60,40
+Burleson,114,Proposition 4,,DEM,No,3,2,1
+Burleson,114,Proposition 5,,DEM,Yes,101,61,40
+Burleson,114,Proposition 5,,DEM,No,2,1,1
+Burleson,114,Proposition 6,,DEM,Yes,99,58,41
+Burleson,114,Proposition 6,,DEM,No,4,3,1
+Burleson,114,Proposition 7,,DEM,Yes,100,59,41
+Burleson,114,Proposition 7,,DEM,No,3,2,1
+Burleson,114,Proposition 8,,DEM,Yes,99,58,41
+Burleson,114,Proposition 8,,DEM,No,4,3,1
+Burleson,114,Proposition 9,,DEM,Yes,102,61,41
+Burleson,114,Proposition 9,,DEM,No,2,1,1
+Burleson,114,Proposition 10,,DEM,Yes,98,59,39
+Burleson,114,Proposition 10,,DEM,No,5,2,3
+Burleson,114,Proposition 11,,DEM,Yes,95,56,39
+Burleson,114,Proposition 11,,DEM,No,8,5,3
+Burleson,203,President,,DEM,Michael R. Bloomberg,7,6,1
+Burleson,203,President,,DEM,Tulsi Gabbard,0,0,0
+Burleson,203,President,,DEM,Deval Patrick,0,0,0
+Burleson,203,President,,DEM,John K. Delaney,0,0,0
+Burleson,203,President,,DEM,Joseph R. Biden,9,3,6
+Burleson,203,President,,DEM,Robby Wells,0,0,0
+Burleson,203,President,,DEM,Amy Klobuchar,1,1,0
+Burleson,203,President,,DEM,Michael Bennet,0,0,0
+Burleson,203,President,,DEM,Elizabeth Warren,1,0,1
+Burleson,203,President,,DEM,Pete Buttigieg,0,0,0
+Burleson,203,President,,DEM,Bernie Sanders,4,3,1
+Burleson,203,President,,DEM,Cory Booker,0,0,0
+Burleson,203,President,,DEM,"Roque ""Rocky"" De La Fuente",0,0,0
+Burleson,203,President,,DEM,Andrew Yang,0,0,0
+Burleson,203,President,,DEM,Julián Castro,0,0,0
+Burleson,203,President,,DEM,Tom Steyer,1,1,0
+Burleson,203,President,,DEM,Marianne Williamson,0,0,0
+Burleson,203,U.S. Senate,,DEM,Royce West,5,4,1
+Burleson,203,U.S. Senate,,DEM,Michael Cooper,0,0,0
+Burleson,203,U.S. Senate,,DEM,"Annie ""Mamá"" Garcia",2,1,1
+Burleson,203,U.S. Senate,,DEM,Cristina Tzintzun Ramirez,0,0,0
+Burleson,203,U.S. Senate,,DEM,Adrian Ocegueda,0,0,0
+Burleson,203,U.S. Senate,,DEM,Victor Hugo Harris,2,1,1
+Burleson,203,U.S. Senate,,DEM,D.R. Hunter,0,0,0
+Burleson,203,U.S. Senate,,DEM,Jack Daniel Foster Jr,0,0,0
+Burleson,203,U.S. Senate,,DEM,"Mary ""MJ"" Hegar",9,8,1
+Burleson,203,U.S. Senate,,DEM,Chris Bell,1,0,1
+Burleson,203,U.S. Senate,,DEM,Amanda K. Edwards,1,0,1
+Burleson,203,U.S. Senate,,DEM,Sema Hernandez,0,0,0
+Burleson,203,U.S. House,17,DEM,Rick Kennedy,15,11,4
+Burleson,203,U.S. House,17,DEM,William Foster III,3,1,2
+Burleson,203,U.S. House,17,DEM,David Anthony Jaramillo,1,1,0
+Burleson,203,Railroad Commissioner,,DEM,Kelly Stone,6,6,0
+Burleson,203,Railroad Commissioner,,DEM,"Roberto R. ""Beto"" Alonzo",4,2,2
+Burleson,203,Railroad Commissioner,,DEM,Mark Watson,7,3,4
+Burleson,203,Railroad Commissioner,,DEM,Chrysta Castañeda,4,3,1
+Burleson,203,"Chief Justice, Supreme Court",,DEM,Jerry Zimmerer,10,6,4
+Burleson,203,"Chief Justice, Supreme Court",,DEM,Amy Clark Meachum,9,7,2
+Burleson,203,"Justice, Supreme Court, Place 6",,DEM,Larry Praeger,14,8,6
+Burleson,203,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,6,5,1
+Burleson,203,"Justice, Supreme Court, Place 7",,DEM,Brandy Voss,11,7,4
+Burleson,203,"Justice, Supreme Court, Place 7",,DEM,Staci Williams,8,6,2
+Burleson,203,"Justice, Supreme Court, Place 8",,DEM,Peter Kelly,16,11,5
+Burleson,203,"Justice, Supreme Court, Place 8",,DEM,Gisela D. Triana,4,3,1
+Burleson,203,"Judge, Court of Criminal Appeals, Place 3",,DEM,Dan Wood,9,6,3
+Burleson,203,"Judge, Court of Criminal Appeals, Place 3",,DEM,William Pieratt Demond,6,3,3
+Burleson,203,"Judge, Court of Criminal Appeals, Place 3",,DEM,Elizabeth Davis Frizell,5,4,1
+Burleson,203,"Judge, Court of Criminal Appeals, Place 4",,DEM,Tina Clinton,13,8,5
+Burleson,203,"Judge, Court of Criminal Appeals, Place 4",,DEM,Steven Miears,6,5,1
+Burleson,203,"Judge, Court of Criminal Appeals, Place 9",,DEM,Brandon Birmingham,17,10,7
+Burleson,203,"Member, State Board of Education, District 10",,DEM,Stephen Wyman,12,8,4
+Burleson,203,"Member, State Board of Education, District 10",,DEM,Marsha Burnett-Webster,7,5,2
+Burleson,203,State Senator,18,DEM,Michael Antalan,15,9,6
+Burleson,203,County Chairman,,DEM,Linda Arbuckle,17,12,5
+Burleson,203,Proposition 1,,DEM,Yes,17,8,9
+Burleson,203,Proposition 1,,DEM,No,4,4,0
+Burleson,203,Proposition 2,,DEM,Yes,21,12,9
+Burleson,203,Proposition 2,,DEM,No,0,0,0
+Burleson,203,Proposition 3,,DEM,Yes,20,11,9
+Burleson,203,Proposition 3,,DEM,No,1,1,0
+Burleson,203,Proposition 4,,DEM,Yes,18,9,9
+Burleson,203,Proposition 4,,DEM,No,3,3,0
+Burleson,203,Proposition 5,,DEM,Yes,20,12,8
+Burleson,203,Proposition 5,,DEM,No,1,0,1
+Burleson,203,Proposition 6,,DEM,Yes,22,13,9
+Burleson,203,Proposition 6,,DEM,No,0,0,0
+Burleson,203,Proposition 7,,DEM,Yes,20,11,9
+Burleson,203,Proposition 7,,DEM,No,1,1,0
+Burleson,203,Proposition 8,,DEM,Yes,20,12,8
+Burleson,203,Proposition 8,,DEM,No,1,0,1
+Burleson,203,Proposition 9,,DEM,Yes,20,12,8
+Burleson,203,Proposition 9,,DEM,No,0,0,0
+Burleson,203,Proposition 10,,DEM,Yes,18,10,8
+Burleson,203,Proposition 10,,DEM,No,4,3,1
+Burleson,203,Proposition 11,,DEM,Yes,15,9,6
+Burleson,203,Proposition 11,,DEM,No,7,4,3
+Burleson,204,President,,DEM,Michael R. Bloomberg,4,2,2
+Burleson,204,President,,DEM,Tulsi Gabbard,1,1,0
+Burleson,204,President,,DEM,Deval Patrick,0,0,0
+Burleson,204,President,,DEM,John K. Delaney,0,0,0
+Burleson,204,President,,DEM,Joseph R. Biden,14,5,9
+Burleson,204,President,,DEM,Robby Wells,0,0,0
+Burleson,204,President,,DEM,Amy Klobuchar,0,0,0
+Burleson,204,President,,DEM,Michael Bennet,0,0,0
+Burleson,204,President,,DEM,Elizabeth Warren,1,0,1
+Burleson,204,President,,DEM,Pete Buttigieg,5,5,0
+Burleson,204,President,,DEM,Bernie Sanders,2,2,0
+Burleson,204,President,,DEM,Cory Booker,0,0,0
+Burleson,204,President,,DEM,"Roque ""Rocky"" De La Fuente",0,0,0
+Burleson,204,President,,DEM,Andrew Yang,0,0,0
+Burleson,204,President,,DEM,Julián Castro,0,0,0
+Burleson,204,President,,DEM,Tom Steyer,1,1,0
+Burleson,204,President,,DEM,Marianne Williamson,0,0,0
+Burleson,204,U.S. Senate,,DEM,Royce West,4,4,0
+Burleson,204,U.S. Senate,,DEM,Michael Cooper,4,2,2
+Burleson,204,U.S. Senate,,DEM,"Annie ""Mamá"" Garcia",1,1,0
+Burleson,204,U.S. Senate,,DEM,Cristina Tzintzun Ramirez,2,2,0
+Burleson,204,U.S. Senate,,DEM,Adrian Ocegueda,0,0,0
+Burleson,204,U.S. Senate,,DEM,Victor Hugo Harris,0,0,0
+Burleson,204,U.S. Senate,,DEM,D.R. Hunter,0,0,0
+Burleson,204,U.S. Senate,,DEM,Jack Daniel Foster Jr,1,0,1
+Burleson,204,U.S. Senate,,DEM,"Mary ""MJ"" Hegar",8,2,6
+Burleson,204,U.S. Senate,,DEM,Chris Bell,2,1,1
+Burleson,204,U.S. Senate,,DEM,Amanda K. Edwards,4,4,0
+Burleson,204,U.S. Senate,,DEM,Sema Hernandez,0,0,0
+Burleson,204,U.S. House,17,DEM,Rick Kennedy,12,6,6
+Burleson,204,U.S. House,17,DEM,William Foster III,9,7,2
+Burleson,204,U.S. House,17,DEM,David Anthony Jaramillo,4,2,2
+Burleson,204,Railroad Commissioner,,DEM,Kelly Stone,7,6,1
+Burleson,204,Railroad Commissioner,,DEM,"Roberto R. ""Beto"" Alonzo",5,3,2
+Burleson,204,Railroad Commissioner,,DEM,Mark Watson,3,1,2
+Burleson,204,Railroad Commissioner,,DEM,Chrysta Castañeda,10,5,5
+Burleson,204,"Chief Justice, Supreme Court",,DEM,Jerry Zimmerer,7,4,3
+Burleson,204,"Chief Justice, Supreme Court",,DEM,Amy Clark Meachum,18,11,7
+Burleson,204,"Justice, Supreme Court, Place 6",,DEM,Larry Praeger,12,9,3
+Burleson,204,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,13,6,7
+Burleson,204,"Justice, Supreme Court, Place 7",,DEM,Brandy Voss,13,7,6
+Burleson,204,"Justice, Supreme Court, Place 7",,DEM,Staci Williams,12,8,4
+Burleson,204,"Justice, Supreme Court, Place 8",,DEM,Peter Kelly,14,10,4
+Burleson,204,"Justice, Supreme Court, Place 8",,DEM,Gisela D. Triana,11,5,6
+Burleson,204,"Judge, Court of Criminal Appeals, Place 3",,DEM,Dan Wood,9,6,3
+Burleson,204,"Judge, Court of Criminal Appeals, Place 3",,DEM,William Pieratt Demond,3,3,0
+Burleson,204,"Judge, Court of Criminal Appeals, Place 3",,DEM,Elizabeth Davis Frizell,13,6,7
+Burleson,204,"Judge, Court of Criminal Appeals, Place 4",,DEM,Tina Clinton,13,8,5
+Burleson,204,"Judge, Court of Criminal Appeals, Place 4",,DEM,Steven Miears,11,6,5
+Burleson,204,"Judge, Court of Criminal Appeals, Place 9",,DEM,Brandon Birmingham,23,13,10
+Burleson,204,"Member, State Board of Education, District 10",,DEM,Stephen Wyman,5,3,2
+Burleson,204,"Member, State Board of Education, District 10",,DEM,Marsha Burnett-Webster,19,11,8
+Burleson,204,State Senator,18,DEM,Michael Antalan,23,13,10
+Burleson,204,County Chairman,,DEM,Linda Arbuckle,25,15,10
+Burleson,204,Proposition 1,,DEM,Yes,27,17,10
+Burleson,204,Proposition 1,,DEM,No,2,0,2
+Burleson,204,Proposition 2,,DEM,Yes,26,17,9
+Burleson,204,Proposition 2,,DEM,No,2,0,2
+Burleson,204,Proposition 3,,DEM,Yes,27,17,10
+Burleson,204,Proposition 3,,DEM,No,2,0,2
+Burleson,204,Proposition 4,,DEM,Yes,27,16,11
+Burleson,204,Proposition 4,,DEM,No,2,1,1
+Burleson,204,Proposition 5,,DEM,Yes,27,16,11
+Burleson,204,Proposition 5,,DEM,No,1,0,1
+Burleson,204,Proposition 6,,DEM,Yes,28,17,11
+Burleson,204,Proposition 6,,DEM,No,1,0,1
+Burleson,204,Proposition 7,,DEM,Yes,26,16,10
+Burleson,204,Proposition 7,,DEM,No,2,0,2
+Burleson,204,Proposition 8,,DEM,Yes,27,17,10
+Burleson,204,Proposition 8,,DEM,No,2,0,2
+Burleson,204,Proposition 9,,DEM,Yes,27,17,10
+Burleson,204,Proposition 9,,DEM,No,1,0,1
+Burleson,204,Proposition 10,,DEM,Yes,27,17,10
+Burleson,204,Proposition 10,,DEM,No,2,0,2
+Burleson,204,Proposition 11,,DEM,Yes,22,14,8
+Burleson,204,Proposition 11,,DEM,No,6,2,4
+Burleson,207,President,,DEM,Michael R. Bloomberg,4,2,2
+Burleson,207,President,,DEM,Tulsi Gabbard,0,0,0
+Burleson,207,President,,DEM,Deval Patrick,0,0,0
+Burleson,207,President,,DEM,John K. Delaney,1,0,1
+Burleson,207,President,,DEM,Joseph R. Biden,40,10,30
+Burleson,207,President,,DEM,Robby Wells,0,0,0
+Burleson,207,President,,DEM,Amy Klobuchar,0,0,0
+Burleson,207,President,,DEM,Michael Bennet,0,0,0
+Burleson,207,President,,DEM,Elizabeth Warren,4,0,4
+Burleson,207,President,,DEM,Pete Buttigieg,0,0,0
+Burleson,207,President,,DEM,Bernie Sanders,0,0,0
+Burleson,207,President,,DEM,Cory Booker,1,1,0
+Burleson,207,President,,DEM,"Roque ""Rocky"" De La Fuente",0,0,0
+Burleson,207,President,,DEM,Andrew Yang,0,0,0
+Burleson,207,President,,DEM,Julián Castro,0,0,0
+Burleson,207,President,,DEM,Tom Steyer,0,0,0
+Burleson,207,President,,DEM,Marianne Williamson,1,0,1
+Burleson,207,U.S. Senate,,DEM,Royce West,6,2,4
+Burleson,207,U.S. Senate,,DEM,Michael Cooper,5,1,4
+Burleson,207,U.S. Senate,,DEM,"Annie ""Mamá"" Garcia",1,0,1
+Burleson,207,U.S. Senate,,DEM,Cristina Tzintzun Ramirez,2,0,2
+Burleson,207,U.S. Senate,,DEM,Adrian Ocegueda,0,0,0
+Burleson,207,U.S. Senate,,DEM,Victor Hugo Harris,3,2,1
+Burleson,207,U.S. Senate,,DEM,D.R. Hunter,2,1,1
+Burleson,207,U.S. Senate,,DEM,Jack Daniel Foster Jr,4,1,3
+Burleson,207,U.S. Senate,,DEM,"Mary ""MJ"" Hegar",4,1,3
+Burleson,207,U.S. Senate,,DEM,Chris Bell,1,1,0
+Burleson,207,U.S. Senate,,DEM,Amanda K. Edwards,9,3,6
+Burleson,207,U.S. Senate,,DEM,Sema Hernandez,0,0,0
+Burleson,207,U.S. House,17,DEM,Rick Kennedy,24,8,16
+Burleson,207,U.S. House,17,DEM,William Foster III,11,2,9
+Burleson,207,U.S. House,17,DEM,David Anthony Jaramillo,5,2,3
+Burleson,207,Railroad Commissioner,,DEM,Kelly Stone,9,2,7
+Burleson,207,Railroad Commissioner,,DEM,"Roberto R. ""Beto"" Alonzo",6,3,3
+Burleson,207,Railroad Commissioner,,DEM,Mark Watson,8,2,6
+Burleson,207,Railroad Commissioner,,DEM,Chrysta Castañeda,11,3,8
+Burleson,207,"Chief Justice, Supreme Court",,DEM,Jerry Zimmerer,11,3,8
+Burleson,207,"Chief Justice, Supreme Court",,DEM,Amy Clark Meachum,25,8,17
+Burleson,207,"Justice, Supreme Court, Place 6",,DEM,Larry Praeger,11,5,6
+Burleson,207,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,22,4,18
+Burleson,207,"Justice, Supreme Court, Place 7",,DEM,Brandy Voss,13,4,9
+Burleson,207,"Justice, Supreme Court, Place 7",,DEM,Staci Williams,21,6,15
+Burleson,207,"Justice, Supreme Court, Place 8",,DEM,Peter Kelly,18,6,12
+Burleson,207,"Justice, Supreme Court, Place 8",,DEM,Gisela D. Triana,13,2,11
+Burleson,207,"Judge, Court of Criminal Appeals, Place 3",,DEM,Dan Wood,8,4,4
+Burleson,207,"Judge, Court of Criminal Appeals, Place 3",,DEM,William Pieratt Demond,4,0,4
+Burleson,207,"Judge, Court of Criminal Appeals, Place 3",,DEM,Elizabeth Davis Frizell,20,6,14
+Burleson,207,"Judge, Court of Criminal Appeals, Place 4",,DEM,Tina Clinton,23,5,18
+Burleson,207,"Judge, Court of Criminal Appeals, Place 4",,DEM,Steven Miears,9,4,5
+Burleson,207,"Judge, Court of Criminal Appeals, Place 9",,DEM,Brandon Birmingham,31,8,23
+Burleson,207,"Member, State Board of Education, District 10",,DEM,Stephen Wyman,5,1,4
+Burleson,207,"Member, State Board of Education, District 10",,DEM,Marsha Burnett-Webster,32,9,23
+Burleson,207,State Senator,18,DEM,Michael Antalan,27,7,20
+Burleson,207,County Chairman,,DEM,Linda Arbuckle,39,12,27
+Burleson,207,Proposition 1,,DEM,Yes,45,10,35
+Burleson,207,Proposition 1,,DEM,No,0,0,0
+Burleson,207,Proposition 2,,DEM,Yes,45,10,35
+Burleson,207,Proposition 2,,DEM,No,0,0,0
+Burleson,207,Proposition 3,,DEM,Yes,43,10,33
+Burleson,207,Proposition 3,,DEM,No,0,0,0
+Burleson,207,Proposition 4,,DEM,Yes,43,10,33
+Burleson,207,Proposition 4,,DEM,No,0,0,0
+Burleson,207,Proposition 5,,DEM,Yes,43,10,33
+Burleson,207,Proposition 5,,DEM,No,0,0,0
+Burleson,207,Proposition 6,,DEM,Yes,46,11,35
+Burleson,207,Proposition 6,,DEM,No,0,0,0
+Burleson,207,Proposition 7,,DEM,Yes,44,10,34
+Burleson,207,Proposition 7,,DEM,No,1,0,1
+Burleson,207,Proposition 8,,DEM,Yes,44,10,34
+Burleson,207,Proposition 8,,DEM,No,0,0,0
+Burleson,207,Proposition 9,,DEM,Yes,44,10,34
+Burleson,207,Proposition 9,,DEM,No,1,0,1
+Burleson,207,Proposition 10,,DEM,Yes,45,10,35
+Burleson,207,Proposition 10,,DEM,No,0,0,0
+Burleson,207,Proposition 11,,DEM,Yes,43,10,33
+Burleson,207,Proposition 11,,DEM,No,0,0,0
+Burleson,211,President,,DEM,Michael R. Bloomberg,13,5,8
+Burleson,211,President,,DEM,Tulsi Gabbard,0,0,0
+Burleson,211,President,,DEM,Deval Patrick,0,0,0
+Burleson,211,President,,DEM,John K. Delaney,0,0,0
+Burleson,211,President,,DEM,Joseph R. Biden,22,13,9
+Burleson,211,President,,DEM,Robby Wells,0,0,0
+Burleson,211,President,,DEM,Amy Klobuchar,1,1,0
+Burleson,211,President,,DEM,Michael Bennet,0,0,0
+Burleson,211,President,,DEM,Elizabeth Warren,2,1,1
+Burleson,211,President,,DEM,Pete Buttigieg,2,2,0
+Burleson,211,President,,DEM,Bernie Sanders,9,4,5
+Burleson,211,President,,DEM,Cory Booker,0,0,0
+Burleson,211,President,,DEM,"Roque ""Rocky"" De La Fuente",0,0,0
+Burleson,211,President,,DEM,Andrew Yang,0,0,0
+Burleson,211,President,,DEM,Julián Castro,0,0,0
+Burleson,211,President,,DEM,Tom Steyer,0,0,0
+Burleson,211,President,,DEM,Marianne Williamson,0,0,0
+Burleson,211,U.S. Senate,,DEM,Royce West,8,6,2
+Burleson,211,U.S. Senate,,DEM,Michael Cooper,4,3,1
+Burleson,211,U.S. Senate,,DEM,"Annie ""Mamá"" Garcia",5,1,4
+Burleson,211,U.S. Senate,,DEM,Cristina Tzintzun Ramirez,6,4,2
+Burleson,211,U.S. Senate,,DEM,Adrian Ocegueda,2,1,1
+Burleson,211,U.S. Senate,,DEM,Victor Hugo Harris,0,0,0
+Burleson,211,U.S. Senate,,DEM,D.R. Hunter,1,0,1
+Burleson,211,U.S. Senate,,DEM,Jack Daniel Foster Jr,0,0,0
+Burleson,211,U.S. Senate,,DEM,"Mary ""MJ"" Hegar",5,2,3
+Burleson,211,U.S. Senate,,DEM,Chris Bell,5,4,1
+Burleson,211,U.S. Senate,,DEM,Amanda K. Edwards,9,2,7
+Burleson,211,U.S. Senate,,DEM,Sema Hernandez,2,0,2
+Burleson,211,U.S. House,17,DEM,Rick Kennedy,31,15,16
+Burleson,211,U.S. House,17,DEM,William Foster III,2,1,1
+Burleson,211,U.S. House,17,DEM,David Anthony Jaramillo,5,2,3
+Burleson,211,Railroad Commissioner,,DEM,Kelly Stone,9,5,4
+Burleson,211,Railroad Commissioner,,DEM,"Roberto R. ""Beto"" Alonzo",12,7,5
+Burleson,211,Railroad Commissioner,,DEM,Mark Watson,10,3,7
+Burleson,211,Railroad Commissioner,,DEM,Chrysta Castañeda,12,6,6
+Burleson,211,"Chief Justice, Supreme Court",,DEM,Jerry Zimmerer,14,6,8
+Burleson,211,"Chief Justice, Supreme Court",,DEM,Amy Clark Meachum,29,15,14
+Burleson,211,"Justice, Supreme Court, Place 6",,DEM,Larry Praeger,18,10,8
+Burleson,211,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,27,12,15
+Burleson,211,"Justice, Supreme Court, Place 7",,DEM,Brandy Voss,17,8,9
+Burleson,211,"Justice, Supreme Court, Place 7",,DEM,Staci Williams,27,13,14
+Burleson,211,"Justice, Supreme Court, Place 8",,DEM,Peter Kelly,19,7,12
+Burleson,211,"Justice, Supreme Court, Place 8",,DEM,Gisela D. Triana,25,14,11
+Burleson,211,"Judge, Court of Criminal Appeals, Place 3",,DEM,Dan Wood,13,6,7
+Burleson,211,"Judge, Court of Criminal Appeals, Place 3",,DEM,William Pieratt Demond,7,4,3
+Burleson,211,"Judge, Court of Criminal Appeals, Place 3",,DEM,Elizabeth Davis Frizell,25,12,13
+Burleson,211,"Judge, Court of Criminal Appeals, Place 4",,DEM,Tina Clinton,29,13,16
+Burleson,211,"Judge, Court of Criminal Appeals, Place 4",,DEM,Steven Miears,15,8,7
+Burleson,211,"Judge, Court of Criminal Appeals, Place 9",,DEM,Brandon Birmingham,37,17,20
+Burleson,211,"Member, State Board of Education, District 10",,DEM,Stephen Wyman,14,6,8
+Burleson,211,"Member, State Board of Education, District 10",,DEM,Marsha Burnett-Webster,30,15,15
+Burleson,211,State Senator,18,DEM,Michael Antalan,40,19,21
+Burleson,211,County Chairman,,DEM,Linda Arbuckle,38,18,20
+Burleson,211,Proposition 1,,DEM,Yes,42,22,20
+Burleson,211,Proposition 1,,DEM,No,4,1,3
+Burleson,211,Proposition 2,,DEM,Yes,43,23,20
+Burleson,211,Proposition 2,,DEM,No,3,0,3
+Burleson,211,Proposition 3,,DEM,Yes,43,24,19
+Burleson,211,Proposition 3,,DEM,No,4,0,4
+Burleson,211,Proposition 4,,DEM,Yes,42,22,20
+Burleson,211,Proposition 4,,DEM,No,5,2,3
+Burleson,211,Proposition 5,,DEM,Yes,46,24,22
+Burleson,211,Proposition 5,,DEM,No,1,0,1
+Burleson,211,Proposition 6,,DEM,Yes,46,24,22
+Burleson,211,Proposition 6,,DEM,No,1,0,1
+Burleson,211,Proposition 7,,DEM,Yes,44,23,21
+Burleson,211,Proposition 7,,DEM,No,2,1,1
+Burleson,211,Proposition 8,,DEM,Yes,45,24,21
+Burleson,211,Proposition 8,,DEM,No,2,0,2
+Burleson,211,Proposition 9,,DEM,Yes,46,24,22
+Burleson,211,Proposition 9,,DEM,No,1,0,1
+Burleson,211,Proposition 10,,DEM,Yes,43,24,19
+Burleson,211,Proposition 10,,DEM,No,2,0,2
+Burleson,211,Proposition 11,,DEM,Yes,47,24,23
+Burleson,211,Proposition 11,,DEM,No,1,0,1
+Burleson,215,President,,DEM,Michael R. Bloomberg,2,1,1
+Burleson,215,President,,DEM,Tulsi Gabbard,0,0,0
+Burleson,215,President,,DEM,Deval Patrick,0,0,0
+Burleson,215,President,,DEM,John K. Delaney,0,0,0
+Burleson,215,President,,DEM,Joseph R. Biden,5,2,3
+Burleson,215,President,,DEM,Robby Wells,0,0,0
+Burleson,215,President,,DEM,Amy Klobuchar,1,1,0
+Burleson,215,President,,DEM,Michael Bennet,0,0,0
+Burleson,215,President,,DEM,Elizabeth Warren,3,1,2
+Burleson,215,President,,DEM,Pete Buttigieg,1,1,0
+Burleson,215,President,,DEM,Bernie Sanders,13,5,8
+Burleson,215,President,,DEM,Cory Booker,0,0,0
+Burleson,215,President,,DEM,"Roque ""Rocky"" De La Fuente",0,0,0
+Burleson,215,President,,DEM,Andrew Yang,0,0,0
+Burleson,215,President,,DEM,Julián Castro,0,0,0
+Burleson,215,President,,DEM,Tom Steyer,0,0,0
+Burleson,215,President,,DEM,Marianne Williamson,1,0,1
+Burleson,215,U.S. Senate,,DEM,Royce West,3,2,1
+Burleson,215,U.S. Senate,,DEM,Michael Cooper,1,0,1
+Burleson,215,U.S. Senate,,DEM,"Annie ""Mamá"" Garcia",5,2,3
+Burleson,215,U.S. Senate,,DEM,Cristina Tzintzun Ramirez,5,1,4
+Burleson,215,U.S. Senate,,DEM,Adrian Ocegueda,1,1,0
+Burleson,215,U.S. Senate,,DEM,Victor Hugo Harris,1,0,1
+Burleson,215,U.S. Senate,,DEM,D.R. Hunter,0,0,0
+Burleson,215,U.S. Senate,,DEM,Jack Daniel Foster Jr,0,0,0
+Burleson,215,U.S. Senate,,DEM,"Mary ""MJ"" Hegar",2,2,0
+Burleson,215,U.S. Senate,,DEM,Chris Bell,4,0,4
+Burleson,215,U.S. Senate,,DEM,Amanda K. Edwards,3,2,1
+Burleson,215,U.S. Senate,,DEM,Sema Hernandez,1,1,0
+Burleson,215,U.S. House,17,DEM,Rick Kennedy,15,6,9
+Burleson,215,U.S. House,17,DEM,William Foster III,4,2,2
+Burleson,215,U.S. House,17,DEM,David Anthony Jaramillo,6,3,3
+Burleson,215,Railroad Commissioner,,DEM,Kelly Stone,9,4,5
+Burleson,215,Railroad Commissioner,,DEM,"Roberto R. ""Beto"" Alonzo",5,0,5
+Burleson,215,Railroad Commissioner,,DEM,Mark Watson,1,0,1
+Burleson,215,Railroad Commissioner,,DEM,Chrysta Castañeda,11,7,4
+Burleson,215,"Chief Justice, Supreme Court",,DEM,Jerry Zimmerer,5,4,1
+Burleson,215,"Chief Justice, Supreme Court",,DEM,Amy Clark Meachum,21,7,14
+Burleson,215,"Justice, Supreme Court, Place 6",,DEM,Larry Praeger,6,3,3
+Burleson,215,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,19,8,11
+Burleson,215,"Justice, Supreme Court, Place 7",,DEM,Brandy Voss,11,6,5
+Burleson,215,"Justice, Supreme Court, Place 7",,DEM,Staci Williams,14,5,9
+Burleson,215,"Justice, Supreme Court, Place 8",,DEM,Peter Kelly,6,2,4
+Burleson,215,"Justice, Supreme Court, Place 8",,DEM,Gisela D. Triana,19,9,10
+Burleson,215,"Judge, Court of Criminal Appeals, Place 3",,DEM,Dan Wood,3,3,0
+Burleson,215,"Judge, Court of Criminal Appeals, Place 3",,DEM,William Pieratt Demond,5,2,3
+Burleson,215,"Judge, Court of Criminal Appeals, Place 3",,DEM,Elizabeth Davis Frizell,17,6,11
+Burleson,215,"Judge, Court of Criminal Appeals, Place 4",,DEM,Tina Clinton,22,11,11
+Burleson,215,"Judge, Court of Criminal Appeals, Place 4",,DEM,Steven Miears,3,0,3
+Burleson,215,"Judge, Court of Criminal Appeals, Place 9",,DEM,Brandon Birmingham,24,11,13
+Burleson,215,"Member, State Board of Education, District 10",,DEM,Stephen Wyman,3,3,0
+Burleson,215,"Member, State Board of Education, District 10",,DEM,Marsha Burnett-Webster,23,8,15
+Burleson,215,State Senator,18,DEM,Michael Antalan,24,11,13
+Burleson,215,County Chairman,,DEM,Linda Arbuckle,24,11,13
+Burleson,215,Proposition 1,,DEM,Yes,25,11,14
+Burleson,215,Proposition 1,,DEM,No,2,0,2
+Burleson,215,Proposition 2,,DEM,Yes,24,11,13
+Burleson,215,Proposition 2,,DEM,No,3,0,3
+Burleson,215,Proposition 3,,DEM,Yes,25,11,14
+Burleson,215,Proposition 3,,DEM,No,2,0,2
+Burleson,215,Proposition 4,,DEM,Yes,25,11,14
+Burleson,215,Proposition 4,,DEM,No,2,0,2
+Burleson,215,Proposition 5,,DEM,Yes,25,11,14
+Burleson,215,Proposition 5,,DEM,No,2,0,2
+Burleson,215,Proposition 6,,DEM,Yes,25,11,14
+Burleson,215,Proposition 6,,DEM,No,2,0,2
+Burleson,215,Proposition 7,,DEM,Yes,25,11,14
+Burleson,215,Proposition 7,,DEM,No,2,0,2
+Burleson,215,Proposition 8,,DEM,Yes,25,11,14
+Burleson,215,Proposition 8,,DEM,No,2,0,2
+Burleson,215,Proposition 9,,DEM,Yes,25,11,14
+Burleson,215,Proposition 9,,DEM,No,2,0,2
+Burleson,215,Proposition 10,,DEM,Yes,25,11,14
+Burleson,215,Proposition 10,,DEM,No,2,0,2
+Burleson,215,Proposition 11,,DEM,Yes,25,10,15
+Burleson,215,Proposition 11,,DEM,No,2,1,1
+Burleson,301,President,,DEM,Michael R. Bloomberg,16,9,7
+Burleson,301,President,,DEM,Tulsi Gabbard,0,0,0
+Burleson,301,President,,DEM,Deval Patrick,0,0,0
+Burleson,301,President,,DEM,John K. Delaney,1,1,0
+Burleson,301,President,,DEM,Joseph R. Biden,32,16,16
+Burleson,301,President,,DEM,Robby Wells,0,0,0
+Burleson,301,President,,DEM,Amy Klobuchar,6,5,1
+Burleson,301,President,,DEM,Michael Bennet,0,0,0
+Burleson,301,President,,DEM,Elizabeth Warren,7,5,2
+Burleson,301,President,,DEM,Pete Buttigieg,4,3,1
+Burleson,301,President,,DEM,Bernie Sanders,15,6,9
+Burleson,301,President,,DEM,Cory Booker,0,0,0
+Burleson,301,President,,DEM,"Roque ""Rocky"" De La Fuente",0,0,0
+Burleson,301,President,,DEM,Andrew Yang,0,0,0
+Burleson,301,President,,DEM,Julián Castro,0,0,0
+Burleson,301,President,,DEM,Tom Steyer,0,0,0
+Burleson,301,President,,DEM,Marianne Williamson,0,0,0
+Burleson,301,U.S. Senate,,DEM,Royce West,7,5,2
+Burleson,301,U.S. Senate,,DEM,Michael Cooper,7,4,3
+Burleson,301,U.S. Senate,,DEM,"Annie ""Mamá"" Garcia",14,3,11
+Burleson,301,U.S. Senate,,DEM,Cristina Tzintzun Ramirez,5,2,3
+Burleson,301,U.S. Senate,,DEM,Adrian Ocegueda,1,0,1
+Burleson,301,U.S. Senate,,DEM,Victor Hugo Harris,2,1,1
+Burleson,301,U.S. Senate,,DEM,D.R. Hunter,1,0,1
+Burleson,301,U.S. Senate,,DEM,Jack Daniel Foster Jr,0,0,0
+Burleson,301,U.S. Senate,,DEM,"Mary ""MJ"" Hegar",13,10,3
+Burleson,301,U.S. Senate,,DEM,Chris Bell,12,9,3
+Burleson,301,U.S. Senate,,DEM,Amanda K. Edwards,9,5,4
+Burleson,301,U.S. Senate,,DEM,Sema Hernandez,3,2,1
+Burleson,301,U.S. House,17,DEM,Rick Kennedy,39,22,17
+Burleson,301,U.S. House,17,DEM,William Foster III,20,12,8
+Burleson,301,U.S. House,17,DEM,David Anthony Jaramillo,16,7,9
+Burleson,301,Railroad Commissioner,,DEM,Kelly Stone,15,6,9
+Burleson,301,Railroad Commissioner,,DEM,"Roberto R. ""Beto"" Alonzo",24,11,13
+Burleson,301,Railroad Commissioner,,DEM,Mark Watson,16,10,6
+Burleson,301,Railroad Commissioner,,DEM,Chrysta Castañeda,19,12,7
+Burleson,301,"Chief Justice, Supreme Court",,DEM,Jerry Zimmerer,26,13,13
+Burleson,301,"Chief Justice, Supreme Court",,DEM,Amy Clark Meachum,46,25,21
+Burleson,301,"Justice, Supreme Court, Place 6",,DEM,Larry Praeger,31,20,11
+Burleson,301,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,37,17,20
+Burleson,301,"Justice, Supreme Court, Place 7",,DEM,Brandy Voss,37,18,19
+Burleson,301,"Justice, Supreme Court, Place 7",,DEM,Staci Williams,35,20,15
+Burleson,301,"Justice, Supreme Court, Place 8",,DEM,Peter Kelly,32,20,12
+Burleson,301,"Justice, Supreme Court, Place 8",,DEM,Gisela D. Triana,36,16,20
+Burleson,301,"Judge, Court of Criminal Appeals, Place 3",,DEM,Dan Wood,28,18,10
+Burleson,301,"Judge, Court of Criminal Appeals, Place 3",,DEM,William Pieratt Demond,4,2,2
+Burleson,301,"Judge, Court of Criminal Appeals, Place 3",,DEM,Elizabeth Davis Frizell,37,17,20
+Burleson,301,"Judge, Court of Criminal Appeals, Place 4",,DEM,Tina Clinton,53,26,27
+Burleson,301,"Judge, Court of Criminal Appeals, Place 4",,DEM,Steven Miears,16,11,5
+Burleson,301,"Judge, Court of Criminal Appeals, Place 9",,DEM,Brandon Birmingham,67,39,28
+Burleson,301,"Member, State Board of Education, District 10",,DEM,Stephen Wyman,21,11,10
+Burleson,301,"Member, State Board of Education, District 10",,DEM,Marsha Burnett-Webster,49,26,23
+Burleson,301,State Senator,18,DEM,Michael Antalan,67,39,28
+Burleson,301,County Chairman,,DEM,Linda Arbuckle,70,40,30
+Burleson,301,Proposition 1,,DEM,Yes,72,38,34
+Burleson,301,Proposition 1,,DEM,No,6,5,1
+Burleson,301,Proposition 2,,DEM,Yes,72,38,34
+Burleson,301,Proposition 2,,DEM,No,6,4,2
+Burleson,301,Proposition 3,,DEM,Yes,77,41,36
+Burleson,301,Proposition 3,,DEM,No,3,3,0
+Burleson,301,Proposition 4,,DEM,Yes,71,38,33
+Burleson,301,Proposition 4,,DEM,No,6,4,2
+Burleson,301,Proposition 5,,DEM,Yes,73,41,32
+Burleson,301,Proposition 5,,DEM,No,6,3,3
+Burleson,301,Proposition 6,,DEM,Yes,74,41,33
+Burleson,301,Proposition 6,,DEM,No,4,3,1
+Burleson,301,Proposition 7,,DEM,Yes,69,38,31
+Burleson,301,Proposition 7,,DEM,No,6,4,2
+Burleson,301,Proposition 8,,DEM,Yes,75,41,34
+Burleson,301,Proposition 8,,DEM,No,2,2,0
+Burleson,301,Proposition 9,,DEM,Yes,74,40,34
+Burleson,301,Proposition 9,,DEM,No,4,4,0
+Burleson,301,Proposition 10,,DEM,Yes,74,40,34
+Burleson,301,Proposition 10,,DEM,No,4,3,1
+Burleson,301,Proposition 11,,DEM,Yes,72,40,32
+Burleson,301,Proposition 11,,DEM,No,7,4,3
+Burleson,305,President,,DEM,Michael R. Bloomberg,13,12,1
+Burleson,305,President,,DEM,Tulsi Gabbard,0,0,0
+Burleson,305,President,,DEM,Deval Patrick,0,0,0
+Burleson,305,President,,DEM,John K. Delaney,0,0,0
+Burleson,305,President,,DEM,Joseph R. Biden,16,8,8
+Burleson,305,President,,DEM,Robby Wells,0,0,0
+Burleson,305,President,,DEM,Amy Klobuchar,2,2,0
+Burleson,305,President,,DEM,Michael Bennet,0,0,0
+Burleson,305,President,,DEM,Elizabeth Warren,1,1,0
+Burleson,305,President,,DEM,Pete Buttigieg,0,0,0
+Burleson,305,President,,DEM,Bernie Sanders,5,4,1
+Burleson,305,President,,DEM,Cory Booker,0,0,0
+Burleson,305,President,,DEM,"Roque ""Rocky"" De La Fuente",0,0,0
+Burleson,305,President,,DEM,Andrew Yang,0,0,0
+Burleson,305,President,,DEM,Julián Castro,0,0,0
+Burleson,305,President,,DEM,Tom Steyer,0,0,0
+Burleson,305,President,,DEM,Marianne Williamson,0,0,0
+Burleson,305,U.S. Senate,,DEM,Royce West,7,5,2
+Burleson,305,U.S. Senate,,DEM,Michael Cooper,2,1,1
+Burleson,305,U.S. Senate,,DEM,"Annie ""Mamá"" Garcia",6,2,4
+Burleson,305,U.S. Senate,,DEM,Cristina Tzintzun Ramirez,1,1,0
+Burleson,305,U.S. Senate,,DEM,Adrian Ocegueda,0,0,0
+Burleson,305,U.S. Senate,,DEM,Victor Hugo Harris,0,0,0
+Burleson,305,U.S. Senate,,DEM,D.R. Hunter,0,0,0
+Burleson,305,U.S. Senate,,DEM,Jack Daniel Foster Jr,0,0,0
+Burleson,305,U.S. Senate,,DEM,"Mary ""MJ"" Hegar",10,8,2
+Burleson,305,U.S. Senate,,DEM,Chris Bell,1,1,0
+Burleson,305,U.S. Senate,,DEM,Amanda K. Edwards,4,4,0
+Burleson,305,U.S. Senate,,DEM,Sema Hernandez,1,1,0
+Burleson,305,U.S. House,17,DEM,Rick Kennedy,21,15,6
+Burleson,305,U.S. House,17,DEM,William Foster III,6,4,2
+Burleson,305,U.S. House,17,DEM,David Anthony Jaramillo,6,5,1
+Burleson,305,Railroad Commissioner,,DEM,Kelly Stone,15,12,3
+Burleson,305,Railroad Commissioner,,DEM,"Roberto R. ""Beto"" Alonzo",6,5,1
+Burleson,305,Railroad Commissioner,,DEM,Mark Watson,5,3,2
+Burleson,305,Railroad Commissioner,,DEM,Chrysta Castañeda,9,6,3
+Burleson,305,"Chief Justice, Supreme Court",,DEM,Jerry Zimmerer,8,6,2
+Burleson,305,"Chief Justice, Supreme Court",,DEM,Amy Clark Meachum,26,19,7
+Burleson,305,"Justice, Supreme Court, Place 6",,DEM,Larry Praeger,11,9,2
+Burleson,305,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,21,14,7
+Burleson,305,"Justice, Supreme Court, Place 7",,DEM,Brandy Voss,17,14,3
+Burleson,305,"Justice, Supreme Court, Place 7",,DEM,Staci Williams,17,11,6
+Burleson,305,"Justice, Supreme Court, Place 8",,DEM,Peter Kelly,23,18,5
+Burleson,305,"Justice, Supreme Court, Place 8",,DEM,Gisela D. Triana,12,8,4
+Burleson,305,"Judge, Court of Criminal Appeals, Place 3",,DEM,Dan Wood,9,6,3
+Burleson,305,"Judge, Court of Criminal Appeals, Place 3",,DEM,William Pieratt Demond,0,0,0
+Burleson,305,"Judge, Court of Criminal Appeals, Place 3",,DEM,Elizabeth Davis Frizell,26,20,6
+Burleson,305,"Judge, Court of Criminal Appeals, Place 4",,DEM,Tina Clinton,29,21,8
+Burleson,305,"Judge, Court of Criminal Appeals, Place 4",,DEM,Steven Miears,5,4,1
+Burleson,305,"Judge, Court of Criminal Appeals, Place 9",,DEM,Brandon Birmingham,32,24,8
+Burleson,305,"Member, State Board of Education, District 10",,DEM,Stephen Wyman,7,6,1
+Burleson,305,"Member, State Board of Education, District 10",,DEM,Marsha Burnett-Webster,28,20,8
+Burleson,305,State Senator,18,DEM,Michael Antalan,33,24,9
+Burleson,305,County Chairman,,DEM,Linda Arbuckle,33,24,9
+Burleson,305,Proposition 1,,DEM,Yes,37,27,10
+Burleson,305,Proposition 1,,DEM,No,0,0,0
+Burleson,305,Proposition 2,,DEM,Yes,35,26,9
+Burleson,305,Proposition 2,,DEM,No,1,1,0
+Burleson,305,Proposition 3,,DEM,Yes,37,27,10
+Burleson,305,Proposition 3,,DEM,No,0,0,0
+Burleson,305,Proposition 4,,DEM,Yes,36,27,9
+Burleson,305,Proposition 4,,DEM,No,0,0,0
+Burleson,305,Proposition 5,,DEM,Yes,36,27,9
+Burleson,305,Proposition 5,,DEM,No,0,0,0
+Burleson,305,Proposition 6,,DEM,Yes,36,27,9
+Burleson,305,Proposition 6,,DEM,No,0,0,0
+Burleson,305,Proposition 7,,DEM,Yes,36,27,9
+Burleson,305,Proposition 7,,DEM,No,0,0,0
+Burleson,305,Proposition 8,,DEM,Yes,36,27,9
+Burleson,305,Proposition 8,,DEM,No,0,0,0
+Burleson,305,Proposition 9,,DEM,Yes,36,27,9
+Burleson,305,Proposition 9,,DEM,No,0,0,0
+Burleson,305,Proposition 10,,DEM,Yes,36,27,9
+Burleson,305,Proposition 10,,DEM,No,0,0,0
+Burleson,305,Proposition 11,,DEM,Yes,35,26,9
+Burleson,305,Proposition 11,,DEM,No,1,1,0
+Burleson,308,President,,DEM,Michael R. Bloomberg,5,4,1
+Burleson,308,President,,DEM,Tulsi Gabbard,0,0,0
+Burleson,308,President,,DEM,Deval Patrick,0,0,0
+Burleson,308,President,,DEM,John K. Delaney,0,0,0
+Burleson,308,President,,DEM,Joseph R. Biden,25,14,11
+Burleson,308,President,,DEM,Robby Wells,0,0,0
+Burleson,308,President,,DEM,Amy Klobuchar,0,0,0
+Burleson,308,President,,DEM,Michael Bennet,0,0,0
+Burleson,308,President,,DEM,Elizabeth Warren,3,3,0
+Burleson,308,President,,DEM,Pete Buttigieg,1,1,0
+Burleson,308,President,,DEM,Bernie Sanders,5,3,2
+Burleson,308,President,,DEM,Cory Booker,0,0,0
+Burleson,308,President,,DEM,"Roque ""Rocky"" De La Fuente",0,0,0
+Burleson,308,President,,DEM,Andrew Yang,0,0,0
+Burleson,308,President,,DEM,Julián Castro,0,0,0
+Burleson,308,President,,DEM,Tom Steyer,0,0,0
+Burleson,308,President,,DEM,Marianne Williamson,0,0,0
+Burleson,308,U.S. Senate,,DEM,Royce West,8,5,3
+Burleson,308,U.S. Senate,,DEM,Michael Cooper,4,3,1
+Burleson,308,U.S. Senate,,DEM,"Annie ""Mamá"" Garcia",7,4,3
+Burleson,308,U.S. Senate,,DEM,Cristina Tzintzun Ramirez,1,1,0
+Burleson,308,U.S. Senate,,DEM,Adrian Ocegueda,1,1,0
+Burleson,308,U.S. Senate,,DEM,Victor Hugo Harris,1,1,0
+Burleson,308,U.S. Senate,,DEM,D.R. Hunter,0,0,0
+Burleson,308,U.S. Senate,,DEM,Jack Daniel Foster Jr,1,1,0
+Burleson,308,U.S. Senate,,DEM,"Mary ""MJ"" Hegar",5,1,4
+Burleson,308,U.S. Senate,,DEM,Chris Bell,3,2,1
+Burleson,308,U.S. Senate,,DEM,Amanda K. Edwards,4,3,1
+Burleson,308,U.S. Senate,,DEM,Sema Hernandez,0,0,0
+Burleson,308,U.S. House,17,DEM,Rick Kennedy,24,14,10
+Burleson,308,U.S. House,17,DEM,William Foster III,8,6,2
+Burleson,308,U.S. House,17,DEM,David Anthony Jaramillo,5,4,1
+Burleson,308,Railroad Commissioner,,DEM,Kelly Stone,9,7,2
+Burleson,308,Railroad Commissioner,,DEM,"Roberto R. ""Beto"" Alonzo",15,7,8
+Burleson,308,Railroad Commissioner,,DEM,Mark Watson,4,2,2
+Burleson,308,Railroad Commissioner,,DEM,Chrysta Castañeda,5,4,1
+Burleson,308,"Chief Justice, Supreme Court",,DEM,Jerry Zimmerer,10,5,5
+Burleson,308,"Chief Justice, Supreme Court",,DEM,Amy Clark Meachum,21,14,7
+Burleson,308,"Justice, Supreme Court, Place 6",,DEM,Larry Praeger,11,7,4
+Burleson,308,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,20,12,8
+Burleson,308,"Justice, Supreme Court, Place 7",,DEM,Brandy Voss,10,5,5
+Burleson,308,"Justice, Supreme Court, Place 7",,DEM,Staci Williams,21,14,7
+Burleson,308,"Justice, Supreme Court, Place 8",,DEM,Peter Kelly,13,9,4
+Burleson,308,"Justice, Supreme Court, Place 8",,DEM,Gisela D. Triana,16,9,7
+Burleson,308,"Judge, Court of Criminal Appeals, Place 3",,DEM,Dan Wood,10,4,6
+Burleson,308,"Judge, Court of Criminal Appeals, Place 3",,DEM,William Pieratt Demond,3,1,2
+Burleson,308,"Judge, Court of Criminal Appeals, Place 3",,DEM,Elizabeth Davis Frizell,18,13,5
+Burleson,308,"Judge, Court of Criminal Appeals, Place 4",,DEM,Tina Clinton,27,16,11
+Burleson,308,"Judge, Court of Criminal Appeals, Place 4",,DEM,Steven Miears,3,1,2
+Burleson,308,"Judge, Court of Criminal Appeals, Place 9",,DEM,Brandon Birmingham,27,16,11
+Burleson,308,"Member, State Board of Education, District 10",,DEM,Stephen Wyman,4,3,1
+Burleson,308,"Member, State Board of Education, District 10",,DEM,Marsha Burnett-Webster,25,14,11
+Burleson,308,State Senator,18,DEM,Michael Antalan,27,16,11
+Burleson,308,County Chairman,,DEM,Linda Arbuckle,29,18,11
+Burleson,308,Proposition 1,,DEM,Yes,33,22,11
+Burleson,308,Proposition 1,,DEM,No,3,1,2
+Burleson,308,Proposition 2,,DEM,Yes,33,20,13
+Burleson,308,Proposition 2,,DEM,No,3,2,1
+Burleson,308,Proposition 3,,DEM,Yes,37,24,13
+Burleson,308,Proposition 3,,DEM,No,1,0,1
+Burleson,308,Proposition 4,,DEM,Yes,35,22,13
+Burleson,308,Proposition 4,,DEM,No,3,2,1
+Burleson,308,Proposition 5,,DEM,Yes,35,23,12
+Burleson,308,Proposition 5,,DEM,No,1,0,1
+Burleson,308,Proposition 6,,DEM,Yes,37,24,13
+Burleson,308,Proposition 6,,DEM,No,1,0,1
+Burleson,308,Proposition 7,,DEM,Yes,35,23,12
+Burleson,308,Proposition 7,,DEM,No,2,1,1
+Burleson,308,Proposition 8,,DEM,Yes,37,24,13
+Burleson,308,Proposition 8,,DEM,No,2,1,1
+Burleson,308,Proposition 9,,DEM,Yes,37,25,12
+Burleson,308,Proposition 9,,DEM,No,1,0,1
+Burleson,308,Proposition 10,,DEM,Yes,38,25,13
+Burleson,308,Proposition 10,,DEM,No,1,0,1
+Burleson,308,Proposition 11,,DEM,Yes,36,25,11
+Burleson,308,Proposition 11,,DEM,No,2,0,2
+Burleson,309,President,,DEM,Michael R. Bloomberg,10,5,5
+Burleson,309,President,,DEM,Tulsi Gabbard,0,0,0
+Burleson,309,President,,DEM,Deval Patrick,1,1,0
+Burleson,309,President,,DEM,John K. Delaney,0,0,0
+Burleson,309,President,,DEM,Joseph R. Biden,30,11,19
+Burleson,309,President,,DEM,Robby Wells,0,0,0
+Burleson,309,President,,DEM,Amy Klobuchar,0,0,0
+Burleson,309,President,,DEM,Michael Bennet,0,0,0
+Burleson,309,President,,DEM,Elizabeth Warren,5,4,1
+Burleson,309,President,,DEM,Pete Buttigieg,2,2,0
+Burleson,309,President,,DEM,Bernie Sanders,4,3,1
+Burleson,309,President,,DEM,Cory Booker,0,0,0
+Burleson,309,President,,DEM,"Roque ""Rocky"" De La Fuente",0,0,0
+Burleson,309,President,,DEM,Andrew Yang,1,1,0
+Burleson,309,President,,DEM,Julián Castro,0,0,0
+Burleson,309,President,,DEM,Tom Steyer,0,0,0
+Burleson,309,President,,DEM,Marianne Williamson,0,0,0
+Burleson,309,U.S. Senate,,DEM,Royce West,7,2,5
+Burleson,309,U.S. Senate,,DEM,Michael Cooper,7,4,3
+Burleson,309,U.S. Senate,,DEM,"Annie ""Mamá"" Garcia",4,2,2
+Burleson,309,U.S. Senate,,DEM,Cristina Tzintzun Ramirez,0,0,0
+Burleson,309,U.S. Senate,,DEM,Adrian Ocegueda,0,0,0
+Burleson,309,U.S. Senate,,DEM,Victor Hugo Harris,3,2,1
+Burleson,309,U.S. Senate,,DEM,D.R. Hunter,1,1,0
+Burleson,309,U.S. Senate,,DEM,Jack Daniel Foster Jr,2,2,0
+Burleson,309,U.S. Senate,,DEM,"Mary ""MJ"" Hegar",11,4,7
+Burleson,309,U.S. Senate,,DEM,Chris Bell,6,5,1
+Burleson,309,U.S. Senate,,DEM,Amanda K. Edwards,2,2,0
+Burleson,309,U.S. Senate,,DEM,Sema Hernandez,4,2,2
+Burleson,309,U.S. House,17,DEM,Rick Kennedy,30,16,14
+Burleson,309,U.S. House,17,DEM,William Foster III,7,3,4
+Burleson,309,U.S. House,17,DEM,David Anthony Jaramillo,9,6,3
+Burleson,309,Railroad Commissioner,,DEM,Kelly Stone,9,5,4
+Burleson,309,Railroad Commissioner,,DEM,"Roberto R. ""Beto"" Alonzo",12,5,7
+Burleson,309,Railroad Commissioner,,DEM,Mark Watson,13,6,7
+Burleson,309,Railroad Commissioner,,DEM,Chrysta Castañeda,11,9,2
+Burleson,309,"Chief Justice, Supreme Court",,DEM,Jerry Zimmerer,16,9,7
+Burleson,309,"Chief Justice, Supreme Court",,DEM,Amy Clark Meachum,27,16,11
+Burleson,309,"Justice, Supreme Court, Place 6",,DEM,Larry Praeger,21,12,9
+Burleson,309,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,23,13,10
+Burleson,309,"Justice, Supreme Court, Place 7",,DEM,Brandy Voss,16,11,5
+Burleson,309,"Justice, Supreme Court, Place 7",,DEM,Staci Williams,28,14,14
+Burleson,309,"Justice, Supreme Court, Place 8",,DEM,Peter Kelly,22,11,11
+Burleson,309,"Justice, Supreme Court, Place 8",,DEM,Gisela D. Triana,20,12,8
+Burleson,309,"Judge, Court of Criminal Appeals, Place 3",,DEM,Dan Wood,14,8,6
+Burleson,309,"Judge, Court of Criminal Appeals, Place 3",,DEM,William Pieratt Demond,7,4,3
+Burleson,309,"Judge, Court of Criminal Appeals, Place 3",,DEM,Elizabeth Davis Frizell,23,12,11
+Burleson,309,"Judge, Court of Criminal Appeals, Place 4",,DEM,Tina Clinton,28,15,13
+Burleson,309,"Judge, Court of Criminal Appeals, Place 4",,DEM,Steven Miears,13,9,4
+Burleson,309,"Judge, Court of Criminal Appeals, Place 9",,DEM,Brandon Birmingham,43,24,19
+Burleson,309,"Member, State Board of Education, District 10",,DEM,Stephen Wyman,14,6,8
+Burleson,309,"Member, State Board of Education, District 10",,DEM,Marsha Burnett-Webster,29,19,10
+Burleson,309,State Senator,18,DEM,Michael Antalan,43,24,19
+Burleson,309,County Chairman,,DEM,Linda Arbuckle,43,25,18
+Burleson,309,Proposition 1,,DEM,Yes,50,25,25
+Burleson,309,Proposition 1,,DEM,No,2,1,1
+Burleson,309,Proposition 2,,DEM,Yes,45,23,22
+Burleson,309,Proposition 2,,DEM,No,7,3,4
+Burleson,309,Proposition 3,,DEM,Yes,49,25,24
+Burleson,309,Proposition 3,,DEM,No,3,1,2
+Burleson,309,Proposition 4,,DEM,Yes,47,24,23
+Burleson,309,Proposition 4,,DEM,No,5,2,3
+Burleson,309,Proposition 5,,DEM,Yes,51,25,26
+Burleson,309,Proposition 5,,DEM,No,1,1,0
+Burleson,309,Proposition 6,,DEM,Yes,49,25,24
+Burleson,309,Proposition 6,,DEM,No,2,1,1
+Burleson,309,Proposition 7,,DEM,Yes,47,24,23
+Burleson,309,Proposition 7,,DEM,No,4,2,2
+Burleson,309,Proposition 8,,DEM,Yes,46,23,23
+Burleson,309,Proposition 8,,DEM,No,4,2,2
+Burleson,309,Proposition 9,,DEM,Yes,50,25,25
+Burleson,309,Proposition 9,,DEM,No,2,1,1
+Burleson,309,Proposition 10,,DEM,Yes,47,24,23
+Burleson,309,Proposition 10,,DEM,No,4,1,3
+Burleson,309,Proposition 11,,DEM,Yes,44,24,20
+Burleson,309,Proposition 11,,DEM,No,8,2,6
+Burleson,406,President,,DEM,Michael R. Bloomberg,14,8,6
+Burleson,406,President,,DEM,Tulsi Gabbard,0,0,0
+Burleson,406,President,,DEM,Deval Patrick,0,0,0
+Burleson,406,President,,DEM,John K. Delaney,1,1,0
+Burleson,406,President,,DEM,Joseph R. Biden,67,21,46
+Burleson,406,President,,DEM,Robby Wells,0,0,0
+Burleson,406,President,,DEM,Amy Klobuchar,2,2,0
+Burleson,406,President,,DEM,Michael Bennet,1,0,1
+Burleson,406,President,,DEM,Elizabeth Warren,8,2,6
+Burleson,406,President,,DEM,Pete Buttigieg,2,2,0
+Burleson,406,President,,DEM,Bernie Sanders,20,9,11
+Burleson,406,President,,DEM,Cory Booker,0,0,0
+Burleson,406,President,,DEM,"Roque ""Rocky"" De La Fuente",0,0,0
+Burleson,406,President,,DEM,Andrew Yang,0,0,0
+Burleson,406,President,,DEM,Julián Castro,0,0,0
+Burleson,406,President,,DEM,Tom Steyer,0,0,0
+Burleson,406,President,,DEM,Marianne Williamson,0,0,0
+Burleson,406,U.S. Senate,,DEM,Royce West,14,1,13
+Burleson,406,U.S. Senate,,DEM,Michael Cooper,21,10,11
+Burleson,406,U.S. Senate,,DEM,"Annie ""Mamá"" Garcia",12,3,9
+Burleson,406,U.S. Senate,,DEM,Cristina Tzintzun Ramirez,8,4,4
+Burleson,406,U.S. Senate,,DEM,Adrian Ocegueda,4,2,2
+Burleson,406,U.S. Senate,,DEM,Victor Hugo Harris,2,0,2
+Burleson,406,U.S. Senate,,DEM,D.R. Hunter,2,0,2
+Burleson,406,U.S. Senate,,DEM,Jack Daniel Foster Jr,6,3,3
+Burleson,406,U.S. Senate,,DEM,"Mary ""MJ"" Hegar",17,9,8
+Burleson,406,U.S. Senate,,DEM,Chris Bell,4,1,3
+Burleson,406,U.S. Senate,,DEM,Amanda K. Edwards,14,8,6
+Burleson,406,U.S. Senate,,DEM,Sema Hernandez,3,2,1
+Burleson,406,U.S. House,17,DEM,Rick Kennedy,63,25,38
+Burleson,406,U.S. House,17,DEM,William Foster III,18,8,10
+Burleson,406,U.S. House,17,DEM,David Anthony Jaramillo,21,9,12
+Burleson,406,Railroad Commissioner,,DEM,Kelly Stone,37,17,20
+Burleson,406,Railroad Commissioner,,DEM,"Roberto R. ""Beto"" Alonzo",28,12,16
+Burleson,406,Railroad Commissioner,,DEM,Mark Watson,12,2,10
+Burleson,406,Railroad Commissioner,,DEM,Chrysta Castañeda,27,9,18
+Burleson,406,"Chief Justice, Supreme Court",,DEM,Jerry Zimmerer,46,14,32
+Burleson,406,"Chief Justice, Supreme Court",,DEM,Amy Clark Meachum,62,28,34
+Burleson,406,"Justice, Supreme Court, Place 6",,DEM,Larry Praeger,45,14,31
+Burleson,406,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,59,29,30
+Burleson,406,"Justice, Supreme Court, Place 7",,DEM,Brandy Voss,43,19,24
+Burleson,406,"Justice, Supreme Court, Place 7",,DEM,Staci Williams,61,22,39
+Burleson,406,"Justice, Supreme Court, Place 8",,DEM,Peter Kelly,59,27,32
+Burleson,406,"Justice, Supreme Court, Place 8",,DEM,Gisela D. Triana,40,13,27
+Burleson,406,"Judge, Court of Criminal Appeals, Place 3",,DEM,Dan Wood,32,15,17
+Burleson,406,"Judge, Court of Criminal Appeals, Place 3",,DEM,William Pieratt Demond,13,3,10
+Burleson,406,"Judge, Court of Criminal Appeals, Place 3",,DEM,Elizabeth Davis Frizell,50,19,31
+Burleson,406,"Judge, Court of Criminal Appeals, Place 4",,DEM,Tina Clinton,72,27,45
+Burleson,406,"Judge, Court of Criminal Appeals, Place 4",,DEM,Steven Miears,23,12,11
+Burleson,406,"Judge, Court of Criminal Appeals, Place 9",,DEM,Brandon Birmingham,90,36,54
+Burleson,406,"Member, State Board of Education, District 10",,DEM,Stephen Wyman,27,7,20
+Burleson,406,"Member, State Board of Education, District 10",,DEM,Marsha Burnett-Webster,74,33,41
+Burleson,406,State Senator,18,DEM,Michael Antalan,87,35,52
+Burleson,406,County Chairman,,DEM,Linda Arbuckle,96,37,59
+Burleson,406,Proposition 1,,DEM,Yes,100,42,58
+Burleson,406,Proposition 1,,DEM,No,5,1,4
+Burleson,406,Proposition 2,,DEM,Yes,104,40,64
+Burleson,406,Proposition 2,,DEM,No,3,2,1
+Burleson,406,Proposition 3,,DEM,Yes,104,41,63
+Burleson,406,Proposition 3,,DEM,No,3,2,1
+Burleson,406,Proposition 4,,DEM,Yes,102,43,59
+Burleson,406,Proposition 4,,DEM,No,3,0,3
+Burleson,406,Proposition 5,,DEM,Yes,105,42,63
+Burleson,406,Proposition 5,,DEM,No,2,1,1
+Burleson,406,Proposition 6,,DEM,Yes,105,43,62
+Burleson,406,Proposition 6,,DEM,No,3,0,3
+Burleson,406,Proposition 7,,DEM,Yes,99,41,58
+Burleson,406,Proposition 7,,DEM,No,4,0,4
+Burleson,406,Proposition 8,,DEM,Yes,102,43,59
+Burleson,406,Proposition 8,,DEM,No,3,0,3
+Burleson,406,Proposition 9,,DEM,Yes,103,43,60
+Burleson,406,Proposition 9,,DEM,No,3,0,3
+Burleson,406,Proposition 10,,DEM,Yes,96,37,59
+Burleson,406,Proposition 10,,DEM,No,9,5,4
+Burleson,406,Proposition 11,,DEM,Yes,90,39,51
+Burleson,406,Proposition 11,,DEM,No,13,2,11
+Burleson,410,President,,DEM,Michael R. Bloomberg,25,12,13
+Burleson,410,President,,DEM,Tulsi Gabbard,1,0,1
+Burleson,410,President,,DEM,Deval Patrick,0,0,0
+Burleson,410,President,,DEM,John K. Delaney,1,0,1
+Burleson,410,President,,DEM,Joseph R. Biden,65,20,45
+Burleson,410,President,,DEM,Robby Wells,0,0,0
+Burleson,410,President,,DEM,Amy Klobuchar,4,4,0
+Burleson,410,President,,DEM,Michael Bennet,0,0,0
+Burleson,410,President,,DEM,Elizabeth Warren,4,2,2
+Burleson,410,President,,DEM,Pete Buttigieg,0,0,0
+Burleson,410,President,,DEM,Bernie Sanders,20,11,9
+Burleson,410,President,,DEM,Cory Booker,0,0,0
+Burleson,410,President,,DEM,"Roque ""Rocky"" De La Fuente",0,0,0
+Burleson,410,President,,DEM,Andrew Yang,1,1,0
+Burleson,410,President,,DEM,Julián Castro,0,0,0
+Burleson,410,President,,DEM,Tom Steyer,0,0,0
+Burleson,410,President,,DEM,Marianne Williamson,0,0,0
+Burleson,410,U.S. Senate,,DEM,Royce West,14,8,6
+Burleson,410,U.S. Senate,,DEM,Michael Cooper,12,5,7
+Burleson,410,U.S. Senate,,DEM,"Annie ""Mamá"" Garcia",11,3,8
+Burleson,410,U.S. Senate,,DEM,Cristina Tzintzun Ramirez,4,1,3
+Burleson,410,U.S. Senate,,DEM,Adrian Ocegueda,2,0,2
+Burleson,410,U.S. Senate,,DEM,Victor Hugo Harris,6,3,3
+Burleson,410,U.S. Senate,,DEM,D.R. Hunter,2,1,1
+Burleson,410,U.S. Senate,,DEM,Jack Daniel Foster Jr,1,1,0
+Burleson,410,U.S. Senate,,DEM,"Mary ""MJ"" Hegar",24,12,12
+Burleson,410,U.S. Senate,,DEM,Chris Bell,9,2,7
+Burleson,410,U.S. Senate,,DEM,Amanda K. Edwards,13,5,8
+Burleson,410,U.S. Senate,,DEM,Sema Hernandez,5,2,3
+Burleson,410,U.S. House,17,DEM,Rick Kennedy,57,21,36
+Burleson,410,U.S. House,17,DEM,William Foster III,20,12,8
+Burleson,410,U.S. House,17,DEM,David Anthony Jaramillo,24,7,17
+Burleson,410,Railroad Commissioner,,DEM,Kelly Stone,31,13,18
+Burleson,410,Railroad Commissioner,,DEM,"Roberto R. ""Beto"" Alonzo",27,9,18
+Burleson,410,Railroad Commissioner,,DEM,Mark Watson,24,10,14
+Burleson,410,Railroad Commissioner,,DEM,Chrysta Castañeda,19,8,11
+Burleson,410,"Chief Justice, Supreme Court",,DEM,Jerry Zimmerer,30,14,16
+Burleson,410,"Chief Justice, Supreme Court",,DEM,Amy Clark Meachum,71,28,43
+Burleson,410,"Justice, Supreme Court, Place 6",,DEM,Larry Praeger,35,14,21
+Burleson,410,"Justice, Supreme Court, Place 6",,DEM,Kathy Cheng,64,26,38
+Burleson,410,"Justice, Supreme Court, Place 7",,DEM,Brandy Voss,36,14,22
+Burleson,410,"Justice, Supreme Court, Place 7",,DEM,Staci Williams,64,27,37
+Burleson,410,"Justice, Supreme Court, Place 8",,DEM,Peter Kelly,53,23,30
+Burleson,410,"Justice, Supreme Court, Place 8",,DEM,Gisela D. Triana,48,18,30
+Burleson,410,"Judge, Court of Criminal Appeals, Place 3",,DEM,Dan Wood,17,4,13
+Burleson,410,"Judge, Court of Criminal Appeals, Place 3",,DEM,William Pieratt Demond,14,6,8
+Burleson,410,"Judge, Court of Criminal Appeals, Place 3",,DEM,Elizabeth Davis Frizell,71,31,40
+Burleson,410,"Judge, Court of Criminal Appeals, Place 4",,DEM,Tina Clinton,88,39,49
+Burleson,410,"Judge, Court of Criminal Appeals, Place 4",,DEM,Steven Miears,13,2,11
+Burleson,410,"Judge, Court of Criminal Appeals, Place 9",,DEM,Brandon Birmingham,94,36,58
+Burleson,410,"Member, State Board of Education, District 10",,DEM,Stephen Wyman,23,11,12
+Burleson,410,"Member, State Board of Education, District 10",,DEM,Marsha Burnett-Webster,77,29,48
+Burleson,410,State Senator,18,DEM,Michael Antalan,90,35,55
+Burleson,410,County Chairman,,DEM,Linda Arbuckle,95,38,57
+Burleson,410,Proposition 1,,DEM,Yes,110,45,65
+Burleson,410,Proposition 1,,DEM,No,6,3,3
+Burleson,410,Proposition 2,,DEM,Yes,111,44,67
+Burleson,410,Proposition 2,,DEM,No,5,4,1
+Burleson,410,Proposition 3,,DEM,Yes,111,46,65
+Burleson,410,Proposition 3,,DEM,No,4,2,2
+Burleson,410,Proposition 4,,DEM,Yes,111,45,66
+Burleson,410,Proposition 4,,DEM,No,4,2,2
+Burleson,410,Proposition 5,,DEM,Yes,111,46,65
+Burleson,410,Proposition 5,,DEM,No,3,1,2
+Burleson,410,Proposition 6,,DEM,Yes,113,47,66
+Burleson,410,Proposition 6,,DEM,No,5,2,3
+Burleson,410,Proposition 7,,DEM,Yes,113,48,65
+Burleson,410,Proposition 7,,DEM,No,4,1,3
+Burleson,410,Proposition 8,,DEM,Yes,113,47,66
+Burleson,410,Proposition 8,,DEM,No,5,2,3
+Burleson,410,Proposition 9,,DEM,Yes,113,45,68
+Burleson,410,Proposition 9,,DEM,No,5,4,1
+Burleson,410,Proposition 10,,DEM,Yes,109,47,62
+Burleson,410,Proposition 10,,DEM,No,8,2,6
+Burleson,410,Proposition 11,,DEM,Yes,107,46,61
+Burleson,410,Proposition 11,,DEM,No,9,2,7


### PR DESCRIPTION
Burleson County reported to the SoS that Elianor Vessali received 372 votes in the Republican primary for TX-17, but their precinct results file shows that she received 382.