### PR TITLE
Fix values in 2020 Dawson County primary file

### DIFF
--- a/2020/counties/20200303__tx__primary__dawson__precinct.csv
+++ b/2020/counties/20200303__tx__primary__dawson__precinct.csv
@@ -206,7 +206,7 @@ Dawson,Precinct 1,Railroad Commissioner,,Over Votes,REP,0,0,0
 Dawson,Precinct 1,Railroad Commissioner,,Under Votes,REP,47,27,74
 Dawson,Precinct 1,State Senate,28,Charles Perry,REP,127,110,237
 Dawson,Precinct 1,State Senate,28,Over Votes,REP,0,0,0
-Dawson,Precinct 1,State Senate,28,Under Votes,REP,70,35,99
+Dawson,Precinct 1,State Senate,28,Under Votes,REP,64,35,99
 Dawson,Precinct 1,State Representative,82,Tom Craddick,REP,128,112,240
 Dawson,Precinct 1,State Representative,82,Over Votes,REP,0,0,0
 Dawson,Precinct 1,State Representative,82,Under Votes,REP,63,33,96


### PR DESCRIPTION
This fixes some incorrect values in the 2020 Dawson County primary file. According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2020/primary/DAWSON_COUNTY-2020_MARCH_3RD_REPUBLICAN_PRIMARY_332020-REPUBLICAN%20REPORT.pdf), there were `64` early undervotes for the State Senate race in Precinct 1:

![image](https://user-images.githubusercontent.com/17345532/133470387-92c8eff2-901b-495f-90ff-549c0ee269e9.png)
