### PR TITLE
Add back erroneously removed votes

### DIFF
--- a/2018/counties/_20180306__tx__primary__haskell__precinct.csv
+++ b/2018/counties/_20180306__tx__primary__haskell__precinct.csv
@@ -338,8 +338,8 @@ Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 6,Box 6,Early,0,1
 Haskell,U.S. Senate,Bruce Jacobson,REP,Pct. 7,Box 7,Early,0,1
 Haskell,U.S. Senate,Geraldine Sam,REP,Pct. 7,Box 7,Early,0,1
 Haskell,U.S. Senate,Rafael Cruz,REP,Pct. 7,Box 7,Early,8,1
-Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 7,Box 7,Early
-Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 7,Box 7,Early
+Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 7,Box 7,Early,0,3
+Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 7,Box 7,Early,0,0
 Haskell,U.S. Senate,Bruce Jacobson,REP,Pct. 8,Box 8,Early,0,0
 Haskell,U.S. Senate,Geraldine Sam,REP,Pct. 8,Box 8,Early,0,0
 Haskell,U.S. Senate,Rafael Cruz,REP,Pct. 8,Box 8,Early,8,0


### PR DESCRIPTION
This adds back some values that were accidentally removed in revision 0519b8b534.

Note that these are duplicate entries (in addition to several others) for Stefano de Stefano IV in Precinct 7, which will need to be reconciled separately.