### PR TITLE
Fix values in 2018 Duval County general file

### DIFF
--- a/2018/counties/20181106__tx__general__duval__precinct.csv
+++ b/2018/counties/20181106__tx__general__duval__precinct.csv
@@ -66,7 +66,7 @@ Duval,5,U.S. Senate,,,Ballots Cast,135,66,201
 Duval,5,U.S. Senate,,,Over Votes,0,0,0
 Duval,5,U.S. Senate,,,Under Votes,4,2,6
 Duval,6,U.S. Senate,,REP,Ted Cruz,9,7,90
-Duval,6,U.S. Senate,,DEM,Beto O'Rourke,48,26,0
+Duval,6,U.S. Senate,,DEM,Beto O'Rourke,48,26,74
 Duval,6,U.S. Senate,,LIB,Neal M. Dikeman,0,0,2
 Duval,6,U.S. Senate,,,Ballots Cast,57,33,90
 Duval,6,U.S. Senate,,,Over Votes,0,0,11
@@ -161,7 +161,7 @@ Duval,3,Governor,,LIB,Mark Jay Tippetts,2,0,2
 Duval,3,Governor,,,Ballots Cast,166,110,276
 Duval,3,Governor,,,Over Votes,1,0,1
 Duval,3,Governor,,,Under Votes,3,5,8
-Duval,4,Governor,,REP,Greg Abbott,25,18,42
+Duval,4,Governor,,REP,Greg Abbott,25,17,42
 Duval,4,Governor,,DEM,Lupe Valdez,35,18,53
 Duval,4,Governor,,LIB,Mark Jay Tippetts,0,0,0
 Duval,4,Governor,,,Ballots Cast,60,35,95
@@ -266,7 +266,7 @@ Duval,2,Attorney General,,,Under Votes,92,33,125
 Duval,3,Attorney General,,REP,Ken Paxton,30,24,54
 Duval,3,Attorney General,,DEM,Justin Nelson,133,84,217
 Duval,3,Attorney General,,LIB,Michael Ray Harris,1,2,3
-Duval,3,Attorney General,,,Ballots Cast,164,110,270
+Duval,3,Attorney General,,,Ballots Cast,164,110,274
 Duval,3,Attorney General,,,Over Votes,0,0,0
 Duval,3,Attorney General,,,Under Votes,6,5,11
 Duval,4,Attorney General,,REP,Ken Paxton,18,13,31


### PR DESCRIPTION
This fixes some incorrect values in the 2018 Duval County general file. According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2018/general/DUVAL_COUNTY-2018_General_Election_1162018-precinct.pdf2018.pdf),

* Beto O'Rourke received `74` total votes in Precinct 6:
![image](https://user-images.githubusercontent.com/17345532/133646914-bdf14621-bfbd-4d2a-8a2c-5461be88aa17.png)

* Greg Abbot received `17` election day votes in Precinct 4:
![image](https://user-images.githubusercontent.com/17345532/133647047-a174a158-0064-42fb-ae0a-a192ddfc36d7.png)

* There were `274` ballots cast in the Attorney General race in Precinct 3:
![image](https://user-images.githubusercontent.com/17345532/133647161-aeb26abb-8c9f-4d1e-93c0-b354e648594b.png)
