### PR TITLE
Fix values in 2016 Upton County general file

### DIFF
--- a/2016/counties/20161108__tx__general__upton__precinct.csv
+++ b/2016/counties/20161108__tx__general__upton__precinct.csv
@@ -111,13 +111,13 @@ Upton,4,U.S. House,23,Will Hurd,REP,242,166,67,4,5
 Upton,5,U.S. House,23,Will Hurd,REP,55,10,43,1,1
 Upton,6,U.S. House,23,Will Hurd,REP,111,79,22,7,3
 Upton,Total,U.S. House,23,Will Hurd,REP,918,632,246,31,9
-Upton,1,U.S. House,23,Pete P. Gallego,DEM,52,34,15,3,1
+Upton,1,U.S. House,23,Pete P. Gallego,DEM,52,34,15,3,0
 Upton,2,U.S. House,23,Pete P. Gallego,DEM,33,14,16,2,1
 Upton,3,U.S. House,23,Pete P. Gallego,DEM,107,69,29,9,0
 Upton,4,U.S. House,23,Pete P. Gallego,DEM,58,36,17,4,1
 Upton,5,U.S. House,23,Pete P. Gallego,DEM,11,3,8,0,0
 Upton,6,U.S. House,23,Pete P. Gallego,DEM,47,33,12,1,1
-Upton,Total,U.S. House,23,Pete P. Gallego,DEM,308,189,97,19,4
+Upton,Total,U.S. House,23,Pete P. Gallego,DEM,308,189,97,19,3
 Upton,1,U.S. House,23,Ruben S. Corvalan,LIB,15,12,2,0,1
 Upton,2,U.S. House,23,Ruben S. Corvalan,LIB,4,4,0,0,0
 Upton,3,U.S. House,23,Ruben S. Corvalan,LIB,12,8,4,0,0


### PR DESCRIPTION
This fixes some incorrect values in the 2016 Upton County general file. According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2016/UPTON_COUNTY-2016_General_Election_1182016-CANVASSING_VOTES_Precinct..Report.Nov.16_GE_11.16.16.pdf),

* Pete P. Gallego received `0` provisional votes in Precinct 1:
![image](https://user-images.githubusercontent.com/17345532/133647874-0b9e02c5-1a08-49e2-9310-3d613d3d9c62.png)