### PR TITLE
Fix values in 2018 Sterling County general file

### DIFF
--- a/2018/counties/20181106__tx__general__sterling__precinct.csv
+++ b/2018/counties/20181106__tx__general__sterling__precinct.csv
@@ -44,11 +44,11 @@ Sterling,2,U.S. Senate,,Neal M Dikeman,LIB,0,0,0,0
 Sterling,3,U.S. Senate,,Neal M Dikeman,LIB,0,0,0,0
 Sterling,4,U.S. Senate,,Neal M Dikeman,LIB,0,0,0,0
 Sterling,Total,U.S. Senate,,Neal M Dikeman,LIB,0,0,0,0
-Sterling,1,U.S. Senate,,Cast Votes,,10,72,55,131
+Sterling,1,U.S. Senate,,Cast Votes,,10,72,55,137
 Sterling,2,U.S. Senate,,Cast Votes,,5,48,42,95
 Sterling,3,U.S. Senate,,Cast Votes,,13,82,46,141
 Sterling,4,U.S. Senate,,Cast Votes,,4,68,41,113
-Sterling,Total,U.S. Senate,,Cast Votes,,32,270,184,480
+Sterling,Total,U.S. Senate,,Cast Votes,,32,270,184,486
 Sterling,1,U.S. Senate,,Under Votes,,0,0,0,0
 Sterling,2,U.S. Senate,,Under Votes,,0,3,0,3
 Sterling,3,U.S. Senate,,Under Votes,,0,3,0,3
@@ -72,8 +72,8 @@ Sterling,Total,U.S. House,1,Jennie Lou Leeder,DEM,2,11,17,30
 Sterling,1,U.S. House,1,Rhett Rosenquest,LIB,0,0,1,1
 Sterling,2,U.S. House,1,Rhett Rosenquest,LIB,0,0,0,0
 Sterling,3,U.S. House,1,Rhett Rosenquest,LIB,0,0,0,0
-Sterling,4,U.S. House,1,Rhett Rosenquest,LIB,0,2,0,0
-Sterling,Total,U.S. House,1,Rhett Rosenquest,LIB,0,2,1,1
+Sterling,4,U.S. House,1,Rhett Rosenquest,LIB,0,2,0,2
+Sterling,Total,U.S. House,1,Rhett Rosenquest,LIB,0,2,1,3
 Sterling,1,U.S. House,1,Cast Votes,,9,71,55,135
 Sterling,2,U.S. House,1,Cast Votes,,5,50,41,96
 Sterling,3,U.S. House,1,Cast Votes,,13,85,46,144
@@ -134,11 +134,11 @@ Sterling,2,Lieutenant Governor,,Kerry Douglas,LIB,0,1,1,2
 Sterling,3,Lieutenant Governor,,Kerry Douglas,LIB,0,1,0,1
 Sterling,4,Lieutenant Governor,,Kerry Douglas,LIB,0,3,0,3
 Sterling,Total,Lieutenant Governor,,Kerry Douglas,LIB,0,7,1,8
-Sterling,1,Lieutenant Governor,,Cast Votes,,8,67,55,13
+Sterling,1,Lieutenant Governor,,Cast Votes,,8,67,55,130
 Sterling,2,Lieutenant Governor,,Cast Votes,,5,51,41,97
 Sterling,3,Lieutenant Governor,,Cast Votes,,13,82,45,140
 Sterling,4,Lieutenant Governor,,Cast Votes,,4,67,40,111
-Sterling,Total,Lieutenant Governor,,Cast Votes,,30,267,181,361
+Sterling,Total,Lieutenant Governor,,Cast Votes,,30,267,181,478
 Sterling,1,Lieutenant Governor,,Under Votes,,2,5,0,7
 Sterling,2,Lieutenant Governor,,Under Votes,,0,0,1,1
 Sterling,3,Lieutenant Governor,,Under Votes,,0,3,1,4
@@ -196,9 +196,9 @@ Sterling,4,Comptroller of Public Accounts,,Ben Sanders,LIB,0,0,0,0
 Sterling,Total,Comptroller of Public Accounts,,Ben Sanders,LIB,0,3,2,5
 Sterling,1,Comptroller of Public Accounts,,Cast Votes,,7,69,54,130
 Sterling,2,Comptroller of Public Accounts,,Cast Votes,,5,50,41,96
-Sterling,3,Comptroller of Public Accounts,,Cast Votes,,13,85,45,3
+Sterling,3,Comptroller of Public Accounts,,Cast Votes,,13,85,45,143
 Sterling,4,Comptroller of Public Accounts,,Cast Votes,,4,67,40,111
