### PR TITLE
Fix values in 2016 Van Zandt County general file

### DIFF
--- a/2016/counties/20161108__tx__general__van_zandt__precinct.csv
+++ b/2016/counties/20161108__tx__general__van_zandt__precinct.csv
@@ -114,7 +114,7 @@ Van Zandt,4D,President,,Hillary Clinton,DEM,326,27,164,135,0,0
 Van Zandt,4E,President,,Hillary Clinton,DEM,82,8,38,36,0,0
 Van Zandt,Total,President,,Hillary Clinton,DEM,2799,,,,,
 Van Zandt,1A,President,,Gary Johnson,LIB,19,2,12,5,0,0
-Van Zandt,1B,President,,Gary Johnson,LIB,20,2,6,18,0,0
+Van Zandt,1B,President,,Gary Johnson,LIB,20,2,6,12,0,0
 Van Zandt,1C,President,,Gary Johnson,LIB,18,0,5,13,0,0
 Van Zandt,1D,President,,Gary Johnson,LIB,15,0,3,12,0,0
 Van Zandt,1E,President,,Gary Johnson,LIB,11,0,3,8,0,0
@@ -291,7 +291,7 @@ Van Zandt,1D,State Representative,2,Dan Flynn,REP,706,27,271,407,1,0
 Van Zandt,1E,State Representative,2,Dan Flynn,REP,412,13,185,214,0,0
 Van Zandt,2A,State Representative,2,Dan Flynn,REP,1883,95,1352,0,0,436
 Van Zandt,2B,State Representative,2,Dan Flynn,REP,884,34,464,386,0,0
-Van Zandt,2C,State Representative,2,Dan Flynn,REP,1178,38,531,626,0,0
+Van Zandt,2C,State Representative,2,Dan Flynn,REP,1198,41,531,626,0,0
 Van Zandt,2D,State Representative,2,Dan Flynn,REP,1012,53,635,324,0,0
 Van Zandt,3A,State Representative,2,Dan Flynn,REP,534,15,393,126,0,0
 Van Zandt,3B,State Representative,2,Dan Flynn,REP,771,32,354,385,0,0


### PR DESCRIPTION
This fixes some incorrect values in the 2016 Van Zandt County general file. According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2016/2016%20Van%20Zandt%20County%2C%20TX%20precinct-level%20election%20results.pdf),

* Gary Johnson received `12` election day votes in Precinct 1B:
![image](https://user-images.githubusercontent.com/17345532/133935083-8fc4bdd0-8b4b-4517-884a-d7d360ded5d3.png)

* Dan Flynn received `41` mail votes in Precinct 2C:
![image](https://user-images.githubusercontent.com/17345532/133935127-4ebec3aa-a9fa-4f10-a1f4-a922e76a86d1.png)
