### PR TITLE
Remove tabs and extra columns from 2014 Hays primary file

### DIFF
--- a/2014/counties/20140304__tx__primary__hays__precinct.csv
+++ b/2014/counties/20140304__tx__primary__hays__precinct.csv
@@ -9,9 +9,9 @@ Hays,110,U.S. Senate,,REP,Linda Vega,6,3,3
 Hays,110,U.S. Senate,,REP,Chris Mapp,4,1,3
 Hays,110,U.S. Senate,,REP,John Cornyn,45,22,23
 Hays,110,U.S. Senate,,REP,Reid Reasor,1,0,1
-Hays,110,,U.S. House,35,REP,Susan Narvaiz,67,39,28
-Hays,110,,U.S. House,35,REP,Over Votes,0,0,0
-Hays,110,,U.S. House,35,REP,Under Votes,34,15,19
+Hays,110,U.S. House,35,REP,Susan Narvaiz,67,39,28
+Hays,110,U.S. House,35,REP,Over Votes,0,0,0
+Hays,110,U.S. House,35,REP,Under Votes,34,15,19
 Hays,110,GOVERNOR REP,,REP,Lisa Fritsch,7,4,3
 Hays,110,GOVERNOR REP,,REP,Greg Abbott,84,46,38
 Hays,110,GOVERNOR REP,,REP,Over Votes,0,0,0
@@ -319,9 +319,9 @@ Hays,112,U.S. Senate,,REP,Linda Vega,8,4,4
 Hays,112,U.S. Senate,,REP,Chris Mapp,1,0,1
 Hays,112,U.S. Senate,,REP,John Cornyn,20,10,10
 Hays,112,U.S. Senate,,REP,Reid Reasor,3,3,0
-Hays,112,,U.S. House,35,REP,Susan Narvaiz,37,20,17
-Hays,112,,U.S. House,35,REP,Over Votes,0,0,0
-Hays,112,,U.S. House,35,REP,Under Votes,18,9,9
+Hays,112,U.S. House,35,REP,Susan Narvaiz,37,20,17
+Hays,112,U.S. House,35,REP,Over Votes,0,0,0
+Hays,112,U.S. House,35,REP,Under Votes,18,9,9
 Hays,112,GOVERNOR REP,,REP,Lisa Fritsch,9,6,3
 Hays,112,GOVERNOR REP,,REP,Greg Abbott,38,21,17
 Hays,112,GOVERNOR REP,,REP,Over Votes,0,0,0
@@ -471,9 +471,9 @@ Hays,113,U.S. Senate,,REP,Linda Vega,14,6,8
 Hays,113,U.S. Senate,,REP,Chris Mapp,4,1,3
 Hays,113,U.S. Senate,,REP,John Cornyn,68,45,23
 Hays,113,U.S. Senate,,REP,Reid Reasor,5,3,2
-Hays,113,,U.S. House,35,REP,Susan Narvaiz,97,62,35
-Hays,113,,U.S. House,35,REP,Over Votes,0,0,0
-Hays,113,,U.S. House,35,REP,Under Votes,33,18,15
+Hays,113,U.S. House,35,REP,Susan Narvaiz,97,62,35
+Hays,113,U.S. House,35,REP,Over Votes,0,0,0
+Hays,113,U.S. House,35,REP,Under Votes,33,18,15
 Hays,113,GOVERNOR REP,,REP,Lisa Fritsch,14,9,5
 Hays,113,GOVERNOR REP,,REP,Greg Abbott,95,61,34
 Hays,113,GOVERNOR REP,,REP,Over Votes,0,0,0
@@ -627,9 +627,9 @@ Hays,120,U.S. Senate,,REP,Linda Vega,10,3,7
 Hays,120,U.S. Senate,,REP,Chris Mapp,0,0,0
 Hays,120,U.S. Senate,,REP,John Cornyn,46,24,22
 Hays,120,U.S. Senate,,REP,Reid Reasor,6,1,5
-Hays,120,,U.S. House,35,REP,Susan Narvaiz,83,34,49
-Hays,120,,U.S. House,35,REP,Over Votes,0,0,0
-Hays,120,,U.S. House,35,REP,Under Votes,20,6,14
+Hays,120,U.S. House,35,REP,Susan Narvaiz,83,34,49
+Hays,120,U.S. House,35,REP,Over Votes,0,0,0
+Hays,120,U.S. House,35,REP,Under Votes,20,6,14
 Hays,120,GOVERNOR REP,,REP,Lisa Fritsch,13,6,7
 Hays,120,GOVERNOR REP,,REP,Greg Abbott,77,32,45
 Hays,120,GOVERNOR REP,,REP,Over Votes,0,0,0
@@ -783,9 +783,9 @@ Hays,125,U.S. Senate,,REP,Linda Vega,4,3,1
 Hays,125,U.S. Senate,,REP,Chris Mapp,0,0,0
 Hays,125,U.S. Senate,,REP,John Cornyn,28,15,13
 Hays,125,U.S. Senate,,REP,Reid Reasor,2,2,0
-Hays,125,,U.S. House,35,REP,Susan Narvaiz,58,35,23
-Hays,125,,U.S. House,35,REP,Over Votes,0,0,0
-Hays,125,,U.S. House,35,REP,Under Votes,15,7,8
+Hays,125,U.S. House,35,REP,Susan Narvaiz,58,35,23
+Hays,125,U.S. House,35,REP,Over Votes,0,0,0
+Hays,125,U.S. House,35,REP,Under Votes,15,7,8
 Hays,125,GOVERNOR REP,,REP,Lisa Fritsch,9,6,3
 Hays,125,GOVERNOR REP,,REP,Greg Abbott,57,33,24
 Hays,125,GOVERNOR REP,,REP,Over Votes,0,0,0
@@ -931,9 +931,9 @@ Hays,127,U.S. Senate,,REP,Linda Vega,8,3,5
 Hays,127,U.S. Senate,,REP,Chris Mapp,2,1,1
 Hays,127,U.S. Senate,,REP,John Cornyn,79,28,51
 Hays,127,U.S. Senate,,REP,Reid Reasor,6,0,6
-Hays,127,,U.S. House,35,REP,Susan Narvaiz,145,48,97
-Hays,127,,U.S. House,35,REP,Over Votes,0,0,0
-Hays,127,,U.S. House,35,REP,Under Votes,36,18,18
+Hays,127,U.S. House,35,REP,Susan Narvaiz,145,48,97
+Hays,127,U.S. House,35,REP,Over Votes,0,0,0
+Hays,127,U.S. House,35,REP,Under Votes,36,18,18
 Hays,127,GOVERNOR REP,,REP,Lisa Fritsch,13,6,7
 Hays,127,GOVERNOR REP,,REP,Greg Abbott,160,59,101
 Hays,127,GOVERNOR REP,,REP,Over Votes,0,0,0
@@ -1079,9 +1079,9 @@ Hays,129,U.S. Senate,,REP,Linda Vega,6,3,3
 Hays,129,U.S. Senate,,REP,Chris Mapp,4,1,3
 Hays,129,U.S. Senate,,REP,John Cornyn,79,38,41
 Hays,129,U.S. Senate,,REP,Reid Reasor,2,2,0
-Hays,129,,U.S. House,35,REP,Susan Narvaiz,131,66,65
-Hays,129,,U.S. House,35,REP,Over Votes,0,0,0
-Hays,129,,U.S. House,35,REP,Under Votes,26,8,18
+Hays,129,U.S. House,35,REP,Susan Narvaiz,131,66,65
+Hays,129,U.S. House,35,REP,Over Votes,0,0,0
+Hays,129,U.S. House,35,REP,Under Votes,26,8,18
 Hays,129,GOVERNOR REP,,REP,Lisa Fritsch,12,6,6
 Hays,129,GOVERNOR REP,,REP,Greg Abbott,133,62,71
 Hays,129,GOVERNOR REP,,REP,Over Votes,0,0,0
@@ -1232,9 +1232,9 @@ Hays,221,U.S. Senate,,REP,Linda Vega,13,5,8
 Hays,221,U.S. Senate,,REP,Chris Mapp,1,0,1
 Hays,221,U.S. Senate,,REP,John Cornyn,99,45,54
 Hays,221,U.S. Senate,,REP,Reid Reasor,5,3,2
-Hays,221,,U.S. House,35,REP,Susan Narvaiz,153,69,84
-Hays,221,,U.S. House,35,REP,Over Votes,0,0,0
-Hays,221,,U.S. House,35,REP,Under Votes,47,19,28
+Hays,221,U.S. House,35,REP,Susan Narvaiz,153,69,84
+Hays,221,U.S. House,35,REP,Over Votes,0,0,0
+Hays,221,U.S. House,35,REP,Under Votes,47,19,28
 Hays,221,GOVERNOR REP,,REP,Lisa Fritsch,27,8,19
 Hays,221,GOVERNOR REP,,REP,Greg Abbott,158,72,86
 Hays,221,GOVERNOR REP,,REP,Over Votes,0,0,0
@@ -1388,9 +1388,9 @@ Hays,223,U.S. Senate,,REP,Linda Vega,4,2,2
 Hays,223,U.S. Senate,,REP,Chris Mapp,3,2,1
 Hays,223,U.S. Senate,,REP,John Cornyn,62,32,30
 Hays,223,U.S. Senate,,REP,Reid Reasor,1,0,1
-Hays,223,,U.S. House,35,REP,Susan Narvaiz,86,42,44
-Hays,223,,U.S. House,35,REP,Over Votes,0,0,0
-Hays,223,,U.S. House,35,REP,Under Votes,19,7,12
+Hays,223,U.S. House,35,REP,Susan Narvaiz,86,42,44
+Hays,223,U.S. House,35,REP,Over Votes,0,0,0
+Hays,223,U.S. House,35,REP,Under Votes,19,7,12
 Hays,223,GOVERNOR REP,,REP,Lisa Fritsch,10,4,6
 Hays,223,GOVERNOR REP,,REP,Greg Abbott,88,41,47
 Hays,223,GOVERNOR REP,,REP,Over Votes,0,0,0
@@ -2026,9 +2026,9 @@ Hays,228,U.S. Senate,,REP,Linda Vega,12,3,9
 Hays,228,U.S. Senate,,REP,Chris Mapp,1,0,1
 Hays,228,U.S. Senate,,REP,John Cornyn,100,54,46
 Hays,228,U.S. Senate,,REP,Reid Reasor,3,0,3
-Hays,228,,U.S. House,35,REP,Susan Narvaiz,151,65,86
-Hays,228,,U.S. House,35,REP,Over Votes,0,0,0
-Hays,228,,U.S. House,35,REP,Under Votes,42,19,23
+Hays,228,U.S. House,35,REP,Susan Narvaiz,151,65,86
+Hays,228,U.S. House,35,REP,Over Votes,0,0,0
+Hays,228,U.S. House,35,REP,Under Votes,42,19,23
 Hays,228,GOVERNOR REP,,REP,Lisa Fritsch,15,7,8
 Hays,228,GOVERNOR REP,,REP,Greg Abbott,154,71,83
 Hays,228,GOVERNOR REP,,REP,Over Votes,0,0,0
@@ -2182,9 +2182,9 @@ Hays,229,U.S. Senate,,REP,Linda Vega,5,4,1
 Hays,229,U.S. Senate,,REP,Chris Mapp,2,0,2
 Hays,229,U.S. Senate,,REP,John Cornyn,27,13,14
 Hays,229,U.S. Senate,,REP,Reid Reasor,1,1,0
-Hays,229,,U.S. House,35,REP,Susan Narvaiz,50,18,32
-Hays,229,,U.S. House,35,REP,Over Votes,0,0,0
-Hays,229,,U.S. House,35,REP,Under Votes,13,6,7
+Hays,229,U.S. House,35,REP,Susan Narvaiz,50,18,32
+Hays,229,U.S. House,35,REP,Over Votes,0,0,0
+Hays,229,U.S. House,35,REP,Under Votes,13,6,7
 Hays,229,GOVERNOR REP,,REP,Lisa Fritsch,12,4,8
 Hays,229,GOVERNOR REP,,REP,Greg Abbott,44,15,29
 Hays,229,GOVERNOR REP,,REP,Over Votes,0,0,0
@@ -2647,9 +2647,9 @@ Hays,234,U.S. Senate,,REP,Linda Vega,3,0,3
 Hays,234,U.S. Senate,,REP,Chris Mapp,0,0,0
 Hays,234,U.S. Senate,,REP,John Cornyn,18,4,14
 Hays,234,U.S. Senate,,REP,Reid Reasor,0,0,0
-Hays,234,,U.S. House,35,REP,Susan Narvaiz,26,6,20
-Hays,234,,U.S. House,35,REP,Over Votes,0,0,0
-Hays,234,,U.S. House,35,REP,Under Votes,12,2,10
+Hays,234,U.S. House,35,REP,Susan Narvaiz,26,6,20
+Hays,234,U.S. House,35,REP,Over Votes,0,0,0
+Hays,234,U.S. House,35,REP,Under Votes,12,2,10
 Hays,234,GOVERNOR REP,,REP,Lisa Fritsch,5,1,4
 Hays,234,GOVERNOR REP,,REP,Greg Abbott,31,7,24
 Hays,234,GOVERNOR REP,,REP,Over Votes,0,0,0
@@ -3116,9 +3116,9 @@ Hays,301,U.S. Senate,,REP,Linda Vega,0,0,0
 Hays,301,U.S. Senate,,REP,Chris Mapp,0,0,0
 Hays,301,U.S. Senate,,REP,John Cornyn,0,0,0
 Hays,301,U.S. Senate,,REP,Reid Reasor,0,0,0
-Hays,301,,U.S. House,35,REP,Susan Narvaiz,0,0,0
-Hays,301,,U.S. House,35,REP,Over Votes,0,0,0
-Hays,301,,U.S. House,35,REP,Under Votes,0,0,0
+Hays,301,U.S. House,35,REP,Susan Narvaiz,0,0,0
+Hays,301,U.S. House,35,REP,Over Votes,0,0,0
+Hays,301,U.S. House,35,REP,Under Votes,0,0,0
 Hays,301,GOVERNOR REP,,REP,Lisa Fritsch,0,0,0
 Hays,301,GOVERNOR REP,,REP,Greg Abbott,0,0,0
 Hays,301,GOVERNOR REP,,REP,Over Votes,0,0,0
@@ -3581,9 +3581,9 @@ Hays,317,U.S. Senate,,REP,Linda Vega,4,2,2
 Hays,317,U.S. Senate,,REP,Chris Mapp,0,0,0
 Hays,317,U.S. Senate,,REP,John Cornyn,8,4,4
 Hays,317,U.S. Senate,,REP,Reid Reasor,0,0,0
-Hays,317,,U.S. House,35,REP,Susan Narvaiz,8,2,6
-Hays,317,,U.S. House,35,REP,Over Votes,0,0,0
-Hays,317,,U.S. House,35,REP,Under Votes,10,6,4
+Hays,317,U.S. House,35,REP,Susan Narvaiz,8,2,6
+Hays,317,U.S. House,35,REP,Over Votes,0,0,0
+Hays,317,U.S. House,35,REP,Under Votes,10,6,4
 Hays,317,GOVERNOR REP,,REP,Lisa Fritsch,5,3,2
 Hays,317,GOVERNOR REP,,REP,Greg Abbott,11,4,7
 Hays,317,GOVERNOR REP,,REP,Over Votes,0,0,0
@@ -3733,9 +3733,9 @@ Hays,318,U.S. Senate,,REP,Linda Vega,0,0,0
 Hays,318,U.S. Senate,,REP,Chris Mapp,1,1,0
 Hays,318,U.S. Senate,,REP,John Cornyn,6,3,3
 Hays,318,U.S. Senate,,REP,Reid Reasor,0,0,0
-Hays,318,,U.S. House,35,REP,Susan Narvaiz,3,3,0
-Hays,318,,U.S. House,35,REP,Over Votes,0,0,0
-Hays,318,,U.S. House,35,REP,Under Votes,5,2,3
+Hays,318,U.S. House,35,REP,Susan Narvaiz,3,3,0
+Hays,318,U.S. House,35,REP,Over Votes,0,0,0
+Hays,318,U.S. House,35,REP,Under Votes,5,2,3
 Hays,318,GOVERNOR REP,,REP,Lisa Fritsch,0,0,0
 Hays,318,GOVERNOR REP,,REP,Greg Abbott,6,5,1
 Hays,318,GOVERNOR REP,,REP,Over Votes,0,0,0
@@ -4377,9 +4377,9 @@ Hays,334,U.S. Senate,,REP,Linda Vega,1,1,0
 Hays,334,U.S. Senate,,REP,Chris Mapp,0,0,0
 Hays,334,U.S. Senate,,REP,John Cornyn,5,2,3
 Hays,334,U.S. Senate,,REP,Reid Reasor,0,0,0
-Hays,334,,U.S. House,35,REP,Susan Narvaiz,9,6,3
-Hays,334,,U.S. House,35,REP,Over Votes,0,0,0
-Hays,334,,U.S. House,35,REP,Under Votes,6,2,4
+Hays,334,U.S. House,35,REP,Susan Narvaiz,9,6,3
+Hays,334,U.S. House,35,REP,Over Votes,0,0,0
+Hays,334,U.S. House,35,REP,Under Votes,6,2,4
 Hays,334,GOVERNOR REP,,REP,Lisa Fritsch,4,2,2
 Hays,334,GOVERNOR REP,,REP,Greg Abbott,9,6,3
 Hays,334,GOVERNOR REP,,REP,Over Votes,0,0,0
@@ -5171,9 +5171,9 @@ Hays,413,U.S. Senate,,REP,Linda Vega,1,1,0
 Hays,413,U.S. Senate,,REP,Chris Mapp,0,0,0
 Hays,413,U.S. Senate,,REP,John Cornyn,2,2,0
 Hays,413,U.S. Senate,,REP,Reid Reasor,0,0,0
-Hays,413,,U.S. House,35,REP,Susan Narvaiz,3,3,0
-Hays,413,,U.S. House,35,REP,Over Votes,0,0,0
-Hays,413,,U.S. House,35,REP,Under Votes,3,3,0
+Hays,413,U.S. House,35,REP,Susan Narvaiz,3,3,0
+Hays,413,U.S. House,35,REP,Over Votes,0,0,0
+Hays,413,U.S. House,35,REP,Under Votes,3,3,0
 Hays,413,GOVERNOR REP,,REP,Lisa Fritsch,2,2,0
 Hays,413,GOVERNOR REP,,REP,Greg Abbott,3,3,0
 Hays,413,GOVERNOR REP,,REP,Over Votes,0,0,0
