### PR TITLE
Fix values in 2016 Uvalde County general file

### DIFF
--- a/2016/counties/20161108__tx__general__uvalde__precinct.csv
+++ b/2016/counties/20161108__tx__general__uvalde__precinct.csv
@@ -5,7 +5,7 @@ Uvalde,1,President,,Dem,Hillary Clinton,465,56,295,114
 Uvalde,1,President,,Lbt,Gary Johnson,20,1,14,5
 Uvalde,1,President,,Grn,Jill Stein,2,0,0,2
 Uvalde,1,President,,,Darrell Castle,1,0,0,1
-Uvalde,1,President,,,Evan McMullin,1,0,1,1
+Uvalde,1,President,,,Evan McMullin,1,0,1,0
 Uvalde,1,U.S. House,23,Rep,Will Hurd,473,24,360,89
 Uvalde,1,U.S. House,23,Dem,Pete Gallego,447,54,284,109
 Uvalde,1,U.S. House,23,Lbt,Ruben Corvalan,43,2,23,18
@@ -83,9 +83,9 @@ Uvalde,5,State Senate,19,Dem,Carlos Uresti,297,30,184,83
 Uvalde,5,State Senate,19,Lbt,Max Martin,21,3,12,6
 Uvalde,5,State House,80,Dem,Tracy King,667,42,465,160
 Uvalde,6,Ballots Cast,,,,208,3,88,117
-Uvalde,6,President,,Rep,Donald Trump,103,1,67,103
-Uvalde,6,President,,Dem,Hillary Clinton,14,2,17,14
-Uvalde,6,President,,Lbt,Gary Johnson,0,0,3,0
+Uvalde,6,President,,Rep,Donald Trump,171,1,67,103
+Uvalde,6,President,,Dem,Hillary Clinton,33,2,17,14
+Uvalde,6,President,,Lbt,Gary Johnson,3,0,3,0
 Uvalde,6,President,,Grn,Jill Stein,0,0,0,0
 Uvalde,6,U.S. House,23,Rep,Will Hurd,168,1,66,101
 Uvalde,6,U.S. House,23,Dem,Pete Gallego,34,2,20,12


### PR DESCRIPTION
This fixes some incorrect values in the 2016 Uvalde County general file. According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2016/Uvalde_2016_Gen_Elec_part1.tif), 

* Evan McMullin received `0` election day votes in Precinct 1:
![image](https://user-images.githubusercontent.com/17345532/133469004-42f29dee-716a-420c-816c-bd5c0df91781.png)

* The total votes in Precinct 6 for the presidential race should be:
![image](https://user-images.githubusercontent.com/17345532/133469192-967de492-7192-4c2d-a8e2-a03b993c114b.png)

