### PR TITLE
Remove extra column from "Ballots Cast" rows

### DIFF
--- a/2012/counties/20121106__tx__general__burnet__precinct.csv
+++ b/2012/counties/20121106__tx__general__burnet__precinct.csv
@@ -1,6 +1,6 @@
 county,precinct,office,district,party,candidate,votes,early_votes,election_day
 Burnet,01 GENERAL,Registered Voters,,REP,,1136,,
-Burnet,01 GENERAL,Ballots Cast,,,,739,510,229,
+Burnet,01 GENERAL,Ballots Cast,,,,739,510,229
 Burnet,01 GENERAL,Straight Party,,REP,Republican,354,261,93
 Burnet,01 GENERAL,Straight Party,,REP,Over Votes,0,0,0
 Burnet,01 GENERAL,Straight Party,,REP,Under Votes,326,209,117
@@ -114,7 +114,7 @@ Burnet,01 GENERAL,Constable Precinct 1,,REP,Over Votes,0,0,0
 Burnet,01 GENERAL,Constable Precinct 1,,REP,Under Votes,122,80,42
 Burnet,01 GENERAL,Constable Precinct 1,,REP,Mike Harnisch,617,430,187
 Burnet,02 CITY BURNET,Registered Voters,,REP,,2586,,
-Burnet,02 CITY BURNET,Ballots Cast,,,,1486,1021,465,
+Burnet,02 CITY BURNET,Ballots Cast,,,,1486,1021,465
 Burnet,02 CITY BURNET,Straight Party,,REP,Republican,621,458,163
 Burnet,02 CITY BURNET,Straight Party,,REP,Over Votes,0,0,0
 Burnet,02 CITY BURNET,Straight Party,,REP,Under Votes,641,439,202
@@ -231,7 +231,7 @@ Burnet,02 CITY BURNET,"Council Member, Unexpired Term",,"",Pat Riddell,510,349,1
 Burnet,02 CITY BURNET,"Council Member, Unexpired Term",,"",Mary Jane Shanes,135,97,38
 Burnet,02 CITY BURNET,"Council Member, Unexpired Term",,"","Gum Song ""George"" L. Banks",70,46,24
 Burnet,02 GENERAL ONLY,Registered Voters,,REP,,85,,
-Burnet,02 GENERAL ONLY,Ballots Cast,,,,55,38,17,
+Burnet,02 GENERAL ONLY,Ballots Cast,,,,55,38,17
 Burnet,02 GENERAL ONLY,Straight Party,,REP,Republican,20,14,6
 Burnet,02 GENERAL ONLY,Straight Party,,REP,Over Votes,0,0,0
 Burnet,02 GENERAL ONLY,Straight Party,,REP,Under Votes,31,23,8
@@ -342,7 +342,7 @@ Burnet,02 GENERAL ONLY,Constable Precinct 2,,REP,Over Votes,0,0,0
 Burnet,02 GENERAL ONLY,Constable Precinct 2,,REP,Under Votes,15,12,3
 Burnet,02 GENERAL ONLY,Constable Precinct 2,,REP,Garry Adams,40,26,14
 Burnet,03 GENERAL,Registered Voters,,REP,,1217,,
-Burnet,03 GENERAL,Ballots Cast,,,,622,391,231,
+Burnet,03 GENERAL,Ballots Cast,,,,622,391,231
 Burnet,03 GENERAL,Straight Party,,REP,Republican,287,196,91
 Burnet,03 GENERAL,Straight Party,,REP,Over Votes,0,0,0
 Burnet,03 GENERAL,Straight Party,,REP,Under Votes,248,152,96
@@ -453,7 +453,7 @@ Burnet,03 GENERAL,Constable Precinct 4,,REP,Over Votes,0,0,0
 Burnet,03 GENERAL,Constable Precinct 4,,REP,Under Votes,141,80,61
 Burnet,03 GENERAL,Constable Precinct 4,,REP,Chris Jett,481,311,170
 Burnet,04 GENERAL,Registered Voters,,REP,,1712,,
-Burnet,04 GENERAL,Ballots Cast,,,,1222,724,498,
+Burnet,04 GENERAL,Ballots Cast,,,,1222,724,498
 Burnet,04 GENERAL,Straight Party,,REP,Republican,545,358,187
 Burnet,04 GENERAL,Straight Party,,REP,Over Votes,0,0,0
 Burnet,04 GENERAL,Straight Party,,REP,Under Votes,527,295,232
@@ -564,7 +564,7 @@ Burnet,04 GENERAL,Constable Precinct 4,,REP,Over Votes,0,0,0
 Burnet,04 GENERAL,Constable Precinct 4,,REP,Under Votes,270,149,121
 Burnet,04 GENERAL,Constable Precinct 4,,REP,Chris Jett,952,575,377
 Burnet,05 GENERAL,Registered Voters,,REP,,890,,
-Burnet,05 GENERAL,Ballots Cast,,,,619,369,250,
+Burnet,05 GENERAL,Ballots Cast,,,,619,369,250
 Burnet,05 GENERAL,Straight Party,,REP,Republican,297,195,102
 Burnet,05 GENERAL,Straight Party,,REP,Over Votes,0,0,0
 Burnet,05 GENERAL,Straight Party,,REP,Under Votes,234,135,99
@@ -678,7 +678,7 @@ Burnet,05 GENERAL,Constable Precinct 1,,REP,Over Votes,0,0,0
 Burnet,05 GENERAL,Constable Precinct 1,,REP,Under Votes,130,70,60
 Burnet,05 GENERAL,Constable Precinct 1,,REP,Mike Harnisch,489,299,190
 Burnet,06 GENERAL,Registered Voters,,REP,,450,,
-Burnet,06 GENERAL,Ballots Cast,,,,311,156,155,
+Burnet,06 GENERAL,Ballots Cast,,,,311,156,155
 Burnet,06 GENERAL,Straight Party,,REP,Republican,150,82,68
 Burnet,06 GENERAL,Straight Party,,REP,Over Votes,0,0,0
 Burnet,06 GENERAL,Straight Party,,REP,Under Votes,133,60,73
@@ -792,7 +792,7 @@ Burnet,06 GENERAL,Constable Precinct 3,,REP,Over Votes,0,0,0
 Burnet,06 GENERAL,Constable Precinct 3,,REP,Under Votes,59,30,29
 Burnet,06 GENERAL,Constable Precinct 3,,REP,Jimmy Ballard,252,126,126
 Burnet,07 GENERAL,Registered Voters,,REP,,588,,
-Burnet,07 GENERAL,Ballots Cast,,,,440,258,182,
+Burnet,07 GENERAL,Ballots Cast,,,,440,258,182
 Burnet,07 GENERAL,Straight Party,,REP,Republican,188,115,73
 Burnet,07 GENERAL,Straight Party,,REP,Over Votes,0,0,0
 Burnet,07 GENERAL,Straight Party,,REP,Under Votes,195,109,86
@@ -906,7 +906,7 @@ Burnet,07 GENERAL,Constable Precinct 1,,REP,Over Votes,0,0,0
 Burnet,07 GENERAL,Constable Precinct 1,,REP,Under Votes,103,61,42
 Burnet,07 GENERAL,Constable Precinct 1,,REP,Mike Harnisch,337,197,140
 Burnet,08 GENERAL,Registered Voters,,REP,,934,,
-Burnet,08 GENERAL,Ballots Cast,,,,668,369,299,
+Burnet,08 GENERAL,Ballots Cast,,,,668,369,299
 Burnet,08 GENERAL,Straight Party,,REP,Republican,311,178,133
 Burnet,08 GENERAL,Straight Party,,REP,Over Votes,0,0,0
 Burnet,08 GENERAL,Straight Party,,REP,Under Votes,291,165,126
@@ -1020,7 +1020,7 @@ Burnet,08 GENERAL,Constable Precinct 1,,REP,Over Votes,0,0,0
 Burnet,08 GENERAL,Constable Precinct 1,,REP,Under Votes,131,66,65
 Burnet,08 GENERAL,Constable Precinct 1,,REP,Mike Harnisch,537,303,234
 Burnet,09 GENERAL,Registered Voters,,REP,,2424,,
-Burnet,09 GENERAL,Ballots Cast,,,,1678,1169,509,
+Burnet,09 GENERAL,Ballots Cast,,,,1678,1169,509
 Burnet,09 GENERAL,Straight Party,,REP,Republican,821,607,214
 Burnet,09 GENERAL,Straight Party,,REP,Over Votes,0,0,0
 Burnet,09 GENERAL,Straight Party,,REP,Under Votes,692,462,230
@@ -1134,7 +1134,7 @@ Burnet,09 GENERAL,Constable Precinct 1,,REP,Over Votes,0,0,0
 Burnet,09 GENERAL,Constable Precinct 1,,REP,Under Votes,354,229,125
 Burnet,09 GENERAL,Constable Precinct 1,,REP,Mike Harnisch,1324,940,384
 Burnet,10 GENERAL,Registered Voters,,REP,,1043,,
-Burnet,10 GENERAL,Ballots Cast,,,,689,437,252,
+Burnet,10 GENERAL,Ballots Cast,,,,689,437,252
 Burnet,10 GENERAL,Straight Party,,REP,Republican,274,181,93
 Burnet,10 GENERAL,Straight Party,,REP,Over Votes,0,0,0
 Burnet,10 GENERAL,Straight Party,,REP,Under Votes,339,214,125
@@ -1248,7 +1248,7 @@ Burnet,10 GENERAL,Constable Precinct 3,,REP,Over Votes,0,0,0
 Burnet,10 GENERAL,Constable Precinct 3,,REP,Under Votes,166,115,51
 Burnet,10 GENERAL,Constable Precinct 3,,REP,Jimmy Ballard,523,322,201
 Burnet,11 GENERAL,Registered Voters,,REP,,274,,
-Burnet,11 GENERAL,Ballots Cast,,,,204,82,122,
+Burnet,11 GENERAL,Ballots Cast,,,,204,82,122
 Burnet,11 GENERAL,Straight Party,,REP,Republican,112,44,68
 Burnet,11 GENERAL,Straight Party,,REP,Over Votes,0,0,0
 Burnet,11 GENERAL,Straight Party,,REP,Under Votes,84,33,51
@@ -1362,7 +1362,7 @@ Burnet,11 GENERAL,Constable Precinct 1,,REP,Over Votes,0,0,0
 Burnet,11 GENERAL,Constable Precinct 1,,REP,Under Votes,29,11,18
 Burnet,11 GENERAL,Constable Precinct 1,,REP,Mike Harnisch,175,71,104
 Burnet,12 GENERAL,Registered Voters,,REP,,1315,,
-Burnet,12 GENERAL,Ballots Cast,,,,814,352,462,
+Burnet,12 GENERAL,Ballots Cast,,,,814,352,462
 Burnet,12 GENERAL,Straight Party,,REP,Republican,349,175,174
 Burnet,12 GENERAL,Straight Party,,REP,Over Votes,0,0,0
 Burnet,12 GENERAL,Straight Party,,REP,Under Votes,350,136,214
@@ -1476,7 +1476,7 @@ Burnet,12 GENERAL,Constable Precinct 3,,REP,Over Votes,0,0,0
 Burnet,12 GENERAL,Constable Precinct 3,,REP,Under Votes,189,73,116
 Burnet,12 GENERAL,Constable Precinct 3,,REP,Jimmy Ballard,625,279,346
 Burnet,13 GENERAL,Registered Voters,,REP,,904,,
-Burnet,13 GENERAL,Ballots Cast,,,,520,276,244,
+Burnet,13 GENERAL,Ballots Cast,,,,520,276,244
 Burnet,13 GENERAL,Straight Party,,REP,Republican,222,127,95
 Burnet,13 GENERAL,Straight Party,,REP,Over Votes,0,0,0
 Burnet,13 GENERAL,Straight Party,,REP,Under Votes,226,116,110
@@ -1587,7 +1587,7 @@ Burnet,13 GENERAL,Constable Precinct 2,,REP,Over Votes,0,0,0
 Burnet,13 GENERAL,Constable Precinct 2,,REP,Under Votes,123,67,56
 Burnet,13 GENERAL,Constable Precinct 2,,REP,Garry Adams,397,209,188
 Burnet,14 GENERAL,Registered Voters,,REP,,411,,
-Burnet,14 GENERAL,Ballots Cast,,,,291,133,158,
+Burnet,14 GENERAL,Ballots Cast,,,,291,133,158
 Burnet,14 GENERAL,Straight Party,,REP,Republican,112,51,61
 Burnet,14 GENERAL,Straight Party,,REP,Over Votes,0,0,0
 Burnet,14 GENERAL,Straight Party,,REP,Under Votes,160,70,90
@@ -1698,7 +1698,7 @@ Burnet,14 GENERAL,Constable Precinct 2,,REP,Over Votes,0,0,0
 Burnet,14 GENERAL,Constable Precinct 2,,REP,Under Votes,48,26,22
 Burnet,14 GENERAL,Constable Precinct 2,,REP,Garry Adams,243,107,136
 Burnet,15 CHIS TRAIL,Registered Voters,,REP,,157,,
-Burnet,15 CHIS TRAIL,Ballots Cast,,,,95,12,83,
+Burnet,15 CHIS TRAIL,Ballots Cast,,,,95,12,83
 Burnet,15 CHIS TRAIL,Straight Party,,REP,Republican,47,6,41
 Burnet,15 CHIS TRAIL,Straight Party,,REP,Over Votes,0,0,0
 Burnet,15 CHIS TRAIL,Straight Party,,REP,Under Votes,42,6,36
@@ -1820,7 +1820,7 @@ Burnet,15 CHIS TRAIL,Directors Election,,"",Albert Fulton,15,2,13
 Burnet,15 CHIS TRAIL,Directors Election,,"",Delton Robinson,0,0,0
 Burnet,15 CHIS TRAIL,Directors Election,,"",Mike Sweeney,14,2,12
 Burnet,15 GENERAL ONLY,Registered Voters,,REP,,416,,