-Sterling,Total,Comptroller of Public Accounts,,Cast Votes,,29,271,180,340
+Sterling,Total,Comptroller of Public Accounts,,Cast Votes,,29,271,180,480
 Sterling,1,Comptroller of Public Accounts,,Under Votes,,3,3,1,7
 Sterling,2,Comptroller of Public Accounts,,Under Votes,,0,0,0,0
 Sterling,3,Comptroller of Public Accounts,,Under Votes,,0,0,1,1
@@ -211,9 +211,9 @@ Sterling,4,Comptroller of Public Accounts,,Over Votes,,0,0,0,0
 Sterling,Total,Comptroller of Public Accounts,,Over Votes,,0,0,0,0
 Sterling,1,Commissioner of the General Land Office,,George P Bush,REP,6,60,46,112
 Sterling,2,Commissioner of the General Land Office,,George P Bush,REP,5,45,35,85
-Sterling,3,Commissioner of the General Land Office,,George P Bush,REP,12,79,40,1
+Sterling,3,Commissioner of the General Land Office,,George P Bush,REP,12,79,40,131
 Sterling,4,Commissioner of the General Land Office,,George P Bush,REP,4,64,33,101
-Sterling,Total,Commissioner of the General Land Office,,George P Bush,REP,27,248,154,299
+Sterling,Total,Commissioner of the General Land Office,,George P Bush,REP,27,248,154,429
 Sterling,1,Commissioner of the General Land Office,,Miguel Suazo,DEM,1,7,5,13
 Sterling,2,Commissioner of the General Land Office,,Miguel Suazo,DEM,0,2,5,7
 Sterling,3,Commissioner of the General Land Office,,Miguel Suazo,DEM,1,2,5,8
@@ -224,11 +224,11 @@ Sterling,2,Commissioner of the General Land Office,,Matt Piña,LIB,0,3,1,4
 Sterling,3,Commissioner of the General Land Office,,Matt Piria,LIB,0,3,0,3
 Sterling,4,Commissioner of the General Land Office,,Matt Pifia,LIB,0,1,0,1
 Sterling,Total,Commissioner of the General Land Office,,Matt Pifia,LIB,1,8,4,13
-Sterling,1,Commissioner of the General Land Office,,Cast Votes,,8,68,54,30
+Sterling,1,Commissioner of the General Land Office,,Cast Votes,,8,68,54,130
 Sterling,2,Commissioner of the General Land Office,,Cast Votes,,5,50,41,96
 Sterling,3,Commissioner of the General Land Office,,Cast Votes,,13,84,45,142
 Sterling,4,Commissioner of the General Land Office,,Cast Votes,,4,67,40,111
-Sterling,Total,Commissioner of the General Land Office,,Cast Votes,,30,269,180,379
+Sterling,Total,Commissioner of the General Land Office,,Cast Votes,,30,269,180,479
 Sterling,1,Commissioner of the General Land Office,,Under Votes,,2,4,1,7
 Sterling,2,Commissioner of the General Land Office,,Under Votes,,0,0,0,0
 Sterling,3,Commissioner of the General Land Office,,Under Votes,,0,1,1,2

--- a/2018/counties/20181106__tx__general__sterling__precinct.csv
+++ b/2018/counties/20181106__tx__general__sterling__precinct.csv
@@ -59,36 +59,36 @@ Sterling,2,U.S. Senate,,Over Votes,,0,0,0,0
 Sterling,3,U.S. Senate,,Over Votes,,0,0,0,0
 Sterling,4,U.S. Senate,,Over Votes,,0,0,0,0
 Sterling,Total,U.S. Senate,,Over Votes,,0,0,0,0
