### PR TITLE
Fix values in 2018 Lavaca County general file

### DIFF
--- a/2018/counties/20181106__tx__general__lavaca__precinct.csv
+++ b/2018/counties/20181106__tx__general__lavaca__precinct.csv
@@ -203,7 +203,7 @@ Michael Cloud,U.S. House,27,REP,Lavaca,Precinct 12,195,137,71,66,58,40,18
 Eric Holguin,U.S. House,27,DEM,Lavaca,Precinct 12,16,8,8,0,8,6,2
 Daniel Tinus,U.S. House,27,LIB,Lavaca,Precinct 12,0,0,0,0,0,0,0
 James Duerr,U.S. House,27,IND,Lavaca,Precinct 12,2,1,1,0,1,1,0
-Greg Abbott,Governor,,REP,Lavaca,Precinct 12,196,136,70,66,61,42,19
+Greg Abbott,Governor,,REP,Lavaca,Precinct 12,196,135,70,65,61,42,19
 Lupe Valdez,Governor,,DEM,Lavaca,Precinct 12,17,10,9,1,7,5,2
 Mark Jay Tippetts,Governor,,LIB,Lavaca,Precinct 12,1,1,1,0,0,0,0
 Dan Patrick,Lieutenant Governor,,REP,Lavaca,Precinct 12,185,130,68,62,55,38,17
@@ -316,7 +316,7 @@ Miguel Suazo,Commissioner of the General Land Office,,DEM,Lavaca,Precinct 17,20,
 Matt Pina,Commissioner of the General Land Office,,LIB,Lavaca,Precinct 17,9,4,2,2,5,3,2
 Christi Craddick,Railroad Commissioner,,REP,Lavaca,Precinct 17,185,115,57,58,70,54,16
 Roman McAllen,Railroad Commissioner,,DEM,Lavaca,Precinct 17,18,13,8,5,5,4,1
-Mike Wright,Railroad Commissioner,,LIB,Lavaca,Precinct 17,6,6,4,2,3,1,2
+Mike Wright,Railroad Commissioner,,LIB,Lavaca,Precinct 17,6,3,1,2,3,1,2
 Ben Leman,State Representative,13,REP,Lavaca,Precinct 17,187,115,55,60,72,55,17
 Cecil Ray Webster,State Representative,13,DEM,Lavaca,Precinct 17,18,13,8,5,5,3,2
 ,Registered Voters,,,Lavaca,Precinct 19,424,,,,,,


### PR DESCRIPTION
This fixes some incorrect values in the 2018 Lavaca County general file. According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2018/general/LAVACA_COUNTY-2018_General_Election_1162018-PCT%20by%20PCT%20report%20with%20group%20detail%20Official.pdf),

* Greg Abbot received `65` early voting machine votes (for a total of `135` early votes) in Precinct 12:
![image](https://user-images.githubusercontent.com/17345532/133646075-ea014265-e2ee-4422-b506-b897f18ac86e.png)

* Mike Wright received `1` early voting paper votes (for a total of `3` early votes) in Precinct 17:
![image](https://user-images.githubusercontent.com/17345532/133646238-7be74b78-7611-4ac5-9a9b-9a79f384abaa.png)
