### PR TITLE
Fix values in 2016 Bosque County general file

### DIFF
--- a/2016/counties/20161108__tx__general__bosque__precinct.csv
+++ b/2016/counties/20161108__tx__general__bosque__precinct.csv
@@ -164,7 +164,7 @@ Bosque,6,U.S House,25,Loren Marc Schneiderman,LIB,23,15,8
 Bosque,7,U.S House,25,Loren Marc Schneiderman,LIB,8,6,2
 Bosque,8,U.S House,25,Loren Marc Schneiderman,LIB,34,18,16
 Bosque,9,U.S House,25,Loren Marc Schneiderman,LIB,6,4,2
-Bosque,10,U.S House,25,Loren Marc Schneiderman,LIB,16,654,253
+Bosque,10,U.S House,25,Loren Marc Schneiderman,LIB,16,14,2
 Bosque,11,U.S House,25,Loren Marc Schneiderman,LIB,25,16,9
 Bosque,Total,U.S House,25,Loren Marc Schneiderman,LIB,,,
 Bosque,1,Railroad Commissioner,,Wayne Christian,REP,371,210,161


### PR DESCRIPTION
This fixes some incorrect values in the 2016 Bosque County general file. According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2016/2016%20bosque.pdf), Loren Marc Schneiderman received `14` election day and `2` early voting votes in Precinct 10:

![image](https://user-images.githubusercontent.com/17345532/133648283-2aedf73d-9e30-4e5f-a28d-6e68e3d6ad38.png)
