### PR TITLE
Fix values in 2020 Hood County primary file

### DIFF
--- a/2020/counties/20201103__tx__general__hood__precinct.csv
+++ b/2020/counties/20201103__tx__general__hood__precinct.csv
@@ -1,6 +1,6 @@
 county,precinct,office,district,candidate,party,votes,mail,early_voting,election_day,provisional
 Hood,Precinct 16,Registered Voters,,,,5771,,,,
-Hood,Precinct 16,Ballots Cast,,,,4854,825,3099,893,47
+Hood,Precinct 16,Ballots Cast,,,,4864,825,3099,893,47
 Hood,Precinct 16,President / Vice President,,Donald J. Trump / Michael R. Pence,REP,3990,516,2669,763,42
 Hood,Precinct 16,President / Vice President,,Joseph R. Biden / Kamala D. Harris,DEM,806,297,403,101,5
 Hood,Precinct 16,President / Vice President,,"Jo Jorgensen / Jeremy ""Spike"" Cohen",LIB,40,5,14,21,0
@@ -11,7 +11,7 @@ Hood,Precinct 16,President / Vice President,,Under Votes,,15,4,8,3,0
 Hood,Precinct 16,U.S. Senate,,John Cornyn,REP,3998,545,2655,759,39
 Hood,Precinct 16,U.S. Senate,,"Mary ""MJ"" Hegar",DEM,736,260,378,92,6
 Hood,Precinct 16,U.S. Senate,,Kerry Douglas McKennon,LIB,59,7,26,26,0
-Hood,Precinct 16,U.S. Senate,,David B. Collins,GRN,4,1,10,3,0
+Hood,Precinct 16,U.S. Senate,,David B. Collins,GRN,14,1,10,3,0
 Hood,Precinct 16,U.S. Senate,,Write-In,,0,0,0,0,0
 Hood,Precinct 16,U.S. Senate,,Over Votes,,0,0,0,0,0
 Hood,Precinct 16,U.S. Senate,,Under Votes,,57,12,30,13,2
@@ -49,7 +49,7 @@ Hood,Precinct 15,U.S. Senate,,David B. Collins,GRN,2,0,2,0,0
 Hood,Precinct 15,U.S. Senate,,Write-In,,0,0,0,0,0
 Hood,Precinct 15,U.S. Senate,,Over Votes,,0,0,0,0,0
 Hood,Precinct 15,U.S. Senate,,Under Votes,,7,0,5,2,0
-Hood,Precinct 15,U.S. House,11,August Pfluger,REP,255,10,163,92,0
+Hood,Precinct 15,U.S. House,11,August Pfluger,REP,265,10,163,92,0
 Hood,Precinct 15,U.S. House,11,Jon Mark Hogg,DEM,59,8,32,19,0
 Hood,Precinct 15,U.S. House,11,Wacey Alpha Cody,LIB,11,0,7,4,0
 Hood,Precinct 15,U.S. House,11,Over Votes,,0,0,0,0,0
@@ -66,18 +66,18 @@ Hood,Precinct 15,State Senate,22,Over Votes,,0,0,0,0,0
 Hood,Precinct 15,State Senate,22,Under Votes,,17,4,9,4,0
 Hood,Precinct 15,State Representative,60,Glenn Rogers,REP,296,11,187,98,0
 Hood,Precinct 15,State Representative,60,Over Votes,,0,0,0,0,0
-Hood,Precinct 15,State Representative,60,Under Votes,,55,11,25,20,0
+Hood,Precinct 15,State Representative,60,Under Votes,,56,11,25,20,0
 Hood,Precinct 14,Registered Voters,,,,3601,,,,
-Hood,Precinct 14,Ballots Cast,,,,2605,277,1767,538,24
+Hood,Precinct 14,Ballots Cast,,,,2606,277,1767,538,24
 Hood,Precinct 14,President / Vice President,,Donald J. Trump / Michael R. Pence,REP,2055,146,1457,432,20
 Hood,Precinct 14,President / Vice President,,Joseph R. Biden / Kamala D. Harris,DEM,514,129,289,92,4
 Hood,Precinct 14,President / Vice President,,"Jo Jorgensen / Jeremy ""Spike"" Cohen",LIB,24,1,15,8,0
 Hood,Precinct 14,President / Vice President,,Howie Hawkins / Angela Walker,GRN,3,0,2,1,0
