### PR TITLE
Fix values in 2016 Wilson County general file

### DIFF
--- a/2016/counties/20161108__tx__general__wilson__precinct.csv
+++ b/2016/counties/20161108__tx__general__wilson__precinct.csv
@@ -122,7 +122,7 @@ Wilson,101,President,,Gary Johnson,LIB,12,12,0,4,28
 Wilson,102,President,,Gary Johnson,LIB,4,6,0,1,11
 Wilson,103,President,,Gary Johnson,LIB,17,10,0,2,29
 Wilson,104,President,,Gary Johnson,LIB,11,1,0,1,13
-Wilson,205,President,,Gary Johnson,LIB,19,7,0,44,26
+Wilson,205,President,,Gary Johnson,LIB,19,7,0,0,26
 Wilson,206,President,,Gary Johnson,LIB,17,19,0,4,40
 Wilson,207,President,,Gary Johnson,LIB,14,7,0,1,22
 Wilson,208,President,,Gary Johnson,LIB,7,0,0,0,7
@@ -134,7 +134,7 @@ Wilson,313,President,,Gary Johnson,LIB,16,18,0,1,35
 Wilson,414,President,,Gary Johnson,LIB,15,4,0,1,20
 Wilson,415,President,,Gary Johnson,LIB,34,19,0,2,55
 Wilson,416,President,,Gary Johnson,LIB,22,21,0,3,46
-Wilson,Total,President,,Gary Johnson,LIB,225,145,0,66,392
+Wilson,Total,President,,Gary Johnson,LIB,225,145,0,22,392
 Wilson,101,President,,Jill Stein,GRN,7,3,0,0,10
 Wilson,102,President,,Jill Stein,GRN,3,2,0,0,5
 Wilson,103,President,,Jill Stein,GRN,9,2,0,0,11
@@ -237,10 +237,10 @@ Wilson,208,Railroad Commissioner,,Wayne Christian,REP,202,93,0,7,302
 Wilson,209,Railroad Commissioner,,Wayne Christian,REP,202,36,0,4,242
 Wilson,310,Railroad Commissioner,,Wayne Christian,REP,175,155,0,30,360
 Wilson,311,Railroad Commissioner,,Wayne Christian,REP,520,423,0,43,986
-Wilson,312,Railroad Commissioner,,Wayne Christian,REP,632,651,1,55,1
+Wilson,312,Railroad Commissioner,,Wayne Christian,REP,632,651,1,55,1339
 Wilson,313,Railroad Commissioner,,Wayne Christian,REP,525,572,2,26,1125
 Wilson,414,Railroad Commissioner,,Wayne Christian,REP,603,413,0,40,1056
-Wilson,415,Railroad Commissioner,,Wayne Christian,REP,697,1056,0,66,1818
+Wilson,415,Railroad Commissioner,,Wayne Christian,REP,697,1056,0,66,1819
 Wilson,416,Railroad Commissioner,,Wayne Christian,REP,358,641,0,62,1061
 Wilson,Total,Railroad Commissioner,,Wayne Christian,REP,5717,6430,524,5,12676
 Wilson,101,Railroad Commissioner,,Grady Yarbrough,DEM,133,245,0,17,395
@@ -257,7 +257,7 @@ Wilson,311,Railroad Commissioner,,Grady Yarbrough,DEM,59,66,0,8,133
 Wilson,312,Railroad Commissioner,,Grady Yarbrough,DEM,78,94,0,5,177
 Wilson,313,Railroad Commissioner,,Grady Yarbrough,DEM,127,121,0,15,263
 Wilson,414,Railroad Commissioner,,Grady Yarbrough,DEM,119,91,0,19,229
-Wilson,415,Railroad Commissioner,,Grady Yarbrough,DEM,114,206,0,14,333
+Wilson,415,Railroad Commissioner,,Grady Yarbrough,DEM,114,206,0,14,334
 Wilson,416,Railroad Commissioner,,Grady Yarbrough,DEM,123,230,0,21,374
 Wilson,Total,Railroad Commissioner,,Grady Yarbrough,DEM,1822,2159,339,1,4321
 Wilson,101,Railroad Commissioner,,Mark Miller,LIB,38,30,0,0,68


### PR DESCRIPTION
This fixes some incorrect values in the 2016 Wilson County general file. According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2016/2016%20Wilson,%20TX%20precinct-level%20election%20results.pdf),

* Gary Johnson received `0` mail votes in Precinct 205:
![image](https://user-images.githubusercontent.com/17345532/133305964-36e9caff-fae6-43f6-96c5-dca33aa24f10.png)

* Wayne Christian received `1339` total votes in Precinct 415:
![image](https://user-images.githubusercontent.com/17345532/133306173-dd307d48-6f22-4c7b-ae99-694661002868.png)

* The total votes for Wayne Christian and Grady Yarbrough were not updated to reflect the handwritten corrections to the election day votes (see issue #378):
![image](https://user-images.githubusercontent.com/17345532/133304223-01f58133-3306-4b1c-9fea-267b1f7df09f.png)

This fixes #378.