### PR TITLE
Fix values in 2020 Hall County primary file

### DIFF
--- a/2020/counties/20200303__tx__primary__hall__precinct.csv
+++ b/2020/counties/20200303__tx__primary__hall__precinct.csv
@@ -360,8 +360,8 @@ precinct,county,office,district,party,candidate,early_voting,election_day,mail,v
 302,Hall,U.S. Senate,,REP,Mark Yancey,1,4,0,5
 302,Hall,U.S. Senate,,REP,John Anthony Castro,0,2,0,2
 302,Hall,U.S. Senate,,REP,Dwayne Stovall,1,2,0,3
-401,Hall,U.S. Senate,,REP,John Cornyn,17,59,0,60
-401,Hall,U.S. Senate,,REP,Virgil Bierschwale,1,1,0,1
+401,Hall,U.S. Senate,,REP,John Cornyn,1,59,0,60
+401,Hall,U.S. Senate,,REP,Virgil Bierschwale,0,1,0,1
 401,Hall,U.S. Senate,,REP,Mark Yancey,1,0,0,1
 401,Hall,U.S. Senate,,REP,John Anthony Castro,0,1,0,1
 401,Hall,U.S. Senate,,REP,Dwayne Stovall,1,25,0,29
@@ -460,21 +460,21 @@ precinct,county,office,district,party,candidate,early_voting,election_day,mail,v
 401,Hall,U.S. House,13,REP,Josh Winegarner,3,45,0,48
 401,Hall,U.S. House,13,REP,Asusena Resendiz,0,0,0,0
 401,Hall,U.S. House,13,REP,Ronny Jackson,4,13,0,17
-402,Hall,U.S. House,13,REP,Chris Ekstrom,2,22,0,5
+402,Hall,U.S. House,13,REP,Chris Ekstrom,2,3,0,5
 402,Hall,U.S. House,13,REP,Jason Foglesong,0,0,0,0
 402,Hall,U.S. House,13,REP,"Catherine ""I Swear"" Carr",0,0,0,0
 402,Hall,U.S. House,13,REP,Jamie Culley,0,0,0,0
 402,Hall,U.S. House,13,REP,Richard Herman,0,0,0,0
 402,Hall,U.S. House,13,REP,Matt McArthur,0,0,0,0
 402,Hall,U.S. House,13,REP,Vance Snider II,0,3,0,3
-402,Hall,U.S. House,13,REP,Lee Harvey,1,1,0,1
+402,Hall,U.S. House,13,REP,Lee Harvey,1,0,0,1
 402,Hall,U.S. House,13,REP,Diane Knowlton,0,0,0,0
 402,Hall,U.S. House,13,REP,Monique Worthy,0,0,0,0
-402,Hall,U.S. House,13,REP,Mark Neese,0,3,0,0
+402,Hall,U.S. House,13,REP,Mark Neese,0,0,0,0
 402,Hall,U.S. House,13,REP,Elaine Hays,1,1,0,2
-402,Hall,U.S. House,13,REP,Josh Winegarner,10,45,2,26
+402,Hall,U.S. House,13,REP,Josh Winegarner,10,14,2,26
 402,Hall,U.S. House,13,REP,Asusena Resendiz,0,0,0,0
-402,Hall,U.S. House,13,REP,Ronny Jackson,1,13,0,5
+402,Hall,U.S. House,13,REP,Ronny Jackson,1,4,0,5
 101,Hall,Railroad Commissioner,,REP,"James ""Jim"" Wright",30,34,0,64
 101,Hall,Railroad Commissioner,,REP,Ryan Sitton,3,6,2,11
 201,Hall,Railroad Commissioner,,REP,"James ""Jim"" Wright",5,7,0,12


### PR DESCRIPTION
This fixes some incorrect values in the 2020 Hall County general file. According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2020/primary/HALL_COUNTY-2020_MARCH_3RD_REPUBLICAN_PRIMARY_332020-Primary%2003.03.2020%20Precint%20Reporting%20Republican.xlsx), the early voting values for John Cornyn and Virgil Bierschwale should be

![image](https://user-images.githubusercontent.com/17345532/133298954-c3e8fc3b-79da-4618-b7b1-cc2b2c22bea7.png)

and the election day values for the U.S. House District 13 race should be

![image](https://user-images.githubusercontent.com/17345532/133299318-33109f81-f87b-4152-91cb-0beb712e4aa4.png)

In both cases, it appears that the previous values were read from the wrong column.