### PR TITLE
Update format tests

### DIFF
--- a/.github/workflows/format_tests.yml
+++ b/.github/workflows/format_tests.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/checkout@v2.3.4
       with:
         repository: openelections/openelections-format-tests
-        ref: v0.1.0
+        ref: v1.0.0
         path: format_tests
 
     - name: Run format tests


### PR DESCRIPTION
This updates the format tests to version [1.0.0](https://github.com/openelections/openelections-format-tests/releases/tag/v1.0.0).  The tests now verify that the "votes" column contains values that represent integers.  This reveals the following errors:

* 2018/counties/20180306__tx__primary__blanco__precinct.csv
  ```
  * There are 1 rows with votes that aren't integers:

          Headers: ['county', 'precinct', 'office', 'district', 'candidate', 'party', 'votes', 'early_voting', 'election_day']:
          Row 7: ['Blanco', '401', 'Registered Voters', '', '', '', '2.172', '', '']
  ```

* 2018/counties/_20180306__tx__primary__stonewall__precinct.csv
  ```
  * There are 2 rows with votes that aren't integers:

          Headers: ['county', 'precinct', 'office', 'district', 'candidate', 'party', 'votes', 'early_voting', 'election_day']:
          Row 193: ['Stonewall', '2', 'Commissioner of the General Land Office', '', 'George P. Bush', 'REP', '30.77', '2', '2']
          Row 196: ['Stonewall', 'Total', 'Commissioner of the General Land Office', '', 'George P. Bush', 'REP', '80.77', '15', '39']
  ```

* 2014/counties/20141104__tx__general__matagorda__precinct.csv
  ```
  * There are 4 rows with votes that aren't integers:

          Headers: ['county', 'precinct', 'office', 'district', 'candidate', 'party', 'votes', 'early_voting', 'election_day', 'provisional']:
          Row 694: ['Matagorda', '3B', 'Commissioner of Agriculture', '', 'David (Rocky) Palnquist', 'LIB', '3.56', '5', '0', '0']
          Row 695: ['Matagorda', '4', 'Commissioner of Agriculture', '', 'David (Rocky) Palnquist', 'LIB', '2.69', '2', '0', '0']
          Row 698: ['Matagorda', '7', 'Commissioner of Agriculture', '', 'David (Rocky) Palnquist', 'LIB', '5.88', '1', '0', '0']
          Row 701: ['Matagorda', '10', 'Commissioner of Agriculture', '', 'David (Rocky) Palnquist', 'LIB', '1.47', '0', '0', '0']
  ```