### PR TITLE
Fix values in 2014 Chambers County general file

### DIFF
--- a/2014/counties/20141104__tx__general__chambers__precinct.csv
+++ b/2014/counties/20141104__tx__general__chambers__precinct.csv
@@ -202,13 +202,13 @@ Chambers,4- MONT BELVIEU,U.S. House,36,Brian Babin,REP,89,4,35,50
 Chambers,5- BEACH CITY,U.S. House,36,Brian Babin,REP,1006,29,579,398
 Chambers,6- ANAHUAC,U.S. House,36,Brian Babin,REP,482,16,218,248
 Chambers,7- WINNIE,U.S. House,36,Brian Babin,REP,669,14,411,244
-Chambers,8- COVE,U.S. House,36,Brian Babin,REP,1.092,28,503,561
+Chambers,8- COVE,U.S. House,36,Brian Babin,REP,1092,28,503,561
 Chambers,9- OAK ISLAND,U.S. House,36,Brian Babin,REP,91,0,23,68
 Chambers,10- WEST ANNEX,U.S. House,36,Brian Babin,REP,991,35,559,397
 Chambers,11- CEDAR BAYOU,U.S. House,36,Brian Babin,REP,976,21,554,401
 Chambers,12- STOWELL,U.S. House,36,Brian Babin,REP,358,8,204,146
 Chambers,14- ANAHUAC AIRPORT,U.S. House,36,Brian Babin,REP,108,1,40,67
-Chambers,Total,U.S. House,36,Brian Babin,REP,5841.092,198,3611,3123
+Chambers,Total,U.S. House,36,Brian Babin,REP,6932,198,3611,3123
 Chambers,1- WALLISVILLE,U.S. House,36,Michael K. Cole,DEM,33,0,7,26
 Chambers,2- HANKAMER,U.S. House,36,Michael K. Cole,DEM,55,0,14,41
 Chambers,3- PINE ISLAND,U.S. House,36,Michael K. Cole,DEM,54,7,13,34


### PR DESCRIPTION
This fixes some incorrect values in the 2014 Chambers County general file. According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/0894ee5e2ed07bd98dbe0c4181166ae1caa17583/2014/2014%20chambers.pdf), Brian Babin received `1092` votes in Precinct 9 - COVE:

![image](https://user-images.githubusercontent.com/17345532/136706455-db19cbb0-8025-47e4-886c-9d2d22c9e418.png)

Note that this does not address issue #419, so the column order remains incorrect here.
