### PR TITLE
Fix incorrect vote value in 2020 Klebert County general file

### DIFF
--- a/2020/counties/20201103__tx__general__kleberg__precinct.csv
+++ b/2020/counties/20201103__tx__general__kleberg__precinct.csv
@@ -144,7 +144,7 @@ Kleberg,Precinct 21,U.S. Senate,,DEM,"Mary ""MJ"" Hegar",122,13,88,21,0,0
 Kleberg,Precinct 21,U.S. Senate,,LIB,Kerry Douglas McKennon,2,1,1,0,0,0
 Kleberg,Precinct 21,U.S. Senate,,GRN,David B. Collins,4,0,4,0,0,0
 Kleberg,Precinct 21,U.S. Senate,,,Over Votes,1,0,0,1,0,0
-Kleberg,Precinct 21,U.S. Senate,,,Under Votes,6,2,4,2,0,0
+Kleberg,Precinct 21,U.S. Senate,,,Under Votes,6,2,4,0,0,0
 Kleberg,Precinct 21,U.S. House,34,REP,Rey Gonzalez,48,15,31,1,1,0
 Kleberg,Precinct 21,U.S. House,34,DEM,Filemon B. Vela,130,14,93,23,0,0
 Kleberg,Precinct 21,U.S. House,34,LIB,Anthony Cristo,3,0,3,0,0,0


### PR DESCRIPTION
According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2020/general/Kleberg%20TX%202020%20General.pdf), the correct number of mail under votes should be `0`:

![image](https://user-images.githubusercontent.com/17345532/132997919-3827ef0c-d245-4653-a3cb-3b274b7da483.png)
