### PR TITLE
Fix values in 2018 Grimes County general file

### DIFF
--- a/2018/counties/20181106__tx__general__grimes__precinct.csv
+++ b/2018/counties/20181106__tx__general__grimes__precinct.csv
@@ -43,7 +43,7 @@ Grimes,2,U.S. Senate,,Ted Cruz,,150,264,414
 Grimes,2,U.S. Senate,,Beto O'Rourke,,22,27,49
 Grimes,2,U.S. Senate,,Neal M. Dikeman,,0,3,3
 Grimes,2,U.S. House,8,Kevin Brady,,148,265,413
-Grimes,2,U.S. House,8,Steven David,,21,28,46
+Grimes,2,U.S. House,8,Steven David,,21,28,49
 Grimes,2,U.S. House,8,Chris Duncan,,3,3,6
 Grimes,2,Governor,,Greg Abbott,,152,270,422
 Grimes,2,Governor,,Lupe Valdez,,19,24,43


### PR DESCRIPTION
This fixes some incorrect values in the 2018 Grimes County general file. According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2018/general/Grimes%20TX%202018%20general%20election%20by%20precinct.pdf), Steven David received `49` total votes in Precinct 2:

![image](https://user-images.githubusercontent.com/17345532/133819162-f54aa3a8-29e1-4228-88a5-01cc77594ae9.png)
