### PR TITLE
Fix values in 2016 Uvalde County general file

### DIFF
--- a/2016/counties/20161108__tx__general__uvalde__precinct.csv
+++ b/2016/counties/20161108__tx__general__uvalde__precinct.csv
@@ -98,7 +98,7 @@ Uvalde,6,State Senate,19,Rep,Peter Flores,154,1,61,92
 Uvalde,6,State Senate,19,Dem,Carlos Uresti,43,2,23,18
 Uvalde,6,State Senate,19,Lbt,Max Martin,7,0,4,3
 Uvalde,6,State House,80,Dem,Tracy King,99,2,39,58
-Uvalde,7,Ballots Cast,,,,402,26,270,116
+Uvalde,7,Ballots Cast,,,,402,16,270,116
 Uvalde,7,President,,Rep,Donald Trump,317,9,221,87
 Uvalde,7,President,,Dem,Hillary Clinton,69,6,38,25
 Uvalde,7,President,,Lbt,Gary Johnson,5,0,4,1


### PR DESCRIPTION
This fixes some incorrect values in the 2016 Uvalde County general file. According to the [source file](https://github.com/openelections/openelections-sources-tx/blob/master/2016/Uvalde_2016_Gen_Elec_part1.tif), there were `16` absentee votes in precinct 7:

![image](https://user-images.githubusercontent.com/17345532/146659232-04057998-21e0-4231-a537-b61f662c2cb0.png)