-Burnet,15 GENERAL ONLY,Ballots Cast,,,,285,96,189,
+Burnet,15 GENERAL ONLY,Ballots Cast,,,,285,96,189
 Burnet,15 GENERAL ONLY,Straight Party,,REP,Republican,120,44,76
 Burnet,15 GENERAL ONLY,Straight Party,,REP,Over Votes,0,0,0
 Burnet,15 GENERAL ONLY,Straight Party,,REP,Under Votes,129,39,90
@@ -1931,7 +1931,7 @@ Burnet,15 GENERAL ONLY,Constable Precinct 2,,REP,Over Votes,0,0,0
 Burnet,15 GENERAL ONLY,Constable Precinct 2,,REP,Under Votes,63,26,37
 Burnet,15 GENERAL ONLY,Constable Precinct 2,,REP,Garry Adams,222,70,152
 Burnet,16 GENERAL,Registered Voters,,REP,,452,,
-Burnet,16 GENERAL,Ballots Cast,,,,326,108,218,
+Burnet,16 GENERAL,Ballots Cast,,,,326,108,218
 Burnet,16 GENERAL,Straight Party,,REP,Republican,161,63,98
 Burnet,16 GENERAL,Straight Party,,REP,Over Votes,0,0,0
 Burnet,16 GENERAL,Straight Party,,REP,Under Votes,129,31,98
@@ -2042,7 +2042,7 @@ Burnet,16 GENERAL,Constable Precinct 2,,REP,Over Votes,0,0,0
 Burnet,16 GENERAL,Constable Precinct 2,,REP,Under Votes,56,21,35
 Burnet,16 GENERAL,Constable Precinct 2,,REP,Garry Adams,270,87,183
 Burnet,17 CITY BURNET,Registered Voters,,REP,,583,,
-Burnet,17 CITY BURNET,Ballots Cast,,,,402,300,102,
+Burnet,17 CITY BURNET,Ballots Cast,,,,402,300,102
 Burnet,17 CITY BURNET,Straight Party,,REP,Republican,188,152,36
 Burnet,17 CITY BURNET,Straight Party,,REP,Over Votes,0,0,0
 Burnet,17 CITY BURNET,Straight Party,,REP,Under Votes,182,127,55
@@ -2159,7 +2159,7 @@ Burnet,17 CITY BURNET,"Council Member, Unexpired Term",,"",Pat Riddell,144,99,45
 Burnet,17 CITY BURNET,"Council Member, Unexpired Term",,"",Mary Jane Shanes,35,30,5
 Burnet,17 CITY BURNET,"Council Member, Unexpired Term",,"","Gum Song ""George"" L. Banks",14,10,4
 Burnet,17 GENERAL ONLY,Registered Voters,,REP,,792,,
-Burnet,17 GENERAL ONLY,Ballots Cast,,,,580,425,155,
+Burnet,17 GENERAL ONLY,Ballots Cast,,,,580,425,155
 Burnet,17 GENERAL ONLY,Straight Party,,REP,Republican,279,218,61
 Burnet,17 GENERAL ONLY,Straight Party,,REP,Over Votes,0,0,0
 Burnet,17 GENERAL ONLY,Straight Party,,REP,Under Votes,248,178,70
@@ -2270,7 +2270,7 @@ Burnet,17 GENERAL ONLY,Constable Precinct 2,,REP,Over Votes,0,0,0
 Burnet,17 GENERAL ONLY,Constable Precinct 2,,REP,Under Votes,100,60,40
 Burnet,17 GENERAL ONLY,Constable Precinct 2,,REP,Garry Adams,480,365,115
 Burnet,18 GENERAL,Registered Voters,,REP,,1131,,
-Burnet,18 GENERAL,Ballots Cast,,,,707,421,286,
+Burnet,18 GENERAL,Ballots Cast,,,,707,421,286
 Burnet,18 GENERAL,Straight Party,,REP,Republican,343,231,112
 Burnet,18 GENERAL,Straight Party,,REP,Over Votes,0,0,0
 Burnet,18 GENERAL,Straight Party,,REP,Under Votes,270,156,114
@@ -2384,7 +2384,7 @@ Burnet,18 GENERAL,Constable Precinct 1,,REP,Over Votes,0,0,0
 Burnet,18 GENERAL,Constable Precinct 1,,REP,Under Votes,164,77,87
 Burnet,18 GENERAL,Constable Precinct 1,,REP,Mike Harnisch,543,344,199
 Burnet,19 CITY HSBAY,Registered Voters,,REP,,392,,
-Burnet,19 CITY HSBAY,Ballots Cast,,,,264,193,71,
+Burnet,19 CITY HSBAY,Ballots Cast,,,,264,193,71
 Burnet,19 CITY HSBAY,Straight Party,,REP,Republican,125,100,25
 Burnet,19 CITY HSBAY,Straight Party,,REP,Over Votes,0,0,0
 Burnet,19 CITY HSBAY,Straight Party,,REP,Under Votes,111,73,38
@@ -2503,7 +2503,7 @@ Burnet,19 CITY HSBAY,Charter Amendment No. 2,,"",Under Votes,54,44,10
 Burnet,19 CITY HSBAY,Charter Amendment No. 2,,"",FOR,154,111,43
 Burnet,19 CITY HSBAY,Charter Amendment No. 2,,"",AGAINST,56,38,18
 Burnet,19 GENERAL ONLY,Registered Voters,,REP,,2845,,
-Burnet,19 GENERAL ONLY,Ballots Cast,,,,2062,1628,434,
+Burnet,19 GENERAL ONLY,Ballots Cast,,,,2062,1628,434
 Burnet,19 GENERAL ONLY,Straight Party,,REP,Republican,1031,856,175
 Burnet,19 GENERAL ONLY,Straight Party,,REP,Over Votes,0,0,0
 Burnet,19 GENERAL ONLY,Straight Party,,REP,Under Votes,828,619,209
@@ -2614,7 +2614,7 @@ Burnet,19 GENERAL ONLY,Constable Precinct 4,,REP,Over Votes,0,0,0
 Burnet,19 GENERAL ONLY,Constable Precinct 4,,REP,Under Votes,394,300,94
 Burnet,19 GENERAL ONLY,Constable Precinct 4,,REP,Chris Jett,1668,1328,340
 Burnet,20 GENERAL,Registered Voters,,REP,,3427,,
-Burnet,20 GENERAL,Ballots Cast,,,,2004,1354,650,
+Burnet,20 GENERAL,Ballots Cast,,,,2004,1354,650
 Burnet,20 GENERAL,Straight Party,,REP,Republican,924,678,246
 Burnet,20 GENERAL,Straight Party,,REP,Over Votes,0,0,0
 Burnet,20 GENERAL,Straight Party,,REP,Under Votes,811,524,287

--- a/2012/counties/20121106__tx__general__callahan__precinct.csv
+++ b/2012/counties/20121106__tx__general__callahan__precinct.csv
@@ -1,6 +1,6 @@
 county,precinct,office,district,party,candidate,votes,early_votes,election_day
 Callahan,1,Registered Voters,,REP,,2260,,
-Callahan,1,Ballots Cast,,,,1305,724,581,
+Callahan,1,Ballots Cast,,,,1305,724,581
 Callahan,1,Straight Party,,REP,Republican Party,588,352,236
 Callahan,1,Straight Party,,REP,Over Votes,0,0,0
 Callahan,1,Straight Party,,REP,Under Votes,596,311,285
@@ -102,7 +102,7 @@ Callahan,1,"County Commissioner, Precinct No. 1",,REP,Over Votes,0,0,0
 Callahan,1,"County Commissioner, Precinct No. 1",,REP,Under Votes,199,106,93
 Callahan,1,"County Commissioner, Precinct No. 1",,REP,Harold Hicks,1104,616,488
 Callahan,2,Registered Voters,,REP,,1783,,
-Callahan,2,Ballots Cast,,,,1050,460,590,
+Callahan,2,Ballots Cast,,,,1050,460,590
 Callahan,2,Straight Party,,REP,Republican Party,498,233,265
 Callahan,2,Straight Party,,REP,Over Votes,0,0,0
 Callahan,2,Straight Party,,REP,Under Votes,443,184,259
@@ -201,7 +201,7 @@ Callahan,2,Tax Assessor - Collector,,REP,Over Votes,0,0,0
 Callahan,2,Tax Assessor - Collector,,REP,Under Votes,163,67,96
 Callahan,2,Tax Assessor - Collector,,REP,Tammy T. Walker,885,391,494
 Callahan,3,Registered Voters,,REP,,2006,,
-Callahan,3,Ballots Cast,,,,1188,704,484,
+Callahan,3,Ballots Cast,,,,1188,704,484
 Callahan,3,Straight Party,,REP,Republican Party,492,316,176
 Callahan,3,Straight Party,,REP,Over Votes,0,0,0
 Callahan,3,Straight Party,,REP,Under Votes,607,346,261
@@ -303,7 +303,7 @@ Callahan,3,"County Commissioner, Precinct No. 3",,REP,Over Votes,0,0,0
 Callahan,3,"County Commissioner, Precinct No. 3",,REP,Under Votes,173,94,79
 Callahan,3,"County Commissioner, Precinct No. 3",,REP,Tom F. Windham,1013,608,405
 Callahan,4,Registered Voters,,REP,,1367,,
-Callahan,4,Ballots Cast,,,,915,547,368,
+Callahan,4,Ballots Cast,,,,915,547,368
 Callahan,4,Straight Party,,REP,Republican Party,480,290,190
 Callahan,4,Straight Party,,REP,Over Votes,0,0,0
 Callahan,4,Straight Party,,REP,Under Votes,375,224,151
@@ -405,7 +405,7 @@ Callahan,4,"Constable, Precinct No. 4",,REP,Over Votes,0,0,0
 Callahan,4,"Constable, Precinct No. 4",,REP,Under Votes,117,64,53
 Callahan,4,"Constable, Precinct No. 4",,REP,Ed C. Duncan,797,482,315
 Callahan,5,Registered Voters,,REP,,127,,
-Callahan,5,Ballots Cast,,,,87,30,57,
+Callahan,5,Ballots Cast,,,,87,30,57
 Callahan,5,Straight Party,,REP,Republican Party,39,10,29
 Callahan,5,Straight Party,,REP,Over Votes,0,0,0
 Callahan,5,Straight Party,,REP,Under Votes,44,17,27
@@ -507,7 +507,7 @@ Callahan,5,"County Commissioner, Precinct No. 3",,REP,Over Votes,0,0,0
 Callahan,5,"County Commissioner, Precinct No. 3",,REP,Under Votes,14,9,5
 Callahan,5,"County Commissioner, Precinct No. 3",,REP,Tom F. Windham,73,21,52
 Callahan,6,Registered Voters,,REP,,760,,
-Callahan,6,Ballots Cast,,,,472,268,204,
+Callahan,6,Ballots Cast,,,,472,268,204
 Callahan,6,Straight Party,,REP,Republican Party,237,149,88
 Callahan,6,Straight Party,,REP,Over Votes,0,0,0
 Callahan,6,Straight Party,,REP,Under Votes,202,103,99
@@ -609,7 +609,7 @@ Callahan,6,"Constable, Precinct No. 4",,REP,Over Votes,0,0,0
 Callahan,6,"Constable, Precinct No. 4",,REP,Under Votes,54,29,25
 Callahan,6,"Constable, Precinct No. 4",,REP,Ed C. Duncan,416,237,179
 Callahan,7,Registered Voters,,REP,,455,,
-Callahan,7,Ballots Cast,,,,307,107,200,
+Callahan,7,Ballots Cast,,,,307,107,200
 Callahan,7,Straight Party,,REP,Republican Party,176,66,110
 Callahan,7,Straight Party,,REP,Over Votes,0,0,0
 Callahan,7,Straight Party,,REP,Under Votes,107,34,73

--- a/2012/counties/20121106__tx__general__castro__precinct.csv
+++ b/2012/counties/20121106__tx__general__castro__precinct.csv
@@ -1,6 +1,6 @@
 county,precinct,office,district,party,candidate,votes,early_votes,election_day
 Castro,101,Registered Voters,,REP,,806,,
-Castro,101,Ballots Cast,,,,329,71,258,
+Castro,101,Ballots Cast,,,,329,71,258
 Castro,101,Straight Party,,REP,Republican Party,67,22,45
 Castro,101,Straight Party,,REP,Over Votes,0,0,0
 Castro,101,Straight Party,,REP,Under Votes,161,39,122
@@ -103,7 +103,7 @@ Castro,101,"High Plains Underground Water Conservation District DIRECTOR, Precin
 Castro,101,"High Plains Underground Water Conservation District DIRECTOR, Precinct 3",,"",Mike Beauchamp,130,27,103
 Castro,101,"High Plains Underground Water Conservation District DIRECTOR, Precinct 3",,"",Carroll Cook,38,7,31
 Castro,105,Registered Voters,,REP,,77,,
-Castro,105,Ballots Cast,,,,32,14,18,
+Castro,105,Ballots Cast,,,,32,14,18
 Castro,105,Straight Party,,REP,Republican Party,8,5,3
 Castro,105,Straight Party,,REP,Over Votes,0,0,0
 Castro,105,Straight Party,,REP,Under Votes,23,9,14
@@ -206,7 +206,7 @@ Castro,105,"High Plains Underground Water Conservation District DIRECTOR, Precin
 Castro,105,"High Plains Underground Water Conservation District DIRECTOR, Precinct 3",,"",Mike Beauchamp,17,9,8
 Castro,105,"High Plains Underground Water Conservation District DIRECTOR, Precinct 3",,"",Carroll Cook,4,3,1
 Castro,201,Registered Voters,,REP,,810,,
-Castro,201,Ballots Cast,,,,324,153,171,
+Castro,201,Ballots Cast,,,,324,153,171
 Castro,201,Straight Party,,REP,Republican Party,41,25,16
 Castro,201,Straight Party,,REP,Over Votes,0,0,0
 Castro,201,Straight Party,,REP,Under Votes,197,97,100
@@ -306,7 +306,7 @@ Castro,201,"High Plains Underground Water Conservation District DIRECTOR, Precin
 Castro,201,"High Plains Underground Water Conservation District DIRECTOR, Precinct 3",,"",Mike Beauchamp,124,78,46
 Castro,201,"High Plains Underground Water Conservation District DIRECTOR, Precinct 3",,"",Carroll Cook,45,16,29
 Castro,206,Registered Voters,,REP,,142,,
