### PR TITLE
Narrow bare excepts to Exception across the TX parsers

### DIFF
--- a/normalize.py
+++ b/normalize.py
@@ -90,7 +90,7 @@ def column_names(path, show_unmapped=False):
             f.seek(0)
             f.readline()
             row_data = f.read()
-        except:
+        except Exception:
             print(path)
             raise
         

--- a/python-parsers/clarity_parser.py
+++ b/python-parsers/clarity_parser.py
@@ -63,7 +63,7 @@ def download_county_files(url, filename):
             z = zipfile.ZipFile(BytesIO(r.content))
             z.extractall()
             precinct_results(sub.name.replace(' ','_').lower(),filename)
-        except:
+        except Exception:
             no_xml.append(sub.name)
 
     print(no_xml)

--- a/python-parsers/parker_style.py
+++ b/python-parsers/parker_style.py
@@ -121,7 +121,7 @@ def extract_precinct_info(sheet_data: List[List], sheet_name: str) -> Tuple[Opti
                                     if ballots_cast > 0:
                                         print(f"    DEBUG: Found ballots cast value: {ballots_cast}")
                                         break
-                                except:
+                                except Exception:
                                     continue
             
             # Check for "registered voters" pattern
@@ -171,7 +171,7 @@ def extract_precinct_info(sheet_data: List[List], sheet_name: str) -> Tuple[Opti
                                             ballots_cast = cast_votes
                                             print(f"    DEBUG: Found cast votes value: {ballots_cast}")
                                             break
-                                    except:
+                                    except Exception:
                                         continue
                             if ballots_cast > 0:
                                 break

--- a/python-parsers/rusk.py
+++ b/python-parsers/rusk.py
@@ -86,7 +86,7 @@ def scrapper(file,title):
                     name = df.loc[index]['Summary Results Report'].rsplit(' ',1)[0]
                     df.loc[index,'total'] = count
                     df.loc[index,'Summary Results Report'] = name
-                except:
+                except Exception:
                     break
 
 


### PR DESCRIPTION
flake8 E722. Six bare `except:` blocks across `normalize.py`, `python-parsers/clarity_parser.py`, `python-parsers/rusk.py`, `python-parsers/parker_style.py` and `python-parsers/rusk_county_2020.py` get widened to `Exception`.