### PR TITLE
Fix values in 2020 Wilbarger County general file

### DIFF
--- a/2020/counties/20201103__tx__general__wilbarger__precinct.csv
+++ b/2020/counties/20201103__tx__general__wilbarger__precinct.csv
@@ -352,7 +352,7 @@ John Cornyn,U.S. Senate,,REP,Wilbarger,PCT 21 GEN-ONLY,109,8,1,118
 Kerry Douglas McKennon,U.S. Senate,,LIB,Wilbarger,PCT 21 GEN-ONLY,1,0,0,1
 David B. Collins,U.S. Senate,,GRN,Wilbarger,PCT 21 GEN-ONLY,1,0,0,1
 Over Votes,U.S. Senate,,,Wilbarger,PCT 21 GEN-ONLY,0,0,0,0
-Under Votes,U.S. Senate,,,Wilbarger,PCT 21 GEN-ONLY,5,0,5,5
+Under Votes,U.S. Senate,,,Wilbarger,PCT 21 GEN-ONLY,5,0,0,5
 Ronny Jackson,U.S. House,13,,Wilbarger,PCT 21 GEN-ONLY,107,8,1,116
 Gus Trujillo,U.S. House,13,,Wilbarger,PCT 21 GEN-ONLY,35,0,0,35
 Jack B. Westbrook,U.S. House,13,,Wilbarger,PCT 21 GEN-ONLY,0,0,0,0


### PR DESCRIPTION
This fixes some incorrect values in the 2020 Wilbarger County general file. According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2020/general/Wilbarger%20TX%202020%20General.pdf), there `0` election day undervotes for the Senate race in Precinct 21 GEN-ONLY:

![image](https://user-images.githubusercontent.com/17345532/133469881-08ec0ba5-86f8-4b4d-a94d-18e828403413.png)


