### PR TITLE
Fix values in 2018 Deaf Smith County general file

### DIFF
--- a/2018/counties/20181106__tx__general__deaf_smith__precinct.csv
+++ b/2018/counties/20181106__tx__general__deaf_smith__precinct.csv
@@ -56,7 +56,7 @@ Ben Sanders,Comptroller of Public Accounts,,,Deaf Smith,Precinct 2,7,7,14
 George P. Bush,Commissioner of the General Land Office,,,Deaf Smith,Precinct 2,324,93,417
 Miguel Suazo,Commissioner of the General Land Office,,,Deaf Smith,Precinct 2,135,106,241
 Matt Pina,Commissioner of the General Land Office,,,Deaf Smith,Precinct 2,14,4,18
-Christi Craddick,Railroad Commissioner,,,Deaf Smith,Precinct 2,323,92,414
+Christi Craddick,Railroad Commissioner,,,Deaf Smith,Precinct 2,323,92,415
 Roman McAllen,Railroad Commissioner,,,Deaf Smith,Precinct 2,143,103,246
 Mike Wright,Railroad Commissioner,,,Deaf Smith,Precinct 2,3,4,7
 Kel Seliger,State Senate,31,,Deaf Smith,Precinct 2,355,110,465


### PR DESCRIPTION
The early voting value for Christi Craddick in Precinct 2 was hand-corrected in the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2018/general/Deaf%20Smith%20TX%202018%20Precinct%20by%20precinct%20returns.pdf) from `322` to `323`.  However, unlike the other hand-corrected values, the total value for this entry was not updated accordingly.

![image](https://user-images.githubusercontent.com/17345532/133647520-be2e84b6-f5ca-4c1f-83f0-00233a8c8129.png)