-Castro,206,Ballots Cast,,,,102,38,64,
+Castro,206,Ballots Cast,,,,102,38,64
 Castro,206,Straight Party,,REP,Republican Party,33,10,23
 Castro,206,Straight Party,,REP,Over Votes,0,0,0
 Castro,206,Straight Party,,REP,Under Votes,66,27,39
@@ -406,7 +406,7 @@ Castro,206,"High Plains Underground Water Conservation District DIRECTOR, Precin
 Castro,206,"High Plains Underground Water Conservation District DIRECTOR, Precinct 3",,"",Mike Beauchamp,70,21,49
 Castro,206,"High Plains Underground Water Conservation District DIRECTOR, Precinct 3",,"",Carroll Cook,10,6,4
 Castro,301,Registered Voters,,REP,,943,,
-Castro,301,Ballots Cast,,,,640,373,267,
+Castro,301,Ballots Cast,,,,640,373,267
 Castro,301,Straight Party,,REP,Republican Party,117,60,57
 Castro,301,Straight Party,,REP,Over Votes,0,0,0
 Castro,301,Straight Party,,REP,Under Votes,460,286,174
@@ -510,7 +510,7 @@ Castro,301,"High Plains Underground Water Conservation District DIRECTOR, Precin
 Castro,301,"High Plains Underground Water Conservation District DIRECTOR, Precinct 3",,"",Mike Beauchamp,382,229,153
 Castro,301,"High Plains Underground Water Conservation District DIRECTOR, Precinct 3",,"",Carroll Cook,77,40,37
 Castro,307,Registered Voters,,REP,,241,,
-Castro,307,Ballots Cast,,,,121,30,91,
+Castro,307,Ballots Cast,,,,121,30,91
 Castro,307,Straight Party,,REP,Republican Party,48,9,39
 Castro,307,Straight Party,,REP,Over Votes,0,0,0
 Castro,307,Straight Party,,REP,Under Votes,62,19,43
@@ -614,7 +614,7 @@ Castro,307,"High Plains Underground Water Conservation District DIRECTOR, Precin
 Castro,307,"High Plains Underground Water Conservation District DIRECTOR, Precinct 3",,"",Mike Beauchamp,66,18,48
 Castro,307,"High Plains Underground Water Conservation District DIRECTOR, Precinct 3",,"",Carroll Cook,15,2,13
 Castro,401,Registered Voters,,REP,,579,,
-Castro,401,Ballots Cast,,,,222,96,126,
+Castro,401,Ballots Cast,,,,222,96,126
 Castro,401,Straight Party,,REP,Republican Party,24,10,14
 Castro,401,Straight Party,,REP,Over Votes,0,0,0
 Castro,401,Straight Party,,REP,Under Votes,142,62,80
@@ -714,7 +714,7 @@ Castro,401,"High Plains Underground Water Conservation District DIRECTOR, Precin
 Castro,401,"High Plains Underground Water Conservation District DIRECTOR, Precinct 3",,"",Mike Beauchamp,91,41,50
 Castro,401,"High Plains Underground Water Conservation District DIRECTOR, Precinct 3",,"",Carroll Cook,37,11,26
 Castro,408,Registered Voters,,REP,,565,,
-Castro,408,Ballots Cast,,,,397,102,295,
+Castro,408,Ballots Cast,,,,397,102,295
 Castro,408,Straight Party,,REP,Republican Party,109,31,78
 Castro,408,Straight Party,,REP,Over Votes,0,0,0
 Castro,408,Straight Party,,REP,Under Votes,277,67,210

--- a/2012/counties/20121106__tx__general__concho__precinct.csv
+++ b/2012/counties/20121106__tx__general__concho__precinct.csv
@@ -1,6 +1,6 @@
 county,precinct,office,district,party,candidate,votes,early_votes,election_day
 Concho,101,Registered Voters,,REP,,332,,
-Concho,101,Ballots Cast,,,,251,142,109,
+Concho,101,Ballots Cast,,,,251,142,109
 Concho,101,Straight Party,,REP,Republican Party,117,63,54
 Concho,101,Straight Party,,REP,Over Votes,0,0,0
 Concho,101,Straight Party,,REP,Under Votes,112,67,45
@@ -109,7 +109,7 @@ Concho,101,Constable,,REP,Over Votes,0,0,0
 Concho,101,Constable,,REP,Under Votes,31,15,16
 Concho,101,Constable,,REP,Marvin E. Green,215,122,93
 Concho,102,Registered Voters,,REP,,79,,
-Concho,102,Ballots Cast,,,,52,19,33,
+Concho,102,Ballots Cast,,,,52,19,33
 Concho,102,Straight Party,,REP,Republican Party,19,5,14
 Concho,102,Straight Party,,REP,Over Votes,0,0,0
 Concho,102,Straight Party,,REP,Under Votes,25,9,16
@@ -218,7 +218,7 @@ Concho,102,Constable,,REP,Over Votes,0,0,0
 Concho,102,Constable,,REP,Under Votes,4,1,3
 Concho,102,Constable,,REP,Marvin E. Green,48,18,30
 Concho,203,Registered Voters,,REP,,118,,
-Concho,203,Ballots Cast,,,,90,38,52,
+Concho,203,Ballots Cast,,,,90,38,52
 Concho,203,Straight Party,,REP,Republican Party,28,8,20
 Concho,203,Straight Party,,REP,Over Votes,0,0,0
 Concho,203,Straight Party,,REP,Under Votes,47,16,31
@@ -324,7 +324,7 @@ Concho,203,Constable,,REP,Over Votes,0,0,0
 Concho,203,Constable,,REP,Under Votes,11,3,8
 Concho,203,Constable,,REP,Marvin E. Green,75,31,44
 Concho,204,Registered Voters,,REP,,124,,
-Concho,204,Ballots Cast,,,,81,13,68,
+Concho,204,Ballots Cast,,,,81,13,68
 Concho,204,Straight Party,,REP,Republican Party,29,4,25
 Concho,204,Straight Party,,REP,Over Votes,0,0,0
 Concho,204,Straight Party,,REP,Under Votes,41,4,37
@@ -430,7 +430,7 @@ Concho,204,Constable,,REP,Over Votes,0,0,0
 Concho,204,Constable,,REP,Under Votes,20,3,17
 Concho,204,Constable,,REP,Marvin E. Green,61,10,51
 Concho,205,Registered Voters,,REP,,143,,
-Concho,205,Ballots Cast,,,,95,29,66,
+Concho,205,Ballots Cast,,,,95,29,66
 Concho,205,Straight Party,,REP,Republican Party,24,8,16
 Concho,205,Straight Party,,REP,Over Votes,0,0,0
 Concho,205,Straight Party,,REP,Under Votes,47,9,38
@@ -536,7 +536,7 @@ Concho,205,Constable,,REP,Over Votes,0,0,0
 Concho,205,Constable,,REP,Under Votes,20,3,17
 Concho,205,Constable,,REP,Marvin E. Green,74,25,49
 Concho,306,Registered Voters,,REP,,347,,
-Concho,306,Ballots Cast,,,,226,49,177,
+Concho,306,Ballots Cast,,,,226,49,177
 Concho,306,Straight Party,,REP,Republican Party,65,19,46
 Concho,306,Straight Party,,REP,Over Votes,0,0,0
 Concho,306,Straight Party,,REP,Under Votes,111,12,99
@@ -646,7 +646,7 @@ Concho,306,Constable,,REP,Over Votes,0,0,0
 Concho,306,Constable,,REP,Under Votes,49,5,44
 Concho,306,Constable,,REP,Marvin E. Green,176,43,133
 Concho,407,Registered Voters,,REP,,75,,
-Concho,407,Ballots Cast,,,,56,19,37,
+Concho,407,Ballots Cast,,,,56,19,37
 Concho,407,Straight Party,,REP,Republican Party,30,6,24
 Concho,407,Straight Party,,REP,Over Votes,0,0,0
 Concho,407,Straight Party,,REP,Under Votes,21,10,11
@@ -752,7 +752,7 @@ Concho,407,Constable,,REP,Over Votes,0,0,0
 Concho,407,Constable,,REP,Under Votes,6,2,4
 Concho,407,Constable,,REP,Marvin E. Green,49,16,33
 Concho,408,Registered Voters,,REP,,284,,
-Concho,408,Ballots Cast,,,,177,45,132,
+Concho,408,Ballots Cast,,,,177,45,132
 Concho,408,Straight Party,,REP,Republican Party,60,13,47
 Concho,408,Straight Party,,REP,Over Votes,0,0,0
 Concho,408,Straight Party,,REP,Under Votes,84,13,71

--- a/2012/counties/20121106__tx__general__dewitt__precinct.csv
+++ b/2012/counties/20121106__tx__general__dewitt__precinct.csv
@@ -1,6 +1,6 @@
 county,precinct,office,district,party,candidate,votes,early_votes,election_day
 DeWitt,101,Registered Voters,,REP,,1131,,
-DeWitt,101,Ballots Cast,,,,699,509,190,
+DeWitt,101,Ballots Cast,,,,699,509,190
 DeWitt,101,Straight Party,,REP,Republican Party,195,150,45
 DeWitt,101,Straight Party,,REP,Over Votes,2,2,0
 DeWitt,101,Straight Party,,REP,Under Votes,436,317,119
@@ -116,7 +116,7 @@ DeWitt,101,"County Commissioner, Precinct No. 1",,REP,Under Votes,18,12,6
 DeWitt,101,"County Commissioner, Precinct No. 1",,REP,Curtis G. Afflerbach,521,393,128
 DeWitt,101,"County Commissioner, Precinct No. 1",,DEM,Jimmy Solis,156,100,56
 DeWitt,102,Registered Voters,,REP,,1465,,
-DeWitt,102,Ballots Cast,,,,542,302,240,
+DeWitt,102,Ballots Cast,,,,542,302,240
 DeWitt,102,Straight Party,,REP,Republican Party,45,25,20
 DeWitt,102,Straight Party,,REP,Over Votes,0,0,0
 DeWitt,102,Straight Party,,REP,Under Votes,312,178,134
@@ -232,7 +232,7 @@ DeWitt,102,"County Commissioner, Precinct No. 1",,REP,Under Votes,19,6,13
 DeWitt,102,"County Commissioner, Precinct No. 1",,REP,Curtis G. Afflerbach,159,90,69
 DeWitt,102,"County Commissioner, Precinct No. 1",,DEM,Jimmy Solis,364,206,158
 DeWitt,201,Registered Voters,,REP,,492,,
-DeWitt,201,Ballots Cast,,,,283,202,81,
+DeWitt,201,Ballots Cast,,,,283,202,81
 DeWitt,201,Straight Party,,REP,Republican Party,91,71,20
 DeWitt,201,Straight Party,,REP,Over Votes,0,0,0
 DeWitt,201,Straight Party,,REP,Under Votes,172,116,56
@@ -344,7 +344,7 @@ DeWitt,201,Sheriff,,REP,Under Votes,5,3,2
 DeWitt,201,Sheriff,,REP,Jode Zavesky,181,129,52
 DeWitt,201,Sheriff,,DEM,Kevin Kroos,97,70,27
 DeWitt,202,Registered Voters,,REP,,1214,,
-DeWitt,202,Ballots Cast,,,,673,255,418,
+DeWitt,202,Ballots Cast,,,,673,255,418
 DeWitt,202,Straight Party,,REP,Republican Party,270,110,160
 DeWitt,202,Straight Party,,REP,Over Votes,1,1,0
 DeWitt,202,Straight Party,,REP,Under Votes,332,122,210
@@ -456,7 +456,7 @@ DeWitt,202,Sheriff,,REP,Under Votes,24,10,14
 DeWitt,202,Sheriff,,REP,Jode Zavesky,482,183,299
 DeWitt,202,Sheriff,,DEM,Kevin Kroos,166,61,105
 DeWitt,203,Registered Voters,,REP,,933,,
-DeWitt,203,Ballots Cast,,,,556,219,337,
+DeWitt,203,Ballots Cast,,,,556,219,337
 DeWitt,203,Straight Party,,REP,Republican Party,241,103,138
 DeWitt,203,Straight Party,,REP,Over Votes,2,2,0
 DeWitt,203,Straight Party,,REP,Under Votes,268,105,163
@@ -568,7 +568,7 @@ DeWitt,203,Sheriff,,REP,Under Votes,14,6,8
 DeWitt,203,Sheriff,,REP,Jode Zavesky,414,169,245
 DeWitt,203,Sheriff,,DEM,Kevin Kroos,126,42,84
 DeWitt,301,Registered Voters,,REP,,1498,,
-DeWitt,301,Ballots Cast,,,,617,340,277,
+DeWitt,301,Ballots Cast,,,,617,340,277
 DeWitt,301,Straight Party,,REP,Republican Party,233,137,96
 DeWitt,301,Straight Party,,REP,Over Votes,1,1,0
 DeWitt,301,Straight Party,,REP,Under Votes,329,178,151
@@ -680,7 +680,7 @@ DeWitt,301,Sheriff,,REP,Under Votes,11,4,7
 DeWitt,301,Sheriff,,REP,Jode Zavesky,420,255,165
 DeWitt,301,Sheriff,,DEM,Kevin Kroos,184,79,105
 DeWitt,302,Registered Voters,,REP,,1203,,
-DeWitt,302,Ballots Cast,,,,874,298,576,
+DeWitt,302,Ballots Cast,,,,874,298,576
 DeWitt,302,Straight Party,,REP,Republican Party,291,119,172
 DeWitt,302,Straight Party,,REP,Over Votes,2,2,0
 DeWitt,302,Straight Party,,REP,Under Votes,500,150,350
@@ -792,7 +792,7 @@ DeWitt,302,Sheriff,,REP,Under Votes,27,7,20
 DeWitt,302,Sheriff,,REP,Jode Zavesky,560,200,360
 DeWitt,302,Sheriff,,DEM,Kevin Kroos,282,86,196
 DeWitt,303,Registered Voters,,REP,,396,,
