### PR TITLE
Fix values in 2014 Foard County general file

### DIFF
--- a/2014/counties/20141104__tx__general__foard__precinct.csv
+++ b/2014/counties/20141104__tx__general__foard__precinct.csv
@@ -296,9 +296,9 @@
 296,Foard,Total,Railroad Commissioner,,Steve Brown,,49,78,131
 297,Foard,101,Railroad Commissioner,,Mark A. Miller,,1,1,2
 298,Foard,201,Railroad Commissioner,,Mark A. Miller,,0,3,3
-299,Foard,301,Railroad Commissioner,,Mark A. Miller,,0,3,0
+299,Foard,301,Railroad Commissioner,,Mark A. Miller,,0,3,3
 300,Foard,401,Railroad Commissioner,,Mark A. Miller,,0,0,0
-301,Foard,Total,Railroad Commissioner,,Mark A. Miller,,1,7,5
+301,Foard,Total,Railroad Commissioner,,Mark A. Miller,,1,7,8
 302,Foard,101,Railroad Commissioner,,Martina Salinas,,0,0,0
 303,Foard,201,Railroad Commissioner,,Martina Salinas,,0,0,0
 304,Foard,301,Railroad Commissioner,,Martina Salinas,,0,0,0
@@ -310,10 +310,10 @@
 310,Foard,401,Railroad Commissioner,,Over Votes,,0,0,0
 311,Foard,Total,Railroad Commissioner,,Over Votes,,0,0,0
 312,Foard,101,Railroad Commissioner,,Under Votes,,3,3,6
-313,Foard,201,Railroad Commissioner,,Under Votes,,9,12,20
+313,Foard,201,Railroad Commissioner,,Under Votes,,8,12,20
 314,Foard,301,Railroad Commissioner,,Under Votes,,0,2,2
 315,Foard,401,Railroad Commissioner,,Under Votes,,3,9,12
-316,Foard,Total,Railroad Commissioner,,Under Votes,,15,26,40
+316,Foard,Total,Railroad Commissioner,,Under Votes,,14,26,40
 317,Foard,101,State Representative,69,James Frank,,11,23,34
 318,Foard,201,State Representative,69,James Frank,,35,46,81
 319,Foard,301,State Representative,69,James Frank,,13,35,48


### PR DESCRIPTION
This fixes some incorrect values in the 2014 Foard County general file. According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2014/FOARD_COUNTY-2014_General_Election_1142014-Nov%202014%20Gen%20Elect%20Pct%20Rep.pdf),

* Mark A. Miller received `3` total votes in Precinct 301:
![image](https://user-images.githubusercontent.com/17345532/133935375-70a6f6aa-a17b-43e7-b62a-668c4825c2f1.png)

* There were `8` early under votes in the Railroad Commissioner race in Precinct 201:
![image](https://user-images.githubusercontent.com/17345532/133935406-b35c3069-4913-4e24-b194-6ea852ef6ae9.png)
