### PR TITLE
Fix non-integer absentee vote in 2016 Wilson County general file

### DIFF
--- a/2016/counties/20161108__tx__general__wilson__precinct.csv
+++ b/2016/counties/20161108__tx__general__wilson__precinct.csv
@@ -100,7 +100,7 @@ Wilson,313,President,,Donald Trump,REP,597,626,2,28,1253
 Wilson,414,President,,Donald Trump,REP,682,454,0,46,1182
 Wilson,415,President,,Donald Trump,REP,745,1122,1,64,1932
 Wilson,416,President,,Donald Trump,REP,397,695,0,62,1154
-Wilson,Total,President,,Donald Trump,REP,6457,6994,7,532.08,13998
+Wilson,Total,President,,Donald Trump,REP,6457,6994,7,540,13998
 Wilson,101,President,,Hillary Clinton,DEM,158,277,0,25,460
 Wilson,102,President,,Hillary Clinton,DEM,275,363,0,90,728
 Wilson,103,President,,Hillary Clinton,DEM,219,137,0,53,409


### PR DESCRIPTION
This fixes an incorrect value in the 2016 Wilson County general file.  According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2016/2016%20Wilson,%20TX%20precinct-level%20election%20results.pdf), Donald Trump received `540` total absentee votes:

![image](https://user-images.githubusercontent.com/17345532/136667687-6017c202-6c64-4c71-bca6-3e2df7773534.png)


This does not fix the issues described in #416, so the `early_voting` and `election_day` values for this entry remain flipped.