-DeWitt,303,Ballots Cast,,,,225,65,160,
+DeWitt,303,Ballots Cast,,,,225,65,160
 DeWitt,303,Straight Party,,REP,Republican Party,63,22,41
 DeWitt,303,Straight Party,,REP,Over Votes,0,0,0
 DeWitt,303,Straight Party,,REP,Under Votes,148,41,107
@@ -904,7 +904,7 @@ DeWitt,303,Sheriff,,REP,Under Votes,4,1,3
 DeWitt,303,Sheriff,,REP,Jode Zavesky,141,47,94
 DeWitt,303,Sheriff,,DEM,Kevin Kroos,80,17,63
 DeWitt,401,Registered Voters,,REP,,2140,,
-DeWitt,401,Ballots Cast,,,,1314,930,384,
+DeWitt,401,Ballots Cast,,,,1314,930,384
 DeWitt,401,Straight Party,,REP,Republican Party,393,314,79
 DeWitt,401,Straight Party,,REP,Over Votes,3,3,0
 DeWitt,401,Straight Party,,REP,Under Votes,815,547,268
@@ -1016,7 +1016,7 @@ DeWitt,401,Sheriff,,REP,Under Votes,22,17,5
 DeWitt,401,Sheriff,,REP,Jode Zavesky,811,598,213
 DeWitt,401,Sheriff,,DEM,Kevin Kroos,473,307,166
 DeWitt,402,Registered Voters,,REP,,955,,
-DeWitt,402,Ballots Cast,,,,695,393,302,
+DeWitt,402,Ballots Cast,,,,695,393,302
 DeWitt,402,Straight Party,,REP,Republican Party,234,132,102
 DeWitt,402,Straight Party,,REP,Over Votes,0,0,0
 DeWitt,402,Straight Party,,REP,Under Votes,438,252,186
@@ -1128,7 +1128,7 @@ DeWitt,402,Sheriff,,REP,Under Votes,12,9,3
 DeWitt,402,Sheriff,,REP,Jode Zavesky,468,267,201
 DeWitt,402,Sheriff,,DEM,Kevin Kroos,215,117,98
 DeWitt,101 WISD,Registered Voters,,REP,,339,,
-DeWitt,101 WISD,Ballots Cast,,,,235,146,89,
+DeWitt,101 WISD,Ballots Cast,,,,235,146,89
 DeWitt,101 WISD,Straight Party,,REP,Republican Party,69,38,31
 DeWitt,101 WISD,Straight Party,,REP,Over Votes,0,0,0
 DeWitt,101 WISD,Straight Party,,REP,Under Votes,152,100,52

--- a/2012/counties/20121106__tx__general__eastland__precinct.csv
+++ b/2012/counties/20121106__tx__general__eastland__precinct.csv
@@ -1,6 +1,6 @@
 county,precinct,office,district,party,candidate,votes,early_votes,election_day
 Eastland,1.0,Registered Voters,,,,2566.0,,
-Eastland,1.0,Ballots Cast,,,,622.0,371.0,251.0,
+Eastland,1.0,Ballots Cast,,,,622.0,371.0,251.0
 Eastland,1.0,Straight Party,,REP,Republican Party,296.0,173.0,123.0
 Eastland,1.0,Straight Party,,,Over Votes,0.0,0.0,0.0
 Eastland,1.0,Straight Party,,,Under Votes,0.0,0.0,0.0
@@ -103,7 +103,7 @@ Eastland,1.0,"Constable, Precinct No. 1",,,Over Votes,0.0,0.0,0.0
 Eastland,1.0,"Constable, Precinct No. 1",,,Under Votes,0.0,0.0,0.0
 Eastland,1.0,"Constable, Precinct No. 1",,REP,Kenneth Payne,554.0,330.0,224.0
 Eastland,2.0,Registered Voters,,,,326.0,,
-Eastland,2.0,Ballots Cast,,,,220.0,120.0,100.0,
+Eastland,2.0,Ballots Cast,,,,220.0,120.0,100.0
 Eastland,2.0,Straight Party,,REP,Republican Party,95.0,63.0,32.0
 Eastland,2.0,Straight Party,,,Over Votes,0.0,0.0,0.0
 Eastland,2.0,Straight Party,,,Under Votes,0.0,0.0,0.0
@@ -203,7 +203,7 @@ Eastland,2.0,"Constable, Precinct No. 2",,,Over Votes,0.0,0.0,0.0
 Eastland,2.0,"Constable, Precinct No. 2",,,Under Votes,0.0,0.0,0.0
 Eastland,2.0,"Constable, Precinct No. 2",,REP,Jackie (Jack) Daniels,187.0,107.0,80.0
 Eastland,3.0,Registered Voters,,,,1545.0,,
-Eastland,3.0,Ballots Cast,,,,833.0,314.0,519.0,
+Eastland,3.0,Ballots Cast,,,,833.0,314.0,519.0
 Eastland,3.0,Straight Party,,REP,Republican Party,400.0,169.0,231.0
 Eastland,3.0,Straight Party,,,Over Votes,0.0,0.0,0.0
 Eastland,3.0,Straight Party,,,Under Votes,0.0,0.0,0.0
@@ -303,7 +303,7 @@ Eastland,3.0,"Constable, Precinct No. 2",,,Over Votes,0.0,0.0,0.0
 Eastland,3.0,"Constable, Precinct No. 2",,,Under Votes,0.0,0.0,0.0
 Eastland,3.0,"Constable, Precinct No. 2",,REP,Jackie (Jack) Daniels,687.0,260.0,427.0
 Eastland,4.0,Registered Voters,,,,280.0,,
-Eastland,4.0,Ballots Cast,,,,77.0,69.0,8.0,
+Eastland,4.0,Ballots Cast,,,,77.0,69.0,8.0
 Eastland,4.0,Straight Party,,REP,Republican Party,26.0,25.0,1.0
 Eastland,4.0,Straight Party,,,Over Votes,0.0,0.0,0.0
 Eastland,4.0,Straight Party,,,Under Votes,0.0,0.0,0.0
@@ -403,7 +403,7 @@ Eastland,4.0,"Constable, Precinct No. 2",,,Over Votes,0.0,0.0,0.0
 Eastland,4.0,"Constable, Precinct No. 2",,,Under Votes,0.0,0.0,0.0
 Eastland,4.0,"Constable, Precinct No. 2",,REP,Jackie (Jack) Daniels,61.0,55.0,6.0
 Eastland,5.0,Registered Voters,,,,693.0,,
-Eastland,5.0,Ballots Cast,,,,393.0,96.0,297.0,
+Eastland,5.0,Ballots Cast,,,,393.0,96.0,297.0
 Eastland,5.0,Straight Party,,REP,Republican Party,170.0,39.0,131.0
 Eastland,5.0,Straight Party,,,Over Votes,0.0,0.0,0.0
 Eastland,5.0,Straight Party,,,Under Votes,0.0,0.0,0.0
@@ -506,7 +506,7 @@ Eastland,5.0,"Constable, Precinct No. 1",,,Over Votes,0.0,0.0,0.0
 Eastland,5.0,"Constable, Precinct No. 1",,,Under Votes,0.0,0.0,0.0
 Eastland,5.0,"Constable, Precinct No. 1",,REP,Kenneth Payne,320.0,77.0,243.0
 Eastland,6.0,Registered Voters,,,,268.0,,
-Eastland,6.0,Ballots Cast,,,,173.0,62.0,111.0,
+Eastland,6.0,Ballots Cast,,,,173.0,62.0,111.0
 Eastland,6.0,Straight Party,,REP,Republican Party,76.0,28.0,48.0
 Eastland,6.0,Straight Party,,,Over Votes,0.0,0.0,0.0
 Eastland,6.0,Straight Party,,,Under Votes,0.0,0.0,0.0
@@ -609,7 +609,7 @@ Eastland,6.0,"Constable, Precinct No. 1",,,Over Votes,0.0,0.0,0.0
 Eastland,6.0,"Constable, Precinct No. 1",,,Under Votes,0.0,0.0,0.0
 Eastland,6.0,"Constable, Precinct No. 1",,REP,Kenneth Payne,153.0,57.0,96.0
 Eastland,7.0,Registered Voters,,,,1754.0,,
-Eastland,7.0,Ballots Cast,,,,1053.0,531.0,522.0,
+Eastland,7.0,Ballots Cast,,,,1053.0,531.0,522.0
 Eastland,7.0,Straight Party,,REP,Republican Party,515.0,260.0,255.0
 Eastland,7.0,Straight Party,,,Over Votes,0.0,0.0,0.0
 Eastland,7.0,Straight Party,,,Under Votes,0.0,0.0,0.0
@@ -720,7 +720,7 @@ Eastland,7.0,PROPOSITION 2,,,Under Votes,0.0,0.0,0.0
 Eastland,7.0,PROPOSITION 2,,,FOR,570.0,279.0,291.0
 Eastland,7.0,PROPOSITION 2,,,AGAINST,407.0,212.0,195.0
 Eastland,8.0,Registered Voters,,,,2485.0,,
-Eastland,8.0,Ballots Cast,,,,1696.0,927.0,769.0,
+Eastland,8.0,Ballots Cast,,,,1696.0,927.0,769.0
 Eastland,8.0,Straight Party,,REP,Republican Party,748.0,417.0,331.0
 Eastland,8.0,Straight Party,,,Over Votes,0.0,0.0,0.0
 Eastland,8.0,Straight Party,,,Under Votes,0.0,0.0,0.0
@@ -828,7 +828,7 @@ Eastland,8.0,PROPOSITION 2,,,Under Votes,0.0,0.0,0.0
 Eastland,8.0,PROPOSITION 2,,,FOR,1038.0,560.0,478.0
 Eastland,8.0,PROPOSITION 2,,,AGAINST,582.0,324.0,258.0
 Eastland,9.0,Registered Voters,,,,420.0,,
-Eastland,9.0,Ballots Cast,,,,310.0,229.0,81.0,
+Eastland,9.0,Ballots Cast,,,,310.0,229.0,81.0
 Eastland,9.0,Straight Party,,REP,Republican Party,140.0,105.0,35.0
 Eastland,9.0,Straight Party,,,Over Votes,0.0,0.0,0.0
 Eastland,9.0,Straight Party,,,Under Votes,0.0,0.0,0.0
@@ -928,7 +928,7 @@ Eastland,9.0,"Constable, Precinct No. 2",,,Over Votes,0.0,0.0,0.0
 Eastland,9.0,"Constable, Precinct No. 2",,,Under Votes,0.0,0.0,0.0
 Eastland,9.0,"Constable, Precinct No. 2",,REP,Jackie (Jack) Daniels,263.0,199.0,64.0
 Eastland,1.0,Registered Voters,,,,0.0,,
-Eastland,1.0,Ballots Cast,,,,1128.0,797.0,331.0,
+Eastland,1.0,Ballots Cast,,,,1128.0,797.0,331.0
 Eastland,1.0,Straight Party,,REP,Republican Party,460.0,320.0,140.0
 Eastland,1.0,Straight Party,,,Over Votes,0.0,0.0,0.0
 Eastland,1.0,Straight Party,,,Under Votes,0.0,0.0,0.0
@@ -1039,7 +1039,7 @@ Eastland,1.0,PROPOSITION 2 7 CTY JP4LO,,,Under Votes,0.0,0.0,0.0
 Eastland,1.0,PROPOSITION 2 7 CTY JP4LO,,,FOR,618.0,402.0,216.0
 Eastland,1.0,PROPOSITION 2 7 CTY JP4LO,,,AGAINST,440.0,350.0,90.0
 Eastland,7.0,Registered Voters,,,,0.0,,
-Eastland,7.0,Ballots Cast,,,,165.0,150.0,15.0,
+Eastland,7.0,Ballots Cast,,,,165.0,150.0,15.0
 Eastland,7.0,Straight Party,,REP,Republican Party,85.0,74.0,11.0
 Eastland,7.0,Straight Party,,,Over Votes,0.0,0.0,0.0
 Eastland,7.0,Straight Party,,,Under Votes,0.0,0.0,0.0

--- a/2012/counties/20121106__tx__general__grimes__precinct.csv
+++ b/2012/counties/20121106__tx__general__grimes__precinct.csv
@@ -1,6 +1,6 @@
 county,precinct,office,district,party,candidate,votes,early_votes,election_day
 Grimes,1,Registered Voters,,REP,,1639,,
-Grimes,1,Ballots Cast,,,,1084,639,378,
+Grimes,1,Ballots Cast,,,,1084,639,378
 Grimes,1,Straight Party,,REP,Republican Party,446,269,148
 Grimes,1,Straight Party,,REP,Over Votes,0,0,0
 Grimes,1,Straight Party,,REP,Under Votes,0,0,0
@@ -142,7 +142,7 @@ Grimes,1,"Constable, Precinct No. 2",,REP,Over Votes,0,0,0
 Grimes,1,"Constable, Precinct No. 2",,REP,Under Votes,0,0,0
 Grimes,1,"Constable, Precinct No. 2",,REP,George Wells,869,513,310
 Grimes,2,Registered Voters,,REP,,784,,
-Grimes,2,Ballots Cast,,,,486,96,363,
+Grimes,2,Ballots Cast,,,,486,96,363
 Grimes,2,Straight Party,,REP,Republican Party,213,51,146
 Grimes,2,Straight Party,,REP,Over Votes,0,0,0
 Grimes,2,Straight Party,,REP,Under Votes,0,0,0
@@ -287,7 +287,7 @@ Grimes,2,"Constable, Precinct No. 1",,REP,Over Votes,0,0,0
 Grimes,2,"Constable, Precinct No. 1",,REP,Under Votes,0,0,0
 Grimes,2,"Constable, Precinct No. 1",,REP,Dale Schaper,419,85,311
 Grimes,3,Registered Voters,,REP,,1528,,
-Grimes,3,Ballots Cast,,,,758,357,384,
+Grimes,3,Ballots Cast,,,,758,357,384
 Grimes,3,Straight Party,,REP,Republican Party,72,41,29
 Grimes,3,Straight Party,,REP,Over Votes,0,0,0
 Grimes,3,Straight Party,,REP,Under Votes,0,0,0