@@ -5331,9 +5331,9 @@ Hays,414,U.S. Senate,,REP,Linda Vega,1,1,0
 Hays,414,U.S. Senate,,REP,Chris Mapp,1,0,1
 Hays,414,U.S. Senate,,REP,John Cornyn,7,3,4
 Hays,414,U.S. Senate,,REP,Reid Reasor,3,0,3
-Hays,414,,U.S. House,35,REP,Susan Narvaiz,15,6,9
-Hays,414,,U.S. House,35,REP,Over Votes,0,0,0
-Hays,414,,U.S. House,35,REP,Under Votes,9,2,7
+Hays,414,U.S. House,35,REP,Susan Narvaiz,15,6,9
+Hays,414,U.S. House,35,REP,Over Votes,0,0,0
+Hays,414,U.S. House,35,REP,Under Votes,9,2,7
 Hays,414,GOVERNOR REP,,REP,Lisa Fritsch,3,1,2
 Hays,414,GOVERNOR REP,,REP,Greg Abbott,16,5,11
 Hays,414,GOVERNOR REP,,REP,Over Votes,0,0,0
@@ -5486,9 +5486,9 @@ Hays,415,U.S. Senate,,REP,Linda Vega,2,1,1
 Hays,415,U.S. Senate,,REP,Chris Mapp,0,0,0
 Hays,415,U.S. Senate,,REP,John Cornyn,18,13,5
 Hays,415,U.S. Senate,,REP,Reid Reasor,1,1,0
-Hays,415,,U.S. House,35,REP,Susan Narvaiz,24,12,12
-Hays,415,,U.S. House,35,REP,Over Votes,0,0,0
-Hays,415,,U.S. House,35,REP,Under Votes,12,9,3
+Hays,415,U.S. House,35,REP,Susan Narvaiz,24,12,12
+Hays,415,U.S. House,35,REP,Over Votes,0,0,0
+Hays,415,U.S. House,35,REP,Under Votes,12,9,3
 Hays,415,GOVERNOR REP,,REP,Lisa Fritsch,3,1,2
 Hays,415,GOVERNOR REP,,REP,Greg Abbott,28,15,13
 Hays,415,GOVERNOR REP,,REP,Over Votes,0,0,0
@@ -5646,9 +5646,9 @@ Hays,416,U.S. Senate,,REP,Linda Vega,0,0,0
 Hays,416,U.S. Senate,,REP,Chris Mapp,0,0,0
 Hays,416,U.S. Senate,,REP,John Cornyn,2,0,2
 Hays,416,U.S. Senate,,REP,Reid Reasor,0,0,0
-Hays,416,,U.S. House,35,REP,Susan Narvaiz,2,0,2
-Hays,416,,U.S. House,35,REP,Over Votes,0,0,0
-Hays,416,,U.S. House,35,REP,Under Votes,0,0,0
+Hays,416,U.S. House,35,REP,Susan Narvaiz,2,0,2
+Hays,416,U.S. House,35,REP,Over Votes,0,0,0
+Hays,416,U.S. House,35,REP,Under Votes,0,0,0
 Hays,416,GOVERNOR REP,,REP,Lisa Fritsch,0,0,0
 Hays,416,GOVERNOR REP,,REP,Greg Abbott,2,0,2
 Hays,416,GOVERNOR REP,,REP,Over Votes,0,0,0
@@ -5950,9 +5950,9 @@ Hays,418,U.S. Senate,,REP,Linda Vega,0,0,0
 Hays,418,U.S. Senate,,REP,Chris Mapp,0,0,0
 Hays,418,U.S. Senate,,REP,John Cornyn,0,0,0
 Hays,418,U.S. Senate,,REP,Reid Reasor,0,0,0
-Hays,418,,U.S. House,35,REP,Susan Narvaiz,0,0,0
-Hays,418,,U.S. House,35,REP,Over Votes,0,0,0
-Hays,418,,U.S. House,35,REP,Under Votes,0,0,0
+Hays,418,U.S. House,35,REP,Susan Narvaiz,0,0,0
+Hays,418,U.S. House,35,REP,Over Votes,0,0,0
+Hays,418,U.S. House,35,REP,Under Votes,0,0,0
 Hays,418,GOVERNOR REP,,REP,Lisa Fritsch,0,0,0
 Hays,418,GOVERNOR REP,,REP,Greg Abbott,0,0,0
 Hays,418,GOVERNOR REP,,REP,Over Votes,0,0,0
@@ -6106,9 +6106,9 @@ Hays,419,U.S. Senate,,REP,Linda Vega,11,6,5
 Hays,419,U.S. Senate,,REP,Chris Mapp,3,2,1
 Hays,419,U.S. Senate,,REP,John Cornyn,41,22,19
 Hays,419,U.S. Senate,,REP,Reid Reasor,1,1,0
-Hays,419,,U.S. House,35,REP,Susan Narvaiz,69,37,32
-Hays,419,,U.S. House,35,REP,Over Votes,0,0,0
-Hays,419,,U.S. House,35,REP,Under Votes,19,11,8
+Hays,419,U.S. House,35,REP,Susan Narvaiz,69,37,32
+Hays,419,U.S. House,35,REP,Over Votes,0,0,0
+Hays,419,U.S. House,35,REP,Under Votes,19,11,8
 Hays,419,GOVERNOR REP,,REP,Lisa Fritsch,5,1,4
 Hays,419,GOVERNOR REP,,REP,Greg Abbott,78,42,36
 Hays,419,GOVERNOR REP,,REP,Over Votes,0,0,0
@@ -7729,9 +7729,9 @@ Hays,FPCA FED 35,U.S. Senate,,REP,Linda Vega,0,0,0
 Hays,FPCA FED 35,U.S. Senate,,REP,Chris Mapp,0,0,0
 Hays,FPCA FED 35,U.S. Senate,,REP,John Cornyn,0,0,0
 Hays,FPCA FED 35,U.S. Senate,,REP,Reid Reasor,0,0,0
-Hays,FPCA FED 35,,U.S. House,35,REP,Susan Narvaiz,0,0,0
-Hays,FPCA FED 35,,U.S. House,35,REP,Over Votes,0,0,0
-Hays,FPCA FED 35,,U.S. House,35,REP,Under Votes,0,0,0
+Hays,FPCA FED 35,U.S. House,35,REP,Susan Narvaiz,0,0,0
+Hays,FPCA FED 35,U.S. House,35,REP,Over Votes,0,0,0
+Hays,FPCA FED 35,U.S. House,35,REP,Under Votes,0,0,0
 Hays,110,U.S. Senate,,DEM,Maxey Marie Scherr,16,11,5
 Hays,110,U.S. Senate,,DEM,Kesha Rogers,9,7,2
 Hays,110,U.S. Senate,,DEM,David M. Alameel,12,8,4
@@ -7739,9 +7739,9 @@ Hays,110,U.S. Senate,,DEM,"Michael ""Fjet"" Fjetland",2,2,0
 Hays,110,U.S. Senate,,DEM,Over Votes,0,0,0
 Hays,110,U.S. Senate,,DEM,Under Votes,6,2,4
 Hays,110,U.S. Senate,,DEM,Harry Kim,6,2,4
-Hays,110,,U.S. House,35,DEM,Lloyd Doggett,46,30,16
-Hays,110,,U.S. House,35,DEM,Over Votes,0,0,0
-Hays,110,,U.S. House,35,DEM,Under Votes,5,2,3
+Hays,110,U.S. House,35,DEM,Lloyd Doggett,46,30,16
+Hays,110,U.S. House,35,DEM,Over Votes,0,0,0
+Hays,110,U.S. House,35,DEM,Under Votes,5,2,3
 Hays,110,GOVERNOR DEM,,DEM,Wendy R. Davis,43,28,15
 Hays,110,GOVERNOR DEM,,DEM,Over Votes,0,0,0
 Hays,110,GOVERNOR DEM,,DEM,Under Votes,3,1,2
@@ -7898,9 +7898,9 @@ Hays,112,U.S. Senate,,DEM,"Michael ""Fjet"" Fjetland",2,2,0
 Hays,112,U.S. Senate,,DEM,Over Votes,0,0,0
 Hays,112,U.S. Senate,,DEM,Under Votes,10,4,6
 Hays,112,U.S. Senate,,DEM,Harry Kim,6,3,3
-Hays,112,,U.S. House,35,DEM,Lloyd Doggett,69,34,35
-Hays,112,,U.S. House,35,DEM,Over Votes,0,0,0
-Hays,112,,U.S. House,35,DEM,Under Votes,5,1,4
+Hays,112,U.S. House,35,DEM,Lloyd Doggett,69,34,35
+Hays,112,U.S. House,35,DEM,Over Votes,0,0,0
+Hays,112,U.S. House,35,DEM,Under Votes,5,1,4
 Hays,112,GOVERNOR DEM,,DEM,Wendy R. Davis,60,27,33
 Hays,112,GOVERNOR DEM,,DEM,Over Votes,0,0,0
 Hays,112,GOVERNOR DEM,,DEM,Under Votes,2,1,1
@@ -7979,9 +7979,9 @@ Hays,113,U.S. Senate,,DEM,"Michael ""Fjet"" Fjetland",1,1,0
 Hays,113,U.S. Senate,,DEM,Over Votes,0,0,0
 Hays,113,U.S. Senate,,DEM,Under Votes,9,5,4
 Hays,113,U.S. Senate,,DEM,Harry Kim,9,5,4
-Hays,113,,U.S. House,35,DEM,Lloyd Doggett,127,81,46
-Hays,113,,U.S. House,35,DEM,Over Votes,0,0,0
-Hays,113,,U.S. House,35,DEM,Under Votes,4,1,3
+Hays,113,U.S. House,35,DEM,Lloyd Doggett,127,81,46
+Hays,113,U.S. House,35,DEM,Over Votes,0,0,0
+Hays,113,U.S. House,35,DEM,Under Votes,4,1,3
 Hays,113,GOVERNOR DEM,,DEM,Wendy R. Davis,107,69,38
 Hays,113,GOVERNOR DEM,,DEM,Over Votes,0,0,0
 Hays,113,GOVERNOR DEM,,DEM,Under Votes,3,1,2
@@ -8060,9 +8060,9 @@ Hays,120,U.S. Senate,,DEM,"Michael ""Fjet"" Fjetland",3,2,1
 Hays,120,U.S. Senate,,DEM,Over Votes,0,0,0
 Hays,120,U.S. Senate,,DEM,Under Votes,9,5,4
 Hays,120,U.S. Senate,,DEM,Harry Kim,10,3,7
-Hays,120,,U.S. House,35,DEM,Lloyd Doggett,66,38,28
-Hays,120,,U.S. House,35,DEM,Over Votes,0,0,0
-Hays,120,,U.S. House,35,DEM,Under Votes,6,3,3
+Hays,120,U.S. House,35,DEM,Lloyd Doggett,66,38,28
+Hays,120,U.S. House,35,DEM,Over Votes,0,0,0
+Hays,120,U.S. House,35,DEM,Under Votes,6,3,3
 Hays,120,GOVERNOR DEM,,DEM,Wendy R. Davis,62,34,28
 Hays,120,GOVERNOR DEM,,DEM,Over Votes,0,0,0
 Hays,120,GOVERNOR DEM,,DEM,Under Votes,1,1,0
@@ -8141,9 +8141,9 @@ Hays,125,U.S. Senate,,DEM,"Michael ""Fjet"" Fjetland",1,1,0
 Hays,125,U.S. Senate,,DEM,Over Votes,0,0,0
 Hays,125,U.S. Senate,,DEM,Under Votes,6,4,2
 Hays,125,U.S. Senate,,DEM,Harry Kim,2,1,1
-Hays,125,,U.S. House,35,DEM,Lloyd Doggett,47,21,26
-Hays,125,,U.S. House,35,DEM,Over Votes,0,0,0
-Hays,125,,U.S. House,35,DEM,Under Votes,1,1,0
+Hays,125,U.S. House,35,DEM,Lloyd Doggett,47,21,26
+Hays,125,U.S. House,35,DEM,Over Votes,0,0,0
+Hays,125,U.S. House,35,DEM,Under Votes,1,1,0
 Hays,125,GOVERNOR DEM,,DEM,Wendy R. Davis,43,18,25
 Hays,125,GOVERNOR DEM,,DEM,Over Votes,0,0,0
 Hays,125,GOVERNOR DEM,,DEM,Under Votes,1,1,0
@@ -8222,9 +8222,9 @@ Hays,127,U.S. Senate,,DEM,"Michael ""Fjet"" Fjetland",6,3,3
 Hays,127,U.S. Senate,,DEM,Over Votes,0,0,0
 Hays,127,U.S. Senate,,DEM,Under Votes,11,2,9
 Hays,127,U.S. Senate,,DEM,Harry Kim,9,1,8
-Hays,127,,U.S. House,35,DEM,Lloyd Doggett,89,28,61
-Hays,127,,U.S. House,35,DEM,Over Votes,0,0,0
-Hays,127,,U.S. House,35,DEM,Under Votes,4,2,2
+Hays,127,U.S. House,35,DEM,Lloyd Doggett,89,28,61
+Hays,127,U.S. House,35,DEM,Over Votes,0,0,0
+Hays,127,U.S. House,35,DEM,Under Votes,4,2,2
 Hays,127,GOVERNOR DEM,,DEM,Wendy R. Davis,85,25,60
 Hays,127,GOVERNOR DEM,,DEM,Over Votes,0,0,0
 Hays,127,GOVERNOR DEM,,DEM,Under Votes,2,1,1
@@ -8303,9 +8303,9 @@ Hays,129,U.S. Senate,,DEM,"Michael ""Fjet"" Fjetland",3,1,2
 Hays,129,U.S. Senate,,DEM,Over Votes,0,0,0
 Hays,129,U.S. Senate,,DEM,Under Votes,6,2,4
 Hays,129,U.S. Senate,,DEM,Harry Kim,7,3,4
-Hays,129,,U.S. House,35,DEM,Lloyd Doggett,99,57,42
-Hays,129,,U.S. House,35,DEM,Over Votes,0,0,0
-Hays,129,,U.S. House,35,DEM,Under Votes,3,0,3
+Hays,129,U.S. House,35,DEM,Lloyd Doggett,99,57,42
+Hays,129,U.S. House,35,DEM,Over Votes,0,0,0
+Hays,129,U.S. House,35,DEM,Under Votes,3,0,3
 Hays,129,GOVERNOR DEM,,DEM,Wendy R. Davis,95,54,41
 Hays,129,GOVERNOR DEM,,DEM,Over Votes,0,0,0
 Hays,129,GOVERNOR DEM,,DEM,Under Votes,3,1,2
@@ -8387,9 +8387,9 @@ Hays,221,U.S. Senate,,DEM,"Michael ""Fjet"" Fjetland",3,3,0
 Hays,221,U.S. Senate,,DEM,Over Votes,0,0,0
 Hays,221,U.S. Senate,,DEM,Under Votes,8,7,1
 Hays,221,U.S. Senate,,DEM,Harry Kim,6,1,5
-Hays,221,,U.S. House,35,DEM,Lloyd Doggett,106,57,49
-Hays,221,,U.S. House,35,DEM,Over Votes,0,0,0
-Hays,221,,U.S. House,35,DEM,Under Votes,5,2,3
+Hays,221,U.S. House,35,DEM,Lloyd Doggett,106,57,49
+Hays,221,U.S. House,35,DEM,Over Votes,0,0,0
+Hays,221,U.S. House,35,DEM,Under Votes,5,2,3
 Hays,221,GOVERNOR DEM,,DEM,Wendy R. Davis,98,53,45
 Hays,221,GOVERNOR DEM,,DEM,Over Votes,0,0,0
 Hays,221,GOVERNOR DEM,,DEM,Under Votes,2,2,0
@@ -8471,9 +8471,9 @@ Hays,223,U.S. Senate,,DEM,"Michael ""Fjet"" Fjetland",4,3,1
 Hays,223,U.S. Senate,,DEM,Over Votes,0,0,0
 Hays,223,U.S. Senate,,DEM,Under Votes,12,7,5
 Hays,223,U.S. Senate,,DEM,Harry Kim,7,5,2
-Hays,223,,U.S. House,35,DEM,Lloyd Doggett,81,52,29
-Hays,223,,U.S. House,35,DEM,Over Votes,0,0,0
-Hays,223,,U.S. House,35,DEM,Under Votes,6,3,3
+Hays,223,U.S. House,35,DEM,Lloyd Doggett,81,52,29
+Hays,223,U.S. House,35,DEM,Over Votes,0,0,0
+Hays,223,U.S. House,35,DEM,Under Votes,6,3,3
 Hays,223,GOVERNOR DEM,,DEM,Wendy R. Davis,75,45,30
 Hays,223,GOVERNOR DEM,,DEM,Over Votes,0,0,0
 Hays,223,GOVERNOR DEM,,DEM,Under Votes,2,0,2
@@ -8798,9 +8798,9 @@ Hays,228,U.S. Senate,,DEM,"Michael ""Fjet"" Fjetland",7,2,5
 Hays,228,U.S. Senate,,DEM,Over Votes,0,0,0
 Hays,228,U.S. Senate,,DEM,Under Votes,12,7,5
 Hays,228,U.S. Senate,,DEM,Harry Kim,8,5,3
-Hays,228,,U.S. House,35,DEM,Lloyd Doggett,99,53,46
-Hays,228,,U.S. House,35,DEM,Over Votes,0,0,0
-Hays,228,,U.S. House,35,DEM,Under Votes,6,3,3
+Hays,228,U.S. House,35,DEM,Lloyd Doggett,99,53,46
+Hays,228,U.S. House,35,DEM,Over Votes,0,0,0
+Hays,228,U.S. House,35,DEM,Under Votes,6,3,3
 Hays,228,GOVERNOR DEM,,DEM,Wendy R. Davis,97,53,44
 Hays,228,GOVERNOR DEM,,DEM,Over Votes,0,0,0
 Hays,228,GOVERNOR DEM,,DEM,Under Votes,1,0,1
