### PR TITLE
Fix values in 2018 Crosby County general file

### DIFF
--- a/2018/counties/20181106__tx__general__crosby__precinct.csv
+++ b/2018/counties/20181106__tx__general__crosby__precinct.csv
@@ -1,91 +1,91 @@
 county,precinct,office,district,party,candidate,early_voting,election_day,votes
 Crosby,Precinct 11,Registered Voters,,,,,,1444
 Crosby,Precinct 11,Ballots Cast,,,,,,272
-Crosby,Precinct 11,Straight Party,,REP,,,44,60
-Crosby,Precinct 11,Straight Party,,DEM,,,38,22
-Crosby,Precinct 11,Straight Party,,LIB,,,0,1
-Crosby,Precinct 11,U.S. Senate,,REP,Ted Cruz,,78,99
-Crosby,Precinct 11,U.S. Senate,,DEM,Beto O'Rourke,,55,34
-Crosby,Precinct 11,U.S. Senate,,LIB,Neal M Dikeman,,0,2
-Crosby,Precinct 11,U.S. House,19,REP,Jodey Arrington,,80,103
-Crosby,Precinct 11,U.S. House,19,DEM,Miguel Levario,,51,30
-Crosby,Precinct 11,Governor,,REP,Greg Abbott,,79,105
-Crosby,Precinct 11,Governor,,DEM,Lupe Valdez,,52,29
-Crosby,Precinct 11,Governor,,LIB,Mark Jay Tippetts,,2,2
-Crosby,Precinct 11,Lieutenant Governor,,REP,Dan Patrick,,76,99
-Crosby,Precinct 11,Lieutenant Governor,,DEM,Mike Collier,,52,34
-Crosby,Precinct 11,Lieutenant Governor,,LIB,Kerry Douglas McKennon,,2,2
-Crosby,Precinct 11,Attorney General,,REP,Ken Paxton,,73,98
-Crosby,Precinct 11,Attorney General,,DEM,Justin Nelson,,52,34
-Crosby,Precinct 11,Attorney General,,LIB,Michael Ray Harris,,5,3
-Crosby,Precinct 11,Comptroller of Public Accounts,,REP,Glenn Hegar,,76,105
-Crosby,Precinct 11,Comptroller of Public Accounts,,DEM,Joi Chevalier,,52,29
-Crosby,Precinct 11,Comptroller of Public Accounts,,LIB,Ben Sanders,,1,1
-Crosby,Precinct 11,Commissioner of the General Land Office,,REP,George P. Bush,,82,96
-Crosby,Precinct 11,Commissioner of the General Land Office,,DEM,Miguel Suazo,,46,31
-Crosby,Precinct 11,Commissioner of the General Land Office,,LIB,Matt Pina,,4,5
-Crosby,Precinct 11,Railroad Commissioner,,REP,Christi Craddick,,77,99
-Crosby,Precinct 11,Railroad Commissioner,,DEM,Roman McAllen,,53,33
-Crosby,Precinct 11,Railroad Commissioner,,LIB,Mike Wright,,2,4
-Crosby,Precinct 11,State Representative,68,REP,Drew Springer,,97,110
+Crosby,Precinct 11,Straight Party,,REP,,60,44,104
+Crosby,Precinct 11,Straight Party,,DEM,,22,38,60
+Crosby,Precinct 11,Straight Party,,LIB,,1,0,1
+Crosby,Precinct 11,U.S. Senate,,REP,Ted Cruz,99,78,177
+Crosby,Precinct 11,U.S. Senate,,DEM,Beto O'Rourke,34,55,89
+Crosby,Precinct 11,U.S. Senate,,LIB,Neal M Dikeman,2,0,2
+Crosby,Precinct 11,U.S. House,19,REP,Jodey Arrington,103,80,183
+Crosby,Precinct 11,U.S. House,19,DEM,Miguel Levario,30,51,81
+Crosby,Precinct 11,Governor,,REP,Greg Abbott,105,79,184
+Crosby,Precinct 11,Governor,,DEM,Lupe Valdez,29,52,81
+Crosby,Precinct 11,Governor,,LIB,Mark Jay Tippetts,2,2,4
+Crosby,Precinct 11,Lieutenant Governor,,REP,Dan Patrick,99,76,175
+Crosby,Precinct 11,Lieutenant Governor,,DEM,Mike Collier,34,52,86
+Crosby,Precinct 11,Lieutenant Governor,,LIB,Kerry Douglas McKennon,2,2,4
+Crosby,Precinct 11,Attorney General,,REP,Ken Paxton,98,73,171
+Crosby,Precinct 11,Attorney General,,DEM,Justin Nelson,34,52,86
+Crosby,Precinct 11,Attorney General,,LIB,Michael Ray Harris,3,5,8
+Crosby,Precinct 11,Comptroller of Public Accounts,,REP,Glenn Hegar,105,76,181
+Crosby,Precinct 11,Comptroller of Public Accounts,,DEM,Joi Chevalier,29,52,81
+Crosby,Precinct 11,Comptroller of Public Accounts,,LIB,Ben Sanders,1,1,2
+Crosby,Precinct 11,Commissioner of the General Land Office,,REP,George P. Bush,96,82,178
+Crosby,Precinct 11,Commissioner of the General Land Office,,DEM,Miguel Suazo,31,46,77
+Crosby,Precinct 11,Commissioner of the General Land Office,,LIB,Matt Pina,5,4,9
+Crosby,Precinct 11,Railroad Commissioner,,REP,Christi Craddick,99,77,176
+Crosby,Precinct 11,Railroad Commissioner,,DEM,Roman McAllen,33,53,86
+Crosby,Precinct 11,Railroad Commissioner,,LIB,Mike Wright,4,2,6
+Crosby,Precinct 11,State Representative,68,REP,Drew Springer,110,97,207
 Crosby,Precinct 27,Registered Voters,,,,,,1444
 Crosby,Precinct 27,Ballots Cast,,,,,,426
