### PR TITLE
Fix values in 2016 Fisher County primary file

### DIFF
--- a/2016/counties/20160301__tx__primary__fisher__precinct.csv
+++ b/2016/counties/20160301__tx__primary__fisher__precinct.csv
@@ -7,7 +7,7 @@ Fisher,1,President,,DEM,Keith Judd,4,3,1,0,1
 Fisher,1,President,,DEM,"Roque ""Rocky"" De La Fuente",2,2,0,0,0
 Fisher,1,President,,DEM,Calvis L Hawes,0,0,0,0,0
 Fisher,1,President,,DEM,Willie L Wilson,2,2,0,0,0
-Fisher,1,President,,DEM,Hillary Clinton,41,26,23,0,23
+Fisher,1,President,,DEM,Hillary Clinton,49,26,23,0,23
 Fisher,1,President,,DEM,Star Locke,1,0,1,0,1
 Fisher,1,Railroad Commissioner,,DEM,Grady Yarbrough,44,22,22,0,22
 Fisher,1,Railroad Commissioner,,DEM,Cody Garrett,49,25,24,0,24


### PR DESCRIPTION
This fixes some incorrect values in the 2016 Fisher County primary file. According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2016/Fisher%20TX%202016%20PRIMARY%20DEM%20%26%20REP.PDF), Hillary Clinton received `49` total votes in Precinct 1:

![image](https://user-images.githubusercontent.com/17345532/133935256-61f8d6b4-0fe6-4a72-8dd6-a6adca979498.png)