@@ -8882,9 +8882,9 @@ Hays,229,U.S. Senate,,DEM,"Michael ""Fjet"" Fjetland",4,1,3
 Hays,229,U.S. Senate,,DEM,Over Votes,0,0,0
 Hays,229,U.S. Senate,,DEM,Under Votes,3,3,0
 Hays,229,U.S. Senate,,DEM,Harry Kim,1,0,1
-Hays,229,,U.S. House,35,DEM,Lloyd Doggett,29,21,8
-Hays,229,,U.S. House,35,DEM,Over Votes,0,0,0
-Hays,229,,U.S. House,35,DEM,Under Votes,2,2,0
+Hays,229,U.S. House,35,DEM,Lloyd Doggett,29,21,8
+Hays,229,U.S. House,35,DEM,Over Votes,0,0,0
+Hays,229,U.S. House,35,DEM,Under Votes,2,2,0
 Hays,229,GOVERNOR DEM,,DEM,Wendy R. Davis,27,20,7
 Hays,229,GOVERNOR DEM,,DEM,Over Votes,0,0,0
 Hays,229,GOVERNOR DEM,,DEM,Under Votes,1,1,0
@@ -9129,9 +9129,9 @@ Hays,234,U.S. Senate,,DEM,"Michael ""Fjet"" Fjetland",0,0,0
 Hays,234,U.S. Senate,,DEM,Over Votes,0,0,0
 Hays,234,U.S. Senate,,DEM,Under Votes,4,2,2
 Hays,234,U.S. Senate,,DEM,Harry Kim,0,0,0
-Hays,234,,U.S. House,35,DEM,Lloyd Doggett,17,4,13
-Hays,234,,U.S. House,35,DEM,Over Votes,0,0,0
-Hays,234,,U.S. House,35,DEM,Under Votes,1,1,0
+Hays,234,U.S. House,35,DEM,Lloyd Doggett,17,4,13
+Hays,234,U.S. House,35,DEM,Over Votes,0,0,0
+Hays,234,U.S. House,35,DEM,Under Votes,1,1,0
 Hays,234,GOVERNOR DEM,,DEM,Wendy R. Davis,14,3,11
 Hays,234,GOVERNOR DEM,,DEM,Over Votes,0,0,0
 Hays,234,GOVERNOR DEM,,DEM,Under Votes,2,2,0
@@ -9374,9 +9374,9 @@ Hays,301,U.S. Senate,,DEM,"Michael ""Fjet"" Fjetland",0,0,0
 Hays,301,U.S. Senate,,DEM,Over Votes,0,0,0
 Hays,301,U.S. Senate,,DEM,Under Votes,0,0,0
 Hays,301,U.S. Senate,,DEM,Harry Kim,0,0,0
-Hays,301,,U.S. House,35,DEM,Lloyd Doggett,0,0,0
-Hays,301,,U.S. House,35,DEM,Over Votes,0,0,0
-Hays,301,,U.S. House,35,DEM,Under Votes,0,0,0
+Hays,301,U.S. House,35,DEM,Lloyd Doggett,0,0,0
+Hays,301,U.S. House,35,DEM,Over Votes,0,0,0
+Hays,301,U.S. House,35,DEM,Under Votes,0,0,0
 Hays,301,GOVERNOR DEM,,DEM,Wendy R. Davis,0,0,0
 Hays,301,GOVERNOR DEM,,DEM,Over Votes,0,0,0
 Hays,301,GOVERNOR DEM,,DEM,Under Votes,0,0,0
@@ -9614,9 +9614,9 @@ Hays,317,U.S. Senate,,DEM,"Michael ""Fjet"" Fjetland",0,0,0
 Hays,317,U.S. Senate,,DEM,Over Votes,0,0,0
 Hays,317,U.S. Senate,,DEM,Under Votes,0,0,0
 Hays,317,U.S. Senate,,DEM,Harry Kim,2,2,0
-Hays,317,,U.S. House,35,DEM,Lloyd Doggett,12,9,3
-Hays,317,,U.S. House,35,DEM,Over Votes,0,0,0
-Hays,317,,U.S. House,35,DEM,Under Votes,0,0,0
+Hays,317,U.S. House,35,DEM,Lloyd Doggett,12,9,3
+Hays,317,U.S. House,35,DEM,Over Votes,0,0,0
+Hays,317,U.S. House,35,DEM,Under Votes,0,0,0
 Hays,317,GOVERNOR DEM,,DEM,Wendy R. Davis,10,8,2
 Hays,317,GOVERNOR DEM,,DEM,Over Votes,0,0,0
 Hays,317,GOVERNOR DEM,,DEM,Under Votes,0,0,0
@@ -9695,9 +9695,9 @@ Hays,318,U.S. Senate,,DEM,"Michael ""Fjet"" Fjetland",1,0,1
 Hays,318,U.S. Senate,,DEM,Over Votes,0,0,0
 Hays,318,U.S. Senate,,DEM,Under Votes,1,1,0
 Hays,318,U.S. Senate,,DEM,Harry Kim,0,0,0
-Hays,318,,U.S. House,35,DEM,Lloyd Doggett,2,2,0
-Hays,318,,U.S. House,35,DEM,Over Votes,0,0,0
-Hays,318,,U.S. House,35,DEM,Under Votes,1,0,1
+Hays,318,U.S. House,35,DEM,Lloyd Doggett,2,2,0
+Hays,318,U.S. House,35,DEM,Over Votes,0,0,0
+Hays,318,U.S. House,35,DEM,Under Votes,1,0,1
 Hays,318,GOVERNOR DEM,,DEM,Wendy R. Davis,2,2,0
 Hays,318,GOVERNOR DEM,,DEM,Over Votes,0,0,0
 Hays,318,GOVERNOR DEM,,DEM,Under Votes,0,0,0
@@ -10023,9 +10023,9 @@ Hays,334,U.S. Senate,,DEM,"Michael ""Fjet"" Fjetland",0,0,0
 Hays,334,U.S. Senate,,DEM,Over Votes,0,0,0
 Hays,334,U.S. Senate,,DEM,Under Votes,3,3,0
 Hays,334,U.S. Senate,,DEM,Harry Kim,2,1,1
-Hays,334,,U.S. House,35,DEM,Lloyd Doggett,15,9,6
-Hays,334,,U.S. House,35,DEM,Over Votes,0,0,0
-Hays,334,,U.S. House,35,DEM,Under Votes,1,1,0
+Hays,334,U.S. House,35,DEM,Lloyd Doggett,15,9,6
+Hays,334,U.S. House,35,DEM,Over Votes,0,0,0
+Hays,334,U.S. House,35,DEM,Under Votes,1,1,0
 Hays,334,GOVERNOR DEM,,DEM,Wendy R. Davis,16,10,6
 Hays,334,GOVERNOR DEM,,DEM,Over Votes,0,0,0
 Hays,334,GOVERNOR DEM,,DEM,Under Votes,0,0,0
@@ -10430,9 +10430,9 @@ Hays,413,U.S. Senate,,DEM,"Michael ""Fjet"" Fjetland",0,0,0
 Hays,413,U.S. Senate,,DEM,Over Votes,0,0,0
 Hays,413,U.S. Senate,,DEM,Under Votes,1,1,0
 Hays,413,U.S. Senate,,DEM,Harry Kim,1,1,0
-Hays,413,,U.S. House,35,DEM,Lloyd Doggett,8,8,0
-Hays,413,,U.S. House,35,DEM,Over Votes,0,0,0
-Hays,413,,U.S. House,35,DEM,Under Votes,0,0,0
+Hays,413,U.S. House,35,DEM,Lloyd Doggett,8,8,0
+Hays,413,U.S. House,35,DEM,Over Votes,0,0,0
+Hays,413,U.S. House,35,DEM,Under Votes,0,0,0
 Hays,413,GOVERNOR DEM,,DEM,Wendy R. Davis,7,7,0
 Hays,413,GOVERNOR DEM,,DEM,Over Votes,0,0,0
 Hays,413,GOVERNOR DEM,,DEM,Under Votes,0,0,0
@@ -10514,9 +10514,9 @@ Hays,414,U.S. Senate,,DEM,"Michael ""Fjet"" Fjetland",0,0,0
 Hays,414,U.S. Senate,,DEM,Over Votes,0,0,0
 Hays,414,U.S. Senate,,DEM,Under Votes,1,0,1
 Hays,414,U.S. Senate,,DEM,Harry Kim,3,3,0
-Hays,414,,U.S. House,35,DEM,Lloyd Doggett,21,13,8
-Hays,414,,U.S. House,35,DEM,Over Votes,0,0,0
-Hays,414,,U.S. House,35,DEM,Under Votes,0,0,0
+Hays,414,U.S. House,35,DEM,Lloyd Doggett,21,13,8
+Hays,414,U.S. House,35,DEM,Over Votes,0,0,0
+Hays,414,U.S. House,35,DEM,Under Votes,0,0,0
 Hays,414,GOVERNOR DEM,,DEM,Wendy R. Davis,16,10,6
 Hays,414,GOVERNOR DEM,,DEM,Over Votes,0,0,0
 Hays,414,GOVERNOR DEM,,DEM,Under Votes,0,0,0
@@ -10595,9 +10595,9 @@ Hays,415,U.S. Senate,,DEM,"Michael ""Fjet"" Fjetland",3,1,2
 Hays,415,U.S. Senate,,DEM,Over Votes,0,0,0
 Hays,415,U.S. Senate,,DEM,Under Votes,5,1,4
 Hays,415,U.S. Senate,,DEM,Harry Kim,0,0,0
-Hays,415,,U.S. House,35,DEM,Lloyd Doggett,19,11,8
-Hays,415,,U.S. House,35,DEM,Over Votes,0,0,0
-Hays,415,,U.S. House,35,DEM,Under Votes,1,0,1
+Hays,415,U.S. House,35,DEM,Lloyd Doggett,19,11,8
+Hays,415,U.S. House,35,DEM,Over Votes,0,0,0
+Hays,415,U.S. House,35,DEM,Under Votes,1,0,1
 Hays,415,GOVERNOR DEM,,DEM,Wendy R. Davis,18,10,8
 Hays,415,GOVERNOR DEM,,DEM,Over Votes,0,0,0
 Hays,415,GOVERNOR DEM,,DEM,Under Votes,0,0,0
@@ -10679,9 +10679,9 @@ Hays,416,U.S. Senate,,DEM,"Michael ""Fjet"" Fjetland",0,0,0
 Hays,416,U.S. Senate,,DEM,Over Votes,0,0,0
 Hays,416,U.S. Senate,,DEM,Under Votes,0,0,0
 Hays,416,U.S. Senate,,DEM,Harry Kim,0,0,0
-Hays,416,,U.S. House,35,DEM,Lloyd Doggett,0,0,0
-Hays,416,,U.S. House,35,DEM,Over Votes,0,0,0
-Hays,416,,U.S. House,35,DEM,Under Votes,0,0,0
+Hays,416,U.S. House,35,DEM,Lloyd Doggett,0,0,0
+Hays,416,U.S. House,35,DEM,Over Votes,0,0,0
+Hays,416,U.S. House,35,DEM,Under Votes,0,0,0
 Hays,416,GOVERNOR DEM,,DEM,Wendy R. Davis,0,0,0
 Hays,416,GOVERNOR DEM,,DEM,Over Votes,0,0,0
 Hays,416,GOVERNOR DEM,,DEM,Under Votes,0,0,0
@@ -10838,9 +10838,9 @@ Hays,418,U.S. Senate,,DEM,"Michael ""Fjet"" Fjetland",0,0,0
 Hays,418,U.S. Senate,,DEM,Over Votes,0,0,0
 Hays,418,U.S. Senate,,DEM,Under Votes,1,1,0
 Hays,418,U.S. Senate,,DEM,Harry Kim,0,0,0
-Hays,418,,U.S. House,35,DEM,Lloyd Doggett,1,1,0
-Hays,418,,U.S. House,35,DEM,Over Votes,0,0,0
-Hays,418,,U.S. House,35,DEM,Under Votes,0,0,0
+Hays,418,U.S. House,35,DEM,Lloyd Doggett,1,1,0
+Hays,418,U.S. House,35,DEM,Over Votes,0,0,0
+Hays,418,U.S. House,35,DEM,Under Votes,0,0,0
 Hays,418,GOVERNOR DEM,,DEM,Wendy R. Davis,0,0,0
 Hays,418,GOVERNOR DEM,,DEM,Over Votes,0,0,0
 Hays,418,GOVERNOR DEM,,DEM,Under Votes,1,1,0
@@ -10922,9 +10922,9 @@ Hays,419,U.S. Senate,,DEM,"Michael ""Fjet"" Fjetland",1,1,0
 Hays,419,U.S. Senate,,DEM,Over Votes,0,0,0
 Hays,419,U.S. Senate,,DEM,Under Votes,2,2,0
 Hays,419,U.S. Senate,,DEM,Harry Kim,2,1,1
-Hays,419,,U.S. House,35,DEM,Lloyd Doggett,21,8,13
-Hays,419,,U.S. House,35,DEM,Over Votes,0,0,0
-Hays,419,,U.S. House,35,DEM,Under Votes,0,0,0
+Hays,419,U.S. House,35,DEM,Lloyd Doggett,21,8,13
+Hays,419,U.S. House,35,DEM,Over Votes,0,0,0
+Hays,419,U.S. House,35,DEM,Under Votes,0,0,0
 Hays,419,GOVERNOR DEM,,DEM,Wendy R. Davis,20,7,13
 Hays,419,GOVERNOR DEM,,DEM,Over Votes,0,0,0
 Hays,419,GOVERNOR DEM,,DEM,Under Votes,0,0,0
@@ -11756,6 +11756,6 @@ Hays,FPCA FED 35,U.S. Senate,,DEM,"Michael ""Fjet"" Fjetland",0,0,0
 Hays,FPCA FED 35,U.S. Senate,,DEM,Over Votes,0,0,0
 Hays,FPCA FED 35,U.S. Senate,,DEM,Under Votes,0,0,0
 Hays,FPCA FED 35,U.S. Senate,,DEM,Harry Kim,0,0,0
-Hays,FPCA FED 35,,U.S. House,35,DEM,Lloyd Doggett,0,0,0
-Hays,FPCA FED 35,,U.S. House,35,DEM,Over Votes,0,0,0
-Hays,FPCA FED 35,,U.S. House,35,DEM,Under Votes,0,0,0
+Hays,FPCA FED 35,U.S. House,35,DEM,Lloyd Doggett,0,0,0
+Hays,FPCA FED 35,U.S. House,35,DEM,Over Votes,0,0,0
+Hays,FPCA FED 35,U.S. House,35,DEM,Under Votes,0,0,0

--- a/2014/counties/20140304__tx__primary__hays__precinct.csv
+++ b/2014/counties/20140304__tx__primary__hays__precinct.csv
@@ -29,12 +29,12 @@ Hays,110,Attorney General REP,,REP,Barry Smitherman,16,8,8
 Hays,110,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,110,Attorney General REP,,REP,Under Votes,12,6,6
 Hays,110,Attorney General REP,,REP,Ken Paxton,42,24,18
-Hays,110,Comptroller	of Public Accounts REP,,REP,Raul Torres,4,2,2
-Hays,110,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,16,8,8
-Hays,110,Comptroller	of Public Accounts REP,,REP,Debra Medina,28,15,13
-Hays,110,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,41,23,18
-Hays,110,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,110,Comptroller	of Public Accounts REP,,REP,Under Votes,12,6,6
+Hays,110,Comptroller of Public Accounts REP,,REP,Raul Torres,4,2,2
+Hays,110,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,16,8,8
+Hays,110,Comptroller of Public Accounts REP,,REP,Debra Medina,28,15,13
+Hays,110,Comptroller of Public Accounts REP,,REP,Glenn Hegar,41,23,18
+Hays,110,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,110,Comptroller of Public Accounts REP,,REP,Under Votes,12,6,6
 Hays,110,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,31,18,13
 Hays,110,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,59,31,28
 Hays,110,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -187,12 +187,12 @@ Hays,111,Attorney General REP,,REP,Barry Smitherman,0,0,0
 Hays,111,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,111,Attorney General REP,,REP,Under Votes,2,1,1
 Hays,111,Attorney General REP,,REP,Ken Paxton,6,3,3
-Hays,111,Comptroller	of Public Accounts REP,,REP,Raul Torres,0,0,0
-Hays,111,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,6,5,1
-Hays,111,Comptroller	of Public Accounts REP,,REP,Debra Medina,5,3,2
-Hays,111,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,4,0,4
-Hays,111,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,111,Comptroller	of Public Accounts REP,,REP,Under Votes,2,1,1
+Hays,111,Comptroller of Public Accounts REP,,REP,Raul Torres,0,0,0
+Hays,111,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,6,5,1
+Hays,111,Comptroller of Public Accounts REP,,REP,Debra Medina,5,3,2
+Hays,111,Comptroller of Public Accounts REP,,REP,Glenn Hegar,4,0,4
+Hays,111,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,111,Comptroller of Public Accounts REP,,REP,Under Votes,2,1,1
 Hays,111,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,3,3,0
 Hays,111,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,13,6,7
 Hays,111,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -339,12 +339,12 @@ Hays,112,Attorney General REP,,REP,Barry Smitherman,19,9,10
 Hays,112,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,112,Attorney General REP,,REP,Under Votes,5,0,5
 Hays,112,Attorney General REP,,REP,Ken Paxton,16,10,6
-Hays,112,Comptroller	of Public Accounts REP,,REP,Raul Torres,6,2,4
-Hays,112,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,9,8,1
-Hays,112,Comptroller	of Public Accounts REP,,REP,Debra Medina,16,9,7
-Hays,112,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,16,10,6
-Hays,112,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,112,Comptroller	of Public Accounts REP,,REP,Under Votes,8,0,8
+Hays,112,Comptroller of Public Accounts REP,,REP,Raul Torres,6,2,4
+Hays,112,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,9,8,1
+Hays,112,Comptroller of Public Accounts REP,,REP,Debra Medina,16,9,7
+Hays,112,Comptroller of Public Accounts REP,,REP,Glenn Hegar,16,10,6
+Hays,112,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,112,Comptroller of Public Accounts REP,,REP,Under Votes,8,0,8
 Hays,112,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,26,12,14
 Hays,112,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,25,17,8
 Hays,112,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -491,12 +491,12 @@ Hays,113,Attorney General REP,,REP,Barry Smitherman,34,24,10
 Hays,113,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,113,Attorney General REP,,REP,Under Votes,18,9,9
 Hays,113,Attorney General REP,,REP,Ken Paxton,29,14,15
