### PR TITLE
Fix values in 2020 Live Oak County general file

### DIFF
--- a/2020/counties/20201103__tx__general__live_oak__precinct.csv
+++ b/2020/counties/20201103__tx__general__live_oak__precinct.csv
@@ -39,7 +39,7 @@ Live Oak,PCT. 2 LARGATO,Railroad Commissioner,,REP,"James ""Jim"" Wright",598,36
 Live Oak,PCT. 2 LARGATO,Railroad Commissioner,,DEM,Chrysta Castaneda,117,32,46,39,0
 Live Oak,PCT. 2 LARGATO,Railroad Commissioner,,LIB,Matt Sterett,11,1,6,4,0
 Live Oak,PCT. 2 LARGATO,Railroad Commissioner,,GRN,"Katija ""Kat"" Gruene",1,0,0,1,0
-Live Oak,PCT. 2 LARGATO,State Senate,21,REP,Frank Pomeroy,542,33,244,315,0
+Live Oak,PCT. 2 LARGATO,State Senate,21,REP,Frank Pomeroy,592,33,244,315,0
 Live Oak,PCT. 2 LARGATO,State Senate,21,DEM,Judith Zaffirini,128,37,46,45,0
 Live Oak,PCT. 2 LARGATO,State Representative,31,REP,Marian Knowlton,593,34,241,318,0
 Live Oak,PCT. 2 LARGATO,State Representative,31,DEM,Ryan Guillen,125,35,47,43,0
@@ -150,7 +150,7 @@ Live Oak,PCT. 7 NELL,Railroad Commissioner,,DEM,Chrysta Castaneda,6,1,4,1,0
 Live Oak,PCT. 7 NELL,Railroad Commissioner,,LIB,Matt Sterett,1,0,1,0,0
 Live Oak,PCT. 7 NELL,Railroad Commissioner,,GRN,"Katija ""Kat"" Gruene",0,0,0,0,0
 Live Oak,PCT. 7 NELL,State Senate,21,REP,Frank Pomeroy,14,1,10,3,0
-Live Oak,PCT. 7 NELL,State Senate,21,DEM,Judith Zaffirini,6,3,3,2,0
+Live Oak,PCT. 7 NELL,State Senate,21,DEM,Judith Zaffirini,8,3,3,2,0
 Live Oak,PCT. 7 NELL,State Representative,31,REP,Marian Knowlton,14,2,8,4,0
 Live Oak,PCT. 7 NELL,State Representative,31,DEM,Ryan Guillen,8,2,5,1,0
 Live Oak,PCT. 8 WHITSETT,Ballots Cast,,,,107,6,43,58,0
@@ -305,5 +305,5 @@ Live Oak,PCT. 14 SOUTH WEST GEO. W,Railroad Commissioner,,LIB,Matt Sterett,8,2,6
 Live Oak,PCT. 14 SOUTH WEST GEO. W,Railroad Commissioner,,GRN,"Katija ""Kat"" Gruene",1,0,1,0,0
 Live Oak,PCT. 14 SOUTH WEST GEO. W,State Senate,21,REP,Frank Pomeroy,548,36,424,87,1
 Live Oak,PCT. 14 SOUTH WEST GEO. W,State Senate,21,DEM,Judith Zaffirini,161,21,111,29,0
-Live Oak,PCT. 14 SOUTH WEST GEO. W,State Representative,31,REP,Marian Knowlton,561,37,433,96,1
+Live Oak,PCT. 14 SOUTH WEST GEO. W,State Representative,31,REP,Marian Knowlton,567,37,433,96,1
 Live Oak,PCT. 14 SOUTH WEST GEO. W,State Representative,31,DEM,Ryan Guillen,140,21,99,20,0


### PR DESCRIPTION
This fixes some incorrect values in the 2020 Live Oak County general file. According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2020/general/Live%20Oak%20TX%202020%20General.pdf),

* Frank Pomeroy received `592` total votes in Precinct 2:
![image](https://user-images.githubusercontent.com/17345532/133817365-c677722c-3ccb-4861-8a87-e298b3ebf9ed.png)

* Judith Zaffirini received `8` total votes in Precinct 7:
![image](https://user-images.githubusercontent.com/17345532/133817472-89aef3f1-cc42-48aa-a695-1b5de24f5226.png)

* Marian Knowlton received `567` total votes in Precinct 14:
![image](https://user-images.githubusercontent.com/17345532/133817627-5fc44080-f89b-4708-9cc7-01876e644cbd.png)


