### PR TITLE
Fix values in 2016 Lamb County general file

### DIFF
--- a/2016/counties/20161108__tx__general__lamb__precinct.csv
+++ b/2016/counties/20161108__tx__general__lamb__precinct.csv
@@ -30,8 +30,8 @@ Lamb,Lamb County Ag Center,Straight Party,,,DEM,30,4,16,10,0
 Lamb,8 - Lamb County Ag Center,Straight Party,,,DEM,121,11,68,42,0
 Lamb,Lamb County Ag Center,Straight Party,,,DEM,59,2,33,23,1
 Lamb,Amherst Community Cent,Straight Party,,,DEM,34,0,8,26,0
-Lamb,Springlake 1st Baptist,Straight Party,,,DEM,0,0,2,3,0
-Lamb,Total,Straight Party,,,DEM,481,31,215,239,1
+Lamb,Springlake 1st Baptist,Straight Party,,,DEM,5,0,2,3,0
+Lamb,Total,Straight Party,,,DEM,486,31,215,239,1
 Lamb,Olton Community Cente,Straight Party,,,LIB,1,0,0,1,0
 Lamb,Lamb County Ag Center,Straight Party,,,LIB,3,1,1,1,0
 Lamb,Earth Community Center,Straight Party,,,LIB,0,0,0,0,0


### PR DESCRIPTION
This fixes some incorrect values in the 2016 Lamb County general file. According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2016/Lamb%20TX%20November%208th,%202016%20Precinct%20by%20Precinct%20report.pdf), there were `5` total Democratic straight party votes in the Springlake 1st Baptist Precinct:

![image](https://user-images.githubusercontent.com/17345532/133648855-d0e89673-663e-4963-9695-b48b6634b950.png)