-Hays,113,Comptroller	of Public Accounts REP,,REP,Raul Torres,16,10,6
-Hays,113,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,23,15,8
-Hays,113,Comptroller	of Public Accounts REP,,REP,Debra Medina,32,20,12
-Hays,113,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,36,20,16
-Hays,113,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,113,Comptroller	of Public Accounts REP,,REP,Under Votes,23,15,8
+Hays,113,Comptroller of Public Accounts REP,,REP,Raul Torres,16,10,6
+Hays,113,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,23,15,8
+Hays,113,Comptroller of Public Accounts REP,,REP,Debra Medina,32,20,12
+Hays,113,Comptroller of Public Accounts REP,,REP,Glenn Hegar,36,20,16
+Hays,113,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,113,Comptroller of Public Accounts REP,,REP,Under Votes,23,15,8
 Hays,113,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,36,16,20
 Hays,113,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,74,53,21
 Hays,113,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -647,12 +647,12 @@ Hays,120,Attorney General REP,,REP,Barry Smitherman,20,6,14
 Hays,120,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,120,Attorney General REP,,REP,Under Votes,6,2,4
 Hays,120,Attorney General REP,,REP,Ken Paxton,40,19,21
-Hays,120,Comptroller	of Public Accounts REP,,REP,Raul Torres,7,3,4
-Hays,120,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,17,7,10
-Hays,120,Comptroller	of Public Accounts REP,,REP,Debra Medina,30,11,19
-Hays,120,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,35,15,20
-Hays,120,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,120,Comptroller	of Public Accounts REP,,REP,Under Votes,14,4,10
+Hays,120,Comptroller of Public Accounts REP,,REP,Raul Torres,7,3,4
+Hays,120,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,17,7,10
+Hays,120,Comptroller of Public Accounts REP,,REP,Debra Medina,30,11,19
+Hays,120,Comptroller of Public Accounts REP,,REP,Glenn Hegar,35,15,20
+Hays,120,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,120,Comptroller of Public Accounts REP,,REP,Under Votes,14,4,10
 Hays,120,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,35,11,24
 Hays,120,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,58,25,33
 Hays,120,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -803,12 +803,12 @@ Hays,125,Attorney General REP,,REP,Barry Smitherman,10,5,5
 Hays,125,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,125,Attorney General REP,,REP,Under Votes,4,1,3
 Hays,125,Attorney General REP,,REP,Ken Paxton,39,22,17
-Hays,125,Comptroller	of Public Accounts REP,,REP,Raul Torres,4,3,1
-Hays,125,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,13,7,6
-Hays,125,Comptroller	of Public Accounts REP,,REP,Debra Medina,14,8,6
-Hays,125,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,35,20,15
-Hays,125,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,125,Comptroller	of Public Accounts REP,,REP,Under Votes,7,4,3
+Hays,125,Comptroller of Public Accounts REP,,REP,Raul Torres,4,3,1
+Hays,125,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,13,7,6
+Hays,125,Comptroller of Public Accounts REP,,REP,Debra Medina,14,8,6
+Hays,125,Comptroller of Public Accounts REP,,REP,Glenn Hegar,35,20,15
+Hays,125,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,125,Comptroller of Public Accounts REP,,REP,Under Votes,7,4,3
 Hays,125,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,25,13,12
 Hays,125,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,44,28,16
 Hays,125,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -951,12 +951,12 @@ Hays,127,Attorney General REP,,REP,Barry Smitherman,36,14,22
 Hays,127,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,127,Attorney General REP,,REP,Under Votes,15,8,7
 Hays,127,Attorney General REP,,REP,Ken Paxton,72,29,43
-Hays,127,Comptroller	of Public Accounts REP,,REP,Raul Torres,10,4,6
-Hays,127,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,39,13,26
-Hays,127,Comptroller	of Public Accounts REP,,REP,Debra Medina,43,16,27
-Hays,127,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,68,23,45
-Hays,127,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,127,Comptroller	of Public Accounts REP,,REP,Under Votes,21,10,11
+Hays,127,Comptroller of Public Accounts REP,,REP,Raul Torres,10,4,6
+Hays,127,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,39,13,26
+Hays,127,Comptroller of Public Accounts REP,,REP,Debra Medina,43,16,27
+Hays,127,Comptroller of Public Accounts REP,,REP,Glenn Hegar,68,23,45
+Hays,127,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,127,Comptroller of Public Accounts REP,,REP,Under Votes,21,10,11
 Hays,127,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,58,23,35
 Hays,127,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,108,34,74
 Hays,127,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -1099,12 +1099,12 @@ Hays,129,Attorney General REP,,REP,Barry Smitherman,23,12,11
 Hays,129,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,129,Attorney General REP,,REP,Under Votes,6,2,4
 Hays,129,Attorney General REP,,REP,Ken Paxton,74,30,44
-Hays,129,Comptroller	of Public Accounts REP,,REP,Raul Torres,13,3,10
-Hays,129,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,27,17,10
-Hays,129,Comptroller	of Public Accounts REP,,REP,Debra Medina,32,20,12
-Hays,129,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,75,30,45
-Hays,129,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,129,Comptroller	of Public Accounts REP,,REP,Under Votes,10,4,6
+Hays,129,Comptroller of Public Accounts REP,,REP,Raul Torres,13,3,10
+Hays,129,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,27,17,10
+Hays,129,Comptroller of Public Accounts REP,,REP,Debra Medina,32,20,12
+Hays,129,Comptroller of Public Accounts REP,,REP,Glenn Hegar,75,30,45
+Hays,129,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,129,Comptroller of Public Accounts REP,,REP,Under Votes,10,4,6
 Hays,129,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,66,30,36
 Hays,129,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,82,41,41
 Hays,129,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -1252,12 +1252,12 @@ Hays,221,Attorney General REP,,REP,Barry Smitherman,35,19,16
 Hays,221,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,221,Attorney General REP,,REP,Under Votes,20,10,10
 Hays,221,Attorney General REP,,REP,Ken Paxton,79,30,49
-Hays,221,Comptroller	of Public Accounts REP,,REP,Raul Torres,9,5,4
-Hays,221,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,35,14,21
-Hays,221,Comptroller	of Public Accounts REP,,REP,Debra Medina,46,19,27
-Hays,221,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,84,37,47
-Hays,221,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,221,Comptroller	of Public Accounts REP,,REP,Under Votes,26,13,13
+Hays,221,Comptroller of Public Accounts REP,,REP,Raul Torres,9,5,4
+Hays,221,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,35,14,21
+Hays,221,Comptroller of Public Accounts REP,,REP,Debra Medina,46,19,27
+Hays,221,Comptroller of Public Accounts REP,,REP,Glenn Hegar,84,37,47
+Hays,221,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,221,Comptroller of Public Accounts REP,,REP,Under Votes,26,13,13
 Hays,221,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,64,23,41
 Hays,221,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,113,56,57
 Hays,221,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -1408,12 +1408,12 @@ Hays,223,Attorney General REP,,REP,Barry Smitherman,29,15,14
 Hays,223,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,223,Attorney General REP,,REP,Under Votes,7,2,5
 Hays,223,Attorney General REP,,REP,Ken Paxton,35,15,20
-Hays,223,Comptroller	of Public Accounts REP,,REP,Raul Torres,8,2,6
-Hays,223,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,19,10,9
-Hays,223,Comptroller	of Public Accounts REP,,REP,Debra Medina,20,6,14
-Hays,223,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,51,27,24
-Hays,223,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,223,Comptroller	of Public Accounts REP,,REP,Under Votes,7,4,3
+Hays,223,Comptroller of Public Accounts REP,,REP,Raul Torres,8,2,6
+Hays,223,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,19,10,9
+Hays,223,Comptroller of Public Accounts REP,,REP,Debra Medina,20,6,14
+Hays,223,Comptroller of Public Accounts REP,,REP,Glenn Hegar,51,27,24
+Hays,223,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,223,Comptroller of Public Accounts REP,,REP,Under Votes,7,4,3
 Hays,223,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,35,15,20
 Hays,223,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,63,31,32
 Hays,223,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -1566,12 +1566,12 @@ Hays,224,Attorney General REP,,REP,Barry Smitherman,93,47,46
 Hays,224,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,224,Attorney General REP,,REP,Under Votes,19,8,11
 Hays,224,Attorney General REP,,REP,Ken Paxton,152,74,78
-Hays,224,Comptroller	of Public Accounts REP,,REP,Raul Torres,25,13,12
-Hays,224,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,94,58,36
-Hays,224,Comptroller	of Public Accounts REP,,REP,Debra Medina,77,32,45
-Hays,224,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,181,73,108
-Hays,224,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,224,Comptroller	of Public Accounts REP,,REP,Under Votes,46,22,24
+Hays,224,Comptroller of Public Accounts REP,,REP,Raul Torres,25,13,12
+Hays,224,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,94,58,36
+Hays,224,Comptroller of Public Accounts REP,,REP,Debra Medina,77,32,45
+Hays,224,Comptroller of Public Accounts REP,,REP,Glenn Hegar,181,73,108
+Hays,224,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,224,Comptroller of Public Accounts REP,,REP,Under Votes,46,22,24
 Hays,224,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,135,48,87
 Hays,224,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,268,147,121
 Hays,224,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -1724,12 +1724,12 @@ Hays,225,Attorney General REP,,REP,Barry Smitherman,62,36,26
 Hays,225,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,225,Attorney General REP,,REP,Under Votes,14,6,8
 Hays,225,Attorney General REP,,REP,Ken Paxton,85,50,35
-Hays,225,Comptroller	of Public Accounts REP,,REP,Raul Torres,13,4,9
-Hays,225,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,38,21,17
-Hays,225,Comptroller	of Public Accounts REP,,REP,Debra Medina,51,34,17
-Hays,225,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,106,62,44
-Hays,225,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,225,Comptroller	of Public Accounts REP,,REP,Under Votes,22,10,12
+Hays,225,Comptroller of Public Accounts REP,,REP,Raul Torres,13,4,9
+Hays,225,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,38,21,17
+Hays,225,Comptroller of Public Accounts REP,,REP,Debra Medina,51,34,17
+Hays,225,Comptroller of Public Accounts REP,,REP,Glenn Hegar,106,62,44
+Hays,225,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,225,Comptroller of Public Accounts REP,,REP,Under Votes,22,10,12
 Hays,225,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,79,44,35
 Hays,225,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,134,79,55
 Hays,225,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -1886,12 +1886,12 @@ Hays,226,Attorney General REP,,REP,Barry Smitherman,88,37,51
 Hays,226,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,226,Attorney General REP,,REP,Under Votes,15,5,10
 Hays,226,Attorney General REP,,REP,Ken Paxton,124,53,71
-Hays,226,Comptroller	of Public Accounts REP,,REP,Raul Torres,8,4,4
-Hays,226,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,64,31,33
-Hays,226,Comptroller	of Public Accounts REP,,REP,Debra Medina,90,36,54
-Hays,226,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,127,45,82
-Hays,226,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,226,Comptroller	of Public Accounts REP,,REP,Under Votes,21,11,10
+Hays,226,Comptroller of Public Accounts REP,,REP,Raul Torres,8,4,4
+Hays,226,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,64,31,33
+Hays,226,Comptroller of Public Accounts REP,,REP,Debra Medina,90,36,54
+Hays,226,Comptroller of Public Accounts REP,,REP,Glenn Hegar,127,45,82
+Hays,226,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,226,Comptroller of Public Accounts REP,,REP,Under Votes,21,11,10
 Hays,226,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,120,45,75
 Hays,226,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,174,73,101
 Hays,226,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -2046,12 +2046,12 @@ Hays,228,Attorney General REP,,REP,Barry Smitherman,48,26,22
 Hays,228,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,228,Attorney General REP,,REP,Under Votes,10,4,6
 Hays,228,Attorney General REP,,REP,Ken Paxton,76,29,47
-Hays,228,Comptroller	of Public Accounts REP,,REP,Raul Torres,20,7,13
-Hays,228,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,34,20,14
-Hays,228,Comptroller	of Public Accounts REP,,REP,Debra Medina,37,16,21
-Hays,228,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,86,35,51
-Hays,228,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,228,Comptroller	of Public Accounts REP,,REP,Under Votes,16,6,10
+Hays,228,Comptroller of Public Accounts REP,,REP,Raul Torres,20,7,13
+Hays,228,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,34,20,14
+Hays,228,Comptroller of Public Accounts REP,,REP,Debra Medina,37,16,21
+Hays,228,Comptroller of Public Accounts REP,,REP,Glenn Hegar,86,35,51
+Hays,228,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,228,Comptroller of Public Accounts REP,,REP,Under Votes,16,6,10
 Hays,228,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,87,30,57
 Hays,228,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,92,51,41
 Hays,228,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -2202,12 +2202,12 @@ Hays,229,Attorney General REP,,REP,Barry Smitherman,12,5,7
 Hays,229,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,229,Attorney General REP,,REP,Under Votes,4,2,2
 Hays,229,Attorney General REP,,REP,Ken Paxton,28,11,17
-Hays,229,Comptroller	of Public Accounts REP,,REP,Raul Torres,8,2,6
-Hays,229,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,10,4,6
-Hays,229,Comptroller	of Public Accounts REP,,REP,Debra Medina,13,6,7
-Hays,229,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,27,10,17
-Hays,229,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,229,Comptroller	of Public Accounts REP,,REP,Under Votes,5,2,3
+Hays,229,Comptroller of Public Accounts REP,,REP,Raul Torres,8,2,6
+Hays,229,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,10,4,6
+Hays,229,Comptroller of Public Accounts REP,,REP,Debra Medina,13,6,7
+Hays,229,Comptroller of Public Accounts REP,,REP,Glenn Hegar,27,10,17
+Hays,229,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,229,Comptroller of Public Accounts REP,,REP,Under Votes,5,2,3
 Hays,229,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,27,9,18
 Hays,229,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,31,13,18
 Hays,229,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -2353,12 +2353,12 @@ Hays,230,Attorney General REP,,REP,Barry Smitherman,28,14,14
 Hays,230,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,230,Attorney General REP,,REP,Under Votes,12,6,6
 Hays,230,Attorney General REP,,REP,Ken Paxton,46,19,27
-Hays,230,Comptroller	of Public Accounts REP,,REP,Raul Torres,9,2,7
-Hays,230,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,23,10,13
-Hays,230,Comptroller	of Public Accounts REP,,REP,Debra Medina,25,14,11
-Hays,230,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,55,20,35
-Hays,230,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,230,Comptroller	of Public Accounts REP,,REP,Under Votes,10,6,4
+Hays,230,Comptroller of Public Accounts REP,,REP,Raul Torres,9,2,7
+Hays,230,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,23,10,13
+Hays,230,Comptroller of Public Accounts REP,,REP,Debra Medina,25,14,11
+Hays,230,Comptroller of Public Accounts REP,,REP,Glenn Hegar,55,20,35
+Hays,230,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,230,Comptroller of Public Accounts REP,,REP,Under Votes,10,6,4
 Hays,230,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,51,24,27
 Hays,230,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,62,24,38
 Hays,230,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -2511,12 +2511,12 @@ Hays,232,Attorney General REP,,REP,Barry Smitherman,53,31,22
 Hays,232,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,232,Attorney General REP,,REP,Under Votes,13,3,10
 Hays,232,Attorney General REP,,REP,Ken Paxton,70,28,42
-Hays,232,Comptroller	of Public Accounts REP,,REP,Raul Torres,6,1,5
-Hays,232,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,40,27,13
-Hays,232,Comptroller	of Public Accounts REP,,REP,Debra Medina,45,22,23
-Hays,232,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,92,38,54
-Hays,232,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,232,Comptroller	of Public Accounts REP,,REP,Under Votes,17,4,13
+Hays,232,Comptroller of Public Accounts REP,,REP,Raul Torres,6,1,5
+Hays,232,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,40,27,13
+Hays,232,Comptroller of Public Accounts REP,,REP,Debra Medina,45,22,23
+Hays,232,Comptroller of Public Accounts REP,,REP,Glenn Hegar,92,38,54
+Hays,232,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,232,Comptroller of Public Accounts REP,,REP,Under Votes,17,4,13
 Hays,232,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,66,30,36
 Hays,232,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,114,55,59
 Hays,232,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -2667,12 +2667,12 @@ Hays,234,Attorney General REP,,REP,Barry Smitherman,8,2,6
 Hays,234,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,234,Attorney General REP,,REP,Under Votes,4,1,3
 Hays,234,Attorney General REP,,REP,Ken Paxton,12,1,11
-Hays,234,Comptroller	of Public Accounts REP,,REP,Raul Torres,5,0,5
-Hays,234,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,2,0,2
-Hays,234,Comptroller	of Public Accounts REP,,REP,Debra Medina,8,2,6
-Hays,234,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,18,5,13
-Hays,234,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,234,Comptroller	of Public Accounts REP,,REP,Under Votes,5,1,4
+Hays,234,Comptroller of Public Accounts REP,,REP,Raul Torres,5,0,5
+Hays,234,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,2,0,2
+Hays,234,Comptroller of Public Accounts REP,,REP,Debra Medina,8,2,6
+Hays,234,Comptroller of Public Accounts REP,,REP,Glenn Hegar,18,5,13
+Hays,234,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,234,Comptroller of Public Accounts REP,,REP,Under Votes,5,1,4
 Hays,234,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,11,2,9
 Hays,234,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,24,6,18
 Hays,234,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -2818,12 +2818,12 @@ Hays,236,Attorney General REP,,REP,Barry Smitherman,12,3,9
 Hays,236,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,236,Attorney General REP,,REP,Under Votes,4,1,3
 Hays,236,Attorney General REP,,REP,Ken Paxton,21,7,14
