### PR TITLE
Fix incorrect vote value in 2020 Taylor County general file

### DIFF
--- a/2020/counties/20201103__tx__general__taylor__precinct.csv
+++ b/2020/counties/20201103__tx__general__taylor__precinct.csv
@@ -1279,7 +1279,7 @@ Joe Bumes,U.S. House,19,LIB,Taylor,306 - W,11,44,9,64
 "James ""Jim"" Wright",Railroad Commissioner,,REP,Taylor,306 - W,338,2228,357,2923
 Chrysta Castaneda,Railroad Commissioner,,DEM,Taylor,306 - W,128,393,49,570
 Matt Sterett,Railroad Commissioner,,LIB,Taylor,306 - W,11,54,11,76
-"Katija ""Kat"" Gruene",Railroad Commissioner,,GRN,Taylor,306 - W,6,12,7,20
+"Katija ""Kat"" Gruene",Railroad Commissioner,,GRN,Taylor,306 - W,6,12,2,20
 Dawn Buckingham,State Senate,24,REP,Taylor,306 - W,353,2253,362,2968
 Clayton Tucker,State Senate,24,DEM,Taylor,306 - W,134,424,58,616
 Stan Lambert,State Representative,71,REP,Taylor,306 - W,362,2298,365,3025


### PR DESCRIPTION
This was likely caused by an OCR error.  According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2020/general/Taylor%20TX%20Official%20Precinct%20results%20301-0%20through%20308-B.pdf), Katija "Kat" Gruene received 2 election day votes:

![image](https://user-images.githubusercontent.com/17345532/132997856-c0a3aa52-4cc8-4e40-b8a2-3019b91be09a.png)

