### PR TITLE
Fix values in 2018 Lynn County general file

### DIFF
--- a/2018/counties/20181106__tx__general__lynn__precinct.csv
+++ b/2018/counties/20181106__tx__general__lynn__precinct.csv
@@ -28,7 +28,7 @@ Christi Craddick,Railroad Commissioner,,REP,Lynn,Precinct 1,106,51,55
 Roman McAllen,Railroad Commissioner,,DEM,Lynn,Precinct 1,30,17,13
 Mike Wright,Railroad Commissioner,,LIB,Lynn,Precinct 1,4,1,3
 Dustin Burrows,State Representative,83,REP,Lynn,Precinct 1,108,49,59
-Drew Landry,State Representative,83,DEM,Lynn,Precinct 1,31,19,13
+Drew Landry,State Representative,83,DEM,Lynn,Precinct 1,31,19,12
 ,Registered Voters,,,Lynn,Precinct 2/8,460,,
 ,Ballots Cast,,,Lynn,Precinct 2/8,193,58,135
 ,Straight Party,,REP,Lynn,Precinct 2/8,62,19,43
@@ -196,7 +196,7 @@ Dan Patrick,Lieutenant Governor,,REP,Lynn,Precinct 7,27,11,16
 Mike Collier,Lieutenant Governor,,DEM,Lynn,Precinct 7,2,1,1
 Kerry Douglas McKennon,Lieutenant Governor,,LIB,Lynn,Precinct 7,0,0,0
 Ken Paxton,Attorney General,,REP,Lynn,Precinct 7,27,11,16
-Justin Nelson,Attorney General,,DEM,Lynn,Precinct 7,0,1,1
+Justin Nelson,Attorney General,,DEM,Lynn,Precinct 7,2,1,1
 Michael Ray Harris,Attorney General,,LIB,Lynn,Precinct 7,0,0,0
 Glenn Hegar,Comptroller of Public Accounts,,REP,Lynn,Precinct 7,28,12,16
 Joi Chevalier,Comptroller of Public Accounts,,DEM,Lynn,Precinct 7,1,0,1


### PR DESCRIPTION
This fixes some incorrect values in the 2018 Lynn County general file. According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2018/general/LYNN_COUNTY-2018_General_Election_1162018-LynnCountyGeneralElection2018.pdf),

* Drew Landry received `12` election day votes in Precinct 1:
![image](https://user-images.githubusercontent.com/17345532/133471581-bcde2f92-a201-49f6-8574-b9560ffad3fa.png)

* Justin Nelson received `2` total votes in Precinct 7:
![image](https://user-images.githubusercontent.com/17345532/133471744-3fd4f67c-6885-4150-b7f9-c50fb6babb11.png)