-Hays,236,Comptroller	of Public Accounts REP,,REP,Raul Torres,8,5,3
-Hays,236,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,7,4,3
-Hays,236,Comptroller	of Public Accounts REP,,REP,Debra Medina,9,3,6
-Hays,236,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,24,11,13
-Hays,236,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,236,Comptroller	of Public Accounts REP,,REP,Under Votes,6,1,5
+Hays,236,Comptroller of Public Accounts REP,,REP,Raul Torres,8,5,3
+Hays,236,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,7,4,3
+Hays,236,Comptroller of Public Accounts REP,,REP,Debra Medina,9,3,6
+Hays,236,Comptroller of Public Accounts REP,,REP,Glenn Hegar,24,11,13
+Hays,236,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,236,Comptroller of Public Accounts REP,,REP,Under Votes,6,1,5
 Hays,236,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,14,4,10
 Hays,236,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,35,18,17
 Hays,236,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -2977,12 +2977,12 @@ Hays,238,Attorney General REP,,REP,Barry Smitherman,0,0,0
 Hays,238,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,238,Attorney General REP,,REP,Under Votes,0,0,0
 Hays,238,Attorney General REP,,REP,Ken Paxton,0,0,0
-Hays,238,Comptroller	of Public Accounts REP,,REP,Raul Torres,0,0,0
-Hays,238,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,0,0,0
-Hays,238,Comptroller	of Public Accounts REP,,REP,Debra Medina,0,0,0
-Hays,238,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,0,0,0
-Hays,238,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,238,Comptroller	of Public Accounts REP,,REP,Under Votes,0,0,0
+Hays,238,Comptroller of Public Accounts REP,,REP,Raul Torres,0,0,0
+Hays,238,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,0,0,0
+Hays,238,Comptroller of Public Accounts REP,,REP,Debra Medina,0,0,0
+Hays,238,Comptroller of Public Accounts REP,,REP,Glenn Hegar,0,0,0
+Hays,238,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,238,Comptroller of Public Accounts REP,,REP,Under Votes,0,0,0
 Hays,238,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,0,0,0
 Hays,238,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,0,0,0
 Hays,238,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -3136,12 +3136,12 @@ Hays,301,Attorney General REP,,REP,Barry Smitherman,0,0,0
 Hays,301,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,301,Attorney General REP,,REP,Under Votes,0,0,0
 Hays,301,Attorney General REP,,REP,Ken Paxton,0,0,0
-Hays,301,Comptroller	of Public Accounts REP,,REP,Raul Torres,0,0,0
-Hays,301,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,0,0,0
-Hays,301,Comptroller	of Public Accounts REP,,REP,Debra Medina,0,0,0
-Hays,301,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,0,0,0
-Hays,301,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,301,Comptroller	of Public Accounts REP,,REP,Under Votes,0,0,0
+Hays,301,Comptroller of Public Accounts REP,,REP,Raul Torres,0,0,0
+Hays,301,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,0,0,0
+Hays,301,Comptroller of Public Accounts REP,,REP,Debra Medina,0,0,0
+Hays,301,Comptroller of Public Accounts REP,,REP,Glenn Hegar,0,0,0
+Hays,301,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,301,Comptroller of Public Accounts REP,,REP,Under Votes,0,0,0
 Hays,301,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,0,0,0
 Hays,301,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,0,0,0
 Hays,301,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -3290,12 +3290,12 @@ Hays,315,Attorney General REP,,REP,Barry Smitherman,133,85,48
 Hays,315,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,315,Attorney General REP,,REP,Under Votes,39,21,18
 Hays,315,Attorney General REP,,REP,Ken Paxton,192,107,85
-Hays,315,Comptroller	of Public Accounts REP,,REP,Raul Torres,17,11,6
-Hays,315,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,126,76,50
-Hays,315,Comptroller	of Public Accounts REP,,REP,Debra Medina,90,56,34
-Hays,315,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,215,121,94
-Hays,315,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,315,Comptroller	of Public Accounts REP,,REP,Under Votes,71,42,29
+Hays,315,Comptroller of Public Accounts REP,,REP,Raul Torres,17,11,6
+Hays,315,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,126,76,50
+Hays,315,Comptroller of Public Accounts REP,,REP,Debra Medina,90,56,34
+Hays,315,Comptroller of Public Accounts REP,,REP,Glenn Hegar,215,121,94
+Hays,315,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,315,Comptroller of Public Accounts REP,,REP,Under Votes,71,42,29
 Hays,315,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,145,77,68
 Hays,315,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,339,210,129
 Hays,315,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -3449,12 +3449,12 @@ Hays,316,Attorney General REP,,REP,Barry Smitherman,29,18,11
 Hays,316,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,316,Attorney General REP,,REP,Under Votes,5,4,1
 Hays,316,Attorney General REP,,REP,Ken Paxton,27,17,10
-Hays,316,Comptroller	of Public Accounts REP,,REP,Raul Torres,3,1,2
-Hays,316,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,20,13,7
-Hays,316,Comptroller	of Public Accounts REP,,REP,Debra Medina,18,11,7
-Hays,316,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,32,24,8
-Hays,316,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,316,Comptroller	of Public Accounts REP,,REP,Under Votes,16,10,6
+Hays,316,Comptroller of Public Accounts REP,,REP,Raul Torres,3,1,2
+Hays,316,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,20,13,7
+Hays,316,Comptroller of Public Accounts REP,,REP,Debra Medina,18,11,7
+Hays,316,Comptroller of Public Accounts REP,,REP,Glenn Hegar,32,24,8
+Hays,316,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,316,Comptroller of Public Accounts REP,,REP,Under Votes,16,10,6
 Hays,316,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,25,11,14
 Hays,316,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,56,41,15
 Hays,316,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -3601,12 +3601,12 @@ Hays,317,Attorney General REP,,REP,Barry Smitherman,3,2,1
 Hays,317,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,317,Attorney General REP,,REP,Under Votes,1,1,0
 Hays,317,Attorney General REP,,REP,Ken Paxton,5,0,5
-Hays,317,Comptroller	of Public Accounts REP,,REP,Raul Torres,0,0,0
-Hays,317,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,4,1,3
-Hays,317,Comptroller	of Public Accounts REP,,REP,Debra Medina,7,2,5
-Hays,317,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,5,3,2
-Hays,317,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,317,Comptroller	of Public Accounts REP,,REP,Under Votes,2,2,0
+Hays,317,Comptroller of Public Accounts REP,,REP,Raul Torres,0,0,0
+Hays,317,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,4,1,3
+Hays,317,Comptroller of Public Accounts REP,,REP,Debra Medina,7,2,5
+Hays,317,Comptroller of Public Accounts REP,,REP,Glenn Hegar,5,3,2
+Hays,317,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,317,Comptroller of Public Accounts REP,,REP,Under Votes,2,2,0
 Hays,317,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,9,4,5
 Hays,317,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,7,2,5
 Hays,317,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -3753,12 +3753,12 @@ Hays,318,Attorney General REP,,REP,Barry Smitherman,0,0,0
 Hays,318,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,318,Attorney General REP,,REP,Under Votes,2,0,2
 Hays,318,Attorney General REP,,REP,Ken Paxton,3,3,0
-Hays,318,Comptroller	of Public Accounts REP,,REP,Raul Torres,0,0,0
-Hays,318,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,3,2,1
-Hays,318,Comptroller	of Public Accounts REP,,REP,Debra Medina,0,0,0
-Hays,318,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,2,2,0
-Hays,318,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,318,Comptroller	of Public Accounts REP,,REP,Under Votes,3,1,2
+Hays,318,Comptroller of Public Accounts REP,,REP,Raul Torres,0,0,0
+Hays,318,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,3,2,1
+Hays,318,Comptroller of Public Accounts REP,,REP,Debra Medina,0,0,0
+Hays,318,Comptroller of Public Accounts REP,,REP,Glenn Hegar,2,2,0
+Hays,318,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,318,Comptroller of Public Accounts REP,,REP,Under Votes,3,1,2
 Hays,318,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,1,1,0
 Hays,318,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,4,3,1
 Hays,318,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -3912,12 +3912,12 @@ Hays,330,Attorney General REP,,REP,Barry Smitherman,18,13,5
 Hays,330,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,330,Attorney General REP,,REP,Under Votes,18,11,7
 Hays,330,Attorney General REP,,REP,Ken Paxton,27,15,12
-Hays,330,Comptroller	of Public Accounts REP,,REP,Raul Torres,9,7,2
-Hays,330,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,29,21,8
-Hays,330,Comptroller	of Public Accounts REP,,REP,Debra Medina,16,10,6
-Hays,330,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,25,14,11
-Hays,330,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,330,Comptroller	of Public Accounts REP,,REP,Under Votes,19,11,8
+Hays,330,Comptroller of Public Accounts REP,,REP,Raul Torres,9,7,2
+Hays,330,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,29,21,8
+Hays,330,Comptroller of Public Accounts REP,,REP,Debra Medina,16,10,6
+Hays,330,Comptroller of Public Accounts REP,,REP,Glenn Hegar,25,14,11
+Hays,330,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,330,Comptroller of Public Accounts REP,,REP,Under Votes,19,11,8
 Hays,330,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,35,25,10
 Hays,330,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,47,28,19
 Hays,330,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -4075,12 +4075,12 @@ Hays,332,Attorney General REP,,REP,Barry Smitherman,67,44,23
 Hays,332,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,332,Attorney General REP,,REP,Under Votes,26,13,13
 Hays,332,Attorney General REP,,REP,Ken Paxton,69,35,34
-Hays,332,Comptroller	of Public Accounts REP,,REP,Raul Torres,9,7,2
-Hays,332,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,49,33,16
-Hays,332,Comptroller	of Public Accounts REP,,REP,Debra Medina,53,31,22
-Hays,332,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,90,45,45
-Hays,332,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,332,Comptroller	of Public Accounts REP,,REP,Under Votes,40,20,20
+Hays,332,Comptroller of Public Accounts REP,,REP,Raul Torres,9,7,2
+Hays,332,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,49,33,16
+Hays,332,Comptroller of Public Accounts REP,,REP,Debra Medina,53,31,22
+Hays,332,Comptroller of Public Accounts REP,,REP,Glenn Hegar,90,45,45
+Hays,332,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,332,Comptroller of Public Accounts REP,,REP,Under Votes,40,20,20
 Hays,332,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,79,44,35
 Hays,332,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,135,78,57
 Hays,332,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -4236,12 +4236,12 @@ Hays,333,Attorney General REP,,REP,Barry Smitherman,108,74,34
 Hays,333,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,333,Attorney General REP,,REP,Under Votes,49,33,16
 Hays,333,Attorney General REP,,REP,Ken Paxton,176,123,53
-Hays,333,Comptroller	of Public Accounts REP,,REP,Raul Torres,29,22,7
-Hays,333,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,141,93,48
-Hays,333,Comptroller	of Public Accounts REP,,REP,Debra Medina,102,75,27
-Hays,333,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,175,110,65
-Hays,333,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,333,Comptroller	of Public Accounts REP,,REP,Under Votes,87,56,31
+Hays,333,Comptroller of Public Accounts REP,,REP,Raul Torres,29,22,7
+Hays,333,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,141,93,48
+Hays,333,Comptroller of Public Accounts REP,,REP,Debra Medina,102,75,27
+Hays,333,Comptroller of Public Accounts REP,,REP,Glenn Hegar,175,110,65
+Hays,333,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,333,Comptroller of Public Accounts REP,,REP,Under Votes,87,56,31
 Hays,333,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,169,111,58
 Hays,333,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,294,201,93
 Hays,333,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -4397,12 +4397,12 @@ Hays,334,Attorney General REP,,REP,Barry Smitherman,2,2,0
 Hays,334,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,334,Attorney General REP,,REP,Under Votes,4,0,4
 Hays,334,Attorney General REP,,REP,Ken Paxton,7,4,3
-Hays,334,Comptroller	of Public Accounts REP,,REP,Raul Torres,1,0,1
-Hays,334,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,1,1,0
-Hays,334,Comptroller	of Public Accounts REP,,REP,Debra Medina,6,4,2
-Hays,334,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,4,2,2
-Hays,334,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,334,Comptroller	of Public Accounts REP,,REP,Under Votes,3,1,2
+Hays,334,Comptroller of Public Accounts REP,,REP,Raul Torres,1,0,1
+Hays,334,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,1,1,0
+Hays,334,Comptroller of Public Accounts REP,,REP,Debra Medina,6,4,2
+Hays,334,Comptroller of Public Accounts REP,,REP,Glenn Hegar,4,2,2
+Hays,334,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,334,Comptroller of Public Accounts REP,,REP,Under Votes,3,1,2
 Hays,334,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,6,4,2
 Hays,334,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,5,4,1
 Hays,334,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -4554,12 +4554,12 @@ Hays,335,Attorney General REP,,REP,Barry Smitherman,120,90,30
 Hays,335,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,335,Attorney General REP,,REP,Under Votes,51,36,15
 Hays,335,Attorney General REP,,REP,Ken Paxton,152,111,41
-Hays,335,Comptroller	of Public Accounts REP,,REP,Raul Torres,18,15,3
-Hays,335,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,96,73,23
-Hays,335,Comptroller	of Public Accounts REP,,REP,Debra Medina,87,62,25
-Hays,335,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,190,127,63
-Hays,335,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,335,Comptroller	of Public Accounts REP,,REP,Under Votes,75,50,25
+Hays,335,Comptroller of Public Accounts REP,,REP,Raul Torres,18,15,3
+Hays,335,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,96,73,23
+Hays,335,Comptroller of Public Accounts REP,,REP,Debra Medina,87,62,25
+Hays,335,Comptroller of Public Accounts REP,,REP,Glenn Hegar,190,127,63
+Hays,335,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,335,Comptroller of Public Accounts REP,,REP,Under Votes,75,50,25
 Hays,335,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,133,87,46
 Hays,335,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,276,201,75
 Hays,335,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -4716,12 +4716,12 @@ Hays,336,Attorney General REP,,REP,Barry Smitherman,70,38,32
 Hays,336,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,336,Attorney General REP,,REP,Under Votes,31,14,17
 Hays,336,Attorney General REP,,REP,Ken Paxton,77,49,28
-Hays,336,Comptroller	of Public Accounts REP,,REP,Raul Torres,14,8,6
-Hays,336,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,74,43,31
-Hays,336,Comptroller	of Public Accounts REP,,REP,Debra Medina,46,20,26
-Hays,336,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,101,59,42
-Hays,336,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,336,Comptroller	of Public Accounts REP,,REP,Under Votes,45,20,25
+Hays,336,Comptroller of Public Accounts REP,,REP,Raul Torres,14,8,6
+Hays,336,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,74,43,31
+Hays,336,Comptroller of Public Accounts REP,,REP,Debra Medina,46,20,26
+Hays,336,Comptroller of Public Accounts REP,,REP,Glenn Hegar,101,59,42
+Hays,336,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,336,Comptroller of Public Accounts REP,,REP,Under Votes,45,20,25
 Hays,336,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,76,45,31
 Hays,336,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,175,90,85
 Hays,336,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -4877,12 +4877,12 @@ Hays,337,Attorney General REP,,REP,Barry Smitherman,204,157,47
 Hays,337,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,337,Attorney General REP,,REP,Under Votes,47,30,17
 Hays,337,Attorney General REP,,REP,Ken Paxton,234,146,88
-Hays,337,Comptroller	of Public Accounts REP,,REP,Raul Torres,53,40,13
-Hays,337,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,183,127,56
-Hays,337,Comptroller	of Public Accounts REP,,REP,Debra Medina,122,83,39
-Hays,337,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,288,205,83
-Hays,337,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,337,Comptroller	of Public Accounts REP,,REP,Under Votes,68,40,28
+Hays,337,Comptroller of Public Accounts REP,,REP,Raul Torres,53,40,13
+Hays,337,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,183,127,56
+Hays,337,Comptroller of Public Accounts REP,,REP,Debra Medina,122,83,39
+Hays,337,Comptroller of Public Accounts REP,,REP,Glenn Hegar,288,205,83
+Hays,337,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,337,Comptroller of Public Accounts REP,,REP,Under Votes,68,40,28
 Hays,337,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,192,110,82
 Hays,337,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,474,351,123
 Hays,337,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -5035,12 +5035,12 @@ Hays,339,Attorney General REP,,REP,Barry Smitherman,35,25,10
 Hays,339,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,339,Attorney General REP,,REP,Under Votes,9,3,6
 Hays,339,Attorney General REP,,REP,Ken Paxton,63,37,26
-Hays,339,Comptroller	of Public Accounts REP,,REP,Raul Torres,13,9,4
-Hays,339,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,35,22,13
-Hays,339,Comptroller	of Public Accounts REP,,REP,Debra Medina,45,29,16
-Hays,339,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,70,49,21
-Hays,339,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,339,Comptroller	of Public Accounts REP,,REP,Under Votes,15,8,7
+Hays,339,Comptroller of Public Accounts REP,,REP,Raul Torres,13,9,4
+Hays,339,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,35,22,13
+Hays,339,Comptroller of Public Accounts REP,,REP,Debra Medina,45,29,16
+Hays,339,Comptroller of Public Accounts REP,,REP,Glenn Hegar,70,49,21
+Hays,339,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,339,Comptroller of Public Accounts REP,,REP,Under Votes,15,8,7
 Hays,339,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,52,32,20
 Hays,339,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,112,80,32
 Hays,339,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -5191,12 +5191,12 @@ Hays,413,Attorney General REP,,REP,Barry Smitherman,2,2,0
 Hays,413,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,413,Attorney General REP,,REP,Under Votes,1,1,0
 Hays,413,Attorney General REP,,REP,Ken Paxton,3,3,0
-Hays,413,Comptroller	of Public Accounts REP,,REP,Raul Torres,0,0,0
-Hays,413,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,0,0,0
-Hays,413,Comptroller	of Public Accounts REP,,REP,Debra Medina,2,2,0
-Hays,413,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,3,3,0
-Hays,413,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,413,Comptroller	of Public Accounts REP,,REP,Under Votes,1,1,0
+Hays,413,Comptroller of Public Accounts REP,,REP,Raul Torres,0,0,0
+Hays,413,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,0,0,0
+Hays,413,Comptroller of Public Accounts REP,,REP,Debra Medina,2,2,0
+Hays,413,Comptroller of Public Accounts REP,,REP,Glenn Hegar,3,3,0
+Hays,413,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,413,Comptroller of Public Accounts REP,,REP,Under Votes,1,1,0
 Hays,413,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,4,4,0
 Hays,413,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,1,1,0
 Hays,413,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -5351,12 +5351,12 @@ Hays,414,Attorney General REP,,REP,Barry Smitherman,6,3,3
 Hays,414,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,414,Attorney General REP,,REP,Under Votes,6,3,3
 Hays,414,Attorney General REP,,REP,Ken Paxton,8,1,7
