### PR TITLE
Remove misleading entries from 2018 Crosby County general file

### DIFF
--- a/2018/counties/20181106__tx__general__crosby__precinct.csv
+++ b/2018/counties/20181106__tx__general__crosby__precinct.csv
@@ -1,5 +1,4 @@
 county,precinct,office,district,party,candidate,early_voting,election_day,votes
-Crosby,Precinct 11,Registered Voters,,,,,,1444
 Crosby,Precinct 11,Ballots Cast,,,,,,272
 Crosby,Precinct 11,Straight Party,,REP,,60,44,104
 Crosby,Precinct 11,Straight Party,,DEM,,22,38,60
@@ -28,7 +27,6 @@ Crosby,Precinct 11,Railroad Commissioner,,REP,Christi Craddick,99,77,176
 Crosby,Precinct 11,Railroad Commissioner,,DEM,Roman McAllen,33,53,86
 Crosby,Precinct 11,Railroad Commissioner,,LIB,Mike Wright,4,2,6
 Crosby,Precinct 11,State Representative,68,REP,Drew Springer,110,97,207
-Crosby,Precinct 27,Registered Voters,,,,,,1444
 Crosby,Precinct 27,Ballots Cast,,,,,,426
 Crosby,Precinct 27,Straight Party,,REP,,124,51,175
 Crosby,Precinct 27,Straight Party,,DEM,,47,33,80
@@ -57,7 +55,6 @@ Crosby,Precinct 27,Railroad Commissioner,,REP,Christi Craddick,195,87,282
 Crosby,Precinct 27,Railroad Commissioner,,DEM,Roman McAllen,70,51,121
 Crosby,Precinct 27,Railroad Commissioner,,LIB,Mike Wright,8,2,10
 Crosby,Precinct 27,State Representative,68,REP,Drew Springer,215,106,321
-Crosby,Precinct 39,Registered Voters,,,,,,1444
 Crosby,Precinct 39,Ballots Cast,,,,,,319
 Crosby,Precinct 39,Straight Party,,REP,,38,83,121
 Crosby,Precinct 39,Straight Party,,DEM,,11,42,53
@@ -86,7 +83,6 @@ Crosby,Precinct 39,Railroad Commissioner,,REP,Christi Craddick,60,154,214
 Crosby,Precinct 39,Railroad Commissioner,,DEM,Roman McAllen,15,71,86
 Crosby,Precinct 39,Railroad Commissioner,,LIB,Mike Wright,2,6,8
 Crosby,Precinct 39,State Representative,68,REP,Drew Springer,61,174,235
-Crosby,Precinct 44,Registered Voters,,,,,,1444
 Crosby,Precinct 44,Ballots Cast,,,,,,427
 Crosby,Precinct 44,Straight Party,,REP,,113,56,169
 Crosby,Precinct 44,Straight Party,,DEM,,35,27,62


### PR DESCRIPTION
These values actually correspond to the total number of voters in the county, and not the number of registered voters in each precinct.

![image](https://user-images.githubusercontent.com/17345532/133935454-0f673267-a439-404c-8c41-22605edb9ef7.png)