@@ -434,7 +434,7 @@ Grimes,3,"Constable, Precinct No. 3 & 4",,REP,Under Votes,0,0,0
 Grimes,3,"Constable, Precinct No. 3 & 4",,REP,Ann Weaks,167,92,69
 Grimes,3,"Constable, Precinct No. 3 & 4",,DEM,Donna K. Orozco,567,252,309
 Grimes,4,Registered Voters,,REP,,1214,,
-Grimes,4,Ballots Cast,,,,752,285,412,
+Grimes,4,Ballots Cast,,,,752,285,412
 Grimes,4,Straight Party,,REP,Republican Party,374,142,206
 Grimes,4,Straight Party,,REP,Over Votes,0,0,0
 Grimes,4,Straight Party,,REP,Under Votes,0,0,0
@@ -576,7 +576,7 @@ Grimes,4,"Constable, Precinct No. 2",,REP,Over Votes,0,0,0
 Grimes,4,"Constable, Precinct No. 2",,REP,Under Votes,0,0,0
 Grimes,4,"Constable, Precinct No. 2",,REP,George Wells,609,231,335
 Grimes,5,Registered Voters,,REP,,1296,,
-Grimes,5,Ballots Cast,,,,843,454,343,
+Grimes,5,Ballots Cast,,,,843,454,343
 Grimes,5,Straight Party,,REP,Republican Party,305,177,109
 Grimes,5,Straight Party,,REP,Over Votes,0,0,0
 Grimes,5,Straight Party,,REP,Under Votes,0,0,0
@@ -723,7 +723,7 @@ Grimes,5,"Constable, Precinct No. 3 & 4",,REP,Under Votes,0,0,0
 Grimes,5,"Constable, Precinct No. 3 & 4",,REP,Ann Weaks,590,339,221
 Grimes,5,"Constable, Precinct No. 3 & 4",,DEM,Donna K. Orozco,220,103,104
 Grimes,6,Registered Voters,,REP,,1944,,
-Grimes,6,Ballots Cast,,,,1174,724,383,
+Grimes,6,Ballots Cast,,,,1174,724,383
 Grimes,6,Straight Party,,REP,Republican Party,357,227,104
 Grimes,6,Straight Party,,REP,Over Votes,0,0,0
 Grimes,6,Straight Party,,REP,Under Votes,0,0,0
@@ -866,7 +866,7 @@ Grimes,6,"Constable, Precinct No. 3 & 4",,REP,Under Votes,0,0,0
 Grimes,6,"Constable, Precinct No. 3 & 4",,REP,Ann Weaks,770,506,222
 Grimes,6,"Constable, Precinct No. 3 & 4",,DEM,Donna K. Orozco,374,203,153
 Grimes,7,Registered Voters,,REP,,1217,,
-Grimes,7,Ballots Cast,,,,681,145,488,
+Grimes,7,Ballots Cast,,,,681,145,488
 Grimes,7,Straight Party,,REP,Republican Party,329,75,237
 Grimes,7,Straight Party,,REP,Over Votes,0,0,0
 Grimes,7,Straight Party,,REP,Under Votes,0,0,0
@@ -1011,7 +1011,7 @@ Grimes,7,"Constable, Precinct No. 1",,REP,Over Votes,0,0,0
 Grimes,7,"Constable, Precinct No. 1",,REP,Under Votes,0,0,0
 Grimes,7,"Constable, Precinct No. 1",,REP,Dale Schaper,561,125,402
 Grimes,8,Registered Voters,,REP,,504,,
-Grimes,8,Ballots Cast,,,,286,87,184,
+Grimes,8,Ballots Cast,,,,286,87,184
 Grimes,8,Straight Party,,REP,Republican Party,126,44,77
 Grimes,8,Straight Party,,REP,Over Votes,0,0,0
 Grimes,8,Straight Party,,REP,Under Votes,0,0,0
@@ -1156,7 +1156,7 @@ Grimes,8,"Constable, Precinct No. 1",,REP,Over Votes,0,0,0
 Grimes,8,"Constable, Precinct No. 1",,REP,Under Votes,0,0,0
 Grimes,8,"Constable, Precinct No. 1",,REP,Dale Schaper,233,74,150
 Grimes,9,Registered Voters,,REP,,420,,
-Grimes,9,Ballots Cast,,,,257,105,136,
+Grimes,9,Ballots Cast,,,,257,105,136
 Grimes,9,Straight Party,,REP,Republican Party,126,58,63
 Grimes,9,Straight Party,,REP,Over Votes,0,0,0
 Grimes,9,Straight Party,,REP,Under Votes,0,0,0
@@ -1298,7 +1298,7 @@ Grimes,9,"Constable, Precinct No. 2",,REP,Over Votes,0,0,0
 Grimes,9,"Constable, Precinct No. 2",,REP,Under Votes,0,0,0
 Grimes,9,"Constable, Precinct No. 2",,REP,George Wells,199,81,109
 Grimes,10,Registered Voters,,REP,,970,,
-Grimes,10,Ballots Cast,,,,642,202,413,
+Grimes,10,Ballots Cast,,,,642,202,413
 Grimes,10,Straight Party,,REP,Republican Party,328,120,194
 Grimes,10,Straight Party,,REP,Over Votes,0,0,0
 Grimes,10,Straight Party,,REP,Under Votes,0,0,0
@@ -1443,7 +1443,7 @@ Grimes,10,"Constable, Precinct No. 1",,REP,Over Votes,0,0,0
 Grimes,10,"Constable, Precinct No. 1",,REP,Under Votes,0,0,0
 Grimes,10,"Constable, Precinct No. 1",,REP,Dale Schaper,555,186,346
 Grimes,11,Registered Voters,,REP,,201,,
-Grimes,11,Ballots Cast,,,,142,27,107,
+Grimes,11,Ballots Cast,,,,142,27,107
 Grimes,11,Straight Party,,REP,Republican Party,66,12,50
 Grimes,11,Straight Party,,REP,Over Votes,0,0,0
 Grimes,11,Straight Party,,REP,Under Votes,0,0,0
@@ -1588,7 +1588,7 @@ Grimes,11,"Constable, Precinct No. 1",,REP,Over Votes,0,0,0
 Grimes,11,"Constable, Precinct No. 1",,REP,Under Votes,0,0,0
 Grimes,11,"Constable, Precinct No. 1",,REP,Dale Schaper,132,26,99
 Grimes,12,Registered Voters,,REP,,865,,
-Grimes,12,Ballots Cast,,,,555,308,220,
+Grimes,12,Ballots Cast,,,,555,308,220
 Grimes,12,Straight Party,,REP,Republican Party,211,120,79
 Grimes,12,Straight Party,,REP,Over Votes,0,0,0
 Grimes,12,Straight Party,,REP,Under Votes,0,0,0
@@ -1731,7 +1731,7 @@ Grimes,12,"Constable, Precinct No. 3 & 4",,REP,Under Votes,0,0,0
 Grimes,12,"Constable, Precinct No. 3 & 4",,REP,Ann Weaks,403,226,154
 Grimes,12,"Constable, Precinct No. 3 & 4",,DEM,Donna K. Orozco,138,75,61
 Grimes,14,Registered Voters,,REP,,1357,,
-Grimes,14,Ballots Cast,,,,790,277,469,
+Grimes,14,Ballots Cast,,,,790,277,469
 Grimes,14,Straight Party,,REP,Republican Party,394,158,215
 Grimes,14,Straight Party,,REP,Over Votes,0,0,0
 Grimes,14,Straight Party,,REP,Under Votes,0,0,0
@@ -1873,7 +1873,7 @@ Grimes,14,"Constable, Precinct No. 2",,REP,Over Votes,0,0,0
 Grimes,14,"Constable, Precinct No. 2",,REP,Under Votes,0,0,0
 Grimes,14,"Constable, Precinct No. 2",,REP,George Wells,648,244,373
 Grimes,15,Registered Voters,,REP,,505,,
-Grimes,15,Ballots Cast,,,,322,131,170,
+Grimes,15,Ballots Cast,,,,322,131,170
 Grimes,15,Straight Party,,REP,Republican Party,160,71,82
 Grimes,15,Straight Party,,REP,Over Votes,0,0,0
 Grimes,15,Straight Party,,REP,Under Votes,0,0,0

--- a/2012/counties/20121106__tx__general__hunt__precinct.csv
+++ b/2012/counties/20121106__tx__general__hunt__precinct.csv
@@ -1,6 +1,6 @@
 county,precinct,office,district,party,candidate,votes,early_votes,election_day
 Hunt,101,Registered Voters,,REP,,1085,,
-Hunt,101,Ballots Cast,,,,652,212,440,
+Hunt,101,Ballots Cast,,,,652,212,440
 Hunt,101,Straight Party,,REP,Republican Party,254,91,163
 Hunt,101,Straight Party,,REP,Over Votes,0,0,0
 Hunt,101,Straight Party,,REP,Under Votes,0,0,0
@@ -140,7 +140,7 @@ Hunt,101,"Constable, Precinct No. 3",,REP,Over Votes,0,0,0
 Hunt,101,"Constable, Precinct No. 3",,REP,Under Votes,0,0,0
 Hunt,101,"Constable, Precinct No. 3",,REP,Don Morrison,477,160,317
 Hunt,102,Registered Voters,,REP,,1250,,
-Hunt,102,Ballots Cast,,,,725,267,458,
+Hunt,102,Ballots Cast,,,,725,267,458
 Hunt,102,Straight Party,,REP,Republican Party,268,107,161
 Hunt,102,Straight Party,,REP,Over Votes,0,0,0
 Hunt,102,Straight Party,,REP,Under Votes,0,0,0
@@ -280,7 +280,7 @@ Hunt,102,"Constable, Precinct No. 3",,REP,Over Votes,0,0,0
 Hunt,102,"Constable, Precinct No. 3",,REP,Under Votes,0,0,0
 Hunt,102,"Constable, Precinct No. 3",,REP,Don Morrison,555,200,355
 Hunt,103,Registered Voters,,REP,,607,,
-Hunt,103,Ballots Cast,,,,424,180,244,
+Hunt,103,Ballots Cast,,,,424,180,244
 Hunt,103,Straight Party,,REP,Republican Party,198,100,98
 Hunt,103,Straight Party,,REP,Over Votes,0,0,0
 Hunt,103,Straight Party,,REP,Under Votes,0,0,0
@@ -420,7 +420,7 @@ Hunt,103,"Constable, Precinct No. 3",,REP,Over Votes,0,0,0
 Hunt,103,"Constable, Precinct No. 3",,REP,Under Votes,0,0,0
 Hunt,103,"Constable, Precinct No. 3",,REP,Don Morrison,340,157,183
 Hunt,104,Registered Voters,,REP,,832,,
-Hunt,104,Ballots Cast,,,,561,340,221,
+Hunt,104,Ballots Cast,,,,561,340,221
 Hunt,104,Straight Party,,REP,Republican Party,228,147,81
 Hunt,104,Straight Party,,REP,Over Votes,0,0,0
 Hunt,104,Straight Party,,REP,Under Votes,0,0,0
@@ -564,7 +564,7 @@ Hunt,104,"Constable, Precinct No. 1",,REP,Under Votes,0,0,0
 Hunt,104,"Constable, Precinct No. 1",,REP,Terry Jones,423,253,170
 Hunt,104,"Constable, Precinct No. 1",,DEM,Glenn Stone,118,75,43
 Hunt,105,Registered Voters,,REP,,858,,
-Hunt,105,Ballots Cast,,,,436,284,152,
+Hunt,105,Ballots Cast,,,,436,284,152
 Hunt,105,Straight Party,,REP,Republican Party,163,106,57
 Hunt,105,Straight Party,,REP,Over Votes,0,0,0
 Hunt,105,Straight Party,,REP,Under Votes,0,0,0
@@ -708,7 +708,7 @@ Hunt,105,"Constable, Precinct No. 1",,REP,Under Votes,0,0,0
 Hunt,105,"Constable, Precinct No. 1",,REP,Terry Jones,272,181,91
 Hunt,105,"Constable, Precinct No. 1",,DEM,Glenn Stone,136,85,51
 Hunt,106,Registered Voters,,REP,,1895,,
-Hunt,106,Ballots Cast,,,,1060,748,312,
+Hunt,106,Ballots Cast,,,,1060,748,312
 Hunt,106,Straight Party,,REP,Republican Party,394,281,113
 Hunt,106,Straight Party,,REP,Over Votes,0,0,0
 Hunt,106,Straight Party,,REP,Under Votes,0,0,0
@@ -852,7 +852,7 @@ Hunt,106,"Constable, Precinct No. 1",,REP,Under Votes,0,0,0
 Hunt,106,"Constable, Precinct No. 1",,REP,Terry Jones,634,452,182
 Hunt,106,"Constable, Precinct No. 1",,DEM,Glenn Stone,361,248,113
 Hunt,107,Registered Voters,,REP,,2647,,
-Hunt,107,Ballots Cast,,,,1657,1176,481,
+Hunt,107,Ballots Cast,,,,1657,1176,481
 Hunt,107,Straight Party,,REP,Republican Party,705,518,187
 Hunt,107,Straight Party,,REP,Over Votes,0,0,0
 Hunt,107,Straight Party,,REP,Under Votes,0,0,0
@@ -996,7 +996,7 @@ Hunt,107,"Constable, Precinct No. 1",,REP,Under Votes,0,0,0
 Hunt,107,"Constable, Precinct No. 1",,REP,Terry Jones,1171,857,314
 Hunt,107,"Constable, Precinct No. 1",,DEM,Glenn Stone,376,257,119
 Hunt,108,Registered Voters,,REP,,1633,,
-Hunt,108,Ballots Cast,,,,840,539,301,
+Hunt,108,Ballots Cast,,,,840,539,301
 Hunt,108,Straight Party,,REP,Republican Party,288,192,96
 Hunt,108,Straight Party,,REP,Over Votes,0,0,0
 Hunt,108,Straight Party,,REP,Under Votes,0,0,0
@@ -1140,7 +1140,7 @@ Hunt,108,"Constable, Precinct No. 1",,REP,Under Votes,0,0,0
 Hunt,108,"Constable, Precinct No. 1",,REP,Terry Jones,507,347,160
 Hunt,108,"Constable, Precinct No. 1",,DEM,Glenn Stone,279,168,111
 Hunt,109,Registered Voters,,REP,,1045,,
