### PR TITLE
Fix values in 2018 Hardin County general file

### DIFF
--- a/2018/counties/20181106__tx__general__hardin__precinct.csv
+++ b/2018/counties/20181106__tx__general__hardin__precinct.csv
@@ -209,7 +209,7 @@ Hardin,Precinct 7 - ISD,Lieutenant Governor,,Kerry Douglas McKennon,LIB,3,1,4
 Hardin,Precinct 7 - ISD,Attorney General,,Ken Paxton,REP,258,140,398
 Hardin,Precinct 7 - ISD,Attorney General,,Justin Nelson,DEM,22,8,30
 Hardin,Precinct 7 - ISD,Attorney General,,Michael Ray Harris,LIB,1,2,3
-Hardin,Precinct 7 - ISD,Comptroller of Public Accounts,,Glenn Hegar,REP,258,137,392
+Hardin,Precinct 7 - ISD,Comptroller of Public Accounts,,Glenn Hegar,REP,258,137,395
 Hardin,Precinct 7 - ISD,Comptroller of Public Accounts,,Joi Chevalier,DEM,20,9,29
 Hardin,Precinct 7 - ISD,Comptroller of Public Accounts,,Ben Sanders,LIB,1,1,2
 Hardin,Precinct 7 - ISD,Commissioner of the General Land Office,,George P Bush,REP,254,138,392
@@ -501,7 +501,7 @@ Hardin,Precinct 16,Comptroller of Public Accounts,,Glenn Hegar,REP,608,428,1036
 Hardin,Precinct 16,Comptroller of Public Accounts,,Joi Chevalier,DEM,55,41,96
 Hardin,Precinct 16,Comptroller of Public Accounts,,Ben Sanders,LIB,7,18,25
 Hardin,Precinct 16,Commissioner of the General Land Office,,George P Bush,REP,591,427,1018
-Hardin,Precinct 16,Commissioner of the General Land Office,,Miguel Suazo,DEM,62,69,101
+Hardin,Precinct 16,Commissioner of the General Land Office,,Miguel Suazo,DEM,62,39,101
 Hardin,Precinct 16,Commissioner of the General Land Office,,Matt Pina,LIB,25,23,48
 Hardin,Precinct 16,Railroad Commissioner,,Christi Craddick,REP,606,440,1046
 Hardin,Precinct 16,Railroad Commissioner,,Roman McAllen,DEM,58,32,90


### PR DESCRIPTION
This fixes some incorrect values in the 2018 Hardin County general file. According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2018/general/Hardin%20TX%20precinct2018.pdf),

* Glenn Hegar received `395` total votes in Precinct 7 - ISD:
![image](https://user-images.githubusercontent.com/17345532/133472857-99ee5b49-9b78-4797-a2a1-948d4d47c57d.png)

* Miguel Suazo received `39` election day votes in Precinct `6`:
![image](https://user-images.githubusercontent.com/17345532/133472965-4f51dc2d-ee34-441e-ba61-76a10de3d51a.png)