-Sterling,1,U.S. House,1,Mike Conaway,REP,8,66,50,124
-Sterling,2,U.S. House,1,Mike Conaway,REP,5,47,37,89
-Sterling,3,U.S. House,1,Mike Conaway,REP,12,84,43,139
-Sterling,4,U.S. House,1,Mike Conaway,REP,4,64,34,102
-Sterling,Total,U.S. House,1,Mike Conaway,REP,29,261,164,454
-Sterling,1,U.S. House,1,Jennie Lou Leeder,DEM,1,5,4,10
-Sterling,2,U.S. House,1,Jennie Lou Leeder,DEM,0,3,4,7
-Sterling,3,U.S. House,1,Jennie Lou Leeder,DEM,1,1,3,5
-Sterling,4,U.S. House,1,Jennie Lou Leeder,DEM,0,2,6,8
-Sterling,Total,U.S. House,1,Jennie Lou Leeder,DEM,2,11,17,30
-Sterling,1,U.S. House,1,Rhett Rosenquest,LIB,0,0,1,1
-Sterling,2,U.S. House,1,Rhett Rosenquest,LIB,0,0,0,0
-Sterling,3,U.S. House,1,Rhett Rosenquest,LIB,0,0,0,0
-Sterling,4,U.S. House,1,Rhett Rosenquest,LIB,0,2,0,2
-Sterling,Total,U.S. House,1,Rhett Rosenquest,LIB,0,2,1,3
-Sterling,1,U.S. House,1,Cast Votes,,9,71,55,135
-Sterling,2,U.S. House,1,Cast Votes,,5,50,41,96
-Sterling,3,U.S. House,1,Cast Votes,,13,85,46,144
-Sterling,4,U.S. House,1,Cast Votes,,4,68,40,112
-Sterling,Total,U.S. House,1,Cast Votes,,31,274,182,487
-Sterling,1,U.S. House,1,Under Votes,,1,1,0,2
-Sterling,2,U.S. House,1,Under Votes,,0,1,1,2
-Sterling,3,U.S. House,1,Under Votes,,0,0,0,0
-Sterling,4,U.S. House,1,Under Votes,,0,0,1,1
-Sterling,Total,U.S. House,1,Under Votes,,1,2,2,5
-Sterling,1,U.S. House,1,Over Votes,,0,0,0,0
-Sterling,2,U.S. House,1,Over Votes,,0,0,0,0
-Sterling,3,U.S. House,1,Over Votes,,0,0,0,0
-Sterling,4,U.S. House,1,Over Votes,,0,0,0,0
-Sterling,Total,U.S. House,1,Over Votes,,0,0,0,0
+Sterling,1,U.S. House,11,Mike Conaway,REP,8,66,50,124
+Sterling,2,U.S. House,11,Mike Conaway,REP,5,47,37,89
+Sterling,3,U.S. House,11,Mike Conaway,REP,12,84,43,139
+Sterling,4,U.S. House,11,Mike Conaway,REP,4,64,34,102
+Sterling,Total,U.S. House,11,Mike Conaway,REP,29,261,164,454
+Sterling,1,U.S. House,11,Jennie Lou Leeder,DEM,1,5,4,10
+Sterling,2,U.S. House,11,Jennie Lou Leeder,DEM,0,3,4,7
+Sterling,3,U.S. House,11,Jennie Lou Leeder,DEM,1,1,3,5
+Sterling,4,U.S. House,11,Jennie Lou Leeder,DEM,0,2,6,8
+Sterling,Total,U.S. House,11,Jennie Lou Leeder,DEM,2,11,17,30
+Sterling,1,U.S. House,11,Rhett Rosenquest,LIB,0,0,1,1
+Sterling,2,U.S. House,11,Rhett Rosenquest,LIB,0,0,0,0
+Sterling,3,U.S. House,11,Rhett Rosenquest,LIB,0,0,0,0
+Sterling,4,U.S. House,11,Rhett Rosenquest,LIB,0,2,0,2
+Sterling,Total,U.S. House,11,Rhett Rosenquest,LIB,0,2,1,3
+Sterling,1,U.S. House,11,Cast Votes,,9,71,55,135
+Sterling,2,U.S. House,11,Cast Votes,,5,50,41,96
+Sterling,3,U.S. House,11,Cast Votes,,13,85,46,144
+Sterling,4,U.S. House,11,Cast Votes,,4,68,40,112
+Sterling,Total,U.S. House,11,Cast Votes,,31,274,182,487
+Sterling,1,U.S. House,11,Under Votes,,1,1,0,2
+Sterling,2,U.S. House,11,Under Votes,,0,1,1,2
+Sterling,3,U.S. House,11,Under Votes,,0,0,0,0
+Sterling,4,U.S. House,11,Under Votes,,0,0,1,1
+Sterling,Total,U.S. House,11,Under Votes,,1,2,2,5
+Sterling,1,U.S. House,11,Over Votes,,0,0,0,0
+Sterling,2,U.S. House,11,Over Votes,,0,0,0,0
+Sterling,3,U.S. House,11,Over Votes,,0,0,0,0
+Sterling,4,U.S. House,11,Over Votes,,0,0,0,0
+Sterling,Total,U.S. House,11,Over Votes,,0,0,0,0
 Sterling,1,Governor,,Greg Abbott,REP,8,65,51,124
 Sterling,2,Governor,,Greg Abbott,REP,5,45,34,84
 Sterling,3,Governor,,Greg Abbott,REP,12,81,41,134


### PR DESCRIPTION
This fixes some incorrect values in the 2018 Sterling County general file. According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2018/general/Sterling%20TX%20general.pdf), the total number of votes cast in Precinct 1 for the Senate seat should be `137`:

![image](https://user-images.githubusercontent.com/17345532/133467297-97065e6e-0d87-438b-8c96-50fcd51f3498.png)

This also fixes the congressional district for the House race.  It should be `11`, not `1`:

![image](https://user-images.githubusercontent.com/17345532/133467520-f4dbd8f9-2e19-455a-994e-25c76e7f4914.png)