-Hunt,109,Ballots Cast,,,,623,239,384,
+Hunt,109,Ballots Cast,,,,623,239,384
 Hunt,109,Straight Party,,REP,Republican Party,277,108,169
 Hunt,109,Straight Party,,REP,Over Votes,0,0,0
 Hunt,109,Straight Party,,REP,Under Votes,0,0,0
@@ -1284,7 +1284,7 @@ Hunt,109,"Constable, Precinct No. 1",,REP,Under Votes,0,0,0
 Hunt,109,"Constable, Precinct No. 1",,REP,Terry Jones,461,178,283
 Hunt,109,"Constable, Precinct No. 1",,DEM,Glenn Stone,126,45,81
 Hunt,210,Registered Voters,,REP,,667,,
-Hunt,210,Ballots Cast,,,,390,160,230,
+Hunt,210,Ballots Cast,,,,390,160,230
 Hunt,210,Straight Party,,REP,Republican Party,177,79,98
 Hunt,210,Straight Party,,REP,Over Votes,0,0,0
 Hunt,210,Straight Party,,REP,Under Votes,0,0,0
@@ -1424,7 +1424,7 @@ Hunt,210,"Constable, Precinct No. 1",,REP,Under Votes,0,0,0
 Hunt,210,"Constable, Precinct No. 1",,REP,Terry Jones,266,115,151
 Hunt,210,"Constable, Precinct No. 1",,DEM,Glenn Stone,105,40,65
 Hunt,211,Registered Voters,,REP,,607,,
-Hunt,211,Ballots Cast,,,,409,223,186,
+Hunt,211,Ballots Cast,,,,409,223,186
 Hunt,211,Straight Party,,REP,Republican Party,196,103,93
 Hunt,211,Straight Party,,REP,Over Votes,0,0,0
 Hunt,211,Straight Party,,REP,Under Votes,0,0,0
@@ -1564,7 +1564,7 @@ Hunt,211,"Constable, Precinct No. 1",,REP,Under Votes,0,0,0
 Hunt,211,"Constable, Precinct No. 1",,REP,Terry Jones,298,162,136
 Hunt,211,"Constable, Precinct No. 1",,DEM,Glenn Stone,88,50,38
 Hunt,212,Registered Voters,,REP,,1041,,
-Hunt,212,Ballots Cast,,,,599,384,215,
+Hunt,212,Ballots Cast,,,,599,384,215
 Hunt,212,Straight Party,,REP,Republican Party,239,157,82
 Hunt,212,Straight Party,,REP,Over Votes,0,0,0
 Hunt,212,Straight Party,,REP,Under Votes,0,0,0
@@ -1704,7 +1704,7 @@ Hunt,212,"Constable, Precinct No. 1",,REP,Under Votes,0,0,0
 Hunt,212,"Constable, Precinct No. 1",,REP,Terry Jones,404,274,130
 Hunt,212,"Constable, Precinct No. 1",,DEM,Glenn Stone,165,92,73
 Hunt,213,Registered Voters,,REP,,764,,
-Hunt,213,Ballots Cast,,,,511,244,267,
+Hunt,213,Ballots Cast,,,,511,244,267
 Hunt,213,Straight Party,,REP,Republican Party,260,122,138
 Hunt,213,Straight Party,,REP,Over Votes,0,0,0
 Hunt,213,Straight Party,,REP,Under Votes,0,0,0
@@ -1844,7 +1844,7 @@ Hunt,213,"Constable, Precinct No. 1",,REP,Under Votes,0,0,0
 Hunt,213,"Constable, Precinct No. 1",,REP,Terry Jones,405,193,212
 Hunt,213,"Constable, Precinct No. 1",,DEM,Glenn Stone,79,40,39
 Hunt,214,Registered Voters,,REP,,2984,,
-Hunt,214,Ballots Cast,,,,1526,573,953,
+Hunt,214,Ballots Cast,,,,1526,573,953
 Hunt,214,Straight Party,,REP,Republican Party,798,328,470
 Hunt,214,Straight Party,,REP,Over Votes,0,0,0
 Hunt,214,Straight Party,,REP,Under Votes,0,0,0
@@ -1980,7 +1980,7 @@ Hunt,214,"Constable, Precinct No. 4",,REP,Over Votes,0,0,0
 Hunt,214,"Constable, Precinct No. 4",,REP,Under Votes,0,0,0
 Hunt,214,"Constable, Precinct No. 4",,REP,Kent Layton,1196,471,725
 Hunt,215,Registered Voters,,REP,,4069,,
-Hunt,215,Ballots Cast,,,,2462,1126,1336,
+Hunt,215,Ballots Cast,,,,2462,1126,1336
 Hunt,215,Straight Party,,REP,Republican Party,1243,608,635
 Hunt,215,Straight Party,,REP,Over Votes,0,0,0
 Hunt,215,Straight Party,,REP,Under Votes,0,0,0
@@ -2120,7 +2120,7 @@ Hunt,215,"Constable, Precinct No. 1",,REP,Under Votes,0,0,0
 Hunt,215,"Constable, Precinct No. 1",,REP,Terry Jones,1872,888,984
 Hunt,215,"Constable, Precinct No. 1",,DEM,Glenn Stone,445,180,265
 Hunt,216,Registered Voters,,REP,,1621,,
-Hunt,216,Ballots Cast,,,,988,312,676,
+Hunt,216,Ballots Cast,,,,988,312,676
 Hunt,216,Straight Party,,REP,Republican Party,480,160,320
 Hunt,216,Straight Party,,REP,Over Votes,0,0,0
 Hunt,216,Straight Party,,REP,Under Votes,0,0,0
@@ -2256,7 +2256,7 @@ Hunt,216,"Constable, Precinct No. 4",,REP,Over Votes,0,0,0
 Hunt,216,"Constable, Precinct No. 4",,REP,Under Votes,0,0,0
 Hunt,216,"Constable, Precinct No. 4",,REP,Kent Layton,752,235,517
 Hunt,217,Registered Voters,,REP,,1316,,
-Hunt,217,Ballots Cast,,,,879,252,627,
+Hunt,217,Ballots Cast,,,,879,252,627
 Hunt,217,Straight Party,,REP,Republican Party,490,155,335
 Hunt,217,Straight Party,,REP,Over Votes,0,0,0
 Hunt,217,Straight Party,,REP,Under Votes,0,0,0
@@ -2392,7 +2392,7 @@ Hunt,217,"Constable, Precinct No. 4",,REP,Over Votes,0,0,0
 Hunt,217,"Constable, Precinct No. 4",,REP,Under Votes,0,0,0
 Hunt,217,"Constable, Precinct No. 4",,REP,Kent Layton,690,193,497
 Hunt,318,Registered Voters,,REP,,666,,
-Hunt,318,Ballots Cast,,,,389,175,214,
+Hunt,318,Ballots Cast,,,,389,175,214
 Hunt,318,Straight Party,,REP,Republican Party,185,87,98
 Hunt,318,Straight Party,,REP,Over Votes,0,0,0
 Hunt,318,Straight Party,,REP,Under Votes,0,0,0
@@ -2535,7 +2535,7 @@ Hunt,318,"Constable, Precinct No. 1",,REP,Under Votes,0,0,0
 Hunt,318,"Constable, Precinct No. 1",,REP,Terry Jones,298,136,162
 Hunt,318,"Constable, Precinct No. 1",,DEM,Glenn Stone,70,29,41
 Hunt,319,Registered Voters,,REP,,1586,,
-Hunt,319,Ballots Cast,,,,874,288,586,
+Hunt,319,Ballots Cast,,,,874,288,586
 Hunt,319,Straight Party,,REP,Republican Party,385,138,247
 Hunt,319,Straight Party,,REP,Over Votes,0,0,0
 Hunt,319,Straight Party,,REP,Under Votes,0,0,0
@@ -2678,7 +2678,7 @@ Hunt,319,"Constable, Precinct No. 1",,REP,Under Votes,0,0,0
 Hunt,319,"Constable, Precinct No. 1",,REP,Terry Jones,645,226,419
 Hunt,319,"Constable, Precinct No. 1",,DEM,Glenn Stone,176,47,129
 Hunt,320,Registered Voters,,REP,,2399,,
-Hunt,320,Ballots Cast,,,,631,187,444,
+Hunt,320,Ballots Cast,,,,631,187,444
 Hunt,320,Straight Party,,REP,Republican Party,292,101,191
 Hunt,320,Straight Party,,REP,Over Votes,0,0,0
 Hunt,320,Straight Party,,REP,Under Votes,0,0,0
@@ -2817,7 +2817,7 @@ Hunt,320,"Constable, Precinct No. 4",,REP,Over Votes,0,0,0
 Hunt,320,"Constable, Precinct No. 4",,REP,Under Votes,0,0,0
 Hunt,320,"Constable, Precinct No. 4",,REP,Kent Layton,473,150,323
 Hunt,321,Registered Voters,,REP,,1320,,
-Hunt,321,Ballots Cast,,,,640,148,492,
+Hunt,321,Ballots Cast,,,,640,148,492
 Hunt,321,Straight Party,,REP,Republican Party,312,74,238
 Hunt,321,Straight Party,,REP,Over Votes,0,0,0
 Hunt,321,Straight Party,,REP,Under Votes,0,0,0
@@ -2956,7 +2956,7 @@ Hunt,321,"Constable, Precinct No. 4",,REP,Over Votes,0,0,0
 Hunt,321,"Constable, Precinct No. 4",,REP,Under Votes,0,0,0
 Hunt,321,"Constable, Precinct No. 4",,REP,Kent Layton,489,110,379
 Hunt,322,Registered Voters,,REP,,1152,,
-Hunt,322,Ballots Cast,,,,511,132,379,
+Hunt,322,Ballots Cast,,,,511,132,379
 Hunt,322,Straight Party,,REP,Republican Party,226,61,165
 Hunt,322,Straight Party,,REP,Over Votes,0,0,0
 Hunt,322,Straight Party,,REP,Under Votes,0,0,0
@@ -3095,7 +3095,7 @@ Hunt,322,"Constable, Precinct No. 4",,REP,Over Votes,0,0,0
 Hunt,322,"Constable, Precinct No. 4",,REP,Under Votes,0,0,0
 Hunt,322,"Constable, Precinct No. 4",,REP,Kent Layton,376,100,276
 Hunt,323,Registered Voters,,REP,,2278,,
-Hunt,323,Ballots Cast,,,,1331,724,607,
+Hunt,323,Ballots Cast,,,,1331,724,607
 Hunt,323,Straight Party,,REP,Republican Party,630,352,278
 Hunt,323,Straight Party,,REP,Over Votes,0,0,0
 Hunt,323,Straight Party,,REP,Under Votes,0,0,0
@@ -3234,7 +3234,7 @@ Hunt,323,"Constable, Precinct No. 4",,REP,Over Votes,0,0,0
 Hunt,323,"Constable, Precinct No. 4",,REP,Under Votes,0,0,0
 Hunt,323,"Constable, Precinct No. 4",,REP,Kent Layton,1061,589,472
 Hunt,324,Registered Voters,,REP,,1596,,
-Hunt,324,Ballots Cast,,,,1165,795,370,
+Hunt,324,Ballots Cast,,,,1165,795,370
 Hunt,324,Straight Party,,REP,Republican Party,550,381,169
 Hunt,324,Straight Party,,REP,Over Votes,0,0,0
 Hunt,324,Straight Party,,REP,Under Votes,0,0,0
@@ -3377,7 +3377,7 @@ Hunt,324,"Constable, Precinct No. 1",,REP,Under Votes,0,0,0
 Hunt,324,"Constable, Precinct No. 1",,REP,Terry Jones,901,615,286
 Hunt,324,"Constable, Precinct No. 1",,DEM,Glenn Stone,199,138,61
 Hunt,325,Registered Voters,,REP,,2308,,
-Hunt,325,Ballots Cast,,,,1659,1147,512,
+Hunt,325,Ballots Cast,,,,1659,1147,512
 Hunt,325,Straight Party,,REP,Republican Party,709,500,209
 Hunt,325,Straight Party,,REP,Over Votes,0,0,0
 Hunt,325,Straight Party,,REP,Under Votes,0,0,0
@@ -3520,7 +3520,7 @@ Hunt,325,"Constable, Precinct No. 1",,REP,Under Votes,0,0,0
 Hunt,325,"Constable, Precinct No. 1",,REP,Terry Jones,1289,919,370
 Hunt,325,"Constable, Precinct No. 1",,DEM,Glenn Stone,276,175,101
 Hunt,426,Registered Voters,,REP,,396,,
-Hunt,426,Ballots Cast,,,,249,79,170,
+Hunt,426,Ballots Cast,,,,249,79,170
 Hunt,426,Straight Party,,REP,Republican Party,81,32,49
 Hunt,426,Straight Party,,REP,Over Votes,0,0,0
 Hunt,426,Straight Party,,REP,Under Votes,0,0,0
@@ -3657,7 +3657,7 @@ Hunt,426,"Constable, Precinct No. 2",,REP,Under Votes,0,0,0
 Hunt,426,"Constable, Precinct No. 2",,REP,Charles Adams,151,52,99
 Hunt,426,"Constable, Precinct No. 2",,DEM,"Wayne ""Doc"" Pierce",92,26,66
 Hunt,427,Registered Voters,,REP,,2661,,
-Hunt,427,Ballots Cast,,,,1349,437,912,
+Hunt,427,Ballots Cast,,,,1349,437,912
 Hunt,427,Straight Party,,REP,Republican Party,317,104,213
 Hunt,427,Straight Party,,REP,Over Votes,0,0,0
 Hunt,427,Straight Party,,REP,Under Votes,0,0,0
@@ -3794,7 +3794,7 @@ Hunt,427,"Constable, Precinct No. 2",,REP,Under Votes,0,0,0
 Hunt,427,"Constable, Precinct No. 2",,REP,Charles Adams,570,185,385
 Hunt,427,"Constable, Precinct No. 2",,DEM,"Wayne ""Doc"" Pierce",710,223,487
 Hunt,428,Registered Voters,,REP,,1835,,
