### PR TITLE
Fix values in 2018 Runnels County general file

### DIFF
--- a/2018/counties/20181106__tx__general__runnels__precinct.csv
+++ b/2018/counties/20181106__tx__general__runnels__precinct.csv
@@ -22,7 +22,7 @@ Runnels,1,Commissioner of the General Land Office,,George P. Bush,REP,41,323,194
 Runnels,1,Commissioner of the General Land Office,,Miguel Suazo,DEM,10,44,41,95
 Runnels,1,Commissioner of the General Land Office,,Matt Pina,LIB,0,10,8,18
 Runnels,1,Commissioner of Agriculture,,Sid Miller,REP,40,325,194,559
-Runnels,1,Commissioner of Agriculture,,Kim Olson,DEM,11,48,93,102
+Runnels,1,Commissioner of Agriculture,,Kim Olson,DEM,11,48,43,102
 Runnels,1,Commissioner of Agriculture,,Richard Carpenter,LIB,0,5,4,9
 Runnels,1,Railroad Commissioner,,Christi Craddick,REP,41,328,198,567
 Runnels,1,Railroad Commissioner,,Roman McAllen,DEM,10,40,37,87


### PR DESCRIPTION
This fixes some incorrect values in the 2018 Runnels County general file. According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2018/general/Runnells%20TX%20precinct%202018%20Gen.pdf), Kim Olson received `43` election day votes in Precinct 1:

![image](https://user-images.githubusercontent.com/17345532/133645531-d96ace27-1c85-4a36-99f7-c69f93c09ef7.png)