-Hays,414,Comptroller	of Public Accounts REP,,REP,Raul Torres,0,0,0
-Hays,414,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,7,2,5
-Hays,414,Comptroller	of Public Accounts REP,,REP,Debra Medina,4,2,2
-Hays,414,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,8,2,6
-Hays,414,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,414,Comptroller	of Public Accounts REP,,REP,Under Votes,5,2,3
+Hays,414,Comptroller of Public Accounts REP,,REP,Raul Torres,0,0,0
+Hays,414,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,7,2,5
+Hays,414,Comptroller of Public Accounts REP,,REP,Debra Medina,4,2,2
+Hays,414,Comptroller of Public Accounts REP,,REP,Glenn Hegar,8,2,6
+Hays,414,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,414,Comptroller of Public Accounts REP,,REP,Under Votes,5,2,3
 Hays,414,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,7,2,5
 Hays,414,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,13,4,9
 Hays,414,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -5506,12 +5506,12 @@ Hays,415,Attorney General REP,,REP,Barry Smitherman,5,4,1
 Hays,415,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,415,Attorney General REP,,REP,Under Votes,6,4,2
 Hays,415,Attorney General REP,,REP,Ken Paxton,13,5,8
-Hays,415,Comptroller	of Public Accounts REP,,REP,Raul Torres,3,0,3
-Hays,415,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,4,4,0
-Hays,415,Comptroller	of Public Accounts REP,,REP,Debra Medina,3,2,1
-Hays,415,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,18,10,8
-Hays,415,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,415,Comptroller	of Public Accounts REP,,REP,Under Votes,8,5,3
+Hays,415,Comptroller of Public Accounts REP,,REP,Raul Torres,3,0,3
+Hays,415,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,4,4,0
+Hays,415,Comptroller of Public Accounts REP,,REP,Debra Medina,3,2,1
+Hays,415,Comptroller of Public Accounts REP,,REP,Glenn Hegar,18,10,8
+Hays,415,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,415,Comptroller of Public Accounts REP,,REP,Under Votes,8,5,3
 Hays,415,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,11,4,7
 Hays,415,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,18,12,6
 Hays,415,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -5666,12 +5666,12 @@ Hays,416,Attorney General REP,,REP,Barry Smitherman,1,0,1
 Hays,416,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,416,Attorney General REP,,REP,Under Votes,0,0,0
 Hays,416,Attorney General REP,,REP,Ken Paxton,0,0,0
-Hays,416,Comptroller	of Public Accounts REP,,REP,Raul Torres,0,0,0
-Hays,416,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,1,0,1
-Hays,416,Comptroller	of Public Accounts REP,,REP,Debra Medina,0,0,0
-Hays,416,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,1,0,1
-Hays,416,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,416,Comptroller	of Public Accounts REP,,REP,Under Votes,0,0,0
+Hays,416,Comptroller of Public Accounts REP,,REP,Raul Torres,0,0,0
+Hays,416,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,1,0,1
+Hays,416,Comptroller of Public Accounts REP,,REP,Debra Medina,0,0,0
+Hays,416,Comptroller of Public Accounts REP,,REP,Glenn Hegar,1,0,1
+Hays,416,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,416,Comptroller of Public Accounts REP,,REP,Under Votes,0,0,0
 Hays,416,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,0,0,0
 Hays,416,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,2,0,2
 Hays,416,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -5819,12 +5819,12 @@ Hays,417,Attorney General REP,,REP,Barry Smitherman,6,3,3
 Hays,417,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,417,Attorney General REP,,REP,Under Votes,4,0,4
 Hays,417,Attorney General REP,,REP,Ken Paxton,18,9,9
-Hays,417,Comptroller	of Public Accounts REP,,REP,Raul Torres,1,1,0
-Hays,417,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,8,3,5
-Hays,417,Comptroller	of Public Accounts REP,,REP,Debra Medina,5,3,2
-Hays,417,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,22,9,13
-Hays,417,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,417,Comptroller	of Public Accounts REP,,REP,Under Votes,7,1,6
+Hays,417,Comptroller of Public Accounts REP,,REP,Raul Torres,1,1,0
+Hays,417,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,8,3,5
+Hays,417,Comptroller of Public Accounts REP,,REP,Debra Medina,5,3,2
+Hays,417,Comptroller of Public Accounts REP,,REP,Glenn Hegar,22,9,13
+Hays,417,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,417,Comptroller of Public Accounts REP,,REP,Under Votes,7,1,6
 Hays,417,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,13,8,5
 Hays,417,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,25,9,16
 Hays,417,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -5970,12 +5970,12 @@ Hays,418,Attorney General REP,,REP,Barry Smitherman,0,0,0
 Hays,418,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,418,Attorney General REP,,REP,Under Votes,0,0,0
 Hays,418,Attorney General REP,,REP,Ken Paxton,0,0,0
-Hays,418,Comptroller	of Public Accounts REP,,REP,Raul Torres,0,0,0
-Hays,418,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,0,0,0
-Hays,418,Comptroller	of Public Accounts REP,,REP,Debra Medina,0,0,0
-Hays,418,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,0,0,0
-Hays,418,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,418,Comptroller	of Public Accounts REP,,REP,Under Votes,0,0,0
+Hays,418,Comptroller of Public Accounts REP,,REP,Raul Torres,0,0,0
+Hays,418,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,0,0,0
+Hays,418,Comptroller of Public Accounts REP,,REP,Debra Medina,0,0,0
+Hays,418,Comptroller of Public Accounts REP,,REP,Glenn Hegar,0,0,0
+Hays,418,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,418,Comptroller of Public Accounts REP,,REP,Under Votes,0,0,0
 Hays,418,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,0,0,0
 Hays,418,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,0,0,0
 Hays,418,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -6126,12 +6126,12 @@ Hays,419,Attorney General REP,,REP,Barry Smitherman,16,8,8
 Hays,419,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,419,Attorney General REP,,REP,Under Votes,6,5,1
 Hays,419,Attorney General REP,,REP,Ken Paxton,35,13,22
-Hays,419,Comptroller	of Public Accounts REP,,REP,Raul Torres,6,3,3
-Hays,419,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,17,9,8
-Hays,419,Comptroller	of Public Accounts REP,,REP,Debra Medina,19,10,9
-Hays,419,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,33,18,15
-Hays,419,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,419,Comptroller	of Public Accounts REP,,REP,Under Votes,13,8,5
+Hays,419,Comptroller of Public Accounts REP,,REP,Raul Torres,6,3,3
+Hays,419,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,17,9,8
+Hays,419,Comptroller of Public Accounts REP,,REP,Debra Medina,19,10,9
+Hays,419,Comptroller of Public Accounts REP,,REP,Glenn Hegar,33,18,15
+Hays,419,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,419,Comptroller of Public Accounts REP,,REP,Under Votes,13,8,5
 Hays,419,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,36,20,16
 Hays,419,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,42,20,22
 Hays,419,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -6284,12 +6284,12 @@ Hays,420,Attorney General REP,,REP,Barry Smitherman,15,14,1
 Hays,420,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,420,Attorney General REP,,REP,Under Votes,4,3,1
 Hays,420,Attorney General REP,,REP,Ken Paxton,37,24,13
-Hays,420,Comptroller	of Public Accounts REP,,REP,Raul Torres,6,3,3
-Hays,420,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,14,12,2
-Hays,420,Comptroller	of Public Accounts REP,,REP,Debra Medina,20,12,8
-Hays,420,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,35,26,9
-Hays,420,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,420,Comptroller	of Public Accounts REP,,REP,Under Votes,9,7,2
+Hays,420,Comptroller of Public Accounts REP,,REP,Raul Torres,6,3,3
+Hays,420,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,14,12,2
+Hays,420,Comptroller of Public Accounts REP,,REP,Debra Medina,20,12,8
+Hays,420,Comptroller of Public Accounts REP,,REP,Glenn Hegar,35,26,9
+Hays,420,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,420,Comptroller of Public Accounts REP,,REP,Under Votes,9,7,2
 Hays,420,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,24,14,10
 Hays,420,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,53,41,12
 Hays,420,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -6442,12 +6442,12 @@ Hays,421,Attorney General REP,,REP,Barry Smitherman,1,1,0
 Hays,421,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,421,Attorney General REP,,REP,Under Votes,1,1,0
 Hays,421,Attorney General REP,,REP,Ken Paxton,0,0,0
-Hays,421,Comptroller	of Public Accounts REP,,REP,Raul Torres,0,0,0
-Hays,421,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,2,2,0
-Hays,421,Comptroller	of Public Accounts REP,,REP,Debra Medina,0,0,0
-Hays,421,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,3,3,0
-Hays,421,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,421,Comptroller	of Public Accounts REP,,REP,Under Votes,0,0,0
+Hays,421,Comptroller of Public Accounts REP,,REP,Raul Torres,0,0,0
+Hays,421,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,2,2,0
+Hays,421,Comptroller of Public Accounts REP,,REP,Debra Medina,0,0,0
+Hays,421,Comptroller of Public Accounts REP,,REP,Glenn Hegar,3,3,0
+Hays,421,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,421,Comptroller of Public Accounts REP,,REP,Under Votes,0,0,0
 Hays,421,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,0,0,0
 Hays,421,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,4,4,0
 Hays,421,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -6601,12 +6601,12 @@ Hays,440,Attorney General REP,,REP,Barry Smitherman,67,43,24
 Hays,440,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,440,Attorney General REP,,REP,Under Votes,14,12,2
 Hays,440,Attorney General REP,,REP,Ken Paxton,90,49,41
-Hays,440,Comptroller	of Public Accounts REP,,REP,Raul Torres,11,8,3
-Hays,440,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,51,22,29
-Hays,440,Comptroller	of Public Accounts REP,,REP,Debra Medina,61,36,25
-Hays,440,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,117,67,50
-Hays,440,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,440,Comptroller	of Public Accounts REP,,REP,Under Votes,28,21,7
+Hays,440,Comptroller of Public Accounts REP,,REP,Raul Torres,11,8,3
+Hays,440,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,51,22,29
+Hays,440,Comptroller of Public Accounts REP,,REP,Debra Medina,61,36,25
+Hays,440,Comptroller of Public Accounts REP,,REP,Glenn Hegar,117,67,50
+Hays,440,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,440,Comptroller of Public Accounts REP,,REP,Under Votes,28,21,7
 Hays,440,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,87,46,41
 Hays,440,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,158,92,66
 Hays,440,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -6760,12 +6760,12 @@ Hays,441,Attorney General REP,,REP,Barry Smitherman,88,59,29
 Hays,441,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,441,Attorney General REP,,REP,Under Votes,20,12,8
 Hays,441,Attorney General REP,,REP,Ken Paxton,134,83,51
-Hays,441,Comptroller	of Public Accounts REP,,REP,Raul Torres,23,16,7
-Hays,441,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,70,44,26
-Hays,441,Comptroller	of Public Accounts REP,,REP,Debra Medina,60,34,26
-Hays,441,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,146,85,61
-Hays,441,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,441,Comptroller	of Public Accounts REP,,REP,Under Votes,38,22,16
+Hays,441,Comptroller of Public Accounts REP,,REP,Raul Torres,23,16,7
+Hays,441,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,70,44,26
+Hays,441,Comptroller of Public Accounts REP,,REP,Debra Medina,60,34,26
+Hays,441,Comptroller of Public Accounts REP,,REP,Glenn Hegar,146,85,61
+Hays,441,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,441,Comptroller of Public Accounts REP,,REP,Under Votes,38,22,16
 Hays,441,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,122,80,42
 Hays,441,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,192,109,83
 Hays,441,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -6919,12 +6919,12 @@ Hays,442,Attorney General REP,,REP,Barry Smitherman,73,33,40
 Hays,442,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,442,Attorney General REP,,REP,Under Votes,38,10,28
 Hays,442,Attorney General REP,,REP,Ken Paxton,80,36,44
-Hays,442,Comptroller	of Public Accounts REP,,REP,Raul Torres,19,10,9
-Hays,442,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,50,35,15
-Hays,442,Comptroller	of Public Accounts REP,,REP,Debra Medina,57,21,36
-Hays,442,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,102,44,58
-Hays,442,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,442,Comptroller	of Public Accounts REP,,REP,Under Votes,47,13,34
+Hays,442,Comptroller of Public Accounts REP,,REP,Raul Torres,19,10,9
+Hays,442,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,50,35,15
+Hays,442,Comptroller of Public Accounts REP,,REP,Debra Medina,57,21,36
+Hays,442,Comptroller of Public Accounts REP,,REP,Glenn Hegar,102,44,58
+Hays,442,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,442,Comptroller of Public Accounts REP,,REP,Under Votes,47,13,34
 Hays,442,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,78,31,47
 Hays,442,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,156,79,77
 Hays,442,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -7078,12 +7078,12 @@ Hays,443,Attorney General REP,,REP,Barry Smitherman,103,64,39
 Hays,443,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,443,Attorney General REP,,REP,Under Votes,66,17,49
 Hays,443,Attorney General REP,,REP,Ken Paxton,148,69,79
-Hays,443,Comptroller	of Public Accounts REP,,REP,Raul Torres,22,14,8
-Hays,443,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,104,55,49
-Hays,443,Comptroller	of Public Accounts REP,,REP,Debra Medina,67,24,43
-Hays,443,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,187,96,91
-Hays,443,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,443,Comptroller	of Public Accounts REP,,REP,Under Votes,90,28,62
+Hays,443,Comptroller of Public Accounts REP,,REP,Raul Torres,22,14,8
+Hays,443,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,104,55,49
+Hays,443,Comptroller of Public Accounts REP,,REP,Debra Medina,67,24,43
+Hays,443,Comptroller of Public Accounts REP,,REP,Glenn Hegar,187,96,91
+Hays,443,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,443,Comptroller of Public Accounts REP,,REP,Under Votes,90,28,62
 Hays,443,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,143,67,76
 Hays,443,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,278,137,141
 Hays,443,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -7237,12 +7237,12 @@ Hays,444,Attorney General REP,,REP,Barry Smitherman,193,130,63
 Hays,444,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,444,Attorney General REP,,REP,Under Votes,51,22,29
 Hays,444,Attorney General REP,,REP,Ken Paxton,230,123,107
-Hays,444,Comptroller	of Public Accounts REP,,REP,Raul Torres,43,28,15
-Hays,444,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,151,91,60
-Hays,444,Comptroller	of Public Accounts REP,,REP,Debra Medina,109,53,56
-Hays,444,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,282,165,117
-Hays,444,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,444,Comptroller	of Public Accounts REP,,REP,Under Votes,87,45,42
+Hays,444,Comptroller of Public Accounts REP,,REP,Raul Torres,43,28,15
+Hays,444,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,151,91,60
+Hays,444,Comptroller of Public Accounts REP,,REP,Debra Medina,109,53,56
+Hays,444,Comptroller of Public Accounts REP,,REP,Glenn Hegar,282,165,117
+Hays,444,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,444,Comptroller of Public Accounts REP,,REP,Under Votes,87,45,42
 Hays,444,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,204,103,101
 Hays,444,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,423,252,171
 Hays,444,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -7398,12 +7398,12 @@ Hays,447,Attorney General REP,,REP,Barry Smitherman,62,37,25
 Hays,447,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,447,Attorney General REP,,REP,Under Votes,13,6,7
 Hays,447,Attorney General REP,,REP,Ken Paxton,87,41,46
-Hays,447,Comptroller	of Public Accounts REP,,REP,Raul Torres,15,6,9
-Hays,447,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,45,22,23
-Hays,447,Comptroller	of Public Accounts REP,,REP,Debra Medina,56,26,30
-Hays,447,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,108,48,60
-Hays,447,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,447,Comptroller	of Public Accounts REP,,REP,Under Votes,19,13,6
+Hays,447,Comptroller of Public Accounts REP,,REP,Raul Torres,15,6,9
+Hays,447,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,45,22,23
+Hays,447,Comptroller of Public Accounts REP,,REP,Debra Medina,56,26,30
+Hays,447,Comptroller of Public Accounts REP,,REP,Glenn Hegar,108,48,60
+Hays,447,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,447,Comptroller of Public Accounts REP,,REP,Under Votes,19,13,6
 Hays,447,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,95,42,53
 Hays,447,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,133,64,69
 Hays,447,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -7562,12 +7562,12 @@ Hays,449,Attorney General REP,,REP,Barry Smitherman,92,63,29
 Hays,449,Attorney General REP,,REP,Over Votes,0,0,0
 Hays,449,Attorney General REP,,REP,Under Votes,29,14,15
 Hays,449,Attorney General REP,,REP,Ken Paxton,104,62,42
-Hays,449,Comptroller	of Public Accounts REP,,REP,Raul Torres,12,9,3
-Hays,449,Comptroller	of Public Accounts REP,,REP,Harvey Hilderbran,87,63,24
-Hays,449,Comptroller	of Public Accounts REP,,REP,Debra Medina,52,33,19
-Hays,449,Comptroller	of Public Accounts REP,,REP,Glenn Hegar,144,89,55
-Hays,449,Comptroller	of Public Accounts REP,,REP,Over Votes,0,0,0
-Hays,449,Comptroller	of Public Accounts REP,,REP,Under Votes,51,26,25
+Hays,449,Comptroller of Public Accounts REP,,REP,Raul Torres,12,9,3
+Hays,449,Comptroller of Public Accounts REP,,REP,Harvey Hilderbran,87,63,24
+Hays,449,Comptroller of Public Accounts REP,,REP,Debra Medina,52,33,19
+Hays,449,Comptroller of Public Accounts REP,,REP,Glenn Hegar,144,89,55
+Hays,449,Comptroller of Public Accounts REP,,REP,Over Votes,0,0,0
+Hays,449,Comptroller of Public Accounts REP,,REP,Under Votes,51,26,25
 Hays,449,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,David Watts,108,67,41
 Hays,449,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,George P. Bush,205,131,74
 Hays,449,COMMISSIONER OF THE GENERAL LAND OFFICE REP,,REP,Over Votes,0,0,0
@@ -7752,9 +7752,9 @@ Hays,110,Lieutenant Governor DEM,,DEM,Under Votes,6,2,4
 Hays,110,Attorney General DEM,,DEM,Sam Houston,44,29,15
 Hays,110,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,110,Attorney General DEM,,DEM,Under Votes,7,3,4
