### PR TITLE
Fix values in 2016 Anderson County primary file

### DIFF
--- a/2016/counties/20161108__tx__general__anderson__precinct.csv
+++ b/2016/counties/20161108__tx__general__anderson__precinct.csv
@@ -521,9 +521,9 @@ Anderson,24,President,,Emidio Soltysik,,0,0,0
 Anderson,24,President,,Dale Steffes,,0,0,0
 Anderson,24,President,,Tony Valdivia,,0,0,0
 Anderson,24,U.S. House,5,Jeb Hensarling,Rep,298,201,499
-Anderson,24,U.S. House,5,Ken Asby,Lib,22,11,0
-Anderson,24,Railroad Commissioner,,Wayne Christian,Rep,288,182,0
-Anderson,24,Railroad Commissioner,,Grady Yarbrough,Dem,35,25,0
-Anderson,24,Railroad Commissioner,,Mark Miller,Lib,7,5,0
-Anderson,24,Railroad Commissioner,,Martina Salinas,Grn,1,1,0
-Anderson,24,State Representative,8,Byron Cook,Rep,303,197,0
+Anderson,24,U.S. House,5,Ken Asby,Lib,22,11,33
+Anderson,24,Railroad Commissioner,,Wayne Christian,Rep,288,182,470
+Anderson,24,Railroad Commissioner,,Grady Yarbrough,Dem,35,25,60
+Anderson,24,Railroad Commissioner,,Mark Miller,Lib,7,5,12
+Anderson,24,Railroad Commissioner,,Martina Salinas,Grn,1,1,2
+Anderson,24,State Representative,8,Byron Cook,Rep,303,197,500


### PR DESCRIPTION
This fixes some incorrect values in the 2016 Anderson County general file. According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2016/2016%20ANDERSON%20TX%20%20General%20PctxPct.xlsx), the early voting and election day values are correct.  The total votes were simply incorrect:

![image](https://user-images.githubusercontent.com/17345532/133300573-fe616148-8163-451f-afdd-b1862c460804.png)

