### PR TITLE
Fix values in 2016 Camp County general file

### DIFF
--- a/2016/counties/20161108__tx__general__camp__precinct.csv
+++ b/2016/counties/20161108__tx__general__camp__precinct.csv
@@ -4,7 +4,7 @@ Camp,2,,,Straight Party,REP,601,497,104
 Camp,3,,,Straight Party,REP,278,222,56
 Camp,4,,,Straight Party,REP,435,349,86
 Camp,Total,,,Straight Party,REP,1686,,
-Camp,1,,,Straight Party,DEM,202,138,74
+Camp,1,,,Straight Party,DEM,202,128,74
 Camp,2,,,Straight Party,DEM,150,95,55
 Camp,3,,,Straight Party,DEM,321,179,142
 Camp,4,,,Straight Party,DEM,185,123,62
@@ -30,7 +30,7 @@ Camp,3,President,,Hillary Clinton,DEM,425,247,178
 Camp,4,President,,Hillary Clinton,DEM,272,181,91
 Camp,Total,President,,Hillary Clinton,DEM,1260,,
 Camp,1,President,,Gary Johnson,LIB,22,7,15
-Camp,2,President,,Gary Johnson,LIB,19,9,110
+Camp,2,President,,Gary Johnson,LIB,19,9,10
 Camp,3,President,,Gary Johnson,LIB,17,11,6
 Camp,4,President,,Gary Johnson,LIB,8,2,6
 Camp,Total,President,,Gary Johnson,LIB,66,,


### PR DESCRIPTION
This fixes some incorrect values in the 2016 Camp County general file. According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2016/CAMP%20TX%20FINAL%20ELECTION%20RESULTS%20by%20PCT%20EL30A.pdf),

* There were `128` early Democratic straight party votes in Precinct 1:
![image](https://user-images.githubusercontent.com/17345532/133820447-9fb016d6-c499-4fcc-83dd-2079cca66607.png)

* Gary Johnson received `10` election day votes in Precinct 2:
![image](https://user-images.githubusercontent.com/17345532/133820527-85dbd1c3-8b46-4500-a0f9-a8feb952a829.png)