-Hays,110,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,45,30,15
-Hays,110,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,110,Comptroller	of Public Accounts DEM,,DEM,Under Votes,6,2,4
+Hays,110,Comptroller of Public Accounts DEM,,DEM,Mike Collier,45,30,15
+Hays,110,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,110,Comptroller of Public Accounts DEM,,DEM,Under Votes,6,2,4
 Hays,110,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,44,30,14
 Hays,110,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,110,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,7,2,5
@@ -7830,9 +7830,9 @@ Hays,111,Lieutenant Governor DEM,,DEM,Under Votes,1,0,1
 Hays,111,Attorney General DEM,,DEM,Sam Houston,10,4,6
 Hays,111,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,111,Attorney General DEM,,DEM,Under Votes,2,0,2
-Hays,111,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,10,4,6
-Hays,111,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,111,Comptroller	of Public Accounts DEM,,DEM,Under Votes,2,0,2
+Hays,111,Comptroller of Public Accounts DEM,,DEM,Mike Collier,10,4,6
+Hays,111,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,111,Comptroller of Public Accounts DEM,,DEM,Under Votes,2,0,2
 Hays,111,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,9,4,5
 Hays,111,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,111,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,3,0,3
@@ -7911,9 +7911,9 @@ Hays,112,Lieutenant Governor DEM,,DEM,Under Votes,9,4,5
 Hays,112,Attorney General DEM,,DEM,Sam Houston,64,31,33
 Hays,112,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,112,Attorney General DEM,,DEM,Under Votes,10,4,6
-Hays,112,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,63,31,32
-Hays,112,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,112,Comptroller	of Public Accounts DEM,,DEM,Under Votes,11,4,7
+Hays,112,Comptroller of Public Accounts DEM,,DEM,Mike Collier,63,31,32
+Hays,112,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,112,Comptroller of Public Accounts DEM,,DEM,Under Votes,11,4,7
 Hays,112,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,62,30,32
 Hays,112,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,112,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,12,5,7
@@ -7992,9 +7992,9 @@ Hays,113,Lieutenant Governor DEM,,DEM,Under Votes,14,7,7
 Hays,113,Attorney General DEM,,DEM,Sam Houston,113,72,41
 Hays,113,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,113,Attorney General DEM,,DEM,Under Votes,18,10,8
-Hays,113,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,115,72,43
-Hays,113,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,113,Comptroller	of Public Accounts DEM,,DEM,Under Votes,16,10,6
+Hays,113,Comptroller of Public Accounts DEM,,DEM,Mike Collier,115,72,43
+Hays,113,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,113,Comptroller of Public Accounts DEM,,DEM,Under Votes,16,10,6
 Hays,113,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,113,71,42
 Hays,113,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,113,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,18,11,7
@@ -8073,9 +8073,9 @@ Hays,120,Lieutenant Governor DEM,,DEM,Under Votes,11,6,5
 Hays,120,Attorney General DEM,,DEM,Sam Houston,65,38,27
 Hays,120,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,120,Attorney General DEM,,DEM,Under Votes,7,3,4
-Hays,120,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,63,38,25
-Hays,120,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,120,Comptroller	of Public Accounts DEM,,DEM,Under Votes,9,3,6
+Hays,120,Comptroller of Public Accounts DEM,,DEM,Mike Collier,63,38,25
+Hays,120,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,120,Comptroller of Public Accounts DEM,,DEM,Under Votes,9,3,6
 Hays,120,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,62,35,27
 Hays,120,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,120,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,10,6,4
@@ -8154,9 +8154,9 @@ Hays,125,Lieutenant Governor DEM,,DEM,Under Votes,4,3,1
 Hays,125,Attorney General DEM,,DEM,Sam Houston,46,20,26
 Hays,125,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,125,Attorney General DEM,,DEM,Under Votes,2,2,0
-Hays,125,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,45,19,26
-Hays,125,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,125,Comptroller	of Public Accounts DEM,,DEM,Under Votes,3,3,0
+Hays,125,Comptroller of Public Accounts DEM,,DEM,Mike Collier,45,19,26
+Hays,125,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,125,Comptroller of Public Accounts DEM,,DEM,Under Votes,3,3,0
 Hays,125,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,45,19,26
 Hays,125,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,125,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,3,3,0
@@ -8235,9 +8235,9 @@ Hays,127,Lieutenant Governor DEM,,DEM,Under Votes,12,2,10
 Hays,127,Attorney General DEM,,DEM,Sam Houston,82,28,54
 Hays,127,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,127,Attorney General DEM,,DEM,Under Votes,11,2,9
-Hays,127,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,80,26,54
-Hays,127,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,127,Comptroller	of Public Accounts DEM,,DEM,Under Votes,13,4,9
+Hays,127,Comptroller of Public Accounts DEM,,DEM,Mike Collier,80,26,54
+Hays,127,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,127,Comptroller of Public Accounts DEM,,DEM,Under Votes,13,4,9
 Hays,127,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,80,27,53
 Hays,127,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,127,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,13,3,10
@@ -8316,9 +8316,9 @@ Hays,129,Lieutenant Governor DEM,,DEM,Under Votes,6,0,6
 Hays,129,Attorney General DEM,,DEM,Sam Houston,96,55,41
 Hays,129,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,129,Attorney General DEM,,DEM,Under Votes,6,2,4
-Hays,129,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,94,54,40
-Hays,129,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,129,Comptroller	of Public Accounts DEM,,DEM,Under Votes,8,3,5
+Hays,129,Comptroller of Public Accounts DEM,,DEM,Mike Collier,94,54,40
+Hays,129,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,129,Comptroller of Public Accounts DEM,,DEM,Under Votes,8,3,5
 Hays,129,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,96,55,41
 Hays,129,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,129,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,6,2,4
@@ -8400,9 +8400,9 @@ Hays,221,Lieutenant Governor DEM,,DEM,Under Votes,7,5,2
 Hays,221,Attorney General DEM,,DEM,Sam Houston,103,54,49
 Hays,221,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,221,Attorney General DEM,,DEM,Under Votes,8,5,3
-Hays,221,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,101,53,48
-Hays,221,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,221,Comptroller	of Public Accounts DEM,,DEM,Under Votes,10,6,4
+Hays,221,Comptroller of Public Accounts DEM,,DEM,Mike Collier,101,53,48
+Hays,221,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,221,Comptroller of Public Accounts DEM,,DEM,Under Votes,10,6,4
 Hays,221,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,102,54,48
 Hays,221,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,221,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,9,5,4
@@ -8484,9 +8484,9 @@ Hays,223,Lieutenant Governor DEM,,DEM,Under Votes,9,6,3
 Hays,223,Attorney General DEM,,DEM,Sam Houston,75,47,28
 Hays,223,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,223,Attorney General DEM,,DEM,Under Votes,12,8,4
-Hays,223,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,76,48,28
-Hays,223,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,223,Comptroller	of Public Accounts DEM,,DEM,Under Votes,11,7,4
+Hays,223,Comptroller of Public Accounts DEM,,DEM,Mike Collier,76,48,28
+Hays,223,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,223,Comptroller of Public Accounts DEM,,DEM,Under Votes,11,7,4
 Hays,223,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,79,50,29
 Hays,223,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,223,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,8,5,3
@@ -8565,9 +8565,9 @@ Hays,224,Lieutenant Governor DEM,,DEM,Under Votes,12,9,3
 Hays,224,Attorney General DEM,,DEM,Sam Houston,120,59,61
 Hays,224,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,224,Attorney General DEM,,DEM,Under Votes,11,6,5
-Hays,224,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,121,60,61
-Hays,224,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,224,Comptroller	of Public Accounts DEM,,DEM,Under Votes,10,5,5
+Hays,224,Comptroller of Public Accounts DEM,,DEM,Mike Collier,121,60,61
+Hays,224,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,224,Comptroller of Public Accounts DEM,,DEM,Under Votes,10,5,5
 Hays,224,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,119,58,61
 Hays,224,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,224,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,12,7,5
@@ -8646,9 +8646,9 @@ Hays,225,Lieutenant Governor DEM,,DEM,Under Votes,4,4,0
 Hays,225,Attorney General DEM,,DEM,Sam Houston,41,22,19
 Hays,225,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,225,Attorney General DEM,,DEM,Under Votes,7,5,2
-Hays,225,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,42,21,21
-Hays,225,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,225,Comptroller	of Public Accounts DEM,,DEM,Under Votes,6,6,0
+Hays,225,Comptroller of Public Accounts DEM,,DEM,Mike Collier,42,21,21
+Hays,225,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,225,Comptroller of Public Accounts DEM,,DEM,Under Votes,6,6,0
 Hays,225,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,40,20,20
 Hays,225,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,225,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,8,7,1
@@ -8727,9 +8727,9 @@ Hays,226,Lieutenant Governor DEM,,DEM,Under Votes,7,2,5
 Hays,226,Attorney General DEM,,DEM,Sam Houston,91,39,52
 Hays,226,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,226,Attorney General DEM,,DEM,Under Votes,10,3,7
-Hays,226,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,86,37,49
-Hays,226,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,226,Comptroller	of Public Accounts DEM,,DEM,Under Votes,15,5,10
+Hays,226,Comptroller of Public Accounts DEM,,DEM,Mike Collier,86,37,49
+Hays,226,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,226,Comptroller of Public Accounts DEM,,DEM,Under Votes,15,5,10
 Hays,226,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,89,36,53
 Hays,226,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,226,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,12,6,6
@@ -8811,9 +8811,9 @@ Hays,228,Lieutenant Governor DEM,,DEM,Under Votes,6,2,4
 Hays,228,Attorney General DEM,,DEM,Sam Houston,99,53,46
 Hays,228,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,228,Attorney General DEM,,DEM,Under Votes,6,3,3
-Hays,228,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,98,52,46
-Hays,228,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,228,Comptroller	of Public Accounts DEM,,DEM,Under Votes,7,4,3
+Hays,228,Comptroller of Public Accounts DEM,,DEM,Mike Collier,98,52,46
+Hays,228,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,228,Comptroller of Public Accounts DEM,,DEM,Under Votes,7,4,3
 Hays,228,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,98,52,46
 Hays,228,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,228,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,7,4,3
@@ -8895,9 +8895,9 @@ Hays,229,Lieutenant Governor DEM,,DEM,Under Votes,4,4,0
 Hays,229,Attorney General DEM,,DEM,Sam Houston,25,18,7
 Hays,229,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,229,Attorney General DEM,,DEM,Under Votes,6,5,1
-Hays,229,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,26,18,8
-Hays,229,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,229,Comptroller	of Public Accounts DEM,,DEM,Under Votes,5,5,0
+Hays,229,Comptroller of Public Accounts DEM,,DEM,Mike Collier,26,18,8
+Hays,229,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,229,Comptroller of Public Accounts DEM,,DEM,Under Votes,5,5,0
 Hays,229,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,25,17,8
 Hays,229,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,229,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,6,6,0
@@ -8977,9 +8977,9 @@ Hays,230,Lieutenant Governor DEM,,DEM,Under Votes,3,3,0
 Hays,230,Attorney General DEM,,DEM,Sam Houston,33,12,21
 Hays,230,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,230,Attorney General DEM,,DEM,Under Votes,5,2,3
-Hays,230,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,32,11,21
-Hays,230,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,230,Comptroller	of Public Accounts DEM,,DEM,Under Votes,6,3,3
+Hays,230,Comptroller of Public Accounts DEM,,DEM,Mike Collier,32,11,21
+Hays,230,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,230,Comptroller of Public Accounts DEM,,DEM,Under Votes,6,3,3
 Hays,230,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,33,12,21
 Hays,230,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,230,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,5,2,3
@@ -9058,9 +9058,9 @@ Hays,232,Lieutenant Governor DEM,,DEM,Under Votes,2,1,1
 Hays,232,Attorney General DEM,,DEM,Sam Houston,43,9,34
 Hays,232,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,232,Attorney General DEM,,DEM,Under Votes,4,2,2
-Hays,232,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,44,10,34
-Hays,232,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,232,Comptroller	of Public Accounts DEM,,DEM,Under Votes,3,1,2
+Hays,232,Comptroller of Public Accounts DEM,,DEM,Mike Collier,44,10,34
+Hays,232,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,232,Comptroller of Public Accounts DEM,,DEM,Under Votes,3,1,2
 Hays,232,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,44,10,34
 Hays,232,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,232,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,3,1,2
@@ -9142,9 +9142,9 @@ Hays,234,Lieutenant Governor DEM,,DEM,Under Votes,2,2,0
 Hays,234,Attorney General DEM,,DEM,Sam Houston,14,3,11
 Hays,234,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,234,Attorney General DEM,,DEM,Under Votes,4,2,2
-Hays,234,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,14,3,11
-Hays,234,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,234,Comptroller	of Public Accounts DEM,,DEM,Under Votes,4,2,2
+Hays,234,Comptroller of Public Accounts DEM,,DEM,Mike Collier,14,3,11
+Hays,234,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,234,Comptroller of Public Accounts DEM,,DEM,Under Votes,4,2,2
 Hays,234,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,14,3,11
 Hays,234,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,234,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,4,2,2
@@ -9224,9 +9224,9 @@ Hays,236,Lieutenant Governor DEM,,DEM,Under Votes,1,0,1
 Hays,236,Attorney General DEM,,DEM,Sam Houston,15,12,3
 Hays,236,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,236,Attorney General DEM,,DEM,Under Votes,1,0,1
-Hays,236,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,16,12,4
-Hays,236,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,236,Comptroller	of Public Accounts DEM,,DEM,Under Votes,0,0,0
+Hays,236,Comptroller of Public Accounts DEM,,DEM,Mike Collier,16,12,4
+Hays,236,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,236,Comptroller of Public Accounts DEM,,DEM,Under Votes,0,0,0
 Hays,236,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,16,12,4
 Hays,236,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,236,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,0,0,0
@@ -9306,9 +9306,9 @@ Hays,238,Lieutenant Governor DEM,,DEM,Under Votes,0,0,0
 Hays,238,Attorney General DEM,,DEM,Sam Houston,0,0,0
 Hays,238,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,238,Attorney General DEM,,DEM,Under Votes,0,0,0
-Hays,238,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,0,0,0
-Hays,238,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,238,Comptroller	of Public Accounts DEM,,DEM,Under Votes,0,0,0
+Hays,238,Comptroller of Public Accounts DEM,,DEM,Mike Collier,0,0,0
+Hays,238,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,238,Comptroller of Public Accounts DEM,,DEM,Under Votes,0,0,0
 Hays,238,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,0,0,0
 Hays,238,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,238,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,0,0,0
@@ -9387,9 +9387,9 @@ Hays,301,Lieutenant Governor DEM,,DEM,Under Votes,0,0,0
 Hays,301,Attorney General DEM,,DEM,Sam Houston,0,0,0
 Hays,301,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,301,Attorney General DEM,,DEM,Under Votes,0,0,0
-Hays,301,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,0,0,0
-Hays,301,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,301,Comptroller	of Public Accounts DEM,,DEM,Under Votes,0,0,0
+Hays,301,Comptroller of Public Accounts DEM,,DEM,Mike Collier,0,0,0
+Hays,301,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,301,Comptroller of Public Accounts DEM,,DEM,Under Votes,0,0,0
 Hays,301,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,0,0,0
 Hays,301,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,301,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,0,0,0
@@ -9465,9 +9465,9 @@ Hays,315,Lieutenant Governor DEM,,DEM,Under Votes,14,8,6
 Hays,315,Attorney General DEM,,DEM,Sam Houston,110,49,61
 Hays,315,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,315,Attorney General DEM,,DEM,Under Votes,26,14,12
-Hays,315,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,117,52,65
-Hays,315,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,315,Comptroller	of Public Accounts DEM,,DEM,Under Votes,19,11,8
+Hays,315,Comptroller of Public Accounts DEM,,DEM,Mike Collier,117,52,65
+Hays,315,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,315,Comptroller of Public Accounts DEM,,DEM,Under Votes,19,11,8
 Hays,315,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,114,50,64
 Hays,315,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,315,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,22,13,9
@@ -9546,9 +9546,9 @@ Hays,316,Lieutenant Governor DEM,,DEM,Under Votes,1,1,0
 Hays,316,Attorney General DEM,,DEM,Sam Houston,39,24,15
 Hays,316,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,316,Attorney General DEM,,DEM,Under Votes,4,1,3
-Hays,316,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,40,24,16
-Hays,316,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,316,Comptroller	of Public Accounts DEM,,DEM,Under Votes,3,1,2
+Hays,316,Comptroller of Public Accounts DEM,,DEM,Mike Collier,40,24,16
+Hays,316,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,316,Comptroller of Public Accounts DEM,,DEM,Under Votes,3,1,2
 Hays,316,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,39,23,16
 Hays,316,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,316,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,4,2,2
@@ -9627,9 +9627,9 @@ Hays,317,Lieutenant Governor DEM,,DEM,Under Votes,1,1,0
 Hays,317,Attorney General DEM,,DEM,Sam Houston,12,9,3
 Hays,317,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,317,Attorney General DEM,,DEM,Under Votes,0,0,0
-Hays,317,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,11,9,2
-Hays,317,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,317,Comptroller	of Public Accounts DEM,,DEM,Under Votes,1,0,1
+Hays,317,Comptroller of Public Accounts DEM,,DEM,Mike Collier,11,9,2
+Hays,317,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,317,Comptroller of Public Accounts DEM,,DEM,Under Votes,1,0,1
 Hays,317,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,11,9,2
 Hays,317,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,317,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,1,0,1
@@ -9708,9 +9708,9 @@ Hays,318,Lieutenant Governor DEM,,DEM,Under Votes,1,0,1
 Hays,318,Attorney General DEM,,DEM,Sam Houston,2,2,0
 Hays,318,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,318,Attorney General DEM,,DEM,Under Votes,1,0,1
-Hays,318,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,2,2,0
-Hays,318,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,318,Comptroller	of Public Accounts DEM,,DEM,Under Votes,1,0,1
+Hays,318,Comptroller of Public Accounts DEM,,DEM,Mike Collier,2,2,0
+Hays,318,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,318,Comptroller of Public Accounts DEM,,DEM,Under Votes,1,0,1
 Hays,318,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,2,2,0
 Hays,318,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,318,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,1,0,1
