### PR TITLE
Fix values in 2016 Duval County general file

### DIFF
--- a/2016/counties/20161108__tx__general__duval__precinct.csv
+++ b/2016/counties/20161108__tx__general__duval__precinct.csv
@@ -60,7 +60,7 @@ Duval,8,Straight Party,,Over Votes,,0,0,0
 Duval,9,Straight Party,,Over Votes,,1,0,1
 Duval,Total,Straight Party,,Over Votes,,4,3,7
 Duval,1,Straight Party,,Under Votes,,280,225,505
-Duval,2,Straight Party,,Under Votes,,127,146,263
+Duval,2,Straight Party,,Under Votes,,127,136,263
 Duval,3,Straight Party,,Under Votes,,80,68,148
 Duval,4,Straight Party,,Under Votes,,40,28,68
 Duval,5,Straight Party,,Under Votes,,43,40,83
@@ -68,7 +68,7 @@ Duval,6,Straight Party,,Under Votes,,11,18,29
 Duval,7,Straight Party,,Under Votes,,26,20,46
 Duval,8,Straight Party,,Under Votes,,397,190,587
 Duval,9,Straight Party,,Under Votes,,163,116,279
-Duval,Total,Straight Party,,Under Votes,,1167,851,2008
+Duval,Total,Straight Party,,Under Votes,,1167,841,2008
 Duval,1,President,,Donald Trump,REP,146,117,263
 Duval,2,President,,Donald Trump,REP,69,71,140
 Duval,3,President,,Donald Trump,REP,33,37,70


### PR DESCRIPTION
This fixes some incorrect values in the 2016 Duval County general file. According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2016/2016%20duval%20tx.pdf), there were `136` election day straight party under votes in Precinct 2:

![image](https://user-images.githubusercontent.com/17345532/133819797-683e81bc-6bff-4a32-8e79-2549c36feb74.png)
