### PR TITLE
Fix values in 2016 Jim Wells County primary file

### DIFF
--- a/2016/counties/20160301__tx__primary__jim_wells__precinct.csv
+++ b/2016/counties/20160301__tx__primary__jim_wells__precinct.csv
@@ -49,22 +49,22 @@ Jim Wells,3,Ballots Cast,,,DEM,5,16,93,114
 Jim Wells,4,Ballots Cast,,,DEM,38,306,220,564
 Jim Wells,5,Ballots Cast,,,DEM,8,27,95,130
 Jim Wells,6,Ballots Cast,,,DEM,36,79,191,306
-Jim Wells,7,Ballots Cast,,,DEM,25,397,344,755
+Jim Wells,7,Ballots Cast,,,DEM,25,397,344,766
 Jim Wells,8,Ballots Cast,,,DEM,53,193,251,497
 Jim Wells,9,Ballots Cast,,,DEM,9,130,76,215
 Jim Wells,10,Ballots Cast,,,DEM,87,377,311,775
 Jim Wells,11,Ballots Cast,,,DEM,46,180,164,390
 Jim Wells,12,Ballots Cast,,,DEM,32,282,278,592
-Jim Wells,13,Ballots Cast,,,DEM,16,62,87,155
+Jim Wells,13,Ballots Cast,,,DEM,16,62,87,165
 Jim Wells,14,Ballots Cast,,,DEM,7,28,40,75
 Jim Wells,15,Ballots Cast,,,DEM,21,255,265,541
 Jim Wells,16,Ballots Cast,,,DEM,38,131,150,319
 Jim Wells,17,Ballots Cast,,,DEM,28,237,307,572
 Jim Wells,18,Ballots Cast,,,DEM,7,46,105,159
 Jim Wells,19,Ballots Cast,,,DEM,1,10,27,38
-Jim Wells,20,Ballots Cast,,,DEM,23,139,108,267
+Jim Wells,20,Ballots Cast,,,DEM,23,139,105,267
 Jim Wells,22,Ballots Cast,,,DEM,44,372,360,776
-Jim Wells,Total,Ballots Cast,,,DEM,562,3361,3578,7499
+Jim Wells,Total,Ballots Cast,,,DEM,562,3361,3576,7499
 Jim Wells,1,President,,John R. Kasich,REP,,,,0
 Jim Wells,2,President,,John R. Kasich,REP,,,,2
 Jim Wells,3,President,,John R. Kasich,REP,,,,7


### PR DESCRIPTION
This fixes some incorrect values in the 2016 Jim Wells County primary file. According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2016/Jim%20Wells%20TX%202016%20pRIMARY%20dEM%20cANVASS%20rEPORT.pdf), the correct values are:

![image](https://user-images.githubusercontent.com/17345532/133468480-5fba57b3-c8bc-4cf3-b42b-6f829935a286.png)