### PR TITLE
Fix spelling error in candidate name

### DIFF
--- a/2014/counties/20141104__tx__general__foard__precinct.csv
+++ b/2014/counties/20141104__tx__general__foard__precinct.csv
@@ -264,11 +264,11 @@
 264,Foard,301,Commissioner of Agriculture,,Jim Hogan,,10,20,30
 265,Foard,401,Commissioner of Agriculture,,Jim Hogan,,12,11,23
 266,Foard,Total,Commissioner of Agriculture,,Jim Hogan,,51,65,116
-267,Foard,101,Commissioner of Agriculture,,David (Rocky) Palnquist,,1,0,1
-268,Foard,201,Commissioner of Agriculture,,David (Rocky) Palnquist,,1,1,2
-269,Foard,301,Commissioner of Agriculture,,David (Rocky) Palnquist,,0,3,3
-270,Foard,401,Commissioner of Agriculture,,David (Rocky) Palnquist,,0,1,1
-271,Foard,Total,Commissioner of Agriculture,,David (Rocky) Palnquist,,2,5,7
+267,Foard,101,Commissioner of Agriculture,,David (Rocky) Palmquist,,1,0,1
+268,Foard,201,Commissioner of Agriculture,,David (Rocky) Palmquist,,1,1,2
+269,Foard,301,Commissioner of Agriculture,,David (Rocky) Palmquist,,0,3,3
+270,Foard,401,Commissioner of Agriculture,,David (Rocky) Palmquist,,0,1,1
+271,Foard,Total,Commissioner of Agriculture,,David (Rocky) Palmquist,,2,5,7
 272,Foard,101,Commissioner of Agriculture,,Kenneth Kendrick,,0,0,0
 273,Foard,201,Commissioner of Agriculture,,Kenneth Kendrick,,0,0,0
 274,Foard,301,Commissioner of Agriculture,,Kenneth Kendrick,,0,2,2

--- a/2014/counties/20141104__tx__general__matagorda__precinct.csv
+++ b/2014/counties/20141104__tx__general__matagorda__precinct.csv
@@ -683,25 +683,25 @@ Matagorda,10,Commissioner of Agriculture,,Jim Hogan,DEM,23,4,19,0
 Matagorda,12,Commissioner of Agriculture,,Jim Hogan,DEM,19,4,15,0
 Matagorda,13,Commissioner of Agriculture,,Jim Hogan,DEM,87,38,49,0
 Matagorda,Total,Commissioner of Agriculture,,Jim Hogan,DEM,2074,1125,946,2
-Matagorda,1A,Commissioner of Agriculture,,David (Rocky) Palnquist,LIB,21,15,6,0
-Matagorda,1B,Commissioner of Agriculture,,David (Rocky) Palnquist,LIB,28,23,5,0
-Matagorda,1C,Commissioner of Agriculture,,David (Rocky) Palnquist,LIB,1,0,1,0
-Matagorda,1D,Commissioner of Agriculture,,David (Rocky) Palnquist,LIB,7,5,2,0
-Matagorda,1E,Commissioner of Agriculture,,David (Rocky) Palnquist,LIB,8,5,3,0
-Matagorda,1F,Commissioner of Agriculture,,David (Rocky) Palnquist,LIB,5,2,3,0
-Matagorda,2,Commissioner of Agriculture,,David (Rocky) Palnquist,LIB,4,0,4,0
-Matagorda,3A,Commissioner of Agriculture,,David (Rocky) Palnquist,LIB,13,7,6,0
-Matagorda,3B,Commissioner of Agriculture,,David (Rocky) Palnquist,LIB,9,5,4,0
-Matagorda,4,Commissioner of Agriculture,,David (Rocky) Palnquist,LIB,11,2,9,0
-Matagorda,5,Commissioner of Agriculture,,David (Rocky) Palnquist,LIB,24,14,10,0
-Matagorda,6,Commissioner of Agriculture,,David (Rocky) Palnquist,LIB,14,3,11,0
-Matagorda,7,Commissioner of Agriculture,,David (Rocky) Palnquist,LIB,4,1,3,0
-Matagorda,8,Commissioner of Agriculture,,David (Rocky) Palnquist,LIB,5,3,2,0
-Matagorda,9,Commissioner of Agriculture,,David (Rocky) Palnquist,LIB,0,0,0,0
-Matagorda,10,Commissioner of Agriculture,,David (Rocky) Palnquist,LIB,2,0,2,0
-Matagorda,12,Commissioner of Agriculture,,David (Rocky) Palnquist,LIB,3,0,3,0
-Matagorda,13,Commissioner of Agriculture,,David (Rocky) Palnquist,LIB,0,0,0,0
-Matagorda,Total,Commissioner of Agriculture,,David (Rocky) Palnquist,LIB,147,85,56,0
+Matagorda,1A,Commissioner of Agriculture,,David (Rocky) Palmquist,LIB,21,15,6,0
+Matagorda,1B,Commissioner of Agriculture,,David (Rocky) Palmquist,LIB,28,23,5,0
+Matagorda,1C,Commissioner of Agriculture,,David (Rocky) Palmquist,LIB,1,0,1,0
+Matagorda,1D,Commissioner of Agriculture,,David (Rocky) Palmquist,LIB,7,5,2,0
+Matagorda,1E,Commissioner of Agriculture,,David (Rocky) Palmquist,LIB,8,5,3,0
+Matagorda,1F,Commissioner of Agriculture,,David (Rocky) Palmquist,LIB,5,2,3,0
+Matagorda,2,Commissioner of Agriculture,,David (Rocky) Palmquist,LIB,4,0,4,0
+Matagorda,3A,Commissioner of Agriculture,,David (Rocky) Palmquist,LIB,13,7,6,0
+Matagorda,3B,Commissioner of Agriculture,,David (Rocky) Palmquist,LIB,9,5,4,0
+Matagorda,4,Commissioner of Agriculture,,David (Rocky) Palmquist,LIB,11,2,9,0
+Matagorda,5,Commissioner of Agriculture,,David (Rocky) Palmquist,LIB,24,14,10,0
+Matagorda,6,Commissioner of Agriculture,,David (Rocky) Palmquist,LIB,14,3,11,0
+Matagorda,7,Commissioner of Agriculture,,David (Rocky) Palmquist,LIB,4,1,3,0
+Matagorda,8,Commissioner of Agriculture,,David (Rocky) Palmquist,LIB,5,3,2,0
+Matagorda,9,Commissioner of Agriculture,,David (Rocky) Palmquist,LIB,0,0,0,0
+Matagorda,10,Commissioner of Agriculture,,David (Rocky) Palmquist,LIB,2,0,2,0
+Matagorda,12,Commissioner of Agriculture,,David (Rocky) Palmquist,LIB,3,0,3,0
+Matagorda,13,Commissioner of Agriculture,,David (Rocky) Palmquist,LIB,0,0,0,0
+Matagorda,Total,Commissioner of Agriculture,,David (Rocky) Palmquist,LIB,147,85,56,0
 Matagorda,1A,Commissioner of Agriculture,,Kenneth Kendrick,GRN,13,7,6,0
 Matagorda,1B,Commissioner of Agriculture,,Kenneth Kendrick,GRN,10,6,4,0
 Matagorda,1C,Commissioner of Agriculture,,Kenneth Kendrick,GRN,3,2,1,0


### PR DESCRIPTION
This fixes a spelling error in a candidate name.  The [correct spelling](https://ballotpedia.org/Rocky_Palmquist) is Pal**m**quist.