-Hunt,428,Ballots Cast,,,,990,331,659,
+Hunt,428,Ballots Cast,,,,990,331,659
 Hunt,428,Straight Party,,REP,Republican Party,241,79,162
 Hunt,428,Straight Party,,REP,Over Votes,0,0,0
 Hunt,428,Straight Party,,REP,Under Votes,0,0,0
@@ -3931,7 +3931,7 @@ Hunt,428,"Constable, Precinct No. 2",,REP,Under Votes,0,0,0
 Hunt,428,"Constable, Precinct No. 2",,REP,Charles Adams,470,165,305
 Hunt,428,"Constable, Precinct No. 2",,DEM,"Wayne ""Doc"" Pierce",471,145,326
 Hunt,429,Registered Voters,,REP,,351,,
-Hunt,429,Ballots Cast,,,,232,86,146,
+Hunt,429,Ballots Cast,,,,232,86,146
 Hunt,429,Straight Party,,REP,Republican Party,69,31,38
 Hunt,429,Straight Party,,REP,Over Votes,0,0,0
 Hunt,429,Straight Party,,REP,Under Votes,0,0,0
@@ -4068,7 +4068,7 @@ Hunt,429,"Constable, Precinct No. 2",,REP,Under Votes,0,0,0
 Hunt,429,"Constable, Precinct No. 2",,REP,Charles Adams,127,52,75
 Hunt,429,"Constable, Precinct No. 2",,DEM,"Wayne ""Doc"" Pierce",100,32,68
 Hunt,430,Registered Voters,,REP,,538,,
-Hunt,430,Ballots Cast,,,,279,192,87,
+Hunt,430,Ballots Cast,,,,279,192,87
 Hunt,430,Straight Party,,REP,Republican Party,101,77,24
 Hunt,430,Straight Party,,REP,Over Votes,0,0,0
 Hunt,430,Straight Party,,REP,Under Votes,0,0,0
@@ -4208,7 +4208,7 @@ Hunt,430,"Constable, Precinct No. 1",,REP,Under Votes,0,0,0
 Hunt,430,"Constable, Precinct No. 1",,REP,Terry Jones,198,145,53
 Hunt,430,"Constable, Precinct No. 1",,DEM,Glenn Stone,68,41,27
 Hunt,431,Registered Voters,,REP,,514,,
-Hunt,431,Ballots Cast,,,,289,171,118,
+Hunt,431,Ballots Cast,,,,289,171,118
 Hunt,431,Straight Party,,REP,Republican Party,93,69,24
 Hunt,431,Straight Party,,REP,Over Votes,0,0,0
 Hunt,431,Straight Party,,REP,Under Votes,0,0,0
@@ -4348,7 +4348,7 @@ Hunt,431,"Constable, Precinct No. 1",,REP,Under Votes,0,0,0
 Hunt,431,"Constable, Precinct No. 1",,REP,Terry Jones,181,117,64
 Hunt,431,"Constable, Precinct No. 1",,DEM,Glenn Stone,91,43,48
 Hunt,432,Registered Voters,,REP,,642,,
-Hunt,432,Ballots Cast,,,,428,210,218,
+Hunt,432,Ballots Cast,,,,428,210,218
 Hunt,432,Straight Party,,REP,Republican Party,200,99,101
 Hunt,432,Straight Party,,REP,Over Votes,0,0,0
 Hunt,432,Straight Party,,REP,Under Votes,0,0,0
@@ -4484,7 +4484,7 @@ Hunt,432,"Constable, Precinct No. 3",,REP,Over Votes,0,0,0
 Hunt,432,"Constable, Precinct No. 3",,REP,Under Votes,0,0,0
 Hunt,432,"Constable, Precinct No. 3",,REP,Don Morrison,350,170,180
 Hunt,433,Registered Voters,,REP,,2498,,
-Hunt,433,Ballots Cast,,,,1049,635,414,
+Hunt,433,Ballots Cast,,,,1049,635,414
 Hunt,433,Straight Party,,REP,Republican Party,146,91,55
 Hunt,433,Straight Party,,REP,Over Votes,0,0,0
 Hunt,433,Straight Party,,REP,Under Votes,0,0,0
@@ -4624,7 +4624,7 @@ Hunt,433,"Constable, Precinct No. 1",,REP,Under Votes,0,0,0
 Hunt,433,"Constable, Precinct No. 1",,REP,Terry Jones,212,131,81
 Hunt,433,"Constable, Precinct No. 1",,DEM,Glenn Stone,780,474,306
 Hunt,434,Registered Voters,,REP,,1185,,
-Hunt,434,Ballots Cast,,,,756,392,364,
+Hunt,434,Ballots Cast,,,,756,392,364
 Hunt,434,Straight Party,,REP,Republican Party,352,189,163
 Hunt,434,Straight Party,,REP,Over Votes,0,0,0
 Hunt,434,Straight Party,,REP,Under Votes,0,0,0
@@ -4764,7 +4764,7 @@ Hunt,434,"Constable, Precinct No. 1",,REP,Under Votes,0,0,0
 Hunt,434,"Constable, Precinct No. 1",,REP,Terry Jones,576,312,264
 Hunt,434,"Constable, Precinct No. 1",,DEM,Glenn Stone,138,52,86
 Hunt,318 SCU,Registered Voters,,REP,,56,,
-Hunt,318 SCU,Ballots Cast,,,,41,15,26,
+Hunt,318 SCU,Ballots Cast,,,,41,15,26
 Hunt,318 SCU,Straight Party,,REP,Republican Party,20,2,18
 Hunt,318 SCU,Straight Party,,REP,Over Votes,0,0,0
 Hunt,318 SCU,Straight Party,,REP,Under Votes,0,0,0
@@ -4913,7 +4913,7 @@ Hunt,318 SCU,"Cumby ISD Trustee, 3 Year Term",,"",Renee Seely,8,2,6
 Hunt,318 SCU,"Cumby ISD Trustee, 3 Year Term",,"",Tammy Giles,5,3,2
 Hunt,318 SCU,"Cumby ISD Trustee, 3 Year Term",,"",David Tremor,14,7,7
 Hunt,429 SCU,Registered Voters,,REP,,14,,
-Hunt,429 SCU,Ballots Cast,,,,11,3,8,
+Hunt,429 SCU,Ballots Cast,,,,11,3,8
 Hunt,429 SCU,Straight Party,,REP,Republican Party,6,2,4
 Hunt,429 SCU,Straight Party,,REP,Over Votes,0,0,0
 Hunt,429 SCU,Straight Party,,REP,Under Votes,0,0,0
@@ -5056,7 +5056,7 @@ Hunt,429 SCU,"Cumby ISD Trustee, 3 Year Term",,"",Renee Seely,0,0,0
 Hunt,429 SCU,"Cumby ISD Trustee, 3 Year Term",,"",Tammy Giles,4,1,3
 Hunt,429 SCU,"Cumby ISD Trustee, 3 Year Term",,"",David Tremor,6,0,6
 Hunt,434 SCU,Registered Voters,,REP,,28,,
-Hunt,434 SCU,Ballots Cast,,,,15,7,8,
+Hunt,434 SCU,Ballots Cast,,,,15,7,8
 Hunt,434 SCU,Straight Party,,REP,Republican Party,7,3,4
 Hunt,434 SCU,Straight Party,,REP,Over Votes,0,0,0
 Hunt,434 SCU,Straight Party,,REP,Under Votes,0,0,0
@@ -5202,7 +5202,7 @@ Hunt,434 SCU,"Cumby ISD Trustee, 3 Year Term",,"",Renee Seely,0,0,0
 Hunt,434 SCU,"Cumby ISD Trustee, 3 Year Term",,"",Tammy Giles,4,0,4
 Hunt,434 SCU,"Cumby ISD Trustee, 3 Year Term",,"",David Tremor,4,0,4
 Hunt,213 SBH,Registered Voters,,REP,,0,,
-Hunt,213 SBH,Ballots Cast,,,,2,0,2,
+Hunt,213 SBH,Ballots Cast,,,,2,0,2
 Hunt,213 SBH,Straight Party,,REP,Republican Party,0,0,0
 Hunt,213 SBH,Straight Party,,REP,Over Votes,0,0,0
 Hunt,213 SBH,Straight Party,,REP,Under Votes,0,0,0
@@ -5352,7 +5352,7 @@ Hunt,213 SBH,"Boles ISD Trustee, 2 Year Unexpired Term",,"",Over Votes,0,0,0
 Hunt,213 SBH,"Boles ISD Trustee, 2 Year Unexpired Term",,"",Under Votes,0,0,0
 Hunt,213 SBH,"Boles ISD Trustee, 2 Year Unexpired Term",,"",William Bacon,1,0,1
 Hunt,214 SBH,Registered Voters,,REP,,79,,
-Hunt,214 SBH,Ballots Cast,,,,18,16,2,
+Hunt,214 SBH,Ballots Cast,,,,18,16,2
 Hunt,214 SBH,Straight Party,,REP,Republican Party,6,5,1
 Hunt,214 SBH,Straight Party,,REP,Over Votes,0,0,0
 Hunt,214 SBH,Straight Party,,REP,Under Votes,0,0,0
@@ -5498,7 +5498,7 @@ Hunt,214 SBH,"Boles ISD Trustee, 2 Year Unexpired Term",,"",Over Votes,0,0,0
 Hunt,214 SBH,"Boles ISD Trustee, 2 Year Unexpired Term",,"",Under Votes,0,0,0
 Hunt,214 SBH,"Boles ISD Trustee, 2 Year Unexpired Term",,"",William Bacon,8,7,1
 Hunt,323 SBH,Registered Voters,,REP,,270,,
-Hunt,323 SBH,Ballots Cast,,,,141,56,85,
+Hunt,323 SBH,Ballots Cast,,,,141,56,85
 Hunt,323 SBH,Straight Party,,REP,Republican Party,80,38,42
 Hunt,323 SBH,Straight Party,,REP,Over Votes,0,0,0
 Hunt,323 SBH,Straight Party,,REP,Under Votes,0,0,0
@@ -5647,7 +5647,7 @@ Hunt,323 SBH,"Boles ISD Trustee, 2 Year Unexpired Term",,"",Over Votes,0,0,0
 Hunt,323 SBH,"Boles ISD Trustee, 2 Year Unexpired Term",,"",Under Votes,0,0,0
 Hunt,323 SBH,"Boles ISD Trustee, 2 Year Unexpired Term",,"",William Bacon,65,19,46
 Hunt,320 CWT,Registered Voters,,REP,,905,,
-Hunt,320 CWT,Ballots Cast,,,,457,112,345,
+Hunt,320 CWT,Ballots Cast,,,,457,112,345
 Hunt,320 CWT,Straight Party,,REP,Republican Party,157,54,103
 Hunt,320 CWT,Straight Party,,REP,Over Votes,0,0,0
 Hunt,320 CWT,Straight Party,,REP,Under Votes,0,0,0

--- a/2012/counties/20121106__tx__general__marion__precinct.csv
+++ b/2012/counties/20121106__tx__general__marion__precinct.csv
@@ -1,6 +1,6 @@
 county,precinct,office,district,party,candidate,votes,early_votes,election_day
 Marion,1,Registered Voters,,REP,,614,,
-Marion,1,Ballots Cast,,,,370,163,207,
+Marion,1,Ballots Cast,,,,370,163,207
 Marion,1,Straight Party,,REP,Republican Party,113,50,63
 Marion,1,Straight Party,,REP,Over Votes,0,0,0
 Marion,1,Straight Party,,REP,Under Votes,127,54,73
@@ -107,7 +107,7 @@ Marion,1,"Constable, Precinct No. 1",,REP,Under Votes,6,4,2
 Marion,1,"Constable, Precinct No. 1",,REP,Stephen Thomas,162,70,92
 Marion,1,"Constable, Precinct No. 1",,DEM,Jerry Dreesen,202,89,113
 Marion,2,Registered Voters,,REP,,1203,,
-Marion,2,Ballots Cast,,,,724,309,415,
+Marion,2,Ballots Cast,,,,724,309,415
 Marion,2,Straight Party,,REP,Republican Party,248,99,149
 Marion,2,Straight Party,,REP,Over Votes,0,0,0
 Marion,2,Straight Party,,REP,Under Votes,379,165,214
@@ -214,7 +214,7 @@ Marion,2,"Constable, Precinct No. 1",,REP,Under Votes,18,5,13
 Marion,2,"Constable, Precinct No. 1",,REP,Stephen Thomas,391,157,234
 Marion,2,"Constable, Precinct No. 1",,DEM,Jerry Dreesen,315,147,168
 Marion,3,Registered Voters,,REP,,521,,
-Marion,3,Ballots Cast,,,,380,181,199,
+Marion,3,Ballots Cast,,,,380,181,199
 Marion,3,Straight Party,,REP,Republican Party,155,72,83
 Marion,3,Straight Party,,REP,Over Votes,0,0,0
 Marion,3,Straight Party,,REP,Under Votes,157,79,78
@@ -317,7 +317,7 @@ Marion,3,"Constable, Precinct No. 1",,REP,Under Votes,14,3,11
 Marion,3,"Constable, Precinct No. 1",,REP,Stephen Thomas,190,92,98
 Marion,3,"Constable, Precinct No. 1",,DEM,Jerry Dreesen,176,86,90
 Marion,4,Registered Voters,,REP,,531,,
-Marion,4,Ballots Cast,,,,333,213,120,
+Marion,4,Ballots Cast,,,,333,213,120
 Marion,4,Straight Party,,REP,Republican Party,94,58,36
 Marion,4,Straight Party,,REP,Over Votes,0,0,0
 Marion,4,Straight Party,,REP,Under Votes,163,116,47
@@ -420,7 +420,7 @@ Marion,4,"Constable, Precinct No. 1",,REP,Under Votes,11,8,3
 Marion,4,"Constable, Precinct No. 1",,REP,Stephen Thomas,103,66,37
 Marion,4,"Constable, Precinct No. 1",,DEM,Jerry Dreesen,219,139,80
 Marion,5,Registered Voters,,REP,,712,,
-Marion,5,Ballots Cast,,,,486,250,236,
+Marion,5,Ballots Cast,,,,486,250,236
 Marion,5,Straight Party,,REP,Republican Party,156,86,70
 Marion,5,Straight Party,,REP,Over Votes,0,0,0
 Marion,5,Straight Party,,REP,Under Votes,237,132,105
@@ -523,7 +523,7 @@ Marion,5,"Constable, Precinct No. 1",,REP,Under Votes,13,8,5
 Marion,5,"Constable, Precinct No. 1",,REP,Stephen Thomas,198,99,99
 Marion,5,"Constable, Precinct No. 1",,DEM,Jerry Dreesen,275,143,132
 Marion,6,Registered Voters,,REP,,923,,
-Marion,6,Ballots Cast,,,,572,221,351,
+Marion,6,Ballots Cast,,,,572,221,351
 Marion,6,Straight Party,,REP,Republican Party,165,62,103
 Marion,6,Straight Party,,REP,Over Votes,0,0,0
 Marion,6,Straight Party,,REP,Under Votes,232,108,124
@@ -630,7 +630,7 @@ Marion,6,"Constable, Precinct No. 2",,REP,Under Votes,18,5,13
 Marion,6,"Constable, Precinct No. 2",,REP,Mel Wolverton,306,124,182
 Marion,6,"Constable, Precinct No. 2",,DEM,Tashia N. Wilson,248,92,156
 Marion,7,Registered Voters,,REP,,835,,
-Marion,7,Ballots Cast,,,,485,301,184,
+Marion,7,Ballots Cast,,,,485,301,184
 Marion,7,Straight Party,,REP,Republican Party,79,62,17
 Marion,7,Straight Party,,REP,Over Votes,0,0,0
 Marion,7,Straight Party,,REP,Under Votes,158,109,49
@@ -737,7 +737,7 @@ Marion,7,"Constable, Precinct No. 2",,REP,Under Votes,10,5,5
 Marion,7,"Constable, Precinct No. 2",,REP,Mel Wolverton,165,127,38
 Marion,7,"Constable, Precinct No. 2",,DEM,Tashia N. Wilson,310,169,141
 Marion,8,Registered Voters,,REP,,797,,
-Marion,8,Ballots Cast,,,,552,365,187,
+Marion,8,Ballots Cast,,,,552,365,187
 Marion,8,Straight Party,,REP,Republican Party,189,130,59
 Marion,8,Straight Party,,REP,Over Votes,0,0,0
 Marion,8,Straight Party,,REP,Under Votes,262,183,79
@@ -840,7 +840,7 @@ Marion,8,"Constable, Precinct No. 1",,REP,Under Votes,25,13,12
 Marion,8,"Constable, Precinct No. 1",,REP,Stephen Thomas,256,172,84
 Marion,8,"Constable, Precinct No. 1",,DEM,Jerry Dreesen,271,180,91
 Marion,9,Registered Voters,,REP,,427,,
-Marion,9,Ballots Cast,,,,248,93,155,
+Marion,9,Ballots Cast,,,,248,93,155
 Marion,9,Straight Party,,REP,Republican Party,94,33,61
 Marion,9,Straight Party,,REP,Over Votes,0,0,0
 Marion,9,Straight Party,,REP,Under Votes,109,39,70
@@ -943,7 +943,7 @@ Marion,9,"Constable, Precinct No. 1",,REP,Under Votes,12,1,11
 Marion,9,"Constable, Precinct No. 1",,REP,Stephen Thomas,152,56,96
 Marion,9,"Constable, Precinct No. 1",,DEM,Jerry Dreesen,84,36,48
 Marion,10,Registered Voters,,REP,,470,,
-Marion,10,Ballots Cast,,,,237,45,192,
+Marion,10,Ballots Cast,,,,237,45,192
 Marion,10,Straight Party,,REP,Republican Party,85,11,74
 Marion,10,Straight Party,,REP,Over Votes,0,0,0
 Marion,10,Straight Party,,REP,Under Votes,62,18,44

--- a/2012/counties/20121106__tx__general__wilbarger__precinct.csv
+++ b/2012/counties/20121106__tx__general__wilbarger__precinct.csv
@@ -1,6 +1,6 @@
 county,precinct,office,district,party,candidate,votes,early_votes,election_day
 Wilbarger,Precinct 1,Registered Voters,,REP,,1365,,
-Wilbarger,Precinct 1,Ballots Cast,,,,723,470,253,
+Wilbarger,Precinct 1,Ballots Cast,,,,723,470,253
 Wilbarger,Precinct 1,Straight Party,,REP,Republican,255,167,88
 Wilbarger,Precinct 1,Straight Party,,REP,Over Votes,0,0,0
 Wilbarger,Precinct 1,Straight Party,,REP,Under Votes,364,249,115
@@ -88,7 +88,7 @@ Wilbarger,Precinct 1,"Constable, Precinct 1",,REP,Under Votes,48,41,7
 Wilbarger,Precinct 1,"Constable, Precinct 1",,REP,Chris D. Bell,404,257,147
 Wilbarger,Precinct 1,"Constable, Precinct 1",,DEM,Bobby Martin,271,172,99
 Wilbarger,Precinct 7,Registered Voters,,REP,,393,,
-Wilbarger,Precinct 7,Ballots Cast,,,,248,142,106,
+Wilbarger,Precinct 7,Ballots Cast,,,,248,142,106
 Wilbarger,Precinct 7,Straight Party,,REP,Republican,100,57,43
 Wilbarger,Precinct 7,Straight Party,,REP,Over Votes,0,0,0
 Wilbarger,Precinct 7,Straight Party,,REP,Under Votes,142,83,59
@@ -172,7 +172,7 @@ Wilbarger,Precinct 7,"Constable, Precinct 2",,REP,Over Votes,0,0,0
 Wilbarger,Precinct 7,"Constable, Precinct 2",,REP,Under Votes,34,17,17
 Wilbarger,Precinct 7,"Constable, Precinct 2",,REP,"James S. ""Jim"" Riggins",214,125,89
 Wilbarger,Precinct 9,Registered Voters,,REP,,984,,
-Wilbarger,Precinct 9,Ballots Cast,,,,575,362,213,
+Wilbarger,Precinct 9,Ballots Cast,,,,575,362,213
 Wilbarger,Precinct 9,Straight Party,,REP,Republican,216,142,74
 Wilbarger,Precinct 9,Straight Party,,REP,Over Votes,0,0,0
 Wilbarger,Precinct 9,Straight Party,,REP,Under Votes,285,179,106
@@ -260,7 +260,7 @@ Wilbarger,Precinct 9,"Constable, Precinct 1",,REP,Under Votes,47,37,10
 Wilbarger,Precinct 9,"Constable, Precinct 1",,REP,Chris D. Bell,297,183,114
 Wilbarger,Precinct 9,"Constable, Precinct 1",,DEM,Bobby Martin,231,142,89
 Wilbarger,Precinct 19,Registered Voters,,REP,,1871,,
-Wilbarger,Precinct 19,Ballots Cast,,,,977,613,364,
+Wilbarger,Precinct 19,Ballots Cast,,,,977,613,364
 Wilbarger,Precinct 19,Straight Party,,REP,Republican,296,203,93
 Wilbarger,Precinct 19,Straight Party,,REP,Over Votes,0,0,0
 Wilbarger,Precinct 19,Straight Party,,REP,Under Votes,423,274,149
@@ -347,7 +347,7 @@ Wilbarger,Precinct 19,"Constable, Precinct 2",,REP,Over Votes,0,0,0
 Wilbarger,Precinct 19,"Constable, Precinct 2",,REP,Under Votes,356,212,144
 Wilbarger,Precinct 19,"Constable, Precinct 2",,REP,"James S. ""Jim"" Riggins",621,401,220
 Wilbarger,Precinct 20,Registered Voters,,REP,,1598,,
-Wilbarger,Precinct 20,Ballots Cast,,,,565,305,260,
+Wilbarger,Precinct 20,Ballots Cast,,,,565,305,260
 Wilbarger,Precinct 20,Straight Party,,REP,Republican,196,110,86
 Wilbarger,Precinct 20,Straight Party,,REP,Over Votes,0,0,0
 Wilbarger,Precinct 20,Straight Party,,REP,Under Votes,227,139,88
@@ -432,7 +432,7 @@ Wilbarger,Precinct 20,"Constable, Precinct 1",,REP,Under Votes,39,27,12
 Wilbarger,Precinct 20,"Constable, Precinct 1",,REP,Chris D. Bell,274,153,121
 Wilbarger,Precinct 20,"Constable, Precinct 1",,DEM,Bobby Martin,252,125,127
 Wilbarger,Precinct 21,Registered Voters,,REP,,1803,,
-Wilbarger,Precinct 21,Ballots Cast,,,,1101,760,341,
+Wilbarger,Precinct 21,Ballots Cast,,,,1101,760,341
 Wilbarger,Precinct 21,Straight Party,,REP,Republican,414,300,114
 Wilbarger,Precinct 21,Straight Party,,REP,Over Votes,0,0,0
 Wilbarger,Precinct 21,Straight Party,,REP,Under Votes,596,412,184

--- a/2018/counties/20181106__tx__general__shackelford__precinct.csv
+++ b/2018/counties/20181106__tx__general__shackelford__precinct.csv
@@ -1,6 +1,6 @@
 county,precinct,office,district,party,candidate,votes,early_voting,election_day
 Shackelford,101,Registered Voters,,REP,,538,,
-Shackelford,101,Ballots Cast,,,,314,241,73,
+Shackelford,101,Ballots Cast,,,,314,241,73
 Shackelford,101,Straight Party,,REP,Over Votes,1,1,0
 Shackelford,101,Straight Party,,REP,Under Votes,115,85,30
 Shackelford,101,Straight Party,,REP,Republican Party,182,142,40
@@ -53,7 +53,7 @@ Shackelford,101,District and County Clerk,,REP,Cheri Hawkins,305,234,71
 Shackelford,101,County Treasurer,,REP,Tammy Brown,298,231,67
 Shackelford,101,Justice of the Peace,,REP,James Breeden,293,228,65
 Shackelford,202,Registered Voters,,REP,,604,,
-Shackelford,202,Ballots Cast,,,,358,244,114,
+Shackelford,202,Ballots Cast,,,,358,244,114
 Shackelford,202,Straight Party,,REP,Over Votes,0,0,0
 Shackelford,202,Straight Party,,REP,Under Votes,125,80,45
 Shackelford,202,Straight Party,,REP,Republican Party,227,160,67
@@ -107,7 +107,7 @@ Shackelford,202,County Treasurer,,REP,Tammy Brown,342,237,105
 Shackelford,202,"County Commissioner, Precinct No. 2",,REP,Ace Reames,350,242,108
 Shackelford,202,Justice of the Peace,,REP,James Breeden,343,236,107
 Shackelford,303,Registered Voters,,REP,,287,,
-Shackelford,303,Ballots Cast,,,,146,71,75,
+Shackelford,303,Ballots Cast,,,,146,71,75
 Shackelford,303,Straight Party,,REP,Over Votes,0,0,0
 Shackelford,303,Straight Party,,REP,Under Votes,41,18,23
 Shackelford,303,Straight Party,,REP,Republican Party,100,51,49
@@ -160,7 +160,7 @@ Shackelford,303,District and County Clerk,,REP,Cheri Hawkins,139,66,73
 Shackelford,303,County Treasurer,,REP,Tammy Brown,135,66,69
 Shackelford,303,Justice of the Peace,,REP,James Breeden,136,67,69
 Shackelford,307,Registered Voters,,REP,,296,,
-Shackelford,307,Ballots Cast,,,,171,111,60,
+Shackelford,307,Ballots Cast,,,,171,111,60
 Shackelford,307,Straight Party,,REP,Over Votes,0,0,0
 Shackelford,307,Straight Party,,REP,Under Votes,56,38,18
 Shackelford,307,Straight Party,,REP,Republican Party,111,71,40
@@ -213,7 +213,7 @@ Shackelford,307,District and County Clerk,,REP,Cheri Hawkins,169,110,59
 Shackelford,307,County Treasurer,,REP,Tammy Brown,166,109,57
 Shackelford,307,Justice of the Peace,,REP,James Breeden,166,109,57
 Shackelford,404,Registered Voters,,REP,,40,,
-Shackelford,404,Ballots Cast,,,,23,4,19,
+Shackelford,404,Ballots Cast,,,,23,4,19
 Shackelford,404,Straight Party,,REP,Over Votes,0,0,0
 Shackelford,404,Straight Party,,REP,Under Votes,11,2,9
 Shackelford,404,Straight Party,,REP,Republican Party,12,2,10
@@ -267,7 +267,7 @@ Shackelford,404,County Treasurer,,REP,Tammy Brown,23,4,19
 Shackelford,404,"County Commissioner, Precinct No. 4",,REP,Cody Jordan,23,4,19
 Shackelford,404,Justice of the Peace,,REP,James Breeden,23,4,19
 Shackelford,405,Registered Voters,,REP,,238,,
-Shackelford,405,Ballots Cast,,,,120,23,97,
+Shackelford,405,Ballots Cast,,,,120,23,97
 Shackelford,405,Straight Party,,REP,Over Votes,0,0,0
 Shackelford,405,Straight Party,,REP,Under Votes,53,5,48
 Shackelford,405,Straight Party,,REP,Republican Party,63,16,47
@@ -321,7 +321,7 @@ Shackelford,405,County Treasurer,,REP,Tammy Brown,108,19,89
 Shackelford,405,"County Commissioner, Precinct No. 4",,REP,Cody Jordan,107,20,87
 Shackelford,405,Justice of the Peace,,REP,James Breeden,109,20,89
 Shackelford,406,Registered Voters,,REP,,285,,
-Shackelford,406,Ballots Cast,,,,162,115,47,
+Shackelford,406,Ballots Cast,,,,162,115,47
 Shackelford,406,Straight Party,,REP,Over Votes,0,0,0
 Shackelford,406,Straight Party,,REP,Under Votes,70,50,20
 Shackelford,406,Straight Party,,REP,Republican Party,83,57,26


### PR DESCRIPTION
This removes an extra column that appeared in the "Ballots Cast" rows in several files.