### PR TITLE
Fix values in 2020 Bosque County primary file

### DIFF
--- a/2020/counties/20200303__tx__primary__bosque__precinct.csv
+++ b/2020/counties/20200303__tx__primary__bosque__precinct.csv
@@ -51,14 +51,14 @@ Bosque,Precinct 1,President,,Joseph R. Biden,DEM,12,11,0,1,0
 Bosque,Precinct 2,President,,Joseph R. Biden,DEM,21,13,5,3,0
 Bosque,Precinct 3,President,,Joseph R. Biden,DEM,21,12,9,0,0
 Bosque,Precinct 4,President,,Joseph R. Biden,DEM,8,3,3,2,0
-Bosque,Precinct 5,President,,Joseph R. Biden,DEM,49,27,12,10,10
+Bosque,Precinct 5,President,,Joseph R. Biden,DEM,49,27,12,10,0
 Bosque,Precinct 6,President,,Joseph R. Biden,DEM,39,28,6,5,0
 Bosque,Precinct 7,President,,Joseph R. Biden,DEM,23,17,3,3,0
 Bosque,Precinct 8,President,,Joseph R. Biden,DEM,50,37,6,7,0
 Bosque,Precinct 9,President,,Joseph R. Biden,DEM,24,20,2,2,0
 Bosque,Precinct 10,President,,Joseph R. Biden,DEM,32,26,2,4,0
 Bosque,Precinct 11,President,,Joseph R. Biden,DEM,14,7,6,1,0
-Bosque,Total,President,,Joseph R. Biden,DEM,293,201,54,38,10
+Bosque,Total,President,,Joseph R. Biden,DEM,293,201,54,38,0
 Bosque,Precinct 1,President,,Tulsi Gabbard,DEM,0,0,0,0,0
 Bosque,Precinct 2,President,,Tulsi Gabbard,DEM,0,0,0,0,0
 Bosque,Precinct 3,President,,Tulsi Gabbard,DEM,0,0,0,0,0
@@ -309,8 +309,8 @@ Bosque,Precinct 7,U.S. Senate,,Adrian Ocegueda,DEM,0,0,0,0,0
 Bosque,Precinct 8,U.S. Senate,,Adrian Ocegueda,DEM,8,7,0,1,0
 Bosque,Precinct 9,U.S. Senate,,Adrian Ocegueda,DEM,4,3,1,0,0
 Bosque,Precinct 10,U.S. Senate,,Adrian Ocegueda,DEM,3,3,0,0,0
-Bosque,Precinct 11,U.S. Senate,,Adrian Ocegueda,DEM,0,0,1,0,0
-Bosque,Total,U.S. Senate,,Adrian Ocegueda,DEM,19,17,2,1,0
+Bosque,Precinct 11,U.S. Senate,,Adrian Ocegueda,DEM,1,0,1,0,0
+Bosque,Total,U.S. Senate,,Adrian Ocegueda,DEM,20,17,2,1,0
 Bosque,Precinct 1,U.S. Senate,,Chris Bell,DEM,2,1,1,0,0
 Bosque,Precinct 2,U.S. Senate,,Chris Bell,DEM,5,4,0,1,0
 Bosque,Precinct 3,U.S. Senate,,Chris Bell,DEM,7,5,2,0,0
@@ -571,10 +571,10 @@ Bosque,Precinct 5,Railroad Commissioner,,Mark Watson,DEM,28,11,7,10,0
 Bosque,Precinct 6,Railroad Commissioner,,Mark Watson,DEM,20,12,5,3,0
 Bosque,Precinct 7,Railroad Commissioner,,Mark Watson,DEM,5,4,1,0,0
 Bosque,Precinct 8,Railroad Commissioner,,Mark Watson,DEM,30,15,5,10,0
-Bosque,Precinct 9,Railroad Commissioner,,Mark Watson,DEM,0,3,1,4,0
+Bosque,Precinct 9,Railroad Commissioner,,Mark Watson,DEM,8,3,1,4,0
 Bosque,Precinct 10,Railroad Commissioner,,Mark Watson,DEM,13,10,2,1,0
 Bosque,Precinct 11,Railroad Commissioner,,Mark Watson,DEM,11,6,4,1,0
-Bosque,Total,Railroad Commissioner,,Mark Watson,DEM,143,82,34,35,0
+Bosque,Total,Railroad Commissioner,,Mark Watson,DEM,151,82,34,35,0
 Bosque,Precinct 1,Railroad Commissioner,,Chrysta Castaneda,DEM,5,4,0,1,0
 Bosque,Precinct 2,Railroad Commissioner,,Chrysta Castaneda,DEM,17,10,7,0,0
 Bosque,Precinct 3,Railroad Commissioner,,Chrysta Castaneda,DEM,7,4,3,0,0


### PR DESCRIPTION
This fixes some incorrect values in the 2020 Bosque County primary file. According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2020/primary/BOSQUE_COUNTY-2020_MARCH_3RD_DEMOCRATIC_PRIMARY_332020-Dem.pdf),

* Joseph R. Biden received `0` provisional votes in Precinct 5:
![image](https://user-images.githubusercontent.com/17345532/133817950-5c4895cf-ae8d-4bf0-a0cf-51d6a3d36410.png)

* Adrian Ocegueda received `1` total vote in Precinct 11:
![image](https://user-images.githubusercontent.com/17345532/133818122-baeba684-5676-4ae2-8779-bd6348f211a4.png)

* Mark Watson received `8` total votes in Precinct 9:
![image](https://user-images.githubusercontent.com/17345532/133818286-bee89f64-b0f9-4737-9e21-1a573ddb60b9.png)
