### PR TITLE
Fix values in 2018 Kimble County primary file

### DIFF
--- a/2018/counties/20180306__tx__primary__kimble__precinct.csv
+++ b/2018/counties/20180306__tx__primary__kimble__precinct.csv
@@ -6,7 +6,7 @@ Kimble,9,Ballots Cast,,,,,,180
 Kimble,3,Ballots Cast,,,,,,85
 Kimble,6,Ballots Cast,,,,,,108
 Kimble,7,Ballots Cast,,,,,,104
-Kimble,Total,Ballots Cast,,,,948,0,0
+Kimble,Total,Ballots Cast,,,,0,0,948
 Kimble,1,U.S. Senate,,"Bruce Jacobson, Jr.",,7,5,12
 Kimble,2,U.S. Senate,,"Bruce Jacobson, Jr.",,5,1,6
 Kimble,4,U.S. Senate,,"Bruce Jacobson, Jr.",,2,1,3


### PR DESCRIPTION
This fixes an issue in the 2018 Kimble County primary file, where the total ballots cast appeared in the wrong column.