### PR TITLE
Bump format tests to version 2.0.0

### DIFF
--- a/.github/workflows/format_tests.yml
+++ b/.github/workflows/format_tests.yml
@@ -9,13 +9,16 @@ jobs:
     strategy:
       fail-fast: false
 
+    env:
+      LOG_FILE: ${{ github.workspace }}/format_tests.txt
+
     steps:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
         python-version: 3.x
 
-    - name: Check out source
+    - name: Check out data
       uses: actions/checkout@v2.3.4
       with:
         path: data
@@ -24,8 +27,15 @@ jobs:
       uses: actions/checkout@v2.3.4
       with:
         repository: openelections/openelections-format-tests
-        ref: v1.0.0
+        ref: v2.0.0
         path: format_tests
 
     - name: Run format tests
-      run: python3 ${{ github.workspace }}/format_tests/run_tests.py ${{ github.workspace }}/data
+      run: python3 ${{ github.workspace }}/format_tests/run_tests.py --group-failures --log-file=${{ env.LOG_FILE }} ${{ github.workspace }}/data
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2.2.4
+      if: failure()
+      with:
+        name: format_tests_full_logs
+        path: ${{ env.LOG_FILE }}


### PR DESCRIPTION
This bumps the format tests to [version 2.0.0](https://github.com/openelections/openelections-format-tests/releases/tag/v2.0.0).