### PR TITLE
Fix values in 2020 Yoakum County general file

### DIFF
--- a/2020/counties/20201103__tx__general__yoakum__precinct.csv
+++ b/2020/counties/20201103__tx__general__yoakum__precinct.csv
@@ -139,7 +139,7 @@ Yoakum,Precinct 404,U.S. Senate,,LIB,Kerry Douglas McKennon,3,0,1,2
 Yoakum,Precinct 404,U.S. Senate,,GRN,David B. Collins,2,0,1,1
 Yoakum,Precinct 404,U.S. Senate,,,Write-in Totals,0,0,0,0
 Yoakum,Precinct 404,U.S. Senate,,,Overvotes,0,0,0,0
-Yoakum,Precinct 404,U.S. Senate,,,Undervotes,4,1,3,9
+Yoakum,Precinct 404,U.S. Senate,,,Undervotes,4,1,3,0
 Yoakum,Precinct 404,U.S. House,19,REP,Jodey C. Arrington,322,11,247,64
 Yoakum,Precinct 404,U.S. House,19,DEM,Tom Watson,45,8,24,13
 Yoakum,Precinct 404,U.S. House,19,LIB,Joe Burnes,8,0,5,3


### PR DESCRIPTION
This fixes an incorrect value in the 2020 Yoakum County general file.  According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2020/general/YOAKUM_COUNTY-2020_NOVEMBER_3RD_GENERAL_ELECTION_1132020-2020%20General%20Election%20PRCT.pdf), there were 0 election day undervotes:

![image](https://user-images.githubusercontent.com/17345532/133118486-08f12f1b-6ddc-40e7-b785-29e4c028114b.png)