@@ -9789,9 +9789,9 @@ Hays,330,Lieutenant Governor DEM,,DEM,Under Votes,5,1,4
 Hays,330,Attorney General DEM,,DEM,Sam Houston,54,20,34
 Hays,330,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,330,Attorney General DEM,,DEM,Under Votes,11,4,7
-Hays,330,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,57,22,35
-Hays,330,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,330,Comptroller	of Public Accounts DEM,,DEM,Under Votes,8,2,6
+Hays,330,Comptroller of Public Accounts DEM,,DEM,Mike Collier,57,22,35
+Hays,330,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,330,Comptroller of Public Accounts DEM,,DEM,Under Votes,8,2,6
 Hays,330,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,58,22,36
 Hays,330,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,330,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,7,2,5
@@ -9870,9 +9870,9 @@ Hays,332,Lieutenant Governor DEM,,DEM,Under Votes,10,5,5
 Hays,332,Attorney General DEM,,DEM,Sam Houston,110,53,57
 Hays,332,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,332,Attorney General DEM,,DEM,Under Votes,13,7,6
-Hays,332,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,107,51,56
-Hays,332,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,332,Comptroller	of Public Accounts DEM,,DEM,Under Votes,16,9,7
+Hays,332,Comptroller of Public Accounts DEM,,DEM,Mike Collier,107,51,56
+Hays,332,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,332,Comptroller of Public Accounts DEM,,DEM,Under Votes,16,9,7
 Hays,332,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,110,53,57
 Hays,332,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,332,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,13,7,6
@@ -9955,9 +9955,9 @@ Hays,333,Lieutenant Governor DEM,,DEM,Under Votes,14,8,6
 Hays,333,Attorney General DEM,,DEM,Sam Houston,132,68,64
 Hays,333,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,333,Attorney General DEM,,DEM,Under Votes,25,13,12
-Hays,333,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,133,68,65
-Hays,333,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,333,Comptroller	of Public Accounts DEM,,DEM,Under Votes,24,13,11
+Hays,333,Comptroller of Public Accounts DEM,,DEM,Mike Collier,133,68,65
+Hays,333,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,333,Comptroller of Public Accounts DEM,,DEM,Under Votes,24,13,11
 Hays,333,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,134,68,66
 Hays,333,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,333,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,23,13,10
@@ -10036,9 +10036,9 @@ Hays,334,Lieutenant Governor DEM,,DEM,Under Votes,0,0,0
 Hays,334,Attorney General DEM,,DEM,Sam Houston,15,9,6
 Hays,334,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,334,Attorney General DEM,,DEM,Under Votes,1,1,0
-Hays,334,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,14,8,6
-Hays,334,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,334,Comptroller	of Public Accounts DEM,,DEM,Under Votes,2,2,0
+Hays,334,Comptroller of Public Accounts DEM,,DEM,Mike Collier,14,8,6
+Hays,334,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,334,Comptroller of Public Accounts DEM,,DEM,Under Votes,2,2,0
 Hays,334,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,14,8,6
 Hays,334,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,334,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,2,2,0
@@ -10121,9 +10121,9 @@ Hays,335,Lieutenant Governor DEM,,DEM,Under Votes,12,6,6
 Hays,335,Attorney General DEM,,DEM,Sam Houston,111,64,47
 Hays,335,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,335,Attorney General DEM,,DEM,Under Votes,11,6,5
-Hays,335,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,110,63,47
-Hays,335,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,335,Comptroller	of Public Accounts DEM,,DEM,Under Votes,12,7,5
+Hays,335,Comptroller of Public Accounts DEM,,DEM,Mike Collier,110,63,47
+Hays,335,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,335,Comptroller of Public Accounts DEM,,DEM,Under Votes,12,7,5
 Hays,335,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,110,63,47
 Hays,335,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,335,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,12,7,5
@@ -10199,9 +10199,9 @@ Hays,336,Lieutenant Governor DEM,,DEM,Under Votes,14,9,5
 Hays,336,Attorney General DEM,,DEM,Sam Houston,137,80,57
 Hays,336,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,336,Attorney General DEM,,DEM,Under Votes,19,11,8
-Hays,336,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,128,76,52
-Hays,336,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,336,Comptroller	of Public Accounts DEM,,DEM,Under Votes,28,15,13
+Hays,336,Comptroller of Public Accounts DEM,,DEM,Mike Collier,128,76,52
+Hays,336,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,336,Comptroller of Public Accounts DEM,,DEM,Under Votes,28,15,13
 Hays,336,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,135,81,54
 Hays,336,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,336,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,21,10,11
@@ -10284,9 +10284,9 @@ Hays,337,Lieutenant Governor DEM,,DEM,Under Votes,23,16,7
 Hays,337,Attorney General DEM,,DEM,Sam Houston,175,124,51
 Hays,337,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,337,Attorney General DEM,,DEM,Under Votes,29,22,7
-Hays,337,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,182,130,52
-Hays,337,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,337,Comptroller	of Public Accounts DEM,,DEM,Under Votes,22,16,6
+Hays,337,Comptroller of Public Accounts DEM,,DEM,Mike Collier,182,130,52
+Hays,337,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,337,Comptroller of Public Accounts DEM,,DEM,Under Votes,22,16,6
 Hays,337,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,181,129,52
 Hays,337,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,337,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,23,17,6
@@ -10362,9 +10362,9 @@ Hays,339,Lieutenant Governor DEM,,DEM,Under Votes,0,0,0
 Hays,339,Attorney General DEM,,DEM,Sam Houston,26,19,7
 Hays,339,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,339,Attorney General DEM,,DEM,Under Votes,2,2,0
-Hays,339,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,26,19,7
-Hays,339,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,339,Comptroller	of Public Accounts DEM,,DEM,Under Votes,2,2,0
+Hays,339,Comptroller of Public Accounts DEM,,DEM,Mike Collier,26,19,7
+Hays,339,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,339,Comptroller of Public Accounts DEM,,DEM,Under Votes,2,2,0
 Hays,339,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,26,19,7
 Hays,339,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,339,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,2,2,0
@@ -10443,9 +10443,9 @@ Hays,413,Lieutenant Governor DEM,,DEM,Under Votes,0,0,0
 Hays,413,Attorney General DEM,,DEM,Sam Houston,7,7,0
 Hays,413,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,413,Attorney General DEM,,DEM,Under Votes,1,1,0
-Hays,413,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,7,7,0
-Hays,413,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,413,Comptroller	of Public Accounts DEM,,DEM,Under Votes,1,1,0
+Hays,413,Comptroller of Public Accounts DEM,,DEM,Mike Collier,7,7,0
+Hays,413,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,413,Comptroller of Public Accounts DEM,,DEM,Under Votes,1,1,0
 Hays,413,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,7,7,0
 Hays,413,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,413,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,1,1,0
@@ -10527,9 +10527,9 @@ Hays,414,Lieutenant Governor DEM,,DEM,Under Votes,1,0,1
 Hays,414,Attorney General DEM,,DEM,Sam Houston,18,11,7
 Hays,414,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,414,Attorney General DEM,,DEM,Under Votes,3,2,1
-Hays,414,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,19,12,7
-Hays,414,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,414,Comptroller	of Public Accounts DEM,,DEM,Under Votes,2,1,1
+Hays,414,Comptroller of Public Accounts DEM,,DEM,Mike Collier,19,12,7
+Hays,414,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,414,Comptroller of Public Accounts DEM,,DEM,Under Votes,2,1,1
 Hays,414,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,19,12,7
 Hays,414,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,414,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,2,1,1
@@ -10608,9 +10608,9 @@ Hays,415,Lieutenant Governor DEM,,DEM,Under Votes,2,0,2
 Hays,415,Attorney General DEM,,DEM,Sam Houston,17,11,6
 Hays,415,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,415,Attorney General DEM,,DEM,Under Votes,3,0,3
-Hays,415,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,16,10,6
-Hays,415,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,415,Comptroller	of Public Accounts DEM,,DEM,Under Votes,4,1,3
+Hays,415,Comptroller of Public Accounts DEM,,DEM,Mike Collier,16,10,6
+Hays,415,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,415,Comptroller of Public Accounts DEM,,DEM,Under Votes,4,1,3
 Hays,415,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,16,10,6
 Hays,415,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,415,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,4,1,3
@@ -10692,9 +10692,9 @@ Hays,416,Lieutenant Governor DEM,,DEM,Under Votes,0,0,0
 Hays,416,Attorney General DEM,,DEM,Sam Houston,0,0,0
 Hays,416,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,416,Attorney General DEM,,DEM,Under Votes,0,0,0
-Hays,416,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,0,0,0
-Hays,416,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,416,Comptroller	of Public Accounts DEM,,DEM,Under Votes,0,0,0
+Hays,416,Comptroller of Public Accounts DEM,,DEM,Mike Collier,0,0,0
+Hays,416,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,416,Comptroller of Public Accounts DEM,,DEM,Under Votes,0,0,0
 Hays,416,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,0,0,0
 Hays,416,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,416,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,0,0,0
@@ -10770,9 +10770,9 @@ Hays,417,Lieutenant Governor DEM,,DEM,Under Votes,0,0,0
 Hays,417,Attorney General DEM,,DEM,Sam Houston,16,9,7
 Hays,417,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,417,Attorney General DEM,,DEM,Under Votes,0,0,0
-Hays,417,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,16,9,7
-Hays,417,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,417,Comptroller	of Public Accounts DEM,,DEM,Under Votes,0,0,0
+Hays,417,Comptroller of Public Accounts DEM,,DEM,Mike Collier,16,9,7
+Hays,417,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,417,Comptroller of Public Accounts DEM,,DEM,Under Votes,0,0,0
 Hays,417,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,16,9,7
 Hays,417,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,417,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,0,0,0
@@ -10851,9 +10851,9 @@ Hays,418,Lieutenant Governor DEM,,DEM,Under Votes,1,1,0
 Hays,418,Attorney General DEM,,DEM,Sam Houston,0,0,0
 Hays,418,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,418,Attorney General DEM,,DEM,Under Votes,1,1,0
-Hays,418,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,0,0,0
-Hays,418,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,418,Comptroller	of Public Accounts DEM,,DEM,Under Votes,1,1,0
+Hays,418,Comptroller of Public Accounts DEM,,DEM,Mike Collier,0,0,0
+Hays,418,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,418,Comptroller of Public Accounts DEM,,DEM,Under Votes,1,1,0
 Hays,418,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,0,0,0
 Hays,418,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,418,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,1,1,0
@@ -10935,9 +10935,9 @@ Hays,419,Lieutenant Governor DEM,,DEM,Under Votes,2,1,1
 Hays,419,Attorney General DEM,,DEM,Sam Houston,19,7,12
 Hays,419,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,419,Attorney General DEM,,DEM,Under Votes,2,1,1
-Hays,419,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,20,7,13
-Hays,419,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,419,Comptroller	of Public Accounts DEM,,DEM,Under Votes,1,1,0
+Hays,419,Comptroller of Public Accounts DEM,,DEM,Mike Collier,20,7,13
+Hays,419,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,419,Comptroller of Public Accounts DEM,,DEM,Under Votes,1,1,0
 Hays,419,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,20,7,13
 Hays,419,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,419,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,1,1,0
@@ -11016,9 +11016,9 @@ Hays,420,Lieutenant Governor DEM,,DEM,Under Votes,1,0,1
 Hays,420,Attorney General DEM,,DEM,Sam Houston,14,4,10
 Hays,420,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,420,Attorney General DEM,,DEM,Under Votes,5,2,3
-Hays,420,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,15,4,11
-Hays,420,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,420,Comptroller	of Public Accounts DEM,,DEM,Under Votes,4,2,2
+Hays,420,Comptroller of Public Accounts DEM,,DEM,Mike Collier,15,4,11
+Hays,420,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,420,Comptroller of Public Accounts DEM,,DEM,Under Votes,4,2,2
 Hays,420,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,14,4,10
 Hays,420,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,420,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,5,2,3
@@ -11097,9 +11097,9 @@ Hays,421,Lieutenant Governor DEM,,DEM,Under Votes,0,0,0
 Hays,421,Attorney General DEM,,DEM,Sam Houston,0,0,0
 Hays,421,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,421,Attorney General DEM,,DEM,Under Votes,0,0,0
-Hays,421,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,0,0,0
-Hays,421,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,421,Comptroller	of Public Accounts DEM,,DEM,Under Votes,0,0,0
+Hays,421,Comptroller of Public Accounts DEM,,DEM,Mike Collier,0,0,0
+Hays,421,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,421,Comptroller of Public Accounts DEM,,DEM,Under Votes,0,0,0
 Hays,421,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,0,0,0
 Hays,421,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,421,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,0,0,0
@@ -11179,9 +11179,9 @@ Hays,440,Lieutenant Governor DEM,,DEM,Under Votes,5,4,1
 Hays,440,Attorney General DEM,,DEM,Sam Houston,58,30,28
 Hays,440,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,440,Attorney General DEM,,DEM,Under Votes,6,5,1
-Hays,440,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,55,29,26
-Hays,440,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,440,Comptroller	of Public Accounts DEM,,DEM,Under Votes,9,6,3
+Hays,440,Comptroller of Public Accounts DEM,,DEM,Mike Collier,55,29,26
+Hays,440,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,440,Comptroller of Public Accounts DEM,,DEM,Under Votes,9,6,3
 Hays,440,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,57,30,27
 Hays,440,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,440,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,7,5,2
@@ -11261,9 +11261,9 @@ Hays,441,Lieutenant Governor DEM,,DEM,Under Votes,9,6,3
 Hays,441,Attorney General DEM,,DEM,Sam Houston,106,59,47
 Hays,441,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,441,Attorney General DEM,,DEM,Under Votes,10,6,4
-Hays,441,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,106,59,47
-Hays,441,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,441,Comptroller	of Public Accounts DEM,,DEM,Under Votes,10,6,4
+Hays,441,Comptroller of Public Accounts DEM,,DEM,Mike Collier,106,59,47
+Hays,441,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,441,Comptroller of Public Accounts DEM,,DEM,Under Votes,10,6,4
 Hays,441,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,108,60,48
 Hays,441,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,441,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,8,5,3
@@ -11343,9 +11343,9 @@ Hays,442,Lieutenant Governor DEM,,DEM,Under Votes,4,2,2
 Hays,442,Attorney General DEM,,DEM,Sam Houston,67,29,38
 Hays,442,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,442,Attorney General DEM,,DEM,Under Votes,9,5,4
-Hays,442,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,71,31,40
-Hays,442,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,442,Comptroller	of Public Accounts DEM,,DEM,Under Votes,5,3,2
+Hays,442,Comptroller of Public Accounts DEM,,DEM,Mike Collier,71,31,40
+Hays,442,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,442,Comptroller of Public Accounts DEM,,DEM,Under Votes,5,3,2
 Hays,442,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,70,31,39
 Hays,442,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,442,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,6,3,3
@@ -11425,9 +11425,9 @@ Hays,443,Lieutenant Governor DEM,,DEM,Under Votes,11,5,6
 Hays,443,Attorney General DEM,,DEM,Sam Houston,91,30,61
 Hays,443,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,443,Attorney General DEM,,DEM,Under Votes,13,6,7
-Hays,443,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,91,28,63
-Hays,443,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,443,Comptroller	of Public Accounts DEM,,DEM,Under Votes,13,8,5
+Hays,443,Comptroller of Public Accounts DEM,,DEM,Mike Collier,91,28,63
+Hays,443,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,443,Comptroller of Public Accounts DEM,,DEM,Under Votes,13,8,5
 Hays,443,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,92,28,64
 Hays,443,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,443,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,12,8,4
@@ -11507,9 +11507,9 @@ Hays,444,Lieutenant Governor DEM,,DEM,Under Votes,16,10,6
 Hays,444,Attorney General DEM,,DEM,Sam Houston,149,75,74
 Hays,444,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,444,Attorney General DEM,,DEM,Under Votes,27,13,14
-Hays,444,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,152,77,75
-Hays,444,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,444,Comptroller	of Public Accounts DEM,,DEM,Under Votes,24,11,13
+Hays,444,Comptroller of Public Accounts DEM,,DEM,Mike Collier,152,77,75
+Hays,444,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,444,Comptroller of Public Accounts DEM,,DEM,Under Votes,24,11,13
 Hays,444,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,151,74,77
 Hays,444,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,444,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,25,14,11
@@ -11585,9 +11585,9 @@ Hays,447,Lieutenant Governor DEM,,DEM,Under Votes,5,3,2
 Hays,447,Attorney General DEM,,DEM,Sam Houston,62,20,42
 Hays,447,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,447,Attorney General DEM,,DEM,Under Votes,10,5,5
-Hays,447,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,62,19,43
-Hays,447,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,447,Comptroller	of Public Accounts DEM,,DEM,Under Votes,10,6,4
+Hays,447,Comptroller of Public Accounts DEM,,DEM,Mike Collier,62,19,43
+Hays,447,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,447,Comptroller of Public Accounts DEM,,DEM,Under Votes,10,6,4
 Hays,447,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,64,20,44
 Hays,447,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,447,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,8,5,3
@@ -11670,9 +11670,9 @@ Hays,449,Lieutenant Governor DEM,,DEM,Under Votes,4,2,2
 Hays,449,Attorney General DEM,,DEM,Sam Houston,74,41,33
 Hays,449,Attorney General DEM,,DEM,Over Votes,0,0,0
 Hays,449,Attorney General DEM,,DEM,Under Votes,10,4,6
-Hays,449,Comptroller	of Public Accounts DEM,,DEM,Mike Collier,77,42,35
-Hays,449,Comptroller	of Public Accounts DEM,,DEM,Over Votes,0,0,0
-Hays,449,Comptroller	of Public Accounts DEM,,DEM,Under Votes,7,3,4
+Hays,449,Comptroller of Public Accounts DEM,,DEM,Mike Collier,77,42,35
+Hays,449,Comptroller of Public Accounts DEM,,DEM,Over Votes,0,0,0
+Hays,449,Comptroller of Public Accounts DEM,,DEM,Under Votes,7,3,4
 Hays,449,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,John Cook,75,41,34
 Hays,449,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Over Votes,0,0,0
 Hays,449,COMMISSIONER OF THE GENERAL LAND OFFICE DEM,,DEM,Under Votes,9,4,5


### PR DESCRIPTION
This fixes a few issues with the 2014 Hays primary file:
* Replace tabs with spaces.
* Remove extra columns.