-Hood,Precinct 14,President / Vice President,,Write-In,,5,1,2,3,0
+Hood,Precinct 14,President / Vice President,,Write-In,,6,1,2,3,0
 Hood,Precinct 14,President / Vice President,,Over Votes,,0,0,0,0,0
 Hood,Precinct 14,President / Vice President,,Under Votes,,4,0,2,2,0
 Hood,Precinct 14,U.S. Senate,,John Cornyn,REP,2053,156,1447,430,20
-Hood,Precinct 14,U.S. Senate,,"Mary ""MJ"" Hegar",DEM,455,111,259,82,4
+Hood,Precinct 14,U.S. Senate,,"Mary ""MJ"" Hegar",DEM,456,111,259,82,4
 Hood,Precinct 14,U.S. Senate,,Kerry Douglas McKennon,LIB,42,3,30,9,0
 Hood,Precinct 14,U.S. Senate,,David B. Collins,GRN,13,1,8,4,0
 Hood,Precinct 14,U.S. Senate,,Write-In,,1,1,0,0,0
@@ -138,7 +138,7 @@ Hood,Precinct 13,State Representative,60,Under Votes,,398,137,217,41,3
 Hood,Precinct 12,Registered Voters,,,,1933,,,,
 Hood,Precinct 12,Ballots Cast,,,,1213,112,860,238,3
 Hood,Precinct 12,President / Vice President,,Donald J. Trump / Michael R. Pence,REP,963,72,694,194,3
-Hood,Precinct 12,President / Vice President,,Joseph R. Biden / Kamala D. Harris,DEM,225,39,153,34,0
+Hood,Precinct 12,President / Vice President,,Joseph R. Biden / Kamala D. Harris,DEM,226,39,153,34,0
 Hood,Precinct 12,President / Vice President,,"Jo Jorgensen / Jeremy ""Spike"" Cohen",LIB,11,1,4,6,0
 Hood,Precinct 12,President / Vice President,,Howie Hawkins / Angela Walker,GRN,9,0,7,2,0
 Hood,Precinct 12,President / Vice President,,Write-In,,0,0,0,0,0


### PR DESCRIPTION
This fixes some incorrect values in the 2020 Hood County general file. Many of these changes correct a possible OCR issue, where a `5` is supposed to be a `6`:

According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2020/general/HOOD_COUNTY-2020_NOVEMBER_3RD_GENERAL_ELECTION_1132020-November%203%202020%20pct%20by%20pct.pdf),

* The total ballots cast in Precinct 16 should be `4864`:
![image](https://user-images.githubusercontent.com/17345532/133301076-82df7ab9-93cb-47a0-b7fd-fc2dcc5d4607.png)

* David B. Collins received `14` total votes in Precinct 16:
![image](https://user-images.githubusercontent.com/17345532/133301179-5deca34e-97d2-4818-bf6d-772f9f3377d2.png)

* August Pfluger received `265` total votes in Precinct 15:
![image](https://user-images.githubusercontent.com/17345532/133301425-fd30f4b3-5613-4049-9458-88db4924b5a8.png)

* There were `56` undervotes in the US House District 60 race in Precinct 15:
![image](https://user-images.githubusercontent.com/17345532/133301538-9eb35de4-b413-4f60-b391-a4707ba9a2f9.png)

* The total ballots cast in Precinct 14 should be `2606`:
![image](https://user-images.githubusercontent.com/17345532/133301607-fb0677d6-96c5-4b21-9d29-d1bf8342211f.png)

* Mary "MJ" Hegar received `456` total votes in Precinct 14:
![image](https://user-images.githubusercontent.com/17345532/133301755-56a060ba-5d2b-4d13-a1db-f98cf6a8ae0e.png)

* Joseph Biden received `226` total votes in Precinct 12:
![image](https://user-images.githubusercontent.com/17345532/133301845-9de8d357-44f4-4531-9a0c-98e14d651b49.png)

This does not fix the problems described in issue #373.


