### PR TITLE
Fix non-integer value in 2018 Bosque County primary file

### DIFF
--- a/2018/counties/20180306__tx__primary__bosque__precinct.csv
+++ b/2018/counties/20180306__tx__primary__bosque__precinct.csv
@@ -814,7 +814,7 @@ Bosque,8,Governor,,Under Votes,DEM,6,3,3
 Bosque,9,Governor,,Under Votes,DEM,0,0,0
 Bosque,10,Governor,,Under Votes,DEM,2,0,2
 Bosque,11,Governor,,Under Votes,DEM,1,0,1
-Bosque,Total,Governor,,Under Votes,DEM,15,4,10.1
+Bosque,Total,Governor,,Under Votes,DEM,15,4,11
 Bosque,1,Lieutenant Governor,,Michael Cooper,DEM,7,0,7
 Bosque,2,Lieutenant Governor,,Michael Cooper,DEM,19,7,12
 Bosque,3,Lieutenant Governor,,Michael Cooper,DEM,13,2,11


### PR DESCRIPTION
This fixes an incorrect value for the total election day under votes in the Governor's race.