### PR TITLE
Fix values in 2020 Glasscock County primary file

### DIFF
--- a/2020/counties/20200303__tx__primary__glasscock__precinct.csv
+++ b/2020/counties/20200303__tx__primary__glasscock__precinct.csv
@@ -35,13 +35,13 @@ Glasscock,2,President,,REP,Bill Weld,0,0,0,0
 Glasscock,2,President,,REP,"Roque ""Rocky"" De La Fuente Guerra",0,0,0,0
 Glasscock,2,President,,REP,Bob Ely,0,0,0,0
 Glasscock,2,President,,REP,Donald J. Trump,4,37,26,67
-Glasscock,2,President,,REP,Joe Walsh,0,0,1,0
+Glasscock,2,President,,REP,Joe Walsh,0,0,1,1
 Glasscock,2,President,,REP,Zoltan G. Istvan,0,0,0,0
 Glasscock,2,President,,REP,Uncommitted,0,0,0,0
 Glasscock,2,U.S. Senate,,REP,John Anthony Castro,1,0,1,2
 Glasscock,2,U.S. Senate,,REP,Dwayne Stovall,0,0,2,2
 Glasscock,2,U.S. Senate,,REP,Virgil Bierschwale,0,0,0,0
-Glasscock,2,U.S. Senate,,REP,Mark Yancey,0,0,3,0
+Glasscock,2,U.S. Senate,,REP,Mark Yancey,0,0,3,3
 Glasscock,2,U.S. Senate,,REP,John Cornyn,3,36,16,55
 Glasscock,2,U.S. House,11,REP,Robert Tucker,0,0,0,0
 Glasscock,2,U.S. House,11,REP,J. Ross Lacy,0,1,0,1


### PR DESCRIPTION
This fixes some incorrect values in the 2020 Glasscock County primary file. According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2020/primary/Glasscock%20TX%20Primary.pdf), 

* Joe Walsh received `1` total vote in Precinct 2:
![image](https://user-images.githubusercontent.com/17345532/133470700-dc71ef6b-7286-49d6-af0c-47606f095235.png)

* Mark Yancey received `3` total votes in Precinct 2:
![image](https://user-images.githubusercontent.com/17345532/133470763-5c2bf551-b8d3-4138-895c-6631317403da.png)
