### PR TITLE
Fix values in 2020 Karnes County general file

### DIFF
--- a/2020/counties/20201103__tx__general__karnes__precinct.csv
+++ b/2020/counties/20201103__tx__general__karnes__precinct.csv
@@ -84,7 +84,7 @@ Karnes,Precinct 1 - BS72,State Senate,21,,Judith Zaffirini,0,0,0,0
 Karnes,Precinct 1 - BS72,State Representative,17,,John P. Cyrier,0,0,0,0
 Karnes,Precinct 1 - BS72,State Representative,17,,Madeline Eden,0,0,0,0
 Karnes,Precinct 1 - BS73,Ballots Cast,,,,,,,118
-Karnes,Precinct 1 - BS73,President,,REP,Donald J Trump,5,47,16,65
+Karnes,Precinct 1 - BS73,President,,REP,Donald J Trump,2,47,16,65
 Karnes,Precinct 1 - BS73,President,,DEM,Joseph R Biden,3,30,10,43
 Karnes,Precinct 1 - BS73,President,,LIB,Jo Jorgensen,0,1,0,1
 Karnes,Precinct 1 - BS73,President,,GRN,Howie Hawkins,0,0,1,1


### PR DESCRIPTION
This fixes an incorrect value in the 2020 Karnes County general file.  According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2020/general/Karnes%20TX%20precinct%202020.pdf), Donald TTrump received 2 absentee votes:

![image](https://user-images.githubusercontent.com/17345532/133118842-5f3176bd-35a9-4603-a22a-c4628dacb853.png)

