### PR TITLE
Fix values in 2020 Lynn County general file

### DIFF
--- a/2020/counties/20201103__tx__general__lynn__precinct.csv
+++ b/2020/counties/20201103__tx__general__lynn__precinct.csv
@@ -148,7 +148,7 @@ Lynn,Precinct 6,U.S. Senate,,,Write-In,0,0,0,0
 Lynn,Precinct 6,U.S. Senate,,,Over Votes,0,0,0,0
 Lynn,Precinct 6,U.S. Senate,,,Under Votes,4,0,1,3
 Lynn,Precinct 6,U.S. House,19,REP,Jodey C. Arrington,186,129,10,47
-Lynn,Precinct 6,U.S. House,19,DEM,Tom Watson,51,38,4,14
+Lynn,Precinct 6,U.S. House,19,DEM,Tom Watson,51,33,4,14
 Lynn,Precinct 6,U.S. House,19,,Over Votes,0,0,0,0
 Lynn,Precinct 6,U.S. House,19,,Under Votes,4,1,0,3
 Lynn,Precinct 6,Railroad Commissioner,,REP,"James ""Jim""Wright",172,123,8,41


### PR DESCRIPTION
This fixes an incorrect value in the 2020 Lynn County general file.  According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2020/general/LYNN_COUNTY-2020_NOVEMBER_3RD_GENERAL_ELECTION_1132020-20201115151646.pdf), Tom Watson received 33 early voting votes:

![image](https://user-images.githubusercontent.com/17345532/133118073-cbe8d7ba-70fa-4771-b413-5b913ae70c4e.png)
