### PR TITLE
Fix incorrect vote in 2020 Brewster County general file

### DIFF
--- a/2020/counties/20201103__tx__general__brewster__precinct.csv
+++ b/2020/counties/20201103__tx__general__brewster__precinct.csv
@@ -15,7 +15,7 @@ Brewster,1,President,,,Abram Loeb (W),0,0,0
 Brewster,1,President,,,Robert Marrow (W),0,0,0
 Brewster,1,President,,,Kasey Wells (W),0,0,0
 Brewster,1,U.S. Senate,,REP,John Cornyn,785,104,889
-Brewster,1,U.S. Senate,,DEM,"Mary ""MJ"" Hegar",453,48,499
+Brewster,1,U.S. Senate,,DEM,"Mary ""MJ"" Hegar",453,46,499
 Brewster,1,U.S. Senate,,LIB,Kerry Douglas McKennon,22,7,29
 Brewster,1,U.S. Senate,,GRN,David B. Collins,1,2,3
 Brewster,1,U.S. Senate,,,Ricardo Turullols-Bonilla (W),0,0,0


### PR DESCRIPTION
This fixes an incorrect vote value, which could have been the result of an OCR error.  According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2020/general/Brewster%20TX%20General-Election-November-3-2020-Canvass-of-Vote-Totals.pdf), Mary "MJ" Hegar received 46 votes in Precinct 1:

![image](https://user-images.githubusercontent.com/17345532/132996863-6ee09a3d-998c-497d-8196-0a0c5b6aae2d.png)