-Crosby,Precinct 27,Straight Party,,REP,,,51,124
-Crosby,Precinct 27,Straight Party,,DEM,,,33,47
-Crosby,Precinct 27,Straight Party,,LIB,,,0,0
-Crosby,Precinct 27,U.S. Senate,,REP,Ted Cruz,,91,204
-Crosby,Precinct 27,U.S. Senate,,DEM,Beto O'Rourke,,51,73
-Crosby,Precinct 27,U.S. Senate,,LIB,Neal M Dikeman,,0,0
-Crosby,Precinct 27,U.S. House,19,REP,Jodey Arrington,,92,212
-Crosby,Precinct 27,U.S. House,19,DEM,Miguel Levario,,45,65
-Crosby,Precinct 27,Governor,,REP,Greg Abbott,,92,205
-Crosby,Precinct 27,Governor,,DEM,Lupe Valdez,,49,67
-Crosby,Precinct 27,Governor,,LIB,Mark Jay Tippetts,,1,4
-Crosby,Precinct 27,Lieutenant Governor,,REP,Dan Patrick,,87,186
-Crosby,Precinct 27,Lieutenant Governor,,DEM,Mike Collier,,56,84
-Crosby,Precinct 27,Lieutenant Governor,,LIB,Kerry Douglas McKennon,,1,5
-Crosby,Precinct 27,Attorney General,,REP,Ken Paxton,,89,190
-Crosby,Precinct 27,Attorney General,,DEM,Justin Nelson,,51,82
-Crosby,Precinct 27,Attorney General,,LIB,Michael Ray Harris,,2,5
-Crosby,Precinct 27,Comptroller of Public Accounts,,REP,Glenn Hegar,,92,201
-Crosby,Precinct 27,Comptroller of Public Accounts,,DEM,Joi Chevalier,,45,64
-Crosby,Precinct 27,Comptroller of Public Accounts,,LIB,Ben Sanders,,3,8
-Crosby,Precinct 27,Commissioner of the General Land Office,,REP,George P. Bush,,92,200
-Crosby,Precinct 27,Commissioner of the General Land Office,,DEM,Miguel Suazo,,50,64
-Crosby,Precinct 27,Commissioner of the General Land Office,,LIB,Matt Pina,,0,8
-Crosby,Precinct 27,Railroad Commissioner,,REP,Christi Craddick,,87,195
-Crosby,Precinct 27,Railroad Commissioner,,DEM,Roman McAllen,,51,70
-Crosby,Precinct 27,Railroad Commissioner,,LIB,Mike Wright,,2,8
-Crosby,Precinct 27,State Representative,68,REP,Drew Springer,,106,215
+Crosby,Precinct 27,Straight Party,,REP,,124,51,175
+Crosby,Precinct 27,Straight Party,,DEM,,47,33,80
+Crosby,Precinct 27,Straight Party,,LIB,,0,0,0
+Crosby,Precinct 27,U.S. Senate,,REP,Ted Cruz,204,91,295
+Crosby,Precinct 27,U.S. Senate,,DEM,Beto O'Rourke,73,51,124
+Crosby,Precinct 27,U.S. Senate,,LIB,Neal M Dikeman,0,0,0
+Crosby,Precinct 27,U.S. House,19,REP,Jodey Arrington,212,92,304
+Crosby,Precinct 27,U.S. House,19,DEM,Miguel Levario,65,45,110
+Crosby,Precinct 27,Governor,,REP,Greg Abbott,205,92,297
+Crosby,Precinct 27,Governor,,DEM,Lupe Valdez,67,49,116
+Crosby,Precinct 27,Governor,,LIB,Mark Jay Tippetts,4,1,5
+Crosby,Precinct 27,Lieutenant Governor,,REP,Dan Patrick,186,87,273
+Crosby,Precinct 27,Lieutenant Governor,,DEM,Mike Collier,84,56,140
+Crosby,Precinct 27,Lieutenant Governor,,LIB,Kerry Douglas McKennon,5,1,6
+Crosby,Precinct 27,Attorney General,,REP,Ken Paxton,190,89,279
+Crosby,Precinct 27,Attorney General,,DEM,Justin Nelson,82,51,133
+Crosby,Precinct 27,Attorney General,,LIB,Michael Ray Harris,5,2,7
+Crosby,Precinct 27,Comptroller of Public Accounts,,REP,Glenn Hegar,201,92,293
+Crosby,Precinct 27,Comptroller of Public Accounts,,DEM,Joi Chevalier,64,45,109
+Crosby,Precinct 27,Comptroller of Public Accounts,,LIB,Ben Sanders,8,3,11
+Crosby,Precinct 27,Commissioner of the General Land Office,,REP,George P. Bush,200,92,292
+Crosby,Precinct 27,Commissioner of the General Land Office,,DEM,Miguel Suazo,64,50,114
+Crosby,Precinct 27,Commissioner of the General Land Office,,LIB,Matt Pina,8,0,8
+Crosby,Precinct 27,Railroad Commissioner,,REP,Christi Craddick,195,87,282
+Crosby,Precinct 27,Railroad Commissioner,,DEM,Roman McAllen,70,51,121
+Crosby,Precinct 27,Railroad Commissioner,,LIB,Mike Wright,8,2,10
+Crosby,Precinct 27,State Representative,68,REP,Drew Springer,215,106,321
 Crosby,Precinct 39,Registered Voters,,,,,,1444
 Crosby,Precinct 39,Ballots Cast,,,,,,319
-Crosby,Precinct 39,Straight Party,,REP,,,83,38
-Crosby,Precinct 39,Straight Party,,DEM,,,42,11
-Crosby,Precinct 39,Straight Party,,LIB,,,2,0
-Crosby,Precinct 39,U.S. Senate,,REP,Ted Cruz,,152,60
-Crosby,Precinct 39,U.S. Senate,,DEM,Beto O'Rourke,,85,18
-Crosby,Precinct 39,U.S. Senate,,LIB,Neal M Dikeman,,1,0
-Crosby,Precinct 39,U.S. House,19,REP,Jodey Arrington,,163,61
-Crosby,Precinct 39,U.S. House,19,DEM,Miguel Levario,,72,17
-Crosby,Precinct 39,Governor,,REP,Greg Abbott,,157,60
-Crosby,Precinct 39,Governor,,DEM,Lupe Valdez,,71,17
-Crosby,Precinct 39,Governor,,LIB,Mark Jay Tippetts,,5,1
-Crosby,Precinct 39,Lieutenant Governor,,REP,Dan Patrick,,136,52
-Crosby,Precinct 39,Lieutenant Governor,,DEM,Mike Collier,,93,25
-Crosby,Precinct 39,Lieutenant Governor,,LIB,Kerry Douglas McKennon,,4,1
-Crosby,Precinct 39,Attorney General,,REP,Ken Paxton,,146,57
-Crosby,Precinct 39,Attorney General,,DEM,Justin Nelson,,78,18
-Crosby,Precinct 39,Attorney General,,LIB,Michael Ray Harris,,10,3
-Crosby,Precinct 39,Comptroller of Public Accounts,,REP,Glenn Hegar,,155,59
-Crosby,Precinct 39,Comptroller of Public Accounts,,DEM,Joi Chevalier,,66,15
-Crosby,Precinct 39,Comptroller of Public Accounts,,LIB,Ben Sanders,,10,3
-Crosby,Precinct 39,Commissioner of the General Land Office,,REP,George P. Bush,,155,59
-Crosby,Precinct 39,Commissioner of the General Land Office,,DEM,Miguel Suazo,,73,15
-Crosby,Precinct 39,Commissioner of the General Land Office,,LIB,Matt Pina,,6,4
-Crosby,Precinct 39,Railroad Commissioner,,REP,Christi Craddick,,154,60
-Crosby,Precinct 39,Railroad Commissioner,,DEM,Roman McAllen,,71,15
-Crosby,Precinct 39,Railroad Commissioner,,LIB,Mike Wright,,6,2
-Crosby,Precinct 39,State Representative,68,REP,Drew Springer,,174,61
+Crosby,Precinct 39,Straight Party,,REP,,38,83,121
+Crosby,Precinct 39,Straight Party,,DEM,,11,42,53
+Crosby,Precinct 39,Straight Party,,LIB,,0,2,2
+Crosby,Precinct 39,U.S. Senate,,REP,Ted Cruz,60,152,212
+Crosby,Precinct 39,U.S. Senate,,DEM,Beto O'Rourke,18,85,103
+Crosby,Precinct 39,U.S. Senate,,LIB,Neal M Dikeman,0,1,1
+Crosby,Precinct 39,U.S. House,19,REP,Jodey Arrington,61,163,224
+Crosby,Precinct 39,U.S. House,19,DEM,Miguel Levario,17,72,89
+Crosby,Precinct 39,Governor,,REP,Greg Abbott,60,157,217
+Crosby,Precinct 39,Governor,,DEM,Lupe Valdez,17,71,88
+Crosby,Precinct 39,Governor,,LIB,Mark Jay Tippetts,1,5,6
+Crosby,Precinct 39,Lieutenant Governor,,REP,Dan Patrick,52,136,188
+Crosby,Precinct 39,Lieutenant Governor,,DEM,Mike Collier,25,93,118
+Crosby,Precinct 39,Lieutenant Governor,,LIB,Kerry Douglas McKennon,1,4,5
+Crosby,Precinct 39,Attorney General,,REP,Ken Paxton,57,146,203
+Crosby,Precinct 39,Attorney General,,DEM,Justin Nelson,18,78,96
+Crosby,Precinct 39,Attorney General,,LIB,Michael Ray Harris,3,10,13
+Crosby,Precinct 39,Comptroller of Public Accounts,,REP,Glenn Hegar,59,155,214
+Crosby,Precinct 39,Comptroller of Public Accounts,,DEM,Joi Chevalier,15,66,81
+Crosby,Precinct 39,Comptroller of Public Accounts,,LIB,Ben Sanders,3,10,13
+Crosby,Precinct 39,Commissioner of the General Land Office,,REP,George P. Bush,59,155,214
+Crosby,Precinct 39,Commissioner of the General Land Office,,DEM,Miguel Suazo,15,73,88
+Crosby,Precinct 39,Commissioner of the General Land Office,,LIB,Matt Pina,4,6,10
+Crosby,Precinct 39,Railroad Commissioner,,REP,Christi Craddick,60,154,214
+Crosby,Precinct 39,Railroad Commissioner,,DEM,Roman McAllen,15,71,86
+Crosby,Precinct 39,Railroad Commissioner,,LIB,Mike Wright,2,6,8
+Crosby,Precinct 39,State Representative,68,REP,Drew Springer,61,174,235
 Crosby,Precinct 44,Registered Voters,,,,,,1444
 Crosby,Precinct 44,Ballots Cast,,,,,,427
 Crosby,Precinct 44,Straight Party,,REP,,113,56,169


### PR DESCRIPTION
This fixes many incorrect values in the 2018 Crosby County general file.

When we fixed the headers in revision 02b6697821f06a70e99cf0937857e28eae5d05b5 ("fixed headers on Crosby general"), we inadvertently rearranged the columns and omitted the total votes.