### PR TITLE
Fix values in 2014 Delta County general file

### DIFF
--- a/2014/counties/20141104__tx__general__delta__precinct.csv
+++ b/2014/counties/20141104__tx__general__delta__precinct.csv
@@ -107,7 +107,7 @@ Delta,1,U S Senate,,Under Votes,,1,9,7,17
 Delta,3,U S Senate,,Under Votes,,2,6,5,13
 Delta,4,U S Senate,,Under Votes,,0,8,12,20
 Delta,5,U S Senate,,Under Votes,,2,3,8,13
-Delta,7,U S Senate,,Under Votes,,1,2,6,8
+Delta,7,U S Senate,,Under Votes,,1,2,6,9
 Delta,9,U S Senate,,Under Votes,,2,2,13,17
 Delta,10,U S Senate,,Under Votes,,0,2,4,6
 Delta,Total,U S Senate,,Under Votes,,8,32,55,95


### PR DESCRIPTION
This fixes some incorrect values in the 2014 Delta County general file. According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2014/DELTA_COUNTY-2014_General_Election_1142014-Election14.pdf), there were `9` total under votes in the U.S. Senate race in Precinct 7:

![image](https://user-images.githubusercontent.com/17345532/133935320-28293055-c941-4a23-983a-74dacd36d9f4.png)
