### PR TITLE
Remove redundant columns with empty headers

### DIFF
--- a/2018/counties/_20180306__tx__primary__haskell__precinct.csv
+++ b/2018/counties/_20180306__tx__primary__haskell__precinct.csv
@@ -1,463 +1,463 @@
-county,office,candidate,party,precinct,,,early_voting,election_day
-Haskell,Commissioner of Agriculture,Kimberly Dawn Olson,DEM,Pct.1,Box 1,Early,1,4
-Haskell,Commissioner of Agriculture,Kimberly Dawn Olson,DEM,Pct.10,Box 10,Early,1,11
-Haskell,Commissioner of Agriculture,Kimberly Dawn Olson,DEM,Pct.2,Box 2,Early,10,17
-Haskell,Commissioner of Agriculture,Kimberly Dawn Olson,DEM,Pct.3,Box 3,Early,10,6
-Haskell,Commissioner of Agriculture,Kimberly Dawn Olson,DEM,Pct.4,Box 4,Early,1,4
-Haskell,Commissioner of Agriculture,Kimberly Dawn Olson,DEM,Pct.5,Box 5,Early,5,5
-Haskell,Commissioner of Agriculture,Kimberly Dawn Olson,DEM,Pct.6,Box 6,Early,3,6
-Haskell,Commissioner of Agriculture,Kimberly Dawn Olson,DEM,Pct.7,Box 7,Early,0,0
-Haskell,Commissioner of Agriculture,Kimberly Dawn Olson,DEM,Pct.8,Box 8,Early,2,6
-Haskell,Commissioner of Agriculture,Kimberly Dawn Olson,DEM,Pct.9,Box 9,Early,2,3
-Haskell,Railroad Commissioner,Christopher Cornell Spellmon,DEM,Pct.1,Box 1,Early,2,3
-Haskell,Railroad Commissioner,Roman James Alfred McAllen,DEM,Pct.1,Box 1,Early,0,2
-Haskell,Railroad Commissioner,Christopher Cornell Spellmon,DEM,Pct.10,Box 10,Early,1,3
-Haskell,Railroad Commissioner,Roman James Alfred McAllen,DEM,Pct.10,Box 10,Early,0,7
-Haskell,Railroad Commissioner,Christopher Cornell Spellmon,DEM,Pct.2,Box 2,Early,4,9
-Haskell,Railroad Commissioner,Roman James Alfred McAllen,DEM,Pct.2,Box 2,Early,3,7
-Haskell,Railroad Commissioner,Christopher Cornell Spellmon,DEM,Pct.3,Box 3,Early,8,6
-Haskell,Railroad Commissioner,Roman James Alfred McAllen,DEM,Pct.3,Box 3,Early,3,3
-Haskell,Railroad Commissioner,Christopher Cornell Spellmon,DEM,Pct.4,Box 4,Early,1,3
-Haskell,Railroad Commissioner,Roman James Alfred McAllen,DEM,Pct.4,Box 4,Early,0,1
-Haskell,Railroad Commissioner,Christopher Cornell Spellmon,DEM,Pct.5,Box 5,Early,1,3
-Haskell,Railroad Commissioner,Roman James Alfred McAllen,DEM,Pct.5,Box 5,Early,2,4
-Haskell,Railroad Commissioner,Christopher Cornell Spellmon,DEM,Pct.6,Box 6,Early,2,6
-Haskell,Railroad Commissioner,Roman James Alfred McAllen,DEM,Pct.6,Box 6,Early,0,1
-Haskell,Railroad Commissioner,Christopher Cornell Spellmon,DEM,Pct.7,Box 7,Early,0,0
-Haskell,Railroad Commissioner,Roman James Alfred McAllen,DEM,Pct.7,Box 7,Early,0,0
-Haskell,Railroad Commissioner,Christopher Cornell Spellmon,DEM,Pct.8,Box 8,Early,3,3
-Haskell,Railroad Commissioner,Roman James Alfred McAllen,DEM,Pct.8,Box 8,Early,0,2
-Haskell,Railroad Commissioner,Christopher Cornell Spellmon,DEM,Pct.9,Box 9,Early,1,1
-Haskell,Railroad Commissioner,Roman James Alfred McAllen,DEM,Pct.9,Box 9,Early,1,2
-Haskell,Commissioner of the General Land Office,Carl Allen Morgan,DEM,Pct.1,Box 1,Early,2,4
-Haskell,Commissioner of the General Land Office,Miguel Andr�s Suazo,DEM,Pct.1,Box 1,Early,0,1
-Haskell,Commissioner of the General Land Office,Carl Allen Morgan,DEM,Pct.10,Box 10,Early,1,9
-Haskell,Commissioner of the General Land Office,Miguel Andr�s Suazo,DEM,Pct.10,Box 10,Early,0,0
-Haskell,Commissioner of the General Land Office,Carl Allen Morgan,DEM,Pct.2,Box 2,Early,3,13
-Haskell,Commissioner of the General Land Office,Miguel Andr�s Suazo,DEM,Pct.2,Box 2,Early,5,5
-Haskell,Commissioner of the General Land Office,Carl Allen Morgan,DEM,Pct.3,Box 3,Early,7,4
-Haskell,Commissioner of the General Land Office,Miguel Andr�s Suazo,DEM,Pct.3,Box 3,Early,3,7
-Haskell,Commissioner of the General Land Office,Carl Allen Morgan,DEM,Pct.4,Box 4,Early,1,0
-Haskell,Commissioner of the General Land Office,Miguel Andr�s Suazo,DEM,Pct.4,Box 4,Early,1,4
-Haskell,Commissioner of the General Land Office,Miguel Andr�s Suazo,DEM,Pct.4,Box 4,Early,1,4
-Haskell,Commissioner of the General Land Office,Carl Allen Morgan,DEM,Pct.5,Box 5,Early,1,2
-Haskell,Commissioner of the General Land Office,Miguel Andr�s Suazo,DEM,Pct.5,Box 5,Early,1,2
-Haskell,Commissioner of the General Land Office,Carl Allen Morgan,DEM,Pct.6,Box 6,Early,0,6
-Haskell,Commissioner of the General Land Office,Miguel Andr�s Suazo,DEM,Pct.6,Box 6,Early,2,1
-Haskell,Commissioner of the General Land Office,Carl Allen Morgan,DEM,Pct.7,Box 7,Early,0,0
-Haskell,Commissioner of the General Land Office,Miguel Andr�s Suazo,DEM,Pct.7,Box 7,Early,0,0
-Haskell,Commissioner of the General Land Office,Carl Allen Morgan,DEM,Pct.8,Box 8,Early,3,3
-Haskell,Commissioner of the General Land Office,Miguel Andr�s Suazo,DEM,Pct.8,Box 8,Early,0,2
-Haskell,Commissioner of the General Land Office,Carl Allen Morgan,DEM,Pct.9,Box 9,Early,1,2
-Haskell,Commissioner of the General Land Office,Miguel Andr�s Suazo,DEM,Pct.9,Box 9,Early,1,1
-Haskell,U.S. Senate,Edward Wayne Kimbrough,DEM,Pct.1,Box 1,Early,1,4
-Haskell,U.S. Senate,Irasema Ramirez-Hernandez,DEM,Pct.1,Box 1,Early,1,0
-Haskell,U.S. Senate,Robert Francis O'Rourke,DEM,Pct.1,Box 1,Early,0,0
-Haskell,U.S. Senate,Edward Wayne Kimbrough,DEM,Pct.10,Box 10,Early,0,9
-Haskell,U.S. Senate,Irasema Ramirez-Hernandez,DEM,Pct.10,Box 10,Early,0,0
-Haskell,U.S. Senate,Robert Francis O'Rourke,DEM,Pct.10,Box 10,Early,1,2
-Haskell,U.S. Senate,Edward Wayne Kimbrough,DEM,Pct.2,Box 2,Early,4,8
-Haskell,U.S. Senate,Irasema Ramirez-Hernandez,DEM,Pct.2,Box 2,Early,1,4
-Haskell,U.S. Senate,Robert Francis O'Rourke,DEM,Pct.2,Box 2,Early,4,6
-Haskell,U.S. Senate,Edward Wayne Kimbrough,DEM,Pct.3,Box 3,Early,5,6
-Haskell,U.S. Senate,Irasema Ramirez-Hernandez,DEM,Pct.3,Box 3,Early,1,2
-Haskell,U.S. Senate,Robert Francis O'Rourke,DEM,Pct.3,Box 3,Early,7,4
-Haskell,U.S. Senate,Edward Wayne Kimbrough,DEM,Pct.4,Box 4,Early,1,0
-Haskell,U.S. Senate,Irasema Ramirez-Hernandez,DEM,Pct.4,Box 4,Early,0,1
-Haskell,U.S. Senate,Robert Francis O'Rourke,DEM,Pct.4,Box 4,Early,2,4
-Haskell,U.S. Senate,Edward Wayne Kimbrough,DEM,Pct.5,Box 5,Early,1,3
-Haskell,U.S. Senate,Irasema Ramirez-Hernandez,DEM,Pct.5,Box 5,Early,1,2
-Haskell,U.S. Senate,Robert Francis O'Rourke,DEM,Pct.5,Box 5,Early,2,0
-Haskell,U.S. Senate,Edward Wayne Kimbrough,DEM,Pct.6,Box 6,Early,1,1
-Haskell,U.S. Senate,Irasema Ramirez-Hernandez,DEM,Pct.6,Box 6,Early,1,1
-Haskell,U.S. Senate,Robert Francis O'Rourke,DEM,Pct.6,Box 6,Early,0,5
-Haskell,U.S. Senate,Edward Wayne Kimbrough,DEM,Pct.7,Box 7,Early,0,0
-Haskell,U.S. Senate,Irasema Ramirez-Hernandez,DEM,Pct.7,Box 7,Early,0,0
-Haskell,U.S. Senate,Robert Francis O'Rourke,DEM,Pct.7,Box 7,Early,0,0
-Haskell,U.S. Senate,Edward Wayne Kimbrough,DEM,Pct.8,Box 8,Early,3,2
-Haskell,U.S. Senate,Irasema Ramirez-Hernandez,DEM,Pct.8,Box 8,Early,0,1
-Haskell,U.S. Senate,Robert Francis O'Rourke,DEM,Pct.8,Box 8,Early,0,3
-Haskell,U.S. Senate,Edward Wayne Kimbrough,DEM,Pct.9,Box 9,Early,1,1
-Haskell,U.S. Senate,Irasema Ramirez-Hernandez,DEM,Pct.9,Box 9,Early,0,0
-Haskell,U.S. Senate,Robert Francis O'Rourke,DEM,Pct.9,Box 9,Early,1,2
-Haskell,Governor,Adrian Ocegueda,DEM,Pct.1,Box 1,Early,0,0
-Haskell,Governor,"Cedric Wayne Davis, Sr.",DEM,Pct.1,Box 1,Early,0,0
-Haskell,Governor,Grady Yarbrough,DEM,Pct.1,Box 1,Early,0,1
-Haskell,Governor,Guadalupe Valdez,DEM,Pct.1,Box 1,Early,0,1
-Haskell,Governor,James Jolly Clark,DEM,Pct.1,Box 1,Early,0,1
-Haskell,Governor,Jeffrey Alan Payne,DEM,Pct.1,Box 1,Early,0,0
-Haskell,Governor,Joseph William Mumbach,DEM,Pct.1,Box 1,Early,0,0
-Haskell,Governor,Robert Andrew White,DEM,Pct.1,Box 1,Early,2,2
-Haskell,Governor,Thomas John Wakely,DEM,Pct.1,Box 1,Early,0,0
-Haskell,Governor,Adrian Ocegueda,DEM,Pct.10,Box 10,Early,0,0
-Haskell,Governor,"Cedric Wayne Davis, Sr.",DEM,Pct.10,Box 10,Early,0,0
-Haskell,Governor,Grady Yarbrough,DEM,Pct.10,Box 10,Early,0,4
-Haskell,Governor,Guadalupe Valdez,DEM,Pct.10,Box 10,Early,0,1
-Haskell,Governor,James Jolly Clark,DEM,Pct.10,Box 10,Early,0,4
-Haskell,Governor,Jeffrey Alan Payne,DEM,Pct.10,Box 10,Early,0,0
-Haskell,Governor,Joseph William Mumbach,DEM,Pct.10,Box 10,Early,0,0
-Haskell,Governor,Robert Andrew White,DEM,Pct.10,Box 10,Early,1,4
-Haskell,Governor,Thomas John Wakely,DEM,Pct.10,Box 10,Early,0,0
-Haskell,Governor,Adrian Ocegueda,DEM,Pct.2,Box 2,Early,0,1
-Haskell,Governor,"Cedric Wayne Davis, Sr.",DEM,Pct.2,Box 2,Early,1,0
-Haskell,Governor,Grady Yarbrough,DEM,Pct.2,Box 2,Early,1,5
-Haskell,Governor,Guadalupe Valdez,DEM,Pct.2,Box 2,Early,1,3
-Haskell,Governor,James Jolly Clark,DEM,Pct.2,Box 2,Early,1,0
-Haskell,Governor,Jeffrey Alan Payne,DEM,Pct.2,Box 2,Early,0,0
-Haskell,Governor,Joseph William Mumbach,DEM,Pct.2,Box 2,Early,0,0
-Haskell,Governor,Robert Andrew White,DEM,Pct.2,Box 2,Early,5,10
-Haskell,Governor,Thomas John Wakely,DEM,Pct.2,Box 2,Early,0,0
-Haskell,Governor,Adrian Ocegueda,DEM,Pct.3,Box 3,Early,0,1
-Haskell,Governor,"Cedric Wayne Davis, Sr.",DEM,Pct.3,Box 3,Early,1,1
-Haskell,Governor,Grady Yarbrough,DEM,Pct.3,Box 3,Early,3,2
-Haskell,Governor,Guadalupe Valdez,DEM,Pct.3,Box 3,Early,2,0
-Haskell,Governor,James Jolly Clark,DEM,Pct.3,Box 3,Early,0,0
-Haskell,Governor,Jeffrey Alan Payne,DEM,Pct.3,Box 3,Early,0,0
-Haskell,Governor,Joseph William Mumbach,DEM,Pct.3,Box 3,Early,0,0
-Haskell,Governor,Robert Andrew White,DEM,Pct.3,Box 3,Early,5,3
-Haskell,Governor,Thomas John Wakely,DEM,Pct.3,Box 3,Early,1,1
-Haskell,Governor,Adrian Ocegueda,DEM,Pct.4,Box 4,Early,0,0
-Haskell,Governor,"Cedric Wayne Davis, Sr.",DEM,Pct.4,Box 4,Early,0,0
-Haskell,Governor,Grady Yarbrough,DEM,Pct.4,Box 4,Early,1,1
-Haskell,Governor,Guadalupe Valdez,DEM,Pct.4,Box 4,Early,0,2
-Haskell,Governor,James Jolly Clark,DEM,Pct.4,Box 4,Early,0,0
-Haskell,Governor,Jeffrey Alan Payne,DEM,Pct.4,Box 4,Early,0,0
-Haskell,Governor,Joseph William Mumbach,DEM,Pct.4,Box 4,Early,0,0
-Haskell,Governor,Robert Andrew White,DEM,Pct.4,Box 4,Early,2,2
-Haskell,Governor,Thomas John Wakely,DEM,Pct.4,Box 4,Early,0,0
-Haskell,Governor,Adrian Ocegueda,DEM,Pct.5,Box 5,Early,0,0
-Haskell,Governor,"Cedric Wayne Davis, Sr.",DEM,Pct.5,Box 5,Early,0,0
-Haskell,Governor,Grady Yarbrough,DEM,Pct.5,Box 5,Early,0,1
-Haskell,Governor,Guadalupe Valdez,DEM,Pct.5,Box 5,Early,0,0
-Haskell,Governor,James Jolly Clark,DEM,Pct.5,Box 5,Early,1,1
-Haskell,Governor,Jeffrey Alan Payne,DEM,Pct.5,Box 5,Early,0,1
-Haskell,Governor,Joseph William Mumbach,DEM,Pct.5,Box 5,Early,0,1
-Haskell,Governor,Robert Andrew White,DEM,Pct.5,Box 5,Early,1,4
-Haskell,Governor,Thomas John Wakely,DEM,Pct.5,Box 5,Early,0,0
-Haskell,Governor,Adrian Ocegueda,DEM,Pct.6,Box 6,Early,0,1
-Haskell,Governor,"Cedric Wayne Davis, Sr.",DEM,Pct.6,Box 6,Early,0,0
-Haskell,Governor,Grady Yarbrough,DEM,Pct.6,Box 6,Early,0,2
-Haskell,Governor,Guadalupe Valdez,DEM,Pct.6,Box 6,Early,2,1
-Haskell,Governor,James Jolly Clark,DEM,Pct.6,Box 6,Early,0,0
-Haskell,Governor,Jeffrey Alan Payne,DEM,Pct.6,Box 6,Early,0,0
-Haskell,Governor,Joseph William Mumbach,DEM,Pct.6,Box 6,Early,0,0
-Haskell,Governor,Robert Andrew White,DEM,Pct.6,Box 6,Early,1,3
-Haskell,Governor,Thomas John Wakely,DEM,Pct.6,Box 6,Early,0,1
-Haskell,Governor,Adrian Ocegueda,DEM,Pct.7,Box 7,Early,0,0
-Haskell,Governor,"Cedric Wayne Davis, Sr.",DEM,Pct.7,Box 7,Early,0,0
-Haskell,Governor,Grady Yarbrough,DEM,Pct.7,Box 7,Early,0,0
-Haskell,Governor,Guadalupe Valdez,DEM,Pct.7,Box 7,Early,0,0
-Haskell,Governor,James Jolly Clark,DEM,Pct.7,Box 7,Early,0,0
-Haskell,Governor,Jeffrey Alan Payne,DEM,Pct.7,Box 7,Early,0,0
-Haskell,Governor,Joseph William Mumbach,DEM,Pct.7,Box 7,Early,0,0
-Haskell,Governor,Robert Andrew White,DEM,Pct.7,Box 7,Early,0,0
-Haskell,Governor,Thomas John Wakely,DEM,Pct.7,Box 7,Early,0,0
-Haskell,Governor,Adrian Ocegueda,DEM,Pct.8,Box 8,Early,0,0
-Haskell,Governor,"Cedric Wayne Davis, Sr.",DEM,Pct.8,Box 8,Early,0,0
-Haskell,Governor,Grady Yarbrough,DEM,Pct.8,Box 8,Early,2,0
-Haskell,Governor,Guadalupe Valdez,DEM,Pct.8,Box 8,Early,0,3
-Haskell,Governor,James Jolly Clark,DEM,Pct.8,Box 8,Early,0,0
-Haskell,Governor,Jeffrey Alan Payne,DEM,Pct.8,Box 8,Early,0,0
-Haskell,Governor,Joseph William Mumbach,DEM,Pct.8,Box 8,Early,0,0
-Haskell,Governor,Robert Andrew White,DEM,Pct.8,Box 8,Early,1,1
-Haskell,Governor,Thomas John Wakely,DEM,Pct.8,Box 8,Early,0,0
-Haskell,Governor,Adrian Ocegueda,DEM,Pct.9,Box 9,Early,0,0
-Haskell,Governor,"Cedric Wayne Davis, Sr.",DEM,Pct.9,Box 9,Early,0,0
-Haskell,Governor,Grady Yarbrough,DEM,Pct.9,Box 9,Early,1,0
-Haskell,Governor,Guadalupe Valdez,DEM,Pct.9,Box 9,Early,0,0
-Haskell,Governor,James Jolly Clark,DEM,Pct.9,Box 9,Early,0,0
-Haskell,Governor,Jeffrey Alan Payne,DEM,Pct.9,Box 9,Early,0,1
-Haskell,Governor,Joseph William Mumbach,DEM,Pct.9,Box 9,Early,0,0
-Haskell,Governor,Robert Andrew White,DEM,Pct.9,Box 9,Early,1,2
-Haskell,Governor,Thomas John Wakely,DEM,Pct.9,Box 9,Early,0,0
-Haskell,Lieutenant Governor,Michael Cooper,DEM,Pct.1,Box 1,Early,1,3
-Haskell,Lieutenant Governor,Michael Edward Collier,DEM,Pct.1,Box 1,Early,1,2
-Haskell,Lieutenant Governor,Michael Cooper,DEM,Pct.10,Box 10,Early,0,4
-Haskell,Lieutenant Governor,Michael Edward Collier,DEM,Pct.10,Box 10,Early,1,9
-Haskell,Lieutenant Governor,Michael Cooper,DEM,Pct.2,Box 2,Early,1,10
-Haskell,Lieutenant Governor,Michael Edward Collier,DEM,Pct.2,Box 2,Early,6,9
-Haskell,Lieutenant Governor,Michael Cooper,DEM,Pct.3,Box 3,Early,3,6
-Haskell,Lieutenant Governor,Michael Edward Collier,DEM,Pct.3,Box 3,Early,9,3
-Haskell,Lieutenant Governor,Michael Cooper,DEM,Pct.4,Box 4,Early,3,2
-Haskell,Lieutenant Governor,Michael Edward Collier,DEM,Pct.4,Box 4,Early,0,3
-Haskell,Lieutenant Governor,Michael Cooper,DEM,Pct.5,Box 5,Early,1,2
-Haskell,Lieutenant Governor,Michael Edward Collier,DEM,Pct.5,Box 5,Early,2,4
-Haskell,Lieutenant Governor,Michael Cooper,DEM,Pct.6,Box 6,Early,0,1
-Haskell,Lieutenant Governor,Michael Edward Collier,DEM,Pct.6,Box 6,Early,2,5
-Haskell,Lieutenant Governor,Michael Cooper,DEM,Pct.7,Box 7,Early,0,0
-Haskell,Lieutenant Governor,Michael Edward Collier,DEM,Pct.7,Box 7,Early,0,0
-Haskell,Lieutenant Governor,Michael Cooper,DEM,Pct.8,Box 8,Early,1,3
-Haskell,Lieutenant Governor,Michael Edward Collier,DEM,Pct.8,Box 8,Early,3,3
-Haskell,Lieutenant Governor,Michael Cooper,DEM,Pct.9,Box 9,Early,1,1
-Haskell,Lieutenant Governor,Michael Edward Collier,DEM,Pct.9,Box 9,Early,1,2
-Haskell,Comptroller of Public Accounts,Joi Lynne Chevalier,DEM,Pct.1,Box 1,Early,0,1
-Haskell,Comptroller of Public Accounts,Timothy Raymond Mahoney,DEM,Pct.1,Box 1,Early,2,3
-Haskell,Comptroller of Public Accounts,Joi Lynne Chevalier,DEM,Pct.10,Box 10,Early,0,0
-Haskell,Comptroller of Public Accounts,Timothy Raymond Mahoney,DEM,Pct.10,Box 10,Early,1,0
-Haskell,Comptroller of Public Accounts,Joi Lynne Chevalier,DEM,Pct.2,Box 2,Early,3,7
-Haskell,Comptroller of Public Accounts,Timothy Raymond Mahoney,DEM,Pct.2,Box 2,Early,5,11
-Haskell,Comptroller of Public Accounts,Joi Lynne Chevalier,DEM,Pct.3,Box 3,Early,1,4
-Haskell,Comptroller of Public Accounts,Timothy Raymond Mahoney,DEM,Pct.3,Box 3,Early,11,5
-Haskell,Comptroller of Public Accounts,Joi Lynne Chevalier,DEM,Pct.4,Box 4,Early,1,1
-Haskell,Comptroller of Public Accounts,Timothy Raymond Mahoney,DEM,Pct.4,Box 4,Early,2,4
-Haskell,Comptroller of Public Accounts,Joi Lynne Chevalier,DEM,Pct.5,Box 5,Early,1,0
-Haskell,Comptroller of Public Accounts,Timothy Raymond Mahoney,DEM,Pct.5,Box 5,Early,2,6
-Haskell,Comptroller of Public Accounts,Joi Lynne Chevalier,DEM,Pct.6,Box 6,Early,0,1
-Haskell,Comptroller of Public Accounts,Timothy Raymond Mahoney,DEM,Pct.6,Box 6,Early,0,6
-Haskell,Comptroller of Public Accounts,Joi Lynne Chevalier,DEM,Pct.7,Box 7,Early,0,0
-Haskell,Comptroller of Public Accounts,Timothy Raymond Mahoney,DEM,Pct.7,Box 7,Early,0,0
-Haskell,Comptroller of Public Accounts,Joi Lynne Chevalier,DEM,Pct.8,Box 8,Early,0,3
-Haskell,Comptroller of Public Accounts,Timothy Raymond Mahoney,DEM,Pct.8,Box 8,Early,3,2
-Haskell,Comptroller of Public Accounts,Joi Lynne Chevalier,DEM,Pct.9,Box 9,Early,1,1
-Haskell,Comptroller of Public Accounts,Timothy Raymond Mahoney,DEM,Pct.9,Box 9,Early,1,2
-Haskell,U. S. Representative District 19,Miguel Antonio Levario,DEM,Pct.1,Box 1,Early,0,3
-Haskell,U. S. Representative District 19,Miguel Antonio Levario,DEM,Pct.10,Box 10,Early,1,2
-Haskell,U. S. Representative District 19,Miguel Antonio Levario,DEM,Pct.2,Box 2,Early,9,16
-Haskell,U. S. Representative District 19,Miguel Antonio Levario,DEM,Pct.3,Box 3,Early,9,6
-Haskell,U. S. Representative District 19,Miguel Antonio Levario,DEM,Pct.4,Box 4,Early,2,5
-Haskell,U. S. Representative District 19,Miguel Antonio Levario,DEM,Pct.5,Box 5,Early,4,5
-Haskell,U. S. Representative District 19,Miguel Antonio Levario,DEM,Pct.6,Box 6,Early,2,5
-Haskell,U. S. Representative District 19,Miguel Antonio Levario,DEM,Pct.7,Box 7,Early,0,0
-Haskell,U. S. Representative District 19,Miguel Antonio Levario,DEM,Pct.8,Box 8,Early,2,4
-Haskell,U. S. Representative District 19,Miguel Antonio Levario,DEM,Pct.9,Box 9,Early,2,2
-Haskell,Attorney General,Justin Adatto Nelson,DEM,Pct.1,Box 1,Early,1,2
-Haskell,Attorney General,Justin Adatto Nelson,DEM,Pct.10,Box 10,Early,1,8
-Haskell,Attorney General,Justin Adatto Nelson,DEM,Pct.2,Box 2,Early,7,17
-Haskell,Attorney General,Justin Adatto Nelson,DEM,Pct.3,Box 3,Early,10,5
-Haskell,Attorney General,Justin Adatto Nelson,DEM,Pct.4,Box 4,Early,0,5
-Haskell,Attorney General,Justin Adatto Nelson,DEM,Pct.5,Box 5,Early,5,5
-Haskell,Attorney General,Justin Adatto Nelson,DEM,Pct.6,Box 6,Early,1,3
-Haskell,Attorney General,Justin Adatto Nelson,DEM,Pct.7,Box 7,Early,0,0
-Haskell,Attorney General,Justin Adatto Nelson,DEM,Pct.8,Box 8,Early,2,5
-Haskell,Attorney General,Justin Adatto Nelson,DEM,Pct.9,Box 9,Early,1,2
-Haskell,Commissioner of the General Land Office,George Bush,REP,Pct. 1,Box 1,Early,16,31
-Haskell,Commissioner of the General Land Office,Jerry Patterson,REP,Pct. 1,Box 1,Early,9,10
-Haskell,Commissioner of the General Land Office,Richard Range,REP,Pct. 1,Box 1,Early,1,5
-Haskell,Commissioner of the General Land Office,William Edwards,REP,Pct. 1,Box 1,Early,5,2
-Haskell,Commissioner of the General Land Office,George Bush,REP,Pct. 10,Box 10,Early,5,13
-Haskell,Commissioner of the General Land Office,Jerry Patterson,REP,Pct. 10,Box 10,Early,2,11
-Haskell,Commissioner of the General Land Office,Richard Range,REP,Pct. 10,Box 10,Early,2,1
-Haskell,Commissioner of the General Land Office,William Edwards,REP,Pct. 10,Box 10,Early,0,4
-Haskell,Commissioner of the General Land Office,George Bush,REP,Pct. 2,Box 2,Early,22,35
-Haskell,Commissioner of the General Land Office,Jerry Patterson,REP,Pct. 2,Box 2,Early,13,11
-Haskell,Commissioner of the General Land Office,Richard Range,REP,Pct. 2,Box 2,Early,8,2
-Haskell,Commissioner of the General Land Office,William Edwards,REP,Pct. 2,Box 2,Early,0,3
-Haskell,Commissioner of the General Land Office,George Bush,REP,Pct. 3,Box 3,Early,10,13
-Haskell,Commissioner of the General Land Office,Jerry Patterson,REP,Pct. 3,Box 3,Early,11,7
-Haskell,Commissioner of the General Land Office,Richard Range,REP,Pct. 3,Box 3,Early,3,3
-Haskell,Commissioner of the General Land Office,William Edwards,REP,Pct. 3,Box 3,Early,1,2
-Haskell,Commissioner of the General Land Office,George Bush,REP,Pct. 4,Box 4,Early,8,16
-Haskell,Commissioner of the General Land Office,Jerry Patterson,REP,Pct. 4,Box 4,Early,4,7
-Haskell,Commissioner of the General Land Office,Richard Range,REP,Pct. 4,Box 4,Early,3,1
-Haskell,Commissioner of the General Land Office,William Edwards,REP,Pct. 4,Box 4,Early,1,3
-Haskell,Commissioner of the General Land Office,George Bush,REP,Pct. 5,Box 5,Early,6,17
-Haskell,Commissioner of the General Land Office,Jerry Patterson,REP,Pct. 5,Box 5,Early,7,14
-Haskell,Commissioner of the General Land Office,Richard Range,REP,Pct. 5,Box 5,Early,2,3
-Haskell,Commissioner of the General Land Office,William Edwards,REP,Pct. 5,Box 5,Early,2,2
-Haskell,Commissioner of the General Land Office,George Bush,REP,Pct. 6,Box 6,Early,5,20
-Haskell,Commissioner of the General Land Office,Jerry Patterson,REP,Pct. 6,Box 6,Early,7,12
-Haskell,Commissioner of the General Land Office,Richard Range,REP,Pct. 6,Box 6,Early,0,4
-Haskell,Commissioner of the General Land Office,William Edwards,REP,Pct. 6,Box 6,Early,0,0
-Haskell,Commissioner of the General Land Office,George Bush,REP,Pct. 7,Box 7,Early,4,1
-Haskell,Commissioner of the General Land Office,Jerry Patterson,REP,Pct. 7,Box 7,Early,4,4
-Haskell,Commissioner of the General Land Office,Richard Range,REP,Pct. 7,Box 7,Early,0,2
-Haskell,Commissioner of the General Land Office,William Edwards,REP,Pct. 7,Box 7,Early,0,0
-Haskell,Commissioner of the General Land Office,George Bush,REP,Pct. 8,Box 8,Early,3,6
-Haskell,Commissioner of the General Land Office,Jerry Patterson,REP,Pct. 8,Box 8,Early,3,1
-Haskell,Commissioner of the General Land Office,Richard Range,REP,Pct. 8,Box 8,Early,0,1
-Haskell,Commissioner of the General Land Office,William Edwards,REP,Pct. 8,Box 8,Early,2,0
-Haskell,Commissioner of the General Land Office,George Bush,REP,Pct. 9,Box 9,Early,4,19
-Haskell,Commissioner of the General Land Office,Jerry Patterson,REP,Pct. 9,Box 9,Early,4,11
-Haskell,Commissioner of the General Land Office,Richard Range,REP,Pct. 9,Box 9,Early,1,1
-Haskell,Commissioner of the General Land Office,William Edwards,REP,Pct. 9,Box 9,Early,0,1
-Haskell,Commissioner of Agriculture,Jimmie Hogan,REP,Pct. 1,Box 1,Early,2,3
-Haskell,Commissioner of Agriculture,Sidney Miller,REP,Pct. 1,Box 1,Early,23,42
-Haskell,Commissioner of Agriculture,Trey Blocker,REP,Pct. 1,Box 1,Early,7,5
-Haskell,Commissioner of Agriculture,Jimmie Hogan,REP,Pct. 10,Box 10,Early,3,8
-Haskell,Commissioner of Agriculture,Sidney Miller,REP,Pct. 10,Box 10,Early,6,19
-Haskell,Commissioner of Agriculture,Trey Blocker,REP,Pct. 10,Box 10,Early,0,2
-Haskell,Commissioner of Agriculture,Jimmie Hogan,REP,Pct. 2,Box 2,Early,5,7
-Haskell,Commissioner of Agriculture,Sidney Miller,REP,Pct. 2,Box 2,Early,33,36
-Haskell,Commissioner of Agriculture,Trey Blocker,REP,Pct. 2,Box 2,Early,9,8
-Haskell,Commissioner of Agriculture,Jimmie Hogan,REP,Pct. 3,Box 3,Early,2,4
-Haskell,Commissioner of Agriculture,Sidney Miller,REP,Pct. 3,Box 3,Early,21,24
-Haskell,Commissioner of Agriculture,Trey Blocker,REP,Pct. 3,Box 3,Early,2,1
-Haskell,Commissioner of Agriculture,Jimmie Hogan,REP,Pct. 4,Box 4,Early,1,3
-Haskell,Commissioner of Agriculture,Sidney Miller,REP,Pct. 4,Box 4,Early,12,22
-Haskell,Commissioner of Agriculture,Trey Blocker,REP,Pct. 4,Box 4,Early,3,3
-Haskell,Commissioner of Agriculture,Jimmie Hogan,REP,Pct. 5,Box 5,Early,1,9
-Haskell,Commissioner of Agriculture,Sidney Miller,REP,Pct. 5,Box 5,Early,13,26
-Haskell,Commissioner of Agriculture,Trey Blocker,REP,Pct. 5,Box 5,Early,3,1
-Haskell,Commissioner of Agriculture,Jimmie Hogan,REP,Pct. 6,Box 6,Early,5,6
-Haskell,Commissioner of Agriculture,Sidney Miller,REP,Pct. 6,Box 6,Early,5,30
-Haskell,Commissioner of Agriculture,Trey Blocker,REP,Pct. 6,Box 6,Early,2,5
-Haskell,Commissioner of Agriculture,Jimmie Hogan,REP,Pct. 7,Box 7,Early,0,3
-Haskell,Commissioner of Agriculture,Sidney Miller,REP,Pct. 7,Box 7,Early,8,2
-Haskell,Commissioner of Agriculture,Trey Blocker,REP,Pct. 7,Box 7,Early,0,1
-Haskell,Commissioner of Agriculture,Jimmie Hogan,REP,Pct. 8,Box 8,Early,0,2
-Haskell,Commissioner of Agriculture,Sidney Miller,REP,Pct. 8,Box 8,Early,5,4
-Haskell,Commissioner of Agriculture,Trey Blocker,REP,Pct. 8,Box 8,Early,3,1
-Haskell,Commissioner of Agriculture,Jimmie Hogan,REP,Pct. 9,Box 9,Early,0,3
-Haskell,Commissioner of Agriculture,Sidney Miller,REP,Pct. 9,Box 9,Early,7,24
-Haskell,Commissioner of Agriculture,Trey Blocker,REP,Pct. 9,Box 9,Early,0,5
-Haskell,U.S. Senate,Bruce Jacobson,REP,Pct. 1,Box 1,Early,1,0
-Haskell,U.S. Senate,Geraldine Sam,REP,Pct. 1,Box 1,Early,2,0
-Haskell,U.S. Senate,Mary Miller,REP,Pct. 1,Box 1,Early,0,1
-Haskell,U.S. Senate,Rafael Cruz,REP,Pct. 1,Box 1,Early,29,53
-Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 1,Box 1,Early,0,0
-Haskell,U.S. Senate,Bruce Jacobson,REP,Pct. 10,Box 10,Early,10,4
-Haskell,U.S. Senate,Geraldine Sam,REP,Pct. 10,Box 10,Early,0,0
-Haskell,U.S. Senate,Mary Miller,REP,Pct. 10,Box 10,Early,0,1
-Haskell,U.S. Senate,Rafael Cruz,REP,Pct. 10,Box 10,Early,9,25
-Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 10,Box 10,Early,0,0
-Haskell,U.S. Senate,Bruce Jacobson,REP,Pct. 2,Box 2,Early,7,5
-Haskell,U.S. Senate,Geraldine Sam,REP,Pct. 2,Box 2,Early,0,6
-Haskell,U.S. Senate,Mary Miller,REP,Pct. 2,Box 2,Early,2,3
-Haskell,U.S. Senate,Rafael Cruz,REP,Pct. 2,Box 2,Early,37,40
-Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 2,Box 2,Early,3,3
-Haskell,U.S. Senate,Bruce Jacobson,REP,Pct. 3,Box 3,Early,1,3
-Haskell,U.S. Senate,Geraldine Sam,REP,Pct. 3,Box 3,Early,0,0
-Haskell,U.S. Senate,Mary Miller,REP,Pct. 3,Box 3,Early,0,0
-Haskell,U.S. Senate,Rafael Cruz,REP,Pct. 3,Box 3,Early,22,25
-Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 3,Box 3,Early,1,1
-Haskell,U.S. Senate,Bruce Jacobson,REP,Pct. 4,Box 4,Early,0,1
-Haskell,U.S. Senate,Geraldine Sam,REP,Pct. 4,Box 4,Early,1,1
-Haskell,U.S. Senate,Rafael Cruz,REP,Pct. 4,Box 4,Early,14,0
-Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 4,Box 4,Early,0,26
-Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 4,Box 4,Early,0,0
-Haskell,U.S. Senate,Bruce Jacobson,REP,Pct. 5,Box 5,Early,1,5
-Haskell,U.S. Senate,Geraldine Sam,REP,Pct. 5,Box 5,Early,1,2
-Haskell,U.S. Senate,Rafael Cruz,REP,Pct. 5,Box 5,Early,13,4
-Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 5,Box 5,Early,1,27
-Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 5,Box 5,Early,1,0
-Haskell,U.S. Senate,Bruce Jacobson,REP,Pct. 6,Box 6,Early,1,3
-Haskell,U.S. Senate,Geraldine Sam,REP,Pct. 6,Box 6,Early,0,0
-Haskell,U.S. Senate,Rafael Cruz,REP,Pct. 6,Box 6,Early,10,0
-Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 6,Box 6,Early,0,35
-Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 6,Box 6,Early,0,1
-Haskell,U.S. Senate,Bruce Jacobson,REP,Pct. 7,Box 7,Early,0,1
-Haskell,U.S. Senate,Geraldine Sam,REP,Pct. 7,Box 7,Early,0,1
-Haskell,U.S. Senate,Rafael Cruz,REP,Pct. 7,Box 7,Early,8,1
-Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 7,Box 7,Early,0,3
-Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 7,Box 7,Early,0,0
-Haskell,U.S. Senate,Bruce Jacobson,REP,Pct. 8,Box 8,Early,0,0
-Haskell,U.S. Senate,Geraldine Sam,REP,Pct. 8,Box 8,Early,0,0
-Haskell,U.S. Senate,Rafael Cruz,REP,Pct. 8,Box 8,Early,8,0
-Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 8,Box 8,Early,0,7
-Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 8,Box 8,Early,0,1
-Haskell,U.S. Senate,Bruce Jacobson,REP,Pct. 9,Box 9,Early,0,7
-Haskell,U.S. Senate,Geraldine Sam,REP,Pct. 9,Box 9,Early,0,0
-Haskell,U.S. Senate,Rafael Cruz,REP,Pct. 9,Box 9,Early,9,3
-Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 9,Box 9,Early,0,24
-Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 9,Box 9,Early,0,0
-Haskell,U. S. Representative District 19,Jodey Arrington,REP,Pct. 1,Box 1,Early,31,
-Haskell,U. S. Representative District 19,Jodey Arrington,REP,Pct. 10,Box 10,Early,9,
-Haskell,U. S. Representative District 19,Jodey Arrington,REP,Pct. 2,Box 2,Early,47,
-Haskell,U. S. Representative District 19,Jodey Arrington,REP,Pct. 3,Box 3,Early,24,
-Haskell,U. S. Representative District 19,Jodey Arrington,REP,Pct. 4,Box 4,Early,15,
-Haskell,U. S. Representative District 19,Jodey Arrington,REP,Pct. 5,Box 5,Early,16,
-Haskell,U. S. Representative District 19,Jodey Arrington,REP,Pct. 6,Box 6,Early,10,
-Haskell,U. S. Representative District 19,Jodey Arrington,REP,Pct. 7,Box 7,Early,8,
-Haskell,U. S. Representative District 19,Jodey Arrington,REP,Pct. 8,Box 8,Early,8,
-Haskell,U. S. Representative District 19,Jodey Arrington,REP,Pct. 9,Box 9,Early,9,
-Haskell,Lieutenant Governor,Dan Patrick,REP,Pct. 1,Box 1,Early,22,
-Haskell,Lieutenant Governor,Scott Milder,REP,Pct. 1,Box 1,Early,15,
-Haskell,Lieutenant Governor,Dan Patrick,REP,Pct. 10,Box 10,Early,3,
-Haskell,Lieutenant Governor,Scott Milder,REP,Pct. 10,Box 10,Early,5,
-Haskell,Lieutenant Governor,Dan Patrick,REP,Pct. 2,Box 2,Early,19,
-Haskell,Lieutenant Governor,Scott Milder,REP,Pct. 2,Box 2,Early,31,
-Haskell,Lieutenant Governor,Dan Patrick,REP,Pct. 3,Box 3,Early,9,
-Haskell,Lieutenant Governor,Scott Milder,REP,Pct. 3,Box 3,Early,0,
-Haskell,Lieutenant Governor,Dan Patrick,REP,Pct. 4,Box 4,Early,6,
-Haskell,Lieutenant Governor,Scott Milder,REP,Pct. 4,Box 4,Early,10,
-Haskell,Lieutenant Governor,Dan Patrick,REP,Pct. 5,Box 5,Early,15,
-Haskell,Lieutenant Governor,Scott Milder,REP,Pct. 5,Box 5,Early,2,
-Haskell,Lieutenant Governor,Dan Patrick,REP,Pct. 6,Box 6,Early,6,
-Haskell,Lieutenant Governor,Scott Milder,REP,Pct. 6,Box 6,Early,6,
-Haskell,Lieutenant Governor,Dan Patrick,REP,Pct. 7,Box 7,Early,8,
-Haskell,Lieutenant Governor,Scott Milder,REP,Pct. 7,Box 7,Early,0,
-Haskell,Lieutenant Governor,Dan Patrick,REP,Pct. 8,Box 8,Early,5,
-Haskell,Lieutenant Governor,Scott Milder,REP,Pct. 8,Box 8,Early,3,
-Haskell,Lieutenant Governor,Dan Patrick,REP,Pct. 9,Box 9,Early,5,
-Haskell,Lieutenant Governor,Scott Milder,REP,Pct. 9,Box 9,Early,4,
-Haskell,State Representative District 68,Drew Springer Jr.,REP,Pct. 1,Box 1,Early,29,
-Haskell,State Representative District 68,Drew Springer Jr.,REP,Pct. 10,Box 10,Early,9,
-Haskell,State Representative District 68,Drew Springer Jr.,REP,Pct. 2,Box 2,Early,38,
-Haskell,State Representative District 68,Drew Springer Jr.,REP,Pct. 3,Box 3,Early,26,
-Haskell,State Representative District 68,Drew Springer Jr.,REP,Pct. 4,Box 4,Early,13,
-Haskell,State Representative District 68,Drew Springer Jr.,REP,Pct. 5,Box 5,Early,15,
-Haskell,State Representative District 68,Drew Springer Jr.,REP,Pct. 6,Box 6,Early,10,
-Haskell,State Representative District 68,Drew Springer Jr.,REP,Pct. 7,Box 7,Early,8,
-Haskell,State Representative District 68,Drew Springer Jr.,REP,Pct. 8,Box 8,Early,1,
-Haskell,State Representative District 68,Drew Springer Jr.,REP,Pct. 9,Box 9,Early,9,
-Haskell,Governor,Barbara Krueger,REP,Pct. 1,Box 1,Early,1,
-Haskell,Governor,Gregory Abbott,REP,Pct. 1,Box 1,Early,32,
-Haskell,Governor,Larry Kilgore,REP,Pct. 1,Box 1,Early,1,
-Haskell,Governor,Barbara Krueger,REP,Pct. 10,Box 10,Early,0,
-Haskell,Governor,Gregory Abbott,REP,Pct. 10,Box 10,Early,9,
-Haskell,Governor,Larry Kilgore,REP,Pct. 10,Box 10,Early,0,
-Haskell,Governor,Barbara Krueger,REP,Pct. 2,Box 2,Early,5,
-Haskell,Governor,Gregory Abbott,REP,Pct. 2,Box 2,Early,36,
-Haskell,Governor,Larry Kilgore,REP,Pct. 2,Box 2,Early,0,
-Haskell,Governor,Barbara Krueger,REP,Pct. 3,Box 3,Early,3,
-Haskell,Governor,Gregory Abbott,REP,Pct. 3,Box 3,Early,22,
-Haskell,Governor,Larry Kilgore,REP,Pct. 3,Box 3,Early,0,
-Haskell,Governor,Barbara Krueger,REP,Pct. 4,Box 4,Early,1,
-Haskell,Governor,Gregory Abbott,REP,Pct. 4,Box 4,Early,11,
-Haskell,Governor,Gregory Abbott,REP,Pct. 4,Box 4,Early,11,
-Haskell,Governor,Larry Kilgore,REP,Pct. 4,Box 4,Early,0,
-Haskell,Governor,Barbara Krueger,REP,Pct. 5,Box 5,Early,1,
-Haskell,Governor,Gregory Abbott,REP,Pct. 5,Box 5,Early,16,
-Haskell,Governor,Larry Kilgore,REP,Pct. 5,Box 5,Early,0,
-Haskell,Governor,Barbara Krueger,REP,Pct. 6,Box 6,Early,1,
-Haskell,Governor,Gregory Abbott,REP,Pct. 6,Box 6,Early,10,
-Haskell,Governor,Larry Kilgore,REP,Pct. 6,Box 6,Early,1,
-Haskell,Governor,Barbara Krueger,REP,Pct. 7,Box 7,Early,0,
-Haskell,Governor,Gregory Abbott,REP,Pct. 7,Box 7,Early,8,
-Haskell,Governor,Larry Kilgore,REP,Pct. 7,Box 7,Early,0,
-Haskell,Governor,Barbara Krueger,REP,Pct. 8,Box 8,Early,0,
-Haskell,Governor,Gregory Abbott,REP,Pct. 8,Box 8,Early,8,
-Haskell,Governor,Larry Kilgore,REP,Pct. 8,Box 8,Early,0,
-Haskell,Governor,Barbara Krueger,REP,Pct. 9,Box 9,Early,0,
-Haskell,Governor,Gregory Abbott,REP,Pct. 9,Box 9,Early,9,
-Haskell,Governor,Larry Kilgore,REP,Pct. 9,Box 9,Early,0,
-Haskell,Railroad Commissioner,Christi Craddick,REP,Pct. 1,Box 1,Early,21,
-Haskell,Railroad Commissioner,Weston Martinez,REP,Pct. 1,Box 1,Early,11,
-Haskell,Railroad Commissioner,Christi Craddick,REP,Pct. 10,Box 10,Early,7,
-Haskell,Railroad Commissioner,Weston Martinez,REP,Pct. 10,Box 10,Early,2,
-Haskell,Railroad Commissioner,Christi Craddick,REP,Pct. 2,Box 2,Early,31,
-Haskell,Railroad Commissioner,Weston Martinez,REP,Pct. 2,Box 2,Early,11,
-Haskell,Railroad Commissioner,Christi Craddick,REP,Pct. 3,Box 3,Early,21,
-Haskell,Railroad Commissioner,Weston Martinez,REP,Pct. 3,Box 3,Early,1,
-Haskell,Railroad Commissioner,Christi Craddick,REP,Pct. 4,Box 4,Early,12,
-Haskell,Railroad Commissioner,Weston Martinez,REP,Pct. 4,Box 4,Early,4,
-Haskell,Railroad Commissioner,Christi Craddick,REP,Pct. 5,Box 5,Early,11,
-Haskell,Railroad Commissioner,Weston Martinez,REP,Pct. 5,Box 5,Early,4,
-Haskell,Railroad Commissioner,Christi Craddick,REP,Pct. 6,Box 6,Early,8,
-Haskell,Railroad Commissioner,Weston Martinez,REP,Pct. 6,Box 6,Early,3,
-Haskell,Railroad Commissioner,Christi Craddick,REP,Pct. 7,Box 7,Early,7,
-Haskell,Railroad Commissioner,Weston Martinez,REP,Pct. 7,Box 7,Early,1,
-Haskell,Railroad Commissioner,Christi Craddick,REP,Pct. 8,Box 8,Early,6,
-Haskell,Railroad Commissioner,Weston Martinez,REP,Pct. 8,Box 8,Early,2,
-Haskell,Railroad Commissioner,Christi Craddick,REP,Pct. 9,Box 9,Early,6,
-Haskell,Railroad Commissioner,Weston Martinez,REP,Pct. 9,Box 9,Early,1,
-Haskell,Attorney General,Warren Paxton,REP,Pct. 1,Box 1,Early,26,
-Haskell,Attorney General,Warren Paxton,REP,Pct. 10,Box 10,Early,9,
-Haskell,Attorney General,Warren Paxton,REP,Pct. 2,Box 2,Early,32,
-Haskell,Attorney General,Warren Paxton,REP,Pct. 3,Box 3,Early,18,
-Haskell,Attorney General,Warren Paxton,REP,Pct. 4,Box 4,Early,13,
-Haskell,Attorney General,Warren Paxton,REP,Pct. 5,Box 5,Early,12,
-Haskell,Attorney General,Warren Paxton,REP,Pct. 6,Box 6,Early,10,
-Haskell,Attorney General,Warren Paxton,REP,Pct. 7,Box 7,Early,8,
-Haskell,Attorney General,Warren Paxton,REP,Pct. 8,Box 8,Early,8,
-Haskell,Attorney General,Warren Paxton,REP,Pct. 9,Box 9,Early,9,
-Haskell,Comptroller of Public Accounts,Glenn Hegar,REP,Pct. 1,Box 1,Early,31,
-Haskell,Comptroller of Public Accounts,Glenn Hegar,REP,Pct. 10,Box 10,Early,9,
-Haskell,Comptroller of Public Accounts,Glenn Hegar,REP,Pct. 2,Box 2,Early,39,
-Haskell,Comptroller of Public Accounts,Glenn Hegar,REP,Pct. 3,Box 3,Early,23,
-Haskell,Comptroller of Public Accounts,Glenn Hegar,REP,Pct. 4,Box 4,Early,14,
-Haskell,Comptroller of Public Accounts,Glenn Hegar,REP,Pct. 5,Box 5,Early,14,
-Haskell,Comptroller of Public Accounts,Glenn Hegar,REP,Pct. 6,Box 6,Early,11,
-Haskell,Comptroller of Public Accounts,Glenn Hegar,REP,Pct. 7,Box 7,Early,8,
-Haskell,Comptroller of Public Accounts,Glenn Hegar,REP,Pct. 8,Box 8,Early,8,
-Haskell,Comptroller of Public Accounts,Glenn Hegar,REP,Pct. 9,Box 9,Early,9,
+county,office,candidate,party,precinct,early_voting,election_day
+Haskell,Commissioner of Agriculture,Kimberly Dawn Olson,DEM,Pct.1,1,4
+Haskell,Commissioner of Agriculture,Kimberly Dawn Olson,DEM,Pct.10,1,11
+Haskell,Commissioner of Agriculture,Kimberly Dawn Olson,DEM,Pct.2,10,17
+Haskell,Commissioner of Agriculture,Kimberly Dawn Olson,DEM,Pct.3,10,6
+Haskell,Commissioner of Agriculture,Kimberly Dawn Olson,DEM,Pct.4,1,4
+Haskell,Commissioner of Agriculture,Kimberly Dawn Olson,DEM,Pct.5,5,5
+Haskell,Commissioner of Agriculture,Kimberly Dawn Olson,DEM,Pct.6,3,6
+Haskell,Commissioner of Agriculture,Kimberly Dawn Olson,DEM,Pct.7,0,0
+Haskell,Commissioner of Agriculture,Kimberly Dawn Olson,DEM,Pct.8,2,6
+Haskell,Commissioner of Agriculture,Kimberly Dawn Olson,DEM,Pct.9,2,3
+Haskell,Railroad Commissioner,Christopher Cornell Spellmon,DEM,Pct.1,2,3
+Haskell,Railroad Commissioner,Roman James Alfred McAllen,DEM,Pct.1,0,2
+Haskell,Railroad Commissioner,Christopher Cornell Spellmon,DEM,Pct.10,1,3
+Haskell,Railroad Commissioner,Roman James Alfred McAllen,DEM,Pct.10,0,7
+Haskell,Railroad Commissioner,Christopher Cornell Spellmon,DEM,Pct.2,4,9
+Haskell,Railroad Commissioner,Roman James Alfred McAllen,DEM,Pct.2,3,7
+Haskell,Railroad Commissioner,Christopher Cornell Spellmon,DEM,Pct.3,8,6
+Haskell,Railroad Commissioner,Roman James Alfred McAllen,DEM,Pct.3,3,3
+Haskell,Railroad Commissioner,Christopher Cornell Spellmon,DEM,Pct.4,1,3
+Haskell,Railroad Commissioner,Roman James Alfred McAllen,DEM,Pct.4,0,1
+Haskell,Railroad Commissioner,Christopher Cornell Spellmon,DEM,Pct.5,1,3
+Haskell,Railroad Commissioner,Roman James Alfred McAllen,DEM,Pct.5,2,4
+Haskell,Railroad Commissioner,Christopher Cornell Spellmon,DEM,Pct.6,2,6
+Haskell,Railroad Commissioner,Roman James Alfred McAllen,DEM,Pct.6,0,1
+Haskell,Railroad Commissioner,Christopher Cornell Spellmon,DEM,Pct.7,0,0
+Haskell,Railroad Commissioner,Roman James Alfred McAllen,DEM,Pct.7,0,0
+Haskell,Railroad Commissioner,Christopher Cornell Spellmon,DEM,Pct.8,3,3
+Haskell,Railroad Commissioner,Roman James Alfred McAllen,DEM,Pct.8,0,2
+Haskell,Railroad Commissioner,Christopher Cornell Spellmon,DEM,Pct.9,1,1
+Haskell,Railroad Commissioner,Roman James Alfred McAllen,DEM,Pct.9,1,2
+Haskell,Commissioner of the General Land Office,Carl Allen Morgan,DEM,Pct.1,2,4
+Haskell,Commissioner of the General Land Office,Miguel Andr�s Suazo,DEM,Pct.1,0,1
+Haskell,Commissioner of the General Land Office,Carl Allen Morgan,DEM,Pct.10,1,9
+Haskell,Commissioner of the General Land Office,Miguel Andr�s Suazo,DEM,Pct.10,0,0
+Haskell,Commissioner of the General Land Office,Carl Allen Morgan,DEM,Pct.2,3,13
+Haskell,Commissioner of the General Land Office,Miguel Andr�s Suazo,DEM,Pct.2,5,5
+Haskell,Commissioner of the General Land Office,Carl Allen Morgan,DEM,Pct.3,7,4
+Haskell,Commissioner of the General Land Office,Miguel Andr�s Suazo,DEM,Pct.3,3,7
+Haskell,Commissioner of the General Land Office,Carl Allen Morgan,DEM,Pct.4,1,0
+Haskell,Commissioner of the General Land Office,Miguel Andr�s Suazo,DEM,Pct.4,1,4
+Haskell,Commissioner of the General Land Office,Miguel Andr�s Suazo,DEM,Pct.4,1,4
+Haskell,Commissioner of the General Land Office,Carl Allen Morgan,DEM,Pct.5,1,2
+Haskell,Commissioner of the General Land Office,Miguel Andr�s Suazo,DEM,Pct.5,1,2
+Haskell,Commissioner of the General Land Office,Carl Allen Morgan,DEM,Pct.6,0,6
+Haskell,Commissioner of the General Land Office,Miguel Andr�s Suazo,DEM,Pct.6,2,1
+Haskell,Commissioner of the General Land Office,Carl Allen Morgan,DEM,Pct.7,0,0
+Haskell,Commissioner of the General Land Office,Miguel Andr�s Suazo,DEM,Pct.7,0,0
+Haskell,Commissioner of the General Land Office,Carl Allen Morgan,DEM,Pct.8,3,3
+Haskell,Commissioner of the General Land Office,Miguel Andr�s Suazo,DEM,Pct.8,0,2
+Haskell,Commissioner of the General Land Office,Carl Allen Morgan,DEM,Pct.9,1,2
+Haskell,Commissioner of the General Land Office,Miguel Andr�s Suazo,DEM,Pct.9,1,1
+Haskell,U.S. Senate,Edward Wayne Kimbrough,DEM,Pct.1,1,4
+Haskell,U.S. Senate,Irasema Ramirez-Hernandez,DEM,Pct.1,1,0
+Haskell,U.S. Senate,Robert Francis O'Rourke,DEM,Pct.1,0,0
+Haskell,U.S. Senate,Edward Wayne Kimbrough,DEM,Pct.10,0,9
+Haskell,U.S. Senate,Irasema Ramirez-Hernandez,DEM,Pct.10,0,0
+Haskell,U.S. Senate,Robert Francis O'Rourke,DEM,Pct.10,1,2
+Haskell,U.S. Senate,Edward Wayne Kimbrough,DEM,Pct.2,4,8
+Haskell,U.S. Senate,Irasema Ramirez-Hernandez,DEM,Pct.2,1,4
+Haskell,U.S. Senate,Robert Francis O'Rourke,DEM,Pct.2,4,6
+Haskell,U.S. Senate,Edward Wayne Kimbrough,DEM,Pct.3,5,6
+Haskell,U.S. Senate,Irasema Ramirez-Hernandez,DEM,Pct.3,1,2
+Haskell,U.S. Senate,Robert Francis O'Rourke,DEM,Pct.3,7,4
+Haskell,U.S. Senate,Edward Wayne Kimbrough,DEM,Pct.4,1,0
+Haskell,U.S. Senate,Irasema Ramirez-Hernandez,DEM,Pct.4,0,1
+Haskell,U.S. Senate,Robert Francis O'Rourke,DEM,Pct.4,2,4
+Haskell,U.S. Senate,Edward Wayne Kimbrough,DEM,Pct.5,1,3
+Haskell,U.S. Senate,Irasema Ramirez-Hernandez,DEM,Pct.5,1,2
+Haskell,U.S. Senate,Robert Francis O'Rourke,DEM,Pct.5,2,0
+Haskell,U.S. Senate,Edward Wayne Kimbrough,DEM,Pct.6,1,1
+Haskell,U.S. Senate,Irasema Ramirez-Hernandez,DEM,Pct.6,1,1
+Haskell,U.S. Senate,Robert Francis O'Rourke,DEM,Pct.6,0,5
+Haskell,U.S. Senate,Edward Wayne Kimbrough,DEM,Pct.7,0,0
+Haskell,U.S. Senate,Irasema Ramirez-Hernandez,DEM,Pct.7,0,0
+Haskell,U.S. Senate,Robert Francis O'Rourke,DEM,Pct.7,0,0
+Haskell,U.S. Senate,Edward Wayne Kimbrough,DEM,Pct.8,3,2
+Haskell,U.S. Senate,Irasema Ramirez-Hernandez,DEM,Pct.8,0,1
+Haskell,U.S. Senate,Robert Francis O'Rourke,DEM,Pct.8,0,3
+Haskell,U.S. Senate,Edward Wayne Kimbrough,DEM,Pct.9,1,1
+Haskell,U.S. Senate,Irasema Ramirez-Hernandez,DEM,Pct.9,0,0
+Haskell,U.S. Senate,Robert Francis O'Rourke,DEM,Pct.9,1,2
+Haskell,Governor,Adrian Ocegueda,DEM,Pct.1,0,0
+Haskell,Governor,"Cedric Wayne Davis, Sr.",DEM,Pct.1,0,0
+Haskell,Governor,Grady Yarbrough,DEM,Pct.1,0,1
+Haskell,Governor,Guadalupe Valdez,DEM,Pct.1,0,1
+Haskell,Governor,James Jolly Clark,DEM,Pct.1,0,1
+Haskell,Governor,Jeffrey Alan Payne,DEM,Pct.1,0,0
+Haskell,Governor,Joseph William Mumbach,DEM,Pct.1,0,0
+Haskell,Governor,Robert Andrew White,DEM,Pct.1,2,2
+Haskell,Governor,Thomas John Wakely,DEM,Pct.1,0,0
+Haskell,Governor,Adrian Ocegueda,DEM,Pct.10,0,0
+Haskell,Governor,"Cedric Wayne Davis, Sr.",DEM,Pct.10,0,0
+Haskell,Governor,Grady Yarbrough,DEM,Pct.10,0,4
+Haskell,Governor,Guadalupe Valdez,DEM,Pct.10,0,1
+Haskell,Governor,James Jolly Clark,DEM,Pct.10,0,4
+Haskell,Governor,Jeffrey Alan Payne,DEM,Pct.10,0,0
+Haskell,Governor,Joseph William Mumbach,DEM,Pct.10,0,0
+Haskell,Governor,Robert Andrew White,DEM,Pct.10,1,4
+Haskell,Governor,Thomas John Wakely,DEM,Pct.10,0,0
+Haskell,Governor,Adrian Ocegueda,DEM,Pct.2,0,1
+Haskell,Governor,"Cedric Wayne Davis, Sr.",DEM,Pct.2,1,0
+Haskell,Governor,Grady Yarbrough,DEM,Pct.2,1,5
+Haskell,Governor,Guadalupe Valdez,DEM,Pct.2,1,3
+Haskell,Governor,James Jolly Clark,DEM,Pct.2,1,0
+Haskell,Governor,Jeffrey Alan Payne,DEM,Pct.2,0,0
+Haskell,Governor,Joseph William Mumbach,DEM,Pct.2,0,0
+Haskell,Governor,Robert Andrew White,DEM,Pct.2,5,10
+Haskell,Governor,Thomas John Wakely,DEM,Pct.2,0,0
+Haskell,Governor,Adrian Ocegueda,DEM,Pct.3,0,1
+Haskell,Governor,"Cedric Wayne Davis, Sr.",DEM,Pct.3,1,1
+Haskell,Governor,Grady Yarbrough,DEM,Pct.3,3,2
+Haskell,Governor,Guadalupe Valdez,DEM,Pct.3,2,0
+Haskell,Governor,James Jolly Clark,DEM,Pct.3,0,0
+Haskell,Governor,Jeffrey Alan Payne,DEM,Pct.3,0,0
+Haskell,Governor,Joseph William Mumbach,DEM,Pct.3,0,0
+Haskell,Governor,Robert Andrew White,DEM,Pct.3,5,3
+Haskell,Governor,Thomas John Wakely,DEM,Pct.3,1,1
+Haskell,Governor,Adrian Ocegueda,DEM,Pct.4,0,0
+Haskell,Governor,"Cedric Wayne Davis, Sr.",DEM,Pct.4,0,0
+Haskell,Governor,Grady Yarbrough,DEM,Pct.4,1,1
+Haskell,Governor,Guadalupe Valdez,DEM,Pct.4,0,2
+Haskell,Governor,James Jolly Clark,DEM,Pct.4,0,0
+Haskell,Governor,Jeffrey Alan Payne,DEM,Pct.4,0,0
+Haskell,Governor,Joseph William Mumbach,DEM,Pct.4,0,0
+Haskell,Governor,Robert Andrew White,DEM,Pct.4,2,2
+Haskell,Governor,Thomas John Wakely,DEM,Pct.4,0,0
+Haskell,Governor,Adrian Ocegueda,DEM,Pct.5,0,0
+Haskell,Governor,"Cedric Wayne Davis, Sr.",DEM,Pct.5,0,0
+Haskell,Governor,Grady Yarbrough,DEM,Pct.5,0,1
+Haskell,Governor,Guadalupe Valdez,DEM,Pct.5,0,0
+Haskell,Governor,James Jolly Clark,DEM,Pct.5,1,1
+Haskell,Governor,Jeffrey Alan Payne,DEM,Pct.5,0,1
+Haskell,Governor,Joseph William Mumbach,DEM,Pct.5,0,1
+Haskell,Governor,Robert Andrew White,DEM,Pct.5,1,4
+Haskell,Governor,Thomas John Wakely,DEM,Pct.5,0,0
+Haskell,Governor,Adrian Ocegueda,DEM,Pct.6,0,1
+Haskell,Governor,"Cedric Wayne Davis, Sr.",DEM,Pct.6,0,0
+Haskell,Governor,Grady Yarbrough,DEM,Pct.6,0,2
+Haskell,Governor,Guadalupe Valdez,DEM,Pct.6,2,1
+Haskell,Governor,James Jolly Clark,DEM,Pct.6,0,0
+Haskell,Governor,Jeffrey Alan Payne,DEM,Pct.6,0,0
+Haskell,Governor,Joseph William Mumbach,DEM,Pct.6,0,0
+Haskell,Governor,Robert Andrew White,DEM,Pct.6,1,3
+Haskell,Governor,Thomas John Wakely,DEM,Pct.6,0,1
+Haskell,Governor,Adrian Ocegueda,DEM,Pct.7,0,0
+Haskell,Governor,"Cedric Wayne Davis, Sr.",DEM,Pct.7,0,0
+Haskell,Governor,Grady Yarbrough,DEM,Pct.7,0,0
+Haskell,Governor,Guadalupe Valdez,DEM,Pct.7,0,0
+Haskell,Governor,James Jolly Clark,DEM,Pct.7,0,0
+Haskell,Governor,Jeffrey Alan Payne,DEM,Pct.7,0,0
+Haskell,Governor,Joseph William Mumbach,DEM,Pct.7,0,0
+Haskell,Governor,Robert Andrew White,DEM,Pct.7,0,0
+Haskell,Governor,Thomas John Wakely,DEM,Pct.7,0,0
+Haskell,Governor,Adrian Ocegueda,DEM,Pct.8,0,0
+Haskell,Governor,"Cedric Wayne Davis, Sr.",DEM,Pct.8,0,0
+Haskell,Governor,Grady Yarbrough,DEM,Pct.8,2,0
+Haskell,Governor,Guadalupe Valdez,DEM,Pct.8,0,3
+Haskell,Governor,James Jolly Clark,DEM,Pct.8,0,0
+Haskell,Governor,Jeffrey Alan Payne,DEM,Pct.8,0,0
+Haskell,Governor,Joseph William Mumbach,DEM,Pct.8,0,0
+Haskell,Governor,Robert Andrew White,DEM,Pct.8,1,1
+Haskell,Governor,Thomas John Wakely,DEM,Pct.8,0,0
+Haskell,Governor,Adrian Ocegueda,DEM,Pct.9,0,0
+Haskell,Governor,"Cedric Wayne Davis, Sr.",DEM,Pct.9,0,0
+Haskell,Governor,Grady Yarbrough,DEM,Pct.9,1,0
+Haskell,Governor,Guadalupe Valdez,DEM,Pct.9,0,0
+Haskell,Governor,James Jolly Clark,DEM,Pct.9,0,0
+Haskell,Governor,Jeffrey Alan Payne,DEM,Pct.9,0,1
+Haskell,Governor,Joseph William Mumbach,DEM,Pct.9,0,0
+Haskell,Governor,Robert Andrew White,DEM,Pct.9,1,2
+Haskell,Governor,Thomas John Wakely,DEM,Pct.9,0,0
+Haskell,Lieutenant Governor,Michael Cooper,DEM,Pct.1,1,3
+Haskell,Lieutenant Governor,Michael Edward Collier,DEM,Pct.1,1,2
+Haskell,Lieutenant Governor,Michael Cooper,DEM,Pct.10,0,4
+Haskell,Lieutenant Governor,Michael Edward Collier,DEM,Pct.10,1,9
+Haskell,Lieutenant Governor,Michael Cooper,DEM,Pct.2,1,10
+Haskell,Lieutenant Governor,Michael Edward Collier,DEM,Pct.2,6,9
+Haskell,Lieutenant Governor,Michael Cooper,DEM,Pct.3,3,6
+Haskell,Lieutenant Governor,Michael Edward Collier,DEM,Pct.3,9,3
+Haskell,Lieutenant Governor,Michael Cooper,DEM,Pct.4,3,2
+Haskell,Lieutenant Governor,Michael Edward Collier,DEM,Pct.4,0,3
+Haskell,Lieutenant Governor,Michael Cooper,DEM,Pct.5,1,2
+Haskell,Lieutenant Governor,Michael Edward Collier,DEM,Pct.5,2,4
+Haskell,Lieutenant Governor,Michael Cooper,DEM,Pct.6,0,1
+Haskell,Lieutenant Governor,Michael Edward Collier,DEM,Pct.6,2,5
+Haskell,Lieutenant Governor,Michael Cooper,DEM,Pct.7,0,0
+Haskell,Lieutenant Governor,Michael Edward Collier,DEM,Pct.7,0,0
+Haskell,Lieutenant Governor,Michael Cooper,DEM,Pct.8,1,3
+Haskell,Lieutenant Governor,Michael Edward Collier,DEM,Pct.8,3,3
+Haskell,Lieutenant Governor,Michael Cooper,DEM,Pct.9,1,1
+Haskell,Lieutenant Governor,Michael Edward Collier,DEM,Pct.9,1,2
+Haskell,Comptroller of Public Accounts,Joi Lynne Chevalier,DEM,Pct.1,0,1
+Haskell,Comptroller of Public Accounts,Timothy Raymond Mahoney,DEM,Pct.1,2,3
+Haskell,Comptroller of Public Accounts,Joi Lynne Chevalier,DEM,Pct.10,0,0
+Haskell,Comptroller of Public Accounts,Timothy Raymond Mahoney,DEM,Pct.10,1,0
+Haskell,Comptroller of Public Accounts,Joi Lynne Chevalier,DEM,Pct.2,3,7
+Haskell,Comptroller of Public Accounts,Timothy Raymond Mahoney,DEM,Pct.2,5,11
+Haskell,Comptroller of Public Accounts,Joi Lynne Chevalier,DEM,Pct.3,1,4
+Haskell,Comptroller of Public Accounts,Timothy Raymond Mahoney,DEM,Pct.3,11,5
+Haskell,Comptroller of Public Accounts,Joi Lynne Chevalier,DEM,Pct.4,1,1
+Haskell,Comptroller of Public Accounts,Timothy Raymond Mahoney,DEM,Pct.4,2,4
+Haskell,Comptroller of Public Accounts,Joi Lynne Chevalier,DEM,Pct.5,1,0
+Haskell,Comptroller of Public Accounts,Timothy Raymond Mahoney,DEM,Pct.5,2,6
+Haskell,Comptroller of Public Accounts,Joi Lynne Chevalier,DEM,Pct.6,0,1
+Haskell,Comptroller of Public Accounts,Timothy Raymond Mahoney,DEM,Pct.6,0,6
+Haskell,Comptroller of Public Accounts,Joi Lynne Chevalier,DEM,Pct.7,0,0
+Haskell,Comptroller of Public Accounts,Timothy Raymond Mahoney,DEM,Pct.7,0,0
+Haskell,Comptroller of Public Accounts,Joi Lynne Chevalier,DEM,Pct.8,0,3
+Haskell,Comptroller of Public Accounts,Timothy Raymond Mahoney,DEM,Pct.8,3,2
+Haskell,Comptroller of Public Accounts,Joi Lynne Chevalier,DEM,Pct.9,1,1
+Haskell,Comptroller of Public Accounts,Timothy Raymond Mahoney,DEM,Pct.9,1,2
+Haskell,U. S. Representative District 19,Miguel Antonio Levario,DEM,Pct.1,0,3
+Haskell,U. S. Representative District 19,Miguel Antonio Levario,DEM,Pct.10,1,2
+Haskell,U. S. Representative District 19,Miguel Antonio Levario,DEM,Pct.2,9,16
+Haskell,U. S. Representative District 19,Miguel Antonio Levario,DEM,Pct.3,9,6
+Haskell,U. S. Representative District 19,Miguel Antonio Levario,DEM,Pct.4,2,5
+Haskell,U. S. Representative District 19,Miguel Antonio Levario,DEM,Pct.5,4,5
+Haskell,U. S. Representative District 19,Miguel Antonio Levario,DEM,Pct.6,2,5
+Haskell,U. S. Representative District 19,Miguel Antonio Levario,DEM,Pct.7,0,0
+Haskell,U. S. Representative District 19,Miguel Antonio Levario,DEM,Pct.8,2,4
+Haskell,U. S. Representative District 19,Miguel Antonio Levario,DEM,Pct.9,2,2
+Haskell,Attorney General,Justin Adatto Nelson,DEM,Pct.1,1,2
+Haskell,Attorney General,Justin Adatto Nelson,DEM,Pct.10,1,8
+Haskell,Attorney General,Justin Adatto Nelson,DEM,Pct.2,7,17
+Haskell,Attorney General,Justin Adatto Nelson,DEM,Pct.3,10,5
+Haskell,Attorney General,Justin Adatto Nelson,DEM,Pct.4,0,5
+Haskell,Attorney General,Justin Adatto Nelson,DEM,Pct.5,5,5
+Haskell,Attorney General,Justin Adatto Nelson,DEM,Pct.6,1,3
+Haskell,Attorney General,Justin Adatto Nelson,DEM,Pct.7,0,0
+Haskell,Attorney General,Justin Adatto Nelson,DEM,Pct.8,2,5
+Haskell,Attorney General,Justin Adatto Nelson,DEM,Pct.9,1,2
+Haskell,Commissioner of the General Land Office,George Bush,REP,Pct. 1,16,31
+Haskell,Commissioner of the General Land Office,Jerry Patterson,REP,Pct. 1,9,10
+Haskell,Commissioner of the General Land Office,Richard Range,REP,Pct. 1,1,5
+Haskell,Commissioner of the General Land Office,William Edwards,REP,Pct. 1,5,2
+Haskell,Commissioner of the General Land Office,George Bush,REP,Pct. 10,5,13
+Haskell,Commissioner of the General Land Office,Jerry Patterson,REP,Pct. 10,2,11
+Haskell,Commissioner of the General Land Office,Richard Range,REP,Pct. 10,2,1
+Haskell,Commissioner of the General Land Office,William Edwards,REP,Pct. 10,0,4
+Haskell,Commissioner of the General Land Office,George Bush,REP,Pct. 2,22,35
+Haskell,Commissioner of the General Land Office,Jerry Patterson,REP,Pct. 2,13,11
+Haskell,Commissioner of the General Land Office,Richard Range,REP,Pct. 2,8,2
+Haskell,Commissioner of the General Land Office,William Edwards,REP,Pct. 2,0,3
+Haskell,Commissioner of the General Land Office,George Bush,REP,Pct. 3,10,13
+Haskell,Commissioner of the General Land Office,Jerry Patterson,REP,Pct. 3,11,7
+Haskell,Commissioner of the General Land Office,Richard Range,REP,Pct. 3,3,3
+Haskell,Commissioner of the General Land Office,William Edwards,REP,Pct. 3,1,2
+Haskell,Commissioner of the General Land Office,George Bush,REP,Pct. 4,8,16
+Haskell,Commissioner of the General Land Office,Jerry Patterson,REP,Pct. 4,4,7
+Haskell,Commissioner of the General Land Office,Richard Range,REP,Pct. 4,3,1
+Haskell,Commissioner of the General Land Office,William Edwards,REP,Pct. 4,1,3
+Haskell,Commissioner of the General Land Office,George Bush,REP,Pct. 5,6,17
+Haskell,Commissioner of the General Land Office,Jerry Patterson,REP,Pct. 5,7,14
+Haskell,Commissioner of the General Land Office,Richard Range,REP,Pct. 5,2,3
+Haskell,Commissioner of the General Land Office,William Edwards,REP,Pct. 5,2,2
+Haskell,Commissioner of the General Land Office,George Bush,REP,Pct. 6,5,20
+Haskell,Commissioner of the General Land Office,Jerry Patterson,REP,Pct. 6,7,12
+Haskell,Commissioner of the General Land Office,Richard Range,REP,Pct. 6,0,4
+Haskell,Commissioner of the General Land Office,William Edwards,REP,Pct. 6,0,0
+Haskell,Commissioner of the General Land Office,George Bush,REP,Pct. 7,4,1
+Haskell,Commissioner of the General Land Office,Jerry Patterson,REP,Pct. 7,4,4
+Haskell,Commissioner of the General Land Office,Richard Range,REP,Pct. 7,0,2
+Haskell,Commissioner of the General Land Office,William Edwards,REP,Pct. 7,0,0
+Haskell,Commissioner of the General Land Office,George Bush,REP,Pct. 8,3,6
+Haskell,Commissioner of the General Land Office,Jerry Patterson,REP,Pct. 8,3,1
+Haskell,Commissioner of the General Land Office,Richard Range,REP,Pct. 8,0,1
+Haskell,Commissioner of the General Land Office,William Edwards,REP,Pct. 8,2,0
+Haskell,Commissioner of the General Land Office,George Bush,REP,Pct. 9,4,19
+Haskell,Commissioner of the General Land Office,Jerry Patterson,REP,Pct. 9,4,11
+Haskell,Commissioner of the General Land Office,Richard Range,REP,Pct. 9,1,1
+Haskell,Commissioner of the General Land Office,William Edwards,REP,Pct. 9,0,1
+Haskell,Commissioner of Agriculture,Jimmie Hogan,REP,Pct. 1,2,3
+Haskell,Commissioner of Agriculture,Sidney Miller,REP,Pct. 1,23,42
+Haskell,Commissioner of Agriculture,Trey Blocker,REP,Pct. 1,7,5
+Haskell,Commissioner of Agriculture,Jimmie Hogan,REP,Pct. 10,3,8
+Haskell,Commissioner of Agriculture,Sidney Miller,REP,Pct. 10,6,19
+Haskell,Commissioner of Agriculture,Trey Blocker,REP,Pct. 10,0,2
+Haskell,Commissioner of Agriculture,Jimmie Hogan,REP,Pct. 2,5,7
+Haskell,Commissioner of Agriculture,Sidney Miller,REP,Pct. 2,33,36
+Haskell,Commissioner of Agriculture,Trey Blocker,REP,Pct. 2,9,8
+Haskell,Commissioner of Agriculture,Jimmie Hogan,REP,Pct. 3,2,4
+Haskell,Commissioner of Agriculture,Sidney Miller,REP,Pct. 3,21,24
+Haskell,Commissioner of Agriculture,Trey Blocker,REP,Pct. 3,2,1
+Haskell,Commissioner of Agriculture,Jimmie Hogan,REP,Pct. 4,1,3
+Haskell,Commissioner of Agriculture,Sidney Miller,REP,Pct. 4,12,22
+Haskell,Commissioner of Agriculture,Trey Blocker,REP,Pct. 4,3,3
+Haskell,Commissioner of Agriculture,Jimmie Hogan,REP,Pct. 5,1,9
+Haskell,Commissioner of Agriculture,Sidney Miller,REP,Pct. 5,13,26
+Haskell,Commissioner of Agriculture,Trey Blocker,REP,Pct. 5,3,1
+Haskell,Commissioner of Agriculture,Jimmie Hogan,REP,Pct. 6,5,6
+Haskell,Commissioner of Agriculture,Sidney Miller,REP,Pct. 6,5,30
+Haskell,Commissioner of Agriculture,Trey Blocker,REP,Pct. 6,2,5
+Haskell,Commissioner of Agriculture,Jimmie Hogan,REP,Pct. 7,0,3
+Haskell,Commissioner of Agriculture,Sidney Miller,REP,Pct. 7,8,2
+Haskell,Commissioner of Agriculture,Trey Blocker,REP,Pct. 7,0,1
+Haskell,Commissioner of Agriculture,Jimmie Hogan,REP,Pct. 8,0,2
+Haskell,Commissioner of Agriculture,Sidney Miller,REP,Pct. 8,5,4
+Haskell,Commissioner of Agriculture,Trey Blocker,REP,Pct. 8,3,1
+Haskell,Commissioner of Agriculture,Jimmie Hogan,REP,Pct. 9,0,3
+Haskell,Commissioner of Agriculture,Sidney Miller,REP,Pct. 9,7,24
+Haskell,Commissioner of Agriculture,Trey Blocker,REP,Pct. 9,0,5
+Haskell,U.S. Senate,Bruce Jacobson,REP,Pct. 1,1,0
+Haskell,U.S. Senate,Geraldine Sam,REP,Pct. 1,2,0
+Haskell,U.S. Senate,Mary Miller,REP,Pct. 1,0,1
+Haskell,U.S. Senate,Rafael Cruz,REP,Pct. 1,29,53
+Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 1,0,0
+Haskell,U.S. Senate,Bruce Jacobson,REP,Pct. 10,10,4
+Haskell,U.S. Senate,Geraldine Sam,REP,Pct. 10,0,0
+Haskell,U.S. Senate,Mary Miller,REP,Pct. 10,0,1
+Haskell,U.S. Senate,Rafael Cruz,REP,Pct. 10,9,25
+Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 10,0,0
+Haskell,U.S. Senate,Bruce Jacobson,REP,Pct. 2,7,5
+Haskell,U.S. Senate,Geraldine Sam,REP,Pct. 2,0,6
+Haskell,U.S. Senate,Mary Miller,REP,Pct. 2,2,3
+Haskell,U.S. Senate,Rafael Cruz,REP,Pct. 2,37,40
+Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 2,3,3
+Haskell,U.S. Senate,Bruce Jacobson,REP,Pct. 3,1,3
+Haskell,U.S. Senate,Geraldine Sam,REP,Pct. 3,0,0
+Haskell,U.S. Senate,Mary Miller,REP,Pct. 3,0,0
+Haskell,U.S. Senate,Rafael Cruz,REP,Pct. 3,22,25
+Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 3,1,1
+Haskell,U.S. Senate,Bruce Jacobson,REP,Pct. 4,0,1
+Haskell,U.S. Senate,Geraldine Sam,REP,Pct. 4,1,1
+Haskell,U.S. Senate,Rafael Cruz,REP,Pct. 4,14,0
+Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 4,0,26
+Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 4,0,0
+Haskell,U.S. Senate,Bruce Jacobson,REP,Pct. 5,1,5
+Haskell,U.S. Senate,Geraldine Sam,REP,Pct. 5,1,2
+Haskell,U.S. Senate,Rafael Cruz,REP,Pct. 5,13,4
+Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 5,1,27
+Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 5,1,0
+Haskell,U.S. Senate,Bruce Jacobson,REP,Pct. 6,1,3
+Haskell,U.S. Senate,Geraldine Sam,REP,Pct. 6,0,0
+Haskell,U.S. Senate,Rafael Cruz,REP,Pct. 6,10,0
+Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 6,0,35
+Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 6,0,1
+Haskell,U.S. Senate,Bruce Jacobson,REP,Pct. 7,0,1
+Haskell,U.S. Senate,Geraldine Sam,REP,Pct. 7,0,1
+Haskell,U.S. Senate,Rafael Cruz,REP,Pct. 7,8,1
+Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 7,0,3
+Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 7,0,0
+Haskell,U.S. Senate,Bruce Jacobson,REP,Pct. 8,0,0
+Haskell,U.S. Senate,Geraldine Sam,REP,Pct. 8,0,0
+Haskell,U.S. Senate,Rafael Cruz,REP,Pct. 8,8,0
+Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 8,0,7
+Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 8,0,1
+Haskell,U.S. Senate,Bruce Jacobson,REP,Pct. 9,0,7
+Haskell,U.S. Senate,Geraldine Sam,REP,Pct. 9,0,0
+Haskell,U.S. Senate,Rafael Cruz,REP,Pct. 9,9,3
+Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 9,0,24
+Haskell,U.S. Senate,Stefano de Stefano IV,REP,Pct. 9,0,0
+Haskell,U. S. Representative District 19,Jodey Arrington,REP,Pct. 1,31,
+Haskell,U. S. Representative District 19,Jodey Arrington,REP,Pct. 10,9,
+Haskell,U. S. Representative District 19,Jodey Arrington,REP,Pct. 2,47,
+Haskell,U. S. Representative District 19,Jodey Arrington,REP,Pct. 3,24,
+Haskell,U. S. Representative District 19,Jodey Arrington,REP,Pct. 4,15,
+Haskell,U. S. Representative District 19,Jodey Arrington,REP,Pct. 5,16,
+Haskell,U. S. Representative District 19,Jodey Arrington,REP,Pct. 6,10,
+Haskell,U. S. Representative District 19,Jodey Arrington,REP,Pct. 7,8,
+Haskell,U. S. Representative District 19,Jodey Arrington,REP,Pct. 8,8,
+Haskell,U. S. Representative District 19,Jodey Arrington,REP,Pct. 9,9,
+Haskell,Lieutenant Governor,Dan Patrick,REP,Pct. 1,22,
+Haskell,Lieutenant Governor,Scott Milder,REP,Pct. 1,15,
+Haskell,Lieutenant Governor,Dan Patrick,REP,Pct. 10,3,
+Haskell,Lieutenant Governor,Scott Milder,REP,Pct. 10,5,
+Haskell,Lieutenant Governor,Dan Patrick,REP,Pct. 2,19,
+Haskell,Lieutenant Governor,Scott Milder,REP,Pct. 2,31,
+Haskell,Lieutenant Governor,Dan Patrick,REP,Pct. 3,9,
+Haskell,Lieutenant Governor,Scott Milder,REP,Pct. 3,0,
+Haskell,Lieutenant Governor,Dan Patrick,REP,Pct. 4,6,
+Haskell,Lieutenant Governor,Scott Milder,REP,Pct. 4,10,
+Haskell,Lieutenant Governor,Dan Patrick,REP,Pct. 5,15,
+Haskell,Lieutenant Governor,Scott Milder,REP,Pct. 5,2,
+Haskell,Lieutenant Governor,Dan Patrick,REP,Pct. 6,6,
+Haskell,Lieutenant Governor,Scott Milder,REP,Pct. 6,6,
+Haskell,Lieutenant Governor,Dan Patrick,REP,Pct. 7,8,
+Haskell,Lieutenant Governor,Scott Milder,REP,Pct. 7,0,
+Haskell,Lieutenant Governor,Dan Patrick,REP,Pct. 8,5,
+Haskell,Lieutenant Governor,Scott Milder,REP,Pct. 8,3,
+Haskell,Lieutenant Governor,Dan Patrick,REP,Pct. 9,5,
+Haskell,Lieutenant Governor,Scott Milder,REP,Pct. 9,4,
+Haskell,State Representative District 68,Drew Springer Jr.,REP,Pct. 1,29,
+Haskell,State Representative District 68,Drew Springer Jr.,REP,Pct. 10,9,
+Haskell,State Representative District 68,Drew Springer Jr.,REP,Pct. 2,38,
+Haskell,State Representative District 68,Drew Springer Jr.,REP,Pct. 3,26,
+Haskell,State Representative District 68,Drew Springer Jr.,REP,Pct. 4,13,
+Haskell,State Representative District 68,Drew Springer Jr.,REP,Pct. 5,15,
+Haskell,State Representative District 68,Drew Springer Jr.,REP,Pct. 6,10,
+Haskell,State Representative District 68,Drew Springer Jr.,REP,Pct. 7,8,
+Haskell,State Representative District 68,Drew Springer Jr.,REP,Pct. 8,1,
+Haskell,State Representative District 68,Drew Springer Jr.,REP,Pct. 9,9,
+Haskell,Governor,Barbara Krueger,REP,Pct. 1,1,
+Haskell,Governor,Gregory Abbott,REP,Pct. 1,32,
+Haskell,Governor,Larry Kilgore,REP,Pct. 1,1,
+Haskell,Governor,Barbara Krueger,REP,Pct. 10,0,
+Haskell,Governor,Gregory Abbott,REP,Pct. 10,9,
+Haskell,Governor,Larry Kilgore,REP,Pct. 10,0,
+Haskell,Governor,Barbara Krueger,REP,Pct. 2,5,
+Haskell,Governor,Gregory Abbott,REP,Pct. 2,36,
+Haskell,Governor,Larry Kilgore,REP,Pct. 2,0,
+Haskell,Governor,Barbara Krueger,REP,Pct. 3,3,
+Haskell,Governor,Gregory Abbott,REP,Pct. 3,22,
+Haskell,Governor,Larry Kilgore,REP,Pct. 3,0,
+Haskell,Governor,Barbara Krueger,REP,Pct. 4,1,
+Haskell,Governor,Gregory Abbott,REP,Pct. 4,11,
+Haskell,Governor,Gregory Abbott,REP,Pct. 4,11,
+Haskell,Governor,Larry Kilgore,REP,Pct. 4,0,
+Haskell,Governor,Barbara Krueger,REP,Pct. 5,1,
+Haskell,Governor,Gregory Abbott,REP,Pct. 5,16,
+Haskell,Governor,Larry Kilgore,REP,Pct. 5,0,
+Haskell,Governor,Barbara Krueger,REP,Pct. 6,1,
+Haskell,Governor,Gregory Abbott,REP,Pct. 6,10,
+Haskell,Governor,Larry Kilgore,REP,Pct. 6,1,
+Haskell,Governor,Barbara Krueger,REP,Pct. 7,0,
+Haskell,Governor,Gregory Abbott,REP,Pct. 7,8,
+Haskell,Governor,Larry Kilgore,REP,Pct. 7,0,
+Haskell,Governor,Barbara Krueger,REP,Pct. 8,0,
+Haskell,Governor,Gregory Abbott,REP,Pct. 8,8,
+Haskell,Governor,Larry Kilgore,REP,Pct. 8,0,
+Haskell,Governor,Barbara Krueger,REP,Pct. 9,0,
+Haskell,Governor,Gregory Abbott,REP,Pct. 9,9,
+Haskell,Governor,Larry Kilgore,REP,Pct. 9,0,
+Haskell,Railroad Commissioner,Christi Craddick,REP,Pct. 1,21,
+Haskell,Railroad Commissioner,Weston Martinez,REP,Pct. 1,11,
+Haskell,Railroad Commissioner,Christi Craddick,REP,Pct. 10,7,
+Haskell,Railroad Commissioner,Weston Martinez,REP,Pct. 10,2,
+Haskell,Railroad Commissioner,Christi Craddick,REP,Pct. 2,31,
+Haskell,Railroad Commissioner,Weston Martinez,REP,Pct. 2,11,
+Haskell,Railroad Commissioner,Christi Craddick,REP,Pct. 3,21,
+Haskell,Railroad Commissioner,Weston Martinez,REP,Pct. 3,1,
+Haskell,Railroad Commissioner,Christi Craddick,REP,Pct. 4,12,
+Haskell,Railroad Commissioner,Weston Martinez,REP,Pct. 4,4,
+Haskell,Railroad Commissioner,Christi Craddick,REP,Pct. 5,11,
+Haskell,Railroad Commissioner,Weston Martinez,REP,Pct. 5,4,
+Haskell,Railroad Commissioner,Christi Craddick,REP,Pct. 6,8,
+Haskell,Railroad Commissioner,Weston Martinez,REP,Pct. 6,3,
+Haskell,Railroad Commissioner,Christi Craddick,REP,Pct. 7,7,
+Haskell,Railroad Commissioner,Weston Martinez,REP,Pct. 7,1,
+Haskell,Railroad Commissioner,Christi Craddick,REP,Pct. 8,6,
+Haskell,Railroad Commissioner,Weston Martinez,REP,Pct. 8,2,
+Haskell,Railroad Commissioner,Christi Craddick,REP,Pct. 9,6,
+Haskell,Railroad Commissioner,Weston Martinez,REP,Pct. 9,1,
+Haskell,Attorney General,Warren Paxton,REP,Pct. 1,26,
+Haskell,Attorney General,Warren Paxton,REP,Pct. 10,9,
+Haskell,Attorney General,Warren Paxton,REP,Pct. 2,32,
+Haskell,Attorney General,Warren Paxton,REP,Pct. 3,18,
+Haskell,Attorney General,Warren Paxton,REP,Pct. 4,13,
+Haskell,Attorney General,Warren Paxton,REP,Pct. 5,12,
+Haskell,Attorney General,Warren Paxton,REP,Pct. 6,10,
+Haskell,Attorney General,Warren Paxton,REP,Pct. 7,8,
+Haskell,Attorney General,Warren Paxton,REP,Pct. 8,8,
+Haskell,Attorney General,Warren Paxton,REP,Pct. 9,9,
+Haskell,Comptroller of Public Accounts,Glenn Hegar,REP,Pct. 1,31,
+Haskell,Comptroller of Public Accounts,Glenn Hegar,REP,Pct. 10,9,
+Haskell,Comptroller of Public Accounts,Glenn Hegar,REP,Pct. 2,39,
+Haskell,Comptroller of Public Accounts,Glenn Hegar,REP,Pct. 3,23,
+Haskell,Comptroller of Public Accounts,Glenn Hegar,REP,Pct. 4,14,
+Haskell,Comptroller of Public Accounts,Glenn Hegar,REP,Pct. 5,14,
+Haskell,Comptroller of Public Accounts,Glenn Hegar,REP,Pct. 6,11,
+Haskell,Comptroller of Public Accounts,Glenn Hegar,REP,Pct. 7,8,
+Haskell,Comptroller of Public Accounts,Glenn Hegar,REP,Pct. 8,8,
+Haskell,Comptroller of Public Accounts,Glenn Hegar,REP,Pct. 9,9,


### PR DESCRIPTION
The "Early" entries are not necessary, and the "Box X" entries are already captured as the precinct.