### PR TITLE
Fix values in 2016 Karnes County general file

### DIFF
--- a/2016/counties/20161108__tx__general__karnes__precinct.csv
+++ b/2016/counties/20161108__tx__general__karnes__precinct.csv
@@ -89,7 +89,7 @@ Karnes,12-13,President,,Hillary Clinton,,65,34,99
 Karnes,14,President,,Hillary Clinton,,113,127,240
 Karnes,15,President,,Hillary Clinton,,8,10,18
 Karnes,Total,President,,Hillary Clinton,,620,525,1145
-Karnes,1,President,,Gary Johnson,,6,5,1
+Karnes,1,President,,Gary Johnson,,6,5,11
 Karnes,3,President,,Gary Johnson,,1,1,2
 Karnes,4,President,,Gary Johnson,,8,6,14
 Karnes,5,President,,Gary Johnson,,4,4,8
@@ -100,7 +100,7 @@ Karnes,11,President,,Gary Johnson,,9,2,11
 Karnes,12-13,President,,Gary Johnson,,2,3,5
 Karnes,14,President,,Gary Johnson,,1,4,5
 Karnes,15,President,,Gary Johnson,,1,3,4
-Karnes,Total,President,,Gary Johnson,,38,32,60
+Karnes,Total,President,,Gary Johnson,,38,32,70
 Karnes,1,President,,Jill Stein,,1,0,1
 Karnes,4,President,,Jill Stein,,0,4,4
 Karnes,5,President,,Jill Stein,,0,2,2


### PR DESCRIPTION
This fixes some incorrect values in the 2016 Karnes County general file. According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2016/2016%20Karnes%20County%20DOC040417-04042017103526.pdf),

* Gary Johnson received `11` total votes in Precinct 1:
![image](https://user-images.githubusercontent.com/17345532/133820219-16d0a38d-010e-4450-ab7a-6567dd815a88.png)
