### PR TITLE
Fix values in 2018 Aransas County primary file

### DIFF
--- a/2018/counties/20181106__tx__general__aransas__precinct.csv
+++ b/2018/counties/20181106__tx__general__aransas__precinct.csv
@@ -179,7 +179,7 @@ Joi Chevalier,Comptroller of Public Accounts,,DEM,Aransas,4A,13,85,23,121
 Ben Sanders,Comptroller of Public Accounts,,LIB,Aransas,4A,1,7,7,15
 George P. Bush,Commissioner of the General Land Office,,REP,Aransas,4A,52,372,129,553
 Miguel Suazo,Commissioner of the General Land Office,,DEM,Aransas,4A,10,90,25,125
-Matt Pina,Commissioner of the General Land Office,,LIB,Aransas,4A,3,11,5,13
+Matt Pina,Commissioner of the General Land Office,,LIB,Aransas,4A,3,11,5,19
 Christi Craddick,Railroad Commissioner,,REP,Aransas,4A,51,386,130,567
 Roman McAllen,Railroad Commissioner,,DEM,Aransas,4A,15,83,25,123
 Mike Wright,Railroad Commissioner,,LIB,Aransas,4A,0,6,4,10


### PR DESCRIPTION
This fixes some incorrect values in the 2018 Aransas County general file. According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2018/general/Aransas%20TX%202018%20general.pdf), Matt Pina received 19 total votes in Precinct 4A:

![image](https://user-images.githubusercontent.com/17345532/133299688-b16c13f0-1051-4660-b578-ce971eb34e42.